### PR TITLE
chore: audit A2–A5 (toast timer, ai live region, spotlight overlay, popover focus trap)

### DIFF
--- a/.changeset/audit-a2-a5-launch-hardening.md
+++ b/.changeset/audit-a2-a5-launch-hardening.md
@@ -1,0 +1,12 @@
+---
+'@tour-kit/announcements': patch
+'@tour-kit/ai': patch
+'@tour-kit/surveys': patch
+---
+
+Launch-hardening audit fixes A2–A5:
+
+- announcements: stabilize the toast auto-dismiss `setInterval` so it no longer re-arms on every parent render (audit A2).
+- ai: declare the chat message list with explicit `aria-live="polite"`, `aria-atomic="false"`, `aria-relevant="additions text"`, and `aria-busy` driven by streaming status so screen readers announce streaming tokens reliably (audit A3).
+- announcements: render the spotlight overlay as a real `<button>` when `closeOnOverlayClick` is enabled, otherwise an inert `aria-hidden` div — element shape is now statically coherent and Enter/Space activation works through the native button (audit A4).
+- surveys: trap focus inside `SurveyPopover`, dismiss with reason `"escape_key"` when Escape is pressed, and restore focus to the anchor on close (audit A5).

--- a/packages/ai/src/__tests__/coverage-gaps/components-coverage.test.tsx
+++ b/packages/ai/src/__tests__/coverage-gaps/components-coverage.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UseAiChatReturn } from '../../hooks/use-ai-chat'
 
 // Mock the context module so AiChatSuggestions can render outside a provider
 vi.mock('../../context/ai-chat-context', () => ({
@@ -11,6 +12,30 @@ vi.mock('../../context/ai-chat-context', () => ({
     })(),
   },
 }))
+
+// Mock useAiChat for AiChatMessageList — set return value per-test via
+// `mockUseAiChat.mockReturnValue(...)` below.
+const mockUseAiChat = vi.fn<() => UseAiChatReturn>()
+vi.mock('../../hooks/use-ai-chat', () => ({
+  useAiChat: () => mockUseAiChat(),
+}))
+
+function buildChatState(overrides: Partial<UseAiChatReturn> = {}): UseAiChatReturn {
+  return {
+    messages: [],
+    status: 'ready',
+    error: null,
+    sendMessage: vi.fn(),
+    stop: vi.fn(),
+    reload: vi.fn(),
+    setMessages: vi.fn(),
+    isOpen: true,
+    open: vi.fn(),
+    close: vi.fn(),
+    toggle: vi.fn(),
+    ...overrides,
+  }
+}
 
 describe('Component coverage gaps', () => {
   afterEach(() => {
@@ -84,6 +109,79 @@ describe('Component coverage gaps', () => {
       )
 
       expect(container.firstElementChild?.className).toContain('my-class')
+    })
+  })
+
+  describe('AiChatMessageList a11y', () => {
+    beforeEach(() => {
+      // jsdom does not implement scrollIntoView; AiChatMessageList calls it
+      // in an effect after each render.
+      Element.prototype.scrollIntoView = vi.fn()
+    })
+
+    it('declares an explicit polite live region with chat-conversation label', async () => {
+      mockUseAiChat.mockReturnValue(
+        buildChatState({
+          messages: [
+            {
+              id: 'm1',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'hello' }],
+            } as never,
+          ],
+          status: 'ready',
+        })
+      )
+      const { AiChatMessageList } = await import('../../components/ai-chat-message-list')
+      render(<AiChatMessageList />)
+
+      const log = screen.getByRole('log', { name: 'Chat conversation' })
+      expect(log.getAttribute('aria-live')).toBe('polite')
+      expect(log.getAttribute('aria-atomic')).toBe('false')
+      expect(log.getAttribute('aria-relevant')).toBe('additions text')
+    })
+
+    it('reports aria-busy="true" while streaming', async () => {
+      mockUseAiChat.mockReturnValue(
+        buildChatState({
+          messages: [
+            { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hi' }] } as never,
+          ],
+          status: 'streaming',
+        })
+      )
+      const { AiChatMessageList } = await import('../../components/ai-chat-message-list')
+      render(<AiChatMessageList />)
+
+      expect(screen.getByRole('log').getAttribute('aria-busy')).toBe('true')
+    })
+
+    it('reports aria-busy="false" when not streaming', async () => {
+      mockUseAiChat.mockReturnValue(
+        buildChatState({
+          messages: [
+            { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hi' }] } as never,
+            {
+              id: 'm2',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'done' }],
+            } as never,
+          ],
+          status: 'ready',
+        })
+      )
+      const { AiChatMessageList } = await import('../../components/ai-chat-message-list')
+      render(<AiChatMessageList />)
+
+      expect(screen.getByRole('log').getAttribute('aria-busy')).toBe('false')
+    })
+
+    it('renders no log region when there are no messages and not streaming', async () => {
+      mockUseAiChat.mockReturnValue(buildChatState({ messages: [], status: 'ready' }))
+      const { AiChatMessageList } = await import('../../components/ai-chat-message-list')
+      const { container } = render(<AiChatMessageList />)
+
+      expect(container.querySelector('[role="log"]')).toBeNull()
     })
   })
 })

