### PR TITLE
fix(core,react): guard onComplete/onSkip against multiple invocations (#6)

### DIFF
--- a/.changeset/fix-oncomplete-double-fire.md
+++ b/.changeset/fix-oncomplete-double-fire.md
@@ -1,0 +1,9 @@
+---
+'@tour-kit/core': patch
+'@tour-kit/react': patch
+---
+
+Fix `onComplete` and `onSkip` callbacks firing multiple times, which caused `Maximum update depth exceeded` when the parent unmounted the `<Tour>` synchronously inside the callback (issue #6).
+
+- `TourProvider` now consolidates every completion path (`complete()`, `next()` at last step, branch `'complete'` / `'skip'` targets, and the no-visible-step auto-finish) through shared `completeTour` / `skipTour` helpers guarded by tour-id-keyed refs. The guard catches both stale-closure synchronous double-calls and post-`COMPLETE_TOUR` re-firing. Refs are re-armed on `start()` and on cross-tour branch transitions, so legitimate restarts still fire the callbacks.
+- `<Tour>` (in `@tour-kit/react`) wraps the consumer-supplied `onComplete` / `onSkip` with the same idempotency guard as a defense-in-depth layer.

--- a/packages/core/src/__tests__/context/branching.test.tsx
+++ b/packages/core/src/__tests__/context/branching.test.tsx
@@ -636,4 +636,146 @@ describe('TourProvider branching logic', () => {
       expect(result.current.currentStep?.id).toBe('step-3')
     })
   })
