### PR TITLE
chore(test): sync vitest + vitest-axe across all packages

### DIFF
--- a/packages/adoption/package.json
+++ b/packages/adoption/package.json
@@ -110,6 +110,7 @@
     "react-dom": "^19.2.0",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/adoption/vitest.config.ts
+++ b/packages/adoption/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',

--- a/packages/adoption/vitest.setup.ts
+++ b/packages/adoption/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -135,6 +135,7 @@
     "react-dom": "^19.2.0",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/analytics/vitest.config.ts
+++ b/packages/analytics/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',
@@ -21,10 +21,10 @@ export default defineConfig({
         'src/plugins/index.ts',
       ],
       thresholds: {
-        statements: 85,
-        branches: 80,
-        functions: 85,
-        lines: 85,
+        statements: 80,
+        branches: 75,
+        functions: 80,
+        lines: 80,
       },
     },
   },

--- a/packages/analytics/vitest.setup.ts
+++ b/packages/analytics/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/announcements/package.json
+++ b/packages/announcements/package.json
@@ -122,12 +122,12 @@
     "@vitejs/plugin-react": "^4.5.2",
     "@vitest/coverage-v8": "catalog:",
     "jsdom": "catalog:",
-    "vitest-axe": "^1.0.0-pre.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwindcss": "^4.1.8",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/announcements/vitest.config.ts
+++ b/packages/announcements/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.tsx'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.tsx'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',

--- a/packages/announcements/vitest.setup.ts
+++ b/packages/announcements/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/checklists/package.json
+++ b/packages/checklists/package.json
@@ -95,6 +95,7 @@
     "react-dom": "^19.2.0",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/checklists/vitest.config.ts
+++ b/packages/checklists/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',

--- a/packages/checklists/vitest.setup.ts
+++ b/packages/checklists/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -90,6 +90,7 @@
     "react-dom": "^19.2.0",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/core/src/__tests__/axe-matcher-canary.test.tsx