--- a/packages/ai/src/__tests__/coverage-gaps/components-coverage.test.tsx
+++ b/packages/ai/src/__tests__/coverage-gaps/components-coverage.test.tsx
@@ -144,9 +144,7 @@ describe('Component coverage gaps', () => {
     it('reports aria-busy="true" while streaming', async () => {
       mockUseAiChat.mockReturnValue(
         buildChatState({
-          messages: [
-            { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hi' }] } as never,
-          ],
+          messages: [{ id: 'm1', role: 'user', parts: [{ type: 'text', text: 'hi' }] } as never],
           status: 'streaming',
         })
       )

--- a/packages/ai/src/components/ai-chat-message-list.tsx
+++ b/packages/ai/src/components/ai-chat-message-list.tsx
@@ -53,7 +53,15 @@ export function AiChatMessageList({
   }
 
   return (
-    <div className={cn('max-h-60 overflow-y-auto space-y-2', className)} role="log">
+    <div
+      className={cn('max-h-60 overflow-y-auto space-y-2', className)}
+      role="log"
+      aria-live="polite"
+      aria-atomic="false"
+      aria-relevant="additions text"
+      aria-busy={isStreaming}
+      aria-label="Chat conversation"
+    >
       {messages.map((message, index) => {
         if (renderMessage) return renderMessage(message, index)
         const text = getTextContent(message)

--- a/packages/announcements/src/__tests__/components/announcement-spotlight-overlay.test.tsx
+++ b/packages/announcements/src/__tests__/components/announcement-spotlight-overlay.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import * as React from 'react'
+import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AnnouncementSpotlight } from '../../components/announcement-spotlight'
 import { AnnouncementsProvider } from '../../context/announcements-provider'

--- a/packages/announcements/src/__tests__/components/announcement-spotlight-overlay.test.tsx
+++ b/packages/announcements/src/__tests__/components/announcement-spotlight-overlay.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AnnouncementSpotlight } from '../../components/announcement-spotlight'
+import { AnnouncementsProvider } from '../../context/announcements-provider'
+import type { AnnouncementConfig } from '../../types/announcement'
+
+const cfg: AnnouncementConfig = {
+  id: 'spot-1',
+  variant: 'spotlight',
+  title: 'Spot',
+  autoShow: false,
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <AnnouncementsProvider announcements={[cfg]} storage={null}>
+      {children}
+    </AnnouncementsProvider>
+  )
+}
+
+describe('AnnouncementSpotlight overlay', () => {
+  let target: HTMLElement
+
+  beforeEach(() => {
+    target = document.createElement('div')
+    target.id = 'spot-target'
+    document.body.appendChild(target)
+  })
+
+  afterEach(() => {
+    target.remove()
+  })
+
+  it('renders the overlay as a button with closeOnOverlayClick=true', () => {
+    render(
+      <Wrapper>
+        <AnnouncementSpotlight
+          id="spot-1"
+          open
+          options={{ targetSelector: '#spot-target', closeOnOverlayClick: true }}
+        />
+      </Wrapper>
+    )
+
+    const overlay = screen.getByRole('button', { name: /close spotlight/i })
+    expect(overlay.tagName).toBe('BUTTON')
+    expect(overlay.getAttribute('type')).toBe('button')
+  })
+
+  it('dismisses on click when closeOnOverlayClick=true', () => {
+    const onOpenChange = vi.fn()
+    render(
+      <Wrapper>
+        <AnnouncementSpotlight
+          id="spot-1"
+          open
+          onOpenChange={onOpenChange}
+          options={{ targetSelector: '#spot-target', closeOnOverlayClick: true }}
+        />
+      </Wrapper>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /close spotlight/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('dismisses on Enter key (native button activation) when closeOnOverlayClick=true', () => {
+    const onOpenChange = vi.fn()
+    render(
+      <Wrapper>
+        <AnnouncementSpotlight
+          id="spot-1"
+          open
+          onOpenChange={onOpenChange}
+          options={{ targetSelector: '#spot-target', closeOnOverlayClick: true }}
+        />
+      </Wrapper>
+    )
+
+    const overlay = screen.getByRole('button', { name: /close spotlight/i })
+    // jsdom does not fire click on Enter automatically — call .click() to
+    // mirror native button keyboard activation.
+    overlay.focus()
+    overlay.click()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('renders the overlay as an inert aria-hidden div with closeOnOverlayClick=false', () => {
+    const { container } = render(
+      <Wrapper>
+        <AnnouncementSpotlight
+          id="spot-1"
+          open
+          options={{ targetSelector: '#spot-target', closeOnOverlayClick: false }}
+        />
+      </Wrapper>
+    )
+
+    expect(screen.queryByRole('button', { name: /close spotlight/i })).toBeNull()
+    const overlay = container.ownerDocument.querySelector('div[aria-hidden="true"]')
+    expect(overlay).not.toBeNull()
+    expect(overlay?.getAttribute('tabindex')).toBeNull()
+    expect(overlay?.getAttribute('role')).toBeNull()
+  })
+
+  it('renders no overlay element when showOverlay=false', () => {
+    render(
+      <Wrapper>
+        <AnnouncementSpotlight
+          id="spot-1"
+          open
+          options={{ targetSelector: '#spot-target', showOverlay: false }}
+        />
+      </Wrapper>
+    )
+
+    expect(screen.queryByRole('button', { name: /close spotlight/i })).toBeNull()
+    expect(document.querySelector('div[aria-hidden="true"]')).toBeNull()
+  })
+})

--- a/packages/announcements/src/__tests__/components/headless-toast-timer.test.tsx
+++ b/packages/announcements/src/__tests__/components/headless-toast-timer.test.tsx
@@ -1,0 +1,139 @@
+import { act, render } from '@testing-library/react'
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HeadlessToast } from '../../components/headless/headless-toast'
+import { AnnouncementsProvider } from '../../context/announcements-provider'
+import type { AnnouncementConfig } from '../../types/announcement'
+
+const cfg: AnnouncementConfig = {
+  id: 'toast-1',
+  variant: 'toast',
+  title: 'Hi',
+  // The toast is driven via the controlled `open` prop in these tests; opt
+  // out of the auto-show path so the provider does not influence timing.
+  autoShow: false,
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <AnnouncementsProvider announcements={[cfg]} storage={null}>
+      {children}
+    </AnnouncementsProvider>
+  )
+}
+
+describe('HeadlessToast auto-dismiss timer', () => {
+  let intervalSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    intervalSpy = vi.spyOn(globalThis, 'setInterval')
+  })
+
+  afterEach(() => {
+    intervalSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('schedules a single interval while open across parent re-renders', () => {
+    const onOpenChange = vi.fn()
+    const renderToast = (key: number) => (
+      <Wrapper>
+        <HeadlessToast
+          id="toast-1"
+          open
+          onOpenChange={onOpenChange}
+          options={{ autoDismiss: true, autoDismissDelay: 5000 }}
+        >
+          {() => <span data-key={key} />}
+        </HeadlessToast>
+      </Wrapper>
+    )
+
+    const { rerender } = render(renderToast(1))
+
+    // Multiple parent re-renders with unchanged primitives must NOT re-arm
+    // the interval. Pre-fix: dismiss closure was a dep; this regressed.
+    rerender(renderToast(2))
+    rerender(renderToast(3))
+    rerender(renderToast(4))
+
+    expect(intervalSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('auto-dismisses after the configured delay', () => {
+    const onOpenChange = vi.fn()
+    render(
+      <Wrapper>
+        <HeadlessToast
+          id="toast-1"
+          open
+          onOpenChange={onOpenChange}
+          options={{ autoDismiss: true, autoDismissDelay: 5000 }}
+        >
+          {() => null}
+        </HeadlessToast>
+      </Wrapper>
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('clears the interval when the toast closes', () => {
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <Wrapper>
+        <HeadlessToast
+          id="toast-1"
+          open
+          onOpenChange={onOpenChange}
+          options={{ autoDismiss: true, autoDismissDelay: 5000 }}
+        >
+          {() => null}
+        </HeadlessToast>
+      </Wrapper>
+    )
+
+    // setInterval ran once for the open render
+    expect(intervalSpy).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <Wrapper>
+        <HeadlessToast
+          id="toast-1"
+          open={false}
+          onOpenChange={onOpenChange}
+          options={{ autoDismiss: true, autoDismissDelay: 5000 }}
+        >
+          {() => null}
+        </HeadlessToast>
+      </Wrapper>
+    )
+
+    // No new interval scheduled after close
+    expect(intervalSpy).toHaveBeenCalledTimes(1)
+
+    // Advancing past the original delay must not fire onOpenChange — interval
+    // was cleared when open flipped to false.
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('does not schedule an interval when autoDismiss is false', () => {
+    render(
+      <Wrapper>
+        <HeadlessToast id="toast-1" open options={{ autoDismiss: false }}>
+          {() => null}
+        </HeadlessToast>
+      </Wrapper>
+    )
+
+    expect(intervalSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/announcements/src/__tests__/components/headless-toast-timer.test.tsx
+++ b/packages/announcements/src/__tests__/components/headless-toast-timer.test.tsx
@@ -1,5 +1,5 @@
 import { act, render } from '@testing-library/react'
-import * as React from 'react'
+import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { HeadlessToast } from '../../components/headless/headless-toast'
 import { AnnouncementsProvider } from '../../context/announcements-provider'

--- a/packages/announcements/src/components/announcement-spotlight.tsx
+++ b/packages/announcements/src/components/announcement-spotlight.tsx
@@ -112,36 +112,32 @@ export const AnnouncementSpotlight = React.forwardRef<HTMLDivElement, Announceme
     // Calculate spotlight cutout position
     const targetRect = targetElement.getBoundingClientRect()
     const padding = 4
+    const overlayBg = `radial-gradient(circle at ${targetRect.left + targetRect.width / 2}px ${targetRect.top + targetRect.height / 2}px, transparent ${Math.max(targetRect.width, targetRect.height) / 2 + padding}px, rgba(0, 0, 0, ${spotlightOptions.overlayOpacity}) ${Math.max(targetRect.width, targetRect.height) / 2 + padding + 1}px)`
 
     const spotlightContent = (
       <>
-        {/* Overlay with cutout */}
-        {spotlightOptions.showOverlay && (
-          <div
-            className={cn(spotlightOverlayVariants({ visible: true }))}
-            style={{
-              background: `radial-gradient(circle at ${targetRect.left + targetRect.width / 2}px ${targetRect.top + targetRect.height / 2}px, transparent ${Math.max(targetRect.width, targetRect.height) / 2 + padding}px, rgba(0, 0, 0, ${spotlightOptions.overlayOpacity}) ${Math.max(targetRect.width, targetRect.height) / 2 + padding + 1}px)`,
-            }}
-            onClick={
-              spotlightOptions.closeOnOverlayClick
-                ? () => handleDismiss('overlay_click')
-                : undefined
-            }
-            onKeyDown={
-              spotlightOptions.closeOnOverlayClick
-                ? (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      handleDismiss('overlay_click')
-                    }
-                  }
-                : undefined
-            }
-            role={spotlightOptions.closeOnOverlayClick ? 'button' : undefined}
-            tabIndex={spotlightOptions.closeOnOverlayClick ? 0 : undefined}
-            aria-label={spotlightOptions.closeOnOverlayClick ? 'Close spotlight' : undefined}
-          />
-        )}
+        {/* Overlay with cutout — statically either an interactive <button> or
+            an inert aria-hidden div so the element shape never mixes
+            interactive ARIA on a non-interactive element. */}
+        {spotlightOptions.showOverlay &&
+          (spotlightOptions.closeOnOverlayClick ? (
+            <button
+              type="button"
+              className={cn(
+                spotlightOverlayVariants({ visible: true }),
+                'pointer-events-auto cursor-pointer border-0 p-0'
+              )}
+              style={{ background: overlayBg }}
+              onClick={() => handleDismiss('overlay_click')}
+              aria-label="Close spotlight"
+            />
+          ) : (
+            <div
+              className={cn(spotlightOverlayVariants({ visible: true }))}
+              style={{ background: overlayBg }}
+              aria-hidden="true"
+            />
+          ))}
 
         {/* Spotlight content */}
         <div

--- a/packages/announcements/src/components/headless/headless-toast.tsx
+++ b/packages/announcements/src/components/headless/headless-toast.tsx
@@ -61,6 +61,13 @@ export function HeadlessToast({
     [announcement, onOpenChange]
   )
 
+  // Hold the latest dismiss in a ref so the auto-dismiss timer effect
+  // does not re-subscribe every render when announcement state ticks.
+  const dismissRef = React.useRef(dismiss)
+  React.useEffect(() => {
+    dismissRef.current = dismiss
+  }, [dismiss])
+
   const toastOptions: ToastOptions = {
     position: 'bottom-right',
     autoDismiss: true,
@@ -71,7 +78,8 @@ export function HeadlessToast({
     ...config?.toastOptions,
   }
 
-  // Auto-dismiss timer
+  // Auto-dismiss timer — depends only on primitive scalars so it does
+  // not tear down on every parent re-render.
   React.useEffect(() => {
     if (!open || !toastOptions.autoDismiss) return
 
@@ -85,7 +93,7 @@ export function HeadlessToast({
 
       if (remaining === 0) {
         clearInterval(timer)
-        dismiss('auto_dismiss')
+        dismissRef.current('auto_dismiss')
       }
     }, 50)
 
@@ -93,7 +101,7 @@ export function HeadlessToast({
       clearInterval(timer)
       setProgress(100)
     }
-  }, [open, toastOptions.autoDismiss, toastOptions.autoDismissDelay, dismiss])
+  }, [open, toastOptions.autoDismiss, toastOptions.autoDismissDelay])
 
   const toastProps = {
     role: 'alert' as const,

--- a/packages/surveys/src/__tests__/survey-popover-focus.test.tsx
+++ b/packages/surveys/src/__tests__/survey-popover-focus.test.tsx
@@ -1,0 +1,193 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SurveyPopover } from '../components/survey-popover'
+import { SurveysProvider } from '../context'
+import { useSurvey } from '../hooks/use-survey'
+import type { SurveyConfig } from '../types'
+
+vi.mock('@tour-kit/license', () => ({
+  ProGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@tour-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tour-kit/core')>()
+  return {
+    ...actual,
+    useTourContext: () => ({ isActive: false }),
+    useTourContextOptional: () => ({ isActive: false }),
+    createStorageAdapter: () => ({
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    }),
+  }
+})
+
+const baseConfig: SurveyConfig = {
+  id: 'p1',
+  type: 'custom',
+  displayMode: 'popover',
+  title: 'Quick Q',
+  questions: [],
+}
+
+function Harness({
+  config = baseConfig,
+  children,
+}: {
+  config?: SurveyConfig
+  children?: React.ReactNode
+}) {
+  return (
+    <SurveysProvider surveys={[config]}>
+      <Inner>{children}</Inner>
+    </SurveysProvider>
+  )
+}
+
+function Inner({ children }: { children?: React.ReactNode }) {
+  const survey = useSurvey('p1')
+  // Pass the anchor as a state-driven ref so the popover sees a real
+  // resolvedAnchor on the render that follows the anchor's commit.
+  const [anchor, setAnchor] = React.useState<HTMLButtonElement | null>(null)
+  return (
+    <>
+      <button
+        ref={setAnchor}
+        type="button"
+        data-testid="anchor"
+        onClick={() => survey.show()}
+      >
+        Open
+      </button>
+      <SurveyPopover surveyId="p1" anchor={anchor} options={{ showCloseButton: false }}>
+        {children ?? (
+          <>
+            <button type="button" data-testid="first">
+              First
+            </button>
+            <button type="button" data-testid="last">
+              Last
+            </button>
+          </>
+        )}
+      </SurveyPopover>
+    </>
+  )
+}
+
+describe('SurveyPopover — focus trap', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('focuses the first focusable inside the popover when activated', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await act(async () => {
+      await user.click(screen.getByTestId('anchor'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    // Focus moves to first focusable after the activate effect runs.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByTestId('first'))
+    })
+  })
+
+  it('cycles focus forward from the last focusable back to the first on Tab', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await act(async () => {
+      await user.click(screen.getByTestId('anchor'))
+    })
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+
+    const last = screen.getByRole('button', { name: /^Last$/ })
+    last.focus()
+    expect(document.activeElement).toBe(last)
+
+    // Direct keydown dispatch bypasses user-event's behavior layer so the
+    // assertion targets the focus-trap's keydown handler exactly.
+    act(() => {
+      fireEvent.keyDown(last, { key: 'Tab' })
+    })
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: /^First$/ }))
+  })
+
+  it('cycles focus backward from the first focusable to the last on Shift+Tab', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await act(async () => {
+      await user.click(screen.getByTestId('anchor'))
+    })
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+
+    const first = screen.getByRole('button', { name: /^First$/ })
+    first.focus()
+    expect(document.activeElement).toBe(first)
+
+    act(() => {
+      fireEvent.keyDown(first, { key: 'Tab', shiftKey: true })
+    })
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: /^Last$/ }))
+  })
+
+  it('dismisses with reason="escape_key" when Escape is pressed inside the popover', async () => {
+    const user = userEvent.setup()
+    const onDismiss = vi.fn()
+    render(<Harness config={{ ...baseConfig, onDismiss }} />)
+
+    await act(async () => {
+      await user.click(screen.getByTestId('anchor'))
+    })
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+
+    await act(async () => {
+      await user.keyboard('{Escape}')
+    })
+
+    expect(onDismiss).toHaveBeenCalledWith('escape_key')
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+
+  it('restores focus to the anchor when the popover closes', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const anchor = screen.getByTestId('anchor')
+    await act(async () => {
+      await user.click(anchor)
+    })
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+
+    await act(async () => {
+      await user.keyboard('{Escape}')
+    })
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+
+    expect(document.activeElement).toBe(anchor)
+  })
+
+  it('does not trap focus globally while the popover is hidden', async () => {
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    render(<Harness />)
+
+    // No popover dialog rendered yet; focus trap should not have wired any
+    // global keydown listener for Tab cycling.
+    expect(screen.queryByRole('dialog')).toBeNull()
+    const keydownAdds = addSpy.mock.calls.filter((call) => call[0] === 'keydown')
+    expect(keydownAdds).toHaveLength(0)
+    addSpy.mockRestore()
+  })
+})

--- a/packages/surveys/src/__tests__/survey-popover-focus.test.tsx
+++ b/packages/surveys/src/__tests__/survey-popover-focus.test.tsx
@@ -54,12 +54,7 @@ function Inner({ children }: { children?: React.ReactNode }) {
   const [anchor, setAnchor] = React.useState<HTMLButtonElement | null>(null)
   return (
     <>
-      <button
-        ref={setAnchor}
-        type="button"
-        data-testid="anchor"
-        onClick={() => survey.show()}
-      >
+      <button ref={setAnchor} type="button" data-testid="anchor" onClick={() => survey.show()}>
         Open
       </button>
       <SurveyPopover surveyId="p1" anchor={anchor} options={{ showCloseButton: false }}>

--- a/packages/surveys/src/components/survey-popover.tsx
+++ b/packages/surveys/src/components/survey-popover.tsx
@@ -9,7 +9,7 @@ import {
   shift,
   useFloating,
 } from '@floating-ui/react'
-import { cn } from '@tour-kit/core'
+import { cn, useFocusTrap } from '@tour-kit/core'
 import * as React from 'react'
 import { useSurvey } from '../hooks/use-survey'
 import type { DismissalReason, PopoverOptions, PopoverPosition } from '../types/survey'
@@ -78,6 +78,36 @@ export const SurveyPopover = React.forwardRef<HTMLDivElement, SurveyPopoverProps
       [survey]
     )
 
+    const {
+      containerRef: focusTrapContainerRef,
+      activate: activateFocusTrap,
+      deactivate: deactivateFocusTrap,
+    } = useFocusTrap(shouldRender)
+
+    // FloatingPortal mounts its node lazily, so the popover content div is
+    // not in the DOM on the first render where shouldRender flips true.
+    // Track the mounted container in state so the focus-trap effect re-runs
+    // once the node actually exists.
+    const [popoverNode, setPopoverNode] = React.useState<HTMLDivElement | null>(null)
+
+    React.useEffect(() => {
+      if (!shouldRender || !popoverNode) return
+      activateFocusTrap()
+      return () => {
+        deactivateFocusTrap()
+      }
+    }, [shouldRender, popoverNode, activateFocusTrap, deactivateFocusTrap])
+
+    const handleKeyDown = React.useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation()
+          handleDismiss('escape_key')
+        }
+      },
+      [handleDismiss]
+    )
+
     if (!shouldRender) return null
 
     return (
@@ -85,6 +115,8 @@ export const SurveyPopover = React.forwardRef<HTMLDivElement, SurveyPopoverProps
         <div
           ref={(node: HTMLDivElement | null) => {
             refs.setFloating(node)
+            focusTrapContainerRef.current = node
+            setPopoverNode(node)
             if (typeof ref === 'function') {
               ref(node)
             } else if (ref) {
@@ -94,6 +126,7 @@ export const SurveyPopover = React.forwardRef<HTMLDivElement, SurveyPopoverProps
           // biome-ignore lint/a11y/useSemanticElements: native <dialog> requires showModal()/show()/close() for correct a11y semantics; this component manages its own visibility via Floating UI
           role="dialog"
           aria-label={config?.title ?? 'Survey'}
+          onKeyDown={handleKeyDown}
           style={floatingStyles}
           className={cn(
             'z-50 rounded-md border bg-background p-4 shadow-md min-w-[280px] max-w-sm',


### PR DESCRIPTION
## Summary

Launch-hardening Phase 0 audit fixes shipping as one PR train:

- **A2 (announcements)** — stabilize the toast auto-dismiss `setInterval` so it no longer re-arms on every parent render. Fix: stash `dismiss` in a ref and depend the timer effect only on the three primitive scalars (`open`, `autoDismiss`, `autoDismissDelay`).
- **A3 (ai)** — declare the chat message list with explicit `aria-live="polite"`, `aria-atomic="false"`, `aria-relevant="additions text"`, `aria-label="Chat conversation"`, and `aria-busy` driven by streaming status so screen readers announce streaming tokens.
- **A4 (announcements)** — render the spotlight overlay as a real `<button>` when `closeOnOverlayClick` is enabled, otherwise an inert `aria-hidden` div. The element shape is now statically coherent (no mixed interactive ARIA on a non-interactive element); native button gives Enter/Space activation for free.
- **A5 (surveys)** — wire `useFocusTrap` from `@tour-kit/core` into `SurveyPopover`; trap focus inside the dialog, dismiss with reason `"escape_key"` on Escape, and restore focus to the anchor on close. Implementation note: track the popover container in state (not just a ref) because `FloatingPortal` mounts its node on a layoutEffect — so the focus-trap effect re-runs once the node actually exists.

## Why now

Phase 0 launch hardening (weeks 2–4). These are the four cheapest concrete a11y/perf wins on the audit roadmap; size-limit gate (Phase 6) is already in place to catch any size regressions.

## Test plan

- [x] `pnpm --filter @tour-kit/announcements test` — 90 passed (was 81; +4 toast timer, +5 spotlight overlay)
- [x] `pnpm --filter @tour-kit/ai test` — 438 passed | 3 skipped (was 434; +4 chat-log a11y)
- [x] `pnpm --filter @tour-kit/surveys test` — 190 passed (was 184; +6 popover focus trap)
- [x] `pnpm test` (full monorepo) — all packages green
- [x] `pnpm build` — all packages build clean
- [x] `pnpm size-limit` — all packages under budget; surveys 89.01 kB / 111 kB
- [x] Sanity-checked A2 + A5 by reverting the source-only change and confirming the new tests fail

## Out of scope

- `survey-modal.tsx` and `announcement-modal.tsx` focus traps → separate PR after this lands.
- Migration guides → blocked on GTM positioning.
- Polar checkout E2E → already covered by `apps/smoke` + release pipeline.
- Lighthouse a11y 100 sweep → easier after A3/A5 land.

## Risk

Low. No public API changes. `DismissalReason` already includes `'escape_key'` (no type widening needed). All changes are additive a11y attributes or internal effect-stability fixes. Backward-compatible.

## Notes for reviewers

- A2 ref pattern: `dismissRef.current = dismiss` is updated in a separate effect so the latest closure is always called from the interval — standard "stable callback ref" pattern.
- A4: the previous implementation had `pointer-events-none` on the overlay yet wired `onClick`; the new button branch adds `pointer-events-auto` so clicks actually fire.
- A5: the popover's anchor resolution pattern (`useMemo` with `[anchor, anchorSelector, surveyId]`) means the new test passes the anchor as a state-driven `HTMLElement` — see test fixture for the recommended consumer pattern.