+
+  // Regression coverage for issue #6: every completion path must fire onComplete
+  // (and onSkip) at most once per tour activation, regardless of how it's reached.
+  describe('terminal-callback idempotency', () => {
+    it('fires onComplete exactly once when reached via "complete" branch target', async () => {
+      const onComplete = vi.fn()
+      const tours: Tour[] = [
+        {
+          id: 'test-tour',
+          onComplete,
+          steps: [createStep('step-1', { onNext: 'complete' }), createStep('step-2')],
+        },
+      ]
+
+      const { result } = renderHook(() => useTourContext(), {
+        wrapper: createWrapper(tours),
+      })
+
+      await act(async () => {
+        await result.current.start('test-tour')
+      })
+      await act(async () => {
+        await result.current.next()
+      })
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(result.current.isActive).toBe(false)
+    })
+
+    it('fires onSkip exactly once when reached via "skip" branch target', async () => {
+      const onSkip = vi.fn()
+      const tours: Tour[] = [
+        {
+          id: 'test-tour',
+          onSkip,
+          steps: [createStep('step-1', { onNext: 'skip' }), createStep('step-2')],
+        },
+      ]
+
+      const { result } = renderHook(() => useTourContext(), {
+        wrapper: createWrapper(tours),
+      })
+
+      await act(async () => {
+        await result.current.start('test-tour')
+      })
+      await act(async () => {
+        await result.current.next()
+      })
+
+      expect(onSkip).toHaveBeenCalledTimes(1)
+      expect(result.current.isActive).toBe(false)
+    })
+
+    it('fires onComplete exactly once when no visible step remains after a branch jump', async () => {
+      const onComplete = vi.fn()
+      const tours: Tour[] = [
+        {
+          id: 'test-tour',
+          onComplete,
+          steps: [
+            // jump forward by id; but step-2 is hidden by `when`, leaving no visible step
+            createStep('step-1', { onNext: 'step-2' }),
+            createStep('step-2', { when: () => false }),
+          ],
+        },
+      ]
+
+      const { result } = renderHook(() => useTourContext(), {
+        wrapper: createWrapper(tours),
+      })
+
+      await act(async () => {
+        await result.current.start('test-tour')
+      })
+      await act(async () => {
+        await result.current.next()
+      })
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(result.current.isActive).toBe(false)
+    })
+
+    it('fires onComplete exactly once when complete() is called twice synchronously', async () => {
+      const onComplete = vi.fn()
+      const tours: Tour[] = [
+        {
+          id: 'test-tour',
+          onComplete,
+          steps: [createStep('step-1'), createStep('step-2')],
+        },
+      ]
+
+      const { result } = renderHook(() => useTourContext(), {
+        wrapper: createWrapper(tours),
+      })
+
+      await act(async () => {
+        await result.current.start('test-tour')
+      })
+
+      // Two synchronous calls inside the same commit phase — would re-fire
+      // onComplete without the ref guard because state.isActive is closure-stale.
+      await act(async () => {
+        result.current.complete()
+        result.current.complete()
+      })
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(result.current.isActive).toBe(false)
+    })
+
+    it('re-arms onComplete after restart so it can fire again on a new activation', async () => {
+      const onComplete = vi.fn()
+      const tours: Tour[] = [
+        {
+          id: 'test-tour',
+          onComplete,
+          steps: [createStep('step-1')],
+        },
+      ]
+
+      const { result } = renderHook(() => useTourContext(), {
+        wrapper: createWrapper(tours),
+      })
+
+      await act(async () => {
+        await result.current.start('test-tour')
+      })
+      await act(async () => {
+        result.current.complete()
+      })
+      await act(async () => {
+        await result.current.start('test-tour')
+      })
+      await act(async () => {
+        result.current.complete()
+      })
+
+      expect(onComplete).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -383,6 +383,13 @@ export function TourProvider({
 
   const [state, dispatch] = React.useReducer(tourReducer, initialState)
 
+  // Idempotency guards: track the last tour for which the terminal callback
+  // (onComplete / onSkip) has already fired. Prevents double-firing inside the
+  // same React commit phase, where reducer state is still closure-stale.
+  // Reset inside start() / handleStartTour-equivalent paths (see below).
+  const completedTourIdRef = React.useRef<string | null>(null)
+  const skippedTourIdRef = React.useRef<string | null>(null)
+
   // Sync tours prop with reducer state when tours are registered/unregistered
   React.useEffect(() => {
     dispatch({ type: 'UPDATE_TOURS', tours })
@@ -478,6 +485,34 @@ export function TourProvider({
     [state, currentTour, data]
   )
 
+  // Helper to complete the current tour. Idempotent across both stale-closure
+  // synchronous double-calls (via ref) and post-COMPLETE_TOUR re-firing (via
+  // isActive). Single source of truth for ALL completion paths — public
+  // complete(), next() at last step, branch 'complete', and the no-visible-step
+  // auto-finish path.
+  const completeTour = React.useCallback(() => {
+    if (!state.isActive || !currentTour) return
+    if (completedTourIdRef.current === currentTour.id) return
+    completedTourIdRef.current = currentTour.id
+    dispatch({ type: 'ADD_COMPLETED', tourId: currentTour.id })
+    dispatch({ type: 'COMPLETE_TOUR' })
+    clear()
+    tourKitContext?.onTourComplete?.(currentTour.id)
+    currentTour.onComplete?.({ ...state, tour: currentTour, data })
+  }, [currentTour, state, data, tourKitContext, clear])
+
+  // Helper to skip the current tour. Mirrors completeTour for skip semantics.
+  const skipTour = React.useCallback(() => {
+    if (!state.isActive || !currentTour) return
+    if (skippedTourIdRef.current === currentTour.id) return
+    skippedTourIdRef.current = currentTour.id
+    dispatch({ type: 'ADD_SKIPPED', tourId: currentTour.id })
+    dispatch({ type: 'SKIP_TOUR' })
+    clear()
+    tourKitContext?.onTourSkip?.(currentTour.id, state.currentStepIndex)
+    currentTour.onSkip?.({ ...state, tour: currentTour, data })
+  }, [currentTour, state, data, tourKitContext, clear])
+
   // Handle branch target resolution and navigation
   const handleBranchTarget = React.useCallback(
     async (
@@ -500,19 +535,11 @@ export function TourProvider({
       if (isSpecialTarget(target)) {
         switch (target) {
           case 'complete':
-            dispatch({ type: 'ADD_COMPLETED', tourId: currentTour.id })
-            dispatch({ type: 'COMPLETE_TOUR' })
-            clear()
-            tourKitContext?.onTourComplete?.(currentTour.id)
-            currentTour.onComplete?.({ ...state, tour: currentTour, data })
+            completeTour()
             return
 
           case 'skip':
-            dispatch({ type: 'ADD_SKIPPED', tourId: currentTour.id })
-            dispatch({ type: 'SKIP_TOUR' })
-            clear()
-            tourKitContext?.onTourSkip?.(currentTour.id, state.currentStepIndex)
-            currentTour.onSkip?.({ ...state, tour: currentTour, data })
+            skipTour()
             return
 
           case 'restart': {
@@ -564,6 +591,10 @@ export function TourProvider({
             newStepIndex = newTourStepMap.get(target.step) ?? 0
           }
         }
+
+        // Re-arm terminal-callback guards for the new tour
+        completedTourIdRef.current = null
+        skippedTourIdRef.current = null
 
         dispatch({ type: 'START_TOUR', tourId: target.tour, stepIndex: newStepIndex })
         tourKitContext?.onTourStart?.(target.tour)
@@ -625,11 +656,7 @@ export function TourProvider({
 
           if (visibleIndex === -1) {
             // No visible steps, complete the tour
-            dispatch({ type: 'ADD_COMPLETED', tourId: currentTour.id })
-            dispatch({ type: 'COMPLETE_TOUR' })
-            clear()
-            tourKitContext?.onTourComplete?.(currentTour.id)
-            currentTour.onComplete?.({ ...state, tour: currentTour, data })
+            completeTour()
             return
           }
 
@@ -671,7 +698,7 @@ export function TourProvider({
         })
       }
     },
-    [currentTour, state, data, stepIdMap, tourKitContext, clear, navigateToStep]
+    [currentTour, state, data, stepIdMap, tourKitContext, navigateToStep, completeTour, skipTour]
   )
 
   // Actions
@@ -707,22 +734,16 @@ export function TourProvider({
         return
       }
 
+      // Re-arm terminal-callback guards for the (re)started tour
+      completedTourIdRef.current = null
+      skippedTourIdRef.current = null
+
       dispatch({ type: 'START_TOUR', tourId: id, stepIndex: visibleIndex })
       tourKitContext?.onTourStart?.(id)
       tour.onStart?.({ ...state, tour, data })
     },
     [tours, state, data, tourKitContext]
   )
-
-  // Helper to complete the current tour
-  const completeTour = React.useCallback(() => {
-    if (!currentTour) return
-    dispatch({ type: 'ADD_COMPLETED', tourId: currentTour.id })
-    dispatch({ type: 'COMPLETE_TOUR' })
-    clear()
-    tourKitContext?.onTourComplete?.(currentTour.id)
-    currentTour.onComplete?.({ ...state, tour: currentTour, data })
-  }, [currentTour, state, data, tourKitContext, clear])
 
   const next = React.useCallback(async () => {
     if (!state.isActive || !currentTour) return
@@ -903,25 +924,8 @@ export function TourProvider({
     [state, currentTour, data, tourKitContext, navigateToStep]
   )
 
-  const skip = React.useCallback(() => {
-    if (!state.isActive || !currentTour) return
-
-    dispatch({ type: 'ADD_SKIPPED', tourId: currentTour.id })
-    dispatch({ type: 'SKIP_TOUR' })
-    clear() // Clear persisted state on skip
-    tourKitContext?.onTourSkip?.(currentTour.id, state.currentStepIndex)
-    currentTour.onSkip?.({ ...state, tour: currentTour, data })
-  }, [state, currentTour, data, tourKitContext, clear])
-
-  const complete = React.useCallback(() => {
-    if (!state.isActive || !currentTour) return
-
-    dispatch({ type: 'ADD_COMPLETED', tourId: currentTour.id })
-    dispatch({ type: 'COMPLETE_TOUR' })
-    clear() // Clear persisted state on complete
-    tourKitContext?.onTourComplete?.(currentTour.id)
-    currentTour.onComplete?.({ ...state, tour: currentTour, data })
-  }, [state, currentTour, data, tourKitContext, clear])
+  const skip = skipTour
+  const complete = completeTour
 
   const stop = React.useCallback(() => {
     dispatch({ type: 'STOP_TOUR' })

--- a/packages/react/src/components/tour/tour.test.tsx
+++ b/packages/react/src/components/tour/tour.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useTour } from '@tour-kit/core'
+import * as React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Tour } from './tour'
 import { TourStep } from './tour-step'
@@ -154,6 +155,36 @@ describe('Tour', () => {
     await user.click(screen.getByText('Start'))
     await user.click(screen.getByText('Next')) // Completes single-step tour
 
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onComplete only once when parent unmounts Tour inside the callback (issue #6)', async () => {
+    const onComplete = vi.fn()
+    const user = userEvent.setup()
+
+    function App() {
+      const [showTour, setShowTour] = React.useState(true)
+      if (!showTour) return <div data-testid="done">Done</div>
+      return (
+        <Tour
+          id="autostart-test"
+          autoStart
+          onComplete={() => {
+            onComplete()
+            setShowTour(false)
+          }}
+        >
+          <TourStep id="s1" target="#step-1" content="Step 1" />
+        </Tour>
+      )
+    }
+
+    render(<App />)
+
+    const finishButton = await screen.findByRole('button', { name: /finish/i })
+    await user.click(finishButton)
+
+    await waitFor(() => expect(screen.getByTestId('done')).toBeInTheDocument())
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/react/src/components/tour/tour.tsx
+++ b/packages/react/src/components/tour/tour.tsx
@@ -60,6 +60,19 @@ export function Tour({
 }: TourProps) {
   const registryContext = useTourRegistryContextOptional()
 
+  // Idempotency guards: ensure onComplete/onSkip fire at most once per tour
+  // activation. Prevents render-loop footgun when the parent unmounts the
+  // Tour synchronously inside the callback (issue #6).
+  const completedRef = React.useRef(false)
+  const skippedRef = React.useRef(false)
+
+  // Re-arm the guards if the tour identity changes (different tour mounted).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `id` is the trigger; the body only resets refs
+  React.useEffect(() => {
+    completedRef.current = false
+    skippedRef.current = false
+  }, [id])
+
   // Extract TourStep children vs other content
   const { steps, content } = React.useMemo(() => {
     const stepElements: TourStepType[] = []
@@ -93,8 +106,20 @@ export function Tour({
       startAt,
       ...config,
       onStart: onStart ? () => onStart() : undefined,
-      onComplete: onComplete ? () => onComplete() : undefined,
-      onSkip: onSkip ? () => onSkip() : undefined,
+      onComplete: onComplete
+        ? () => {
+            if (completedRef.current) return
+            completedRef.current = true
+            onComplete()
+          }
+        : undefined,
+      onSkip: onSkip
+        ? () => {
+            if (skippedRef.current) return
+            skippedRef.current = true
+            onSkip()
+          }
+        : undefined,
       onStepChange: onStepChange ? (step, index) => onStepChange(step, index) : undefined,
     }),
     [id, steps, autoStart, startAt, config, onStart, onComplete, onSkip, onStepChange]


### PR DESCRIPTION
Closes #6.

## Summary

- `<Tour>` with `autoStart` could fire `onComplete` (and `onSkip`) more than once. When the parent unmounted the tour synchronously inside the callback, this triggered `Maximum update depth exceeded` and a render loop.
- Root cause: the public `complete()` / `skip()` callbacks closed over a stale `state.isActive=true` during the same React commit, so a re-entrant call slipped past the `isActive` early-return.

## Fix

Layered idempotency guards:

- **`@tour-kit/core`** — consolidates every terminal path (`complete()`, `next()` at last step, branch `'complete'` / `'skip'` targets, no-visible-step auto-finish) through shared `completeTour` / `skipTour` helpers, each guarded by a tour-id-keyed ref. Refs are re-armed in `start()` and on cross-tour `BranchToTour` transitions so legitimate restarts still fire.
- **`@tour-kit/react`** — `<Tour>` wraps the consumer-supplied `onComplete` / `onSkip` with the same guard as defense-in-depth.

## Test plan

- [x] New integration test in `tour.test.tsx` mirrors the issue reproducer (`autoStart` + parent `setState(false)` inside the callback) and asserts `onComplete` runs exactly once.
- [x] 5 new unit tests in `branching.test.tsx` cover the `'complete'` branch target, `'skip'` branch target, no-visible-step after branch jump, synchronous double `complete()`, and the symmetric "re-arms after restart" check.
- [x] `pnpm --filter @tour-kit/core test` — 428/428 pass.
- [x] `pnpm --filter @tour-kit/react test` — 393/393 pass.
- [x] `pnpm --filter @tour-kit/{core,react} typecheck` — clean.
- [x] Changeset added (`patch` for both packages).