+++ b/packages/core/src/__tests__/axe-matcher-canary.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
+
+describe('vitest-axe matcher (Phase 4 canary)', () => {
+  it('toHaveNoViolations is wired up via vitest.setup.ts', async () => {
+    const { container } = render(
+      <main>
+        <h1>Hello</h1>
+        <button type="button" aria-label="Click me">
+          +
+        </button>
+      </main>
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/packages/core/src/__tests__/vitest-config-alignment.test.ts
+++ b/packages/core/src/__tests__/vitest-config-alignment.test.ts
@@ -40,10 +40,10 @@ describe('Phase 4 — vitest config alignment', () => {
 
     it.each(NON_AI)('%s has canonical coverage thresholds', (pkg) => {
       const cfg = readConfig(pkg)
-      expect(cfg).toMatch(/statements:\s*80/)
-      expect(cfg).toMatch(/branches:\s*75/)
-      expect(cfg).toMatch(/functions:\s*80/)
-      expect(cfg).toMatch(/lines:\s*80/)
+      expect(cfg).toMatch(/statements:\s*80\b/)
+      expect(cfg).toMatch(/branches:\s*75\b/)
+      expect(cfg).toMatch(/functions:\s*80\b/)
+      expect(cfg).toMatch(/lines:\s*80\b/)
     })
   })
 

--- a/packages/core/src/__tests__/vitest-config-alignment.test.ts
+++ b/packages/core/src/__tests__/vitest-config-alignment.test.ts
@@ -1,0 +1,92 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const PACKAGES = [
+  'core',
+  'react',
+  'hints',
+  'adoption',
+  'announcements',
+  'checklists',
+  'media',
+  'surveys',
+  'analytics',
+  'scheduling',
+  'license',
+  'ai',
+] as const
+
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..')
+const NON_AI = PACKAGES.filter((p) => p !== 'ai')
+
+function readConfig(pkg: string): string {
+  return readFileSync(join(REPO_ROOT, 'packages', pkg, 'vitest.config.ts'), 'utf8')
+}
+
+function readSetup(pkg: string): string | null {
+  const p = join(REPO_ROOT, 'packages', pkg, 'vitest.setup.ts')
+  return existsSync(p) ? readFileSync(p, 'utf8') : null
+}
+
+describe('Phase 4 — vitest config alignment', () => {
+  describe('Canonical fields (US-1)', () => {
+    it.each(NON_AI)('%s has environment: jsdom', (pkg) => {
+      expect(readConfig(pkg)).toMatch(/environment:\s*['"]jsdom['"]/)
+    })
+
+    it.each(NON_AI)('%s has canonical coverage thresholds', (pkg) => {
+      const cfg = readConfig(pkg)
+      expect(cfg).toMatch(/statements:\s*80/)
+      expect(cfg).toMatch(/branches:\s*75/)
+      expect(cfg).toMatch(/functions:\s*80/)
+      expect(cfg).toMatch(/lines:\s*80/)
+    })
+  })
+
+  describe('ai exception (US-6)', () => {
+    it('ai uses node environment', () => {
+      expect(readConfig('ai')).toMatch(/environment:\s*['"]node['"]/)
+    })
+
+    it('ai setup (if present) does not import vitest-axe', () => {
+      const setup = readSetup('ai')
+      if (setup === null) return
+      expect(setup).not.toMatch(/vitest-axe/)
+    })
+  })
+
+  describe('Setup files (US-3, US-5)', () => {
+    it.each(NON_AI)('%s vitest.setup.ts imports vitest-axe/extend-expect', (pkg) => {
+      const setup = readSetup(pkg)
+      expect(setup, `${pkg}/vitest.setup.ts missing`).not.toBeNull()
+      expect(setup as string).toMatch(/['"]vitest-axe\/extend-expect['"]/)
+    })
+  })
+
+  describe('package.json catalog references (US-2)', () => {
+    it.each(NON_AI)('%s declares "vitest-axe": "catalog:"', (pkg) => {
+      const pj = JSON.parse(
+        readFileSync(join(REPO_ROOT, 'packages', pkg, 'package.json'), 'utf8')
+      ) as { devDependencies?: Record<string, string> }
+      expect(pj.devDependencies?.['vitest-axe']).toBe('catalog:')
+    })
+
+    it('ai does not declare vitest-axe', () => {
+      const pj = JSON.parse(
+        readFileSync(join(REPO_ROOT, 'packages', 'ai', 'package.json'), 'utf8')
+      ) as { devDependencies?: Record<string, string> }
+      expect(pj.devDependencies?.['vitest-axe']).toBeUndefined()
+    })
+  })
+
+  describe('Workspace catalog pin (US-2)', () => {
+    it('pins vitest-axe in pnpm-workspace.yaml catalog', () => {
+      const ws = readFileSync(join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8')
+      expect(ws).toMatch(/vitest-axe:\s*['"]?\^1\.0\.0-pre\.3['"]?/)
+    })
+  })
+})

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',
@@ -12,7 +12,7 @@ export default defineConfig({
       exclude: ['node_modules/', 'src/__tests__/', 'dist/', '**/*.d.ts'],
       thresholds: {
         statements: 80,
-        branches: 80,
+        branches: 75,
         functions: 80,
         lines: 80,
       },

--- a/packages/core/vitest.setup.ts
+++ b/packages/core/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/hints/package.json
+++ b/packages/hints/package.json
@@ -115,12 +115,12 @@
     "@vitejs/plugin-react": "^4.5.2",
     "@vitest/coverage-v8": "catalog:",
     "jsdom": "catalog:",
-    "vitest-axe": "^1.0.0-pre.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwindcss": "^4.1.8",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/hints/vitest.config.ts
+++ b/packages/hints/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',

--- a/packages/hints/vitest.setup.ts
+++ b/packages/hints/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/license/package.json
+++ b/packages/license/package.json
@@ -90,6 +90,7 @@
     "react-dom": "^19.2.0",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/license/vitest.config.ts
+++ b/packages/license/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',

--- a/packages/license/vitest.setup.ts
+++ b/packages/license/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -109,6 +109,7 @@
     "react-dom": "^19.2.0",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/media/vitest.config.ts
+++ b/packages/media/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',

--- a/packages/media/vitest.setup.ts
+++ b/packages/media/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -157,6 +157,7 @@
     "tailwindcss": "^4.1.8",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/scheduling/package.json
+++ b/packages/scheduling/package.json
@@ -75,6 +75,7 @@
     "react-dom": "^19.2.0",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/scheduling/vitest.config.ts
+++ b/packages/scheduling/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',

--- a/packages/scheduling/vitest.setup.ts
+++ b/packages/scheduling/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -114,11 +114,11 @@
     "@vitejs/plugin-react": "^4.5.2",
     "@vitest/coverage-v8": "catalog:",
     "jsdom": "catalog:",
-    "vitest-axe": "^1.0.0-pre.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
   }
 }

--- a/packages/surveys/vitest.config.ts
+++ b/packages/surveys/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     include: ['src/**/*.test.{ts,tsx}'],
-    setupFiles: ['./src/__tests__/setup.ts'],
+    setupFiles: ['./vitest.setup.ts', './src/__tests__/setup.ts'],
     coverage: {
       provider: 'v8',
       include: [

--- a/packages/surveys/vitest.setup.ts
+++ b/packages/surveys/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ catalogs:
     vitest:
       specifier: ^4.1.0
       version: 4.1.2
+    vitest-axe:
+      specifier: ^1.0.0-pre.3
+      version: 1.0.0-pre.5
     zod:
       specifier: ^4.3.6
       version: 4.3.6
@@ -627,6 +630,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/ai:
     dependencies:
@@ -743,6 +749,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/announcements:
     dependencies:
@@ -820,7 +829,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       vitest-axe:
-        specifier: ^1.0.0-pre.3
+        specifier: 'catalog:'
         version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/checklists:
@@ -889,6 +898,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/core:
     dependencies:
@@ -935,6 +947,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/hints:
     dependencies:
@@ -1003,7 +1018,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       vitest-axe:
-        specifier: ^1.0.0-pre.3
+        specifier: 'catalog:'
         version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/license:
@@ -1048,6 +1063,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/media:
     dependencies:
@@ -1112,6 +1130,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/react:
     dependencies:
@@ -1188,6 +1209,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/scheduling:
     dependencies:
@@ -1225,6 +1249,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   packages/surveys:
     dependencies:
@@ -1299,7 +1326,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       vitest-axe:
-        specifier: ^1.0.0-pre.3
+        specifier: 'catalog:'
         version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
 
   tooling/biome: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
 
 catalog:
   vitest: ^4.1.0
+  vitest-axe: ^1.0.0-pre.3
   jsdom: ^27.3.0
   typescript: ^5.9.3
   tsup: ^8.5.1


### PR DESCRIPTION
## Phase 4 — Vitest + Axe Sync

Aligns the 12-package vitest test infrastructure to a single canonical shape so future drift is mechanical to spot. No production source changed.

### Changes
- **`pnpm-workspace.yaml`**: pin `vitest-axe: ^1.0.0-pre.3` in catalog (alongside existing `vitest`/`jsdom`).
- **11 new `packages/<pkg>/vitest.setup.ts`** files (single line: `import 'vitest-axe/extend-expect'`). `ai` is exempt — node env, no DOM matchers.
- **12 `vitest.config.ts`** updates: every package now loads `./vitest.setup.ts` first plus its existing per-package mock setup. Coverage thresholds normalized to **80/75/80/80** across the board (analytics dropped from 85/80/85/85 → canonical; core branches 80 → 75).
- **11 `package.json`** files now declare `"vitest-axe": "catalog:"`. The 3 packages that previously hard-coded `^1.0.0-pre.3` (hints, announcements, surveys) now reference the catalog. `ai` excluded.
- **2 new tests in `@tour-kit/core`**:
  - `axe-matcher-canary.test.tsx` — proves `expect(...).toHaveNoViolations()` is wired via `vitest.setup.ts`.
  - `vitest-config-alignment.test.ts` — text-asserts every `vitest.config.ts`, `vitest.setup.ts`, `package.json`, and the workspace catalog match the canonical shape (parametrized `it.each(NON_AI)` for clear failures).

### Test Results
- `pnpm -r test` exits 0 across all 13 packages (workspace + apps/docs).
- New `core` tests: **49 passed (49)** — alignment for 11 packages plus ai exception, plus axe canary.
- `pnpm ls -r vitest-axe` resolves uniformly to `1.0.0-pre.5` (within `^1.0.0-pre.3` range).

### Bundle Sizes
`pnpm exec size-limit` shows 3 packages over budget (core/react/hints) — these overruns are **pre-existing** from before Phase 4. Phase 4 modifies only test infrastructure (not bundled). Phase 5+ may address actual bundle reduction.

### Why This Matters
- Single source of truth for test thresholds — Phase 5 can lower them with documented follow-ups.
- New accessibility tests in any package automatically pick up the `toHaveNoViolations` matcher.
- Version drift in `vitest-axe` is now mechanically prevented by the catalog pin.

🤖 Generated with run-phase skill