### PR TITLE
feat(core): flow session resume + cross-tab pause (phase 1.1)

### DIFF
--- a/.changeset/phase-1-flow-session-and-cross-tab.md
+++ b/.changeset/phase-1-flow-session-and-cross-tab.md
@@ -1,0 +1,11 @@
+---
+"@tour-kit/core": minor
+---
+
+Add `useFlowSession` and `useBroadcast` hooks for active-tour resume and cross-tab pause.
+
+- `routePersistence.flowSession` (opt-in) persists the active tour's `(tourId, stepIndex)` so a hard refresh resumes the tour at the same step. Defaults: `sessionStorage` with 1h TTL, throttled writes (200ms trailing edge).
+- `routePersistence.crossTab` (opt-in) coordinates across tabs via `BroadcastChannel`. When tab A starts a tour, any tab with the same active tour id pauses and fires the new `onTourPaused(tourId, 'cross-tab')` callback on `<TourProvider>`.
+- New types: `FlowSessionConfig`, `CrossTabConfig`, `UseFlowSessionConfig`, `UseFlowSessionReturn`, `UseBroadcastReturn`.
+
+Both fields are `undefined` by default — apps that don't pass them keep current behavior bit-for-bit. No new runtime dependencies; the `BroadcastChannel`-undefined fallback is a no-op so older Safari users still get a working tour without cross-tab sync.

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -9,6 +9,7 @@
     "animations",
     "branching",
     "persistence",
+    "multi-tab",
     "router-integration",
     "base-ui",
     "troubleshooting",

--- a/apps/docs/content/docs/guides/multi-tab.mdx
+++ b/apps/docs/content/docs/guides/multi-tab.mdx
@@ -1,0 +1,170 @@
+---
+title: Multi-tab Tours
+description: >-
+  Pause an active tour in tab B when the user starts the same flow in tab A —
+  cross-tab coordination via BroadcastChannel.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+A user with five tabs open is still one user. Without cross-tab coordination, they can trigger your onboarding tour in three of them at once and end up confused about which "step 2" they're looking at.
+
+userTourKit ships a `crossTab` gate built on the native `BroadcastChannel` API — when you opt in, starting a tour in one tab pauses any active tour with the same id in every other tab.
+
+---
+
+## Why this matters
+
+| Without `crossTab` | With `crossTab` |
+|---|---|
+| User opens app in 2 tabs → tour shows in both | Tour shows in the tab that started it; other tab pauses |
+| `localStorage` flow session resumes everywhere on refresh | Resume only happens where the tour is "owned" |
+| `onComplete` may fire twice for the same user session | Single source of truth per browser |
+
+Most apps don't notice the problem until a user opens "the same dashboard, but logged in" in a new tab and gets the welcome tour again. `crossTab.enabled: true` is the fix.
+
+---
+
+## Quick start
+
+```tsx title="One-line opt-in"
+import { TourProvider } from '@tour-kit/core'
+
+<TourProvider
+  tours={[onboardingTour]}
+  routePersistence={{
+    enabled: true,
+    flowSession: { storage: 'localStorage' },
+    crossTab: { enabled: true },
+  }}
+  onTourPaused={(tourId, reason) => {
+    console.log('paused', tourId, 'because', reason) // → 'cross-tab'
+  }}
+>
+  {children}
+</TourProvider>
+```
+
+That's all that's required. The provider:
+
+1. Generates a per-mount `tabId` (via `crypto.randomUUID()`)
+2. Posts `{ type: 'tour:active', tourId, tabId }` whenever a tour activates
+3. Subscribes to the channel and stops the local tour when another tab announces the same tour id
+
+The `onTourPaused` callback is the integration point for analytics ("pause-on-cross-tab") or UX hooks ("resume in this tab" button).
+
+<Callout type="info">
+  `crossTab` is **opt-in**. Apps that don't pass it keep their current behavior. There is no default cross-tab gate.
+</Callout>
+
+---
+
+## When to enable
+
+| Scenario | `crossTab.enabled`? |
+|---|---|
+| Single-page app with `sessionStorage` flow session | **No** — sessionStorage is per-tab anyway |
+| Multi-tab dashboard with `localStorage` flow session | **Yes** — prevents stale resume in tab B after tour was closed in tab A |
+| Tour ends with a destructive action (delete, charge) | **Yes** — avoid the user re-confirming the same action |
+| Tour is purely informational (intro tooltip) | Either; opt in if you want analytics consistency |
+
+The strong recommendation: **always enable `crossTab` when `flowSession.storage` is `'localStorage'`**. The two combine to give "resume after refresh, but only here" — the predictable behavior most users expect.
+
+---
+
+## API
+
+`routePersistence.crossTab` accepts a `CrossTabConfig`:
+
+```ts
+interface CrossTabConfig {
+  /** Master switch. */
+  enabled: boolean
+  /** BroadcastChannel name. Default: 'tourkit:active-flow'. */
+  channel?: string
+}
+```
+
+### `onTourPaused` callback
+
+```ts
+onTourPaused?: (tourId: string, reason: 'cross-tab') => void
+```
+
+Fires after the local tour has been stopped (`state.isActive` is already `false` at this point). The `reason` discriminator is room for future pause sources (idle timeout, focus loss); today only `'cross-tab'` is emitted.
+
+### Custom channel name
+
+By default every tour shares the channel `'tourkit:active-flow'`. If you have multiple isolated apps on the same origin and want them not to interfere, set a unique name:
+
+```tsx
+<TourProvider
+  routePersistence={{
+    enabled: true,
+    crossTab: { enabled: true, channel: 'admin-app:tour' },
+  }}
+>
+```
+
+---
+
+## Browser support
+
+`BroadcastChannel` is available everywhere modern apps run:
+
+| Browser | Minimum version |
+|---|---|
+| Chrome / Edge | 54+ (2016) |
+| Firefox | 38+ (2015) |
+| Safari (macOS) | 15.4+ (2022) |
+| Safari (iOS) | 15.4+ (2022) |
+| Opera | 41+ (2016) |
+
+Older Safari (≤ 15.3) doesn't expose the API. The hook detects this and falls back to a no-op — your tour still runs, it just won't pause across tabs. **No polyfill is required**, and userTourKit deliberately doesn't bundle one (a `BroadcastChannel` polyfill weighs ~6KB gzipped).
+
+If you need cross-tab support on legacy Safari, use a `localStorage` "storage" event polyfill in your app shell — userTourKit will pick it up automatically because the no-op only kicks in when `typeof BroadcastChannel === 'undefined'`.
+
+---
+
+## Failure modes
+
+The hook is built so the tour never crashes from a cross-tab failure:
+
+- **`BroadcastChannel` undefined** → `post` and `subscribe` are no-ops; tour runs normally with no cross-tab coordination.
+- **Channel name collision with non-tour-kit code** → use the `channel` option above.
+- **Self-broadcast** — messages are filtered by `tabId` so you don't pause yourself.
+
+---
+
+## Testing
+
+The recommended pattern in Vitest + jsdom is to mount two `<TourProvider>` siblings in the same test process — they share the native `BroadcastChannel` automatically:
+
+```tsx title="cross-tab.test.tsx"
+import { renderHook, act } from '@testing-library/react'
+
+const tabA = renderHook(() => useTour(), { wrapper: makeWrapper(spyA) })
+const tabB = renderHook(() => useTour(), { wrapper: makeWrapper(spyB) })
+
+await act(async () => tabB.result.current.start('onboarding'))
+await act(async () => tabA.result.current.start('onboarding'))
+await act(async () => new Promise((r) => setTimeout(r, 0)))
+
+expect(spyB).toHaveBeenCalledWith('onboarding', 'cross-tab')
+expect(tabB.result.current.isActive).toBe(false)
+```
+
+For the no-channel fallback, stub `BroadcastChannel` to `undefined` in a single test only:
+
+```ts
+beforeEach(() => vi.stubGlobal('BroadcastChannel', undefined))
+afterEach(() => vi.unstubAllGlobals())
+```
+
+---
+
+## Related Resources
+
+- [Persistence Guide — Flow Session](/docs/guides/persistence#flow-session)
+- [`useBroadcast` Hook](/docs/core/hooks/use-broadcast)
+- [`useFlowSession` Hook](/docs/core/hooks/use-flow-session)

--- a/apps/docs/content/docs/guides/persistence.mdx
+++ b/apps/docs/content/docs/guides/persistence.mdx
@@ -655,6 +655,67 @@ async function loadWithMigration(key: string) {
 
 ---
 
+## Flow Session
+
+`useFlowSession` is a tour-scoped session — it remembers **which tour the user was in and what step they reached**, so a hard reload puts them back exactly where they were. It runs in parallel with `useRoutePersistence` (which handles multi-tour, cross-route state) but takes a different shape:
+
+| Concern | `useRoutePersistence` | `useFlowSession` |
+|---|---|---|
+| Scope | All tours, all routes | The single active tour |
+| Use case | "Continue this tour after I navigate" | "Resume this tour after I refresh" |
+| Default storage | `localStorage` | `sessionStorage` (per-tab) |
+| TTL | 24h (configurable) | 1h sessionStorage / 24h localStorage |
+| Storage key | `tourkit-route-state` | `tourkit:flow:active` |
+
+It's **opt-in** via `routePersistence.flowSession`. Existing apps that don't pass the field keep their current behavior bit-for-bit.
+
+### Quick start
+
+```tsx title="Reload-resume tour"
+import { TourProvider } from '@tour-kit/core'
+
+<TourProvider
+  tours={[onboardingTour]}
+  routePersistence={{
+    enabled: true,
+    flowSession: { storage: 'sessionStorage' },
+  }}
+>
+  {children}
+</TourProvider>
+```
+
+That's it — start a tour, hard-reload the page, and it resumes at the same step. Saves are throttled (200ms trailing edge) so a rapid burst of step changes coalesces into one storage write per window.
+
+### Choosing storage
+
+- **`sessionStorage` (default)** — perfect for the common "user accidentally hit refresh" case. Cleared automatically when the tab closes.
+- **`localStorage`** — survives a full browser quit. **Pair it with `crossTab.enabled: true`** (see [Multi-tab Tours](/docs/guides/multi-tab)) so a tour explicitly closed in one tab doesn't reappear when another tab reloads.
+
+```tsx title="Cross-session resume"
+<TourProvider
+  routePersistence={{
+    enabled: true,
+    flowSession: { storage: 'localStorage', ttlMs: 12 * 60 * 60 * 1000 }, // 12h
+    crossTab: { enabled: true },
+  }}
+>
+```
+
+### TTL & expiry
+
+Stale sessions are filtered on read — `useFlowSession` checks `Date.now() - lastUpdatedAt > ttlMs` and removes the blob if it's expired. Defaults: **1 hour** for `sessionStorage`, **24 hours** for `localStorage`. Pass `ttlMs: 0` to disable expiry.
+
+### Failure modes
+
+`useFlowSession` is designed not to crash the tour:
+
+- **Quota exceeded** — `setItem` errors are caught, logged via `logger.warn`, and swallowed.
+- **Stale schema** — a blob written by an older app version (different shape, missing fields, wrong `schemaVersion`) parses to `null`; the bad blob is removed and the next save writes fresh.
+- **SSR** — when `window` is undefined the hook returns no-op `save` / `clear` and `session: null`.
+
+---
+
 ## Best Practices
 
 1. **Use consistent prefixes** - Namespace all keys to avoid collisions
@@ -671,5 +732,6 @@ async function loadWithMigration(key: string) {
 - [usePersistence Hook](/docs/core/hooks/use-persistence)
 - [useRoutePersistence Hook](/docs/core/hooks/use-route-persistence)
 - [useChecklistPersistence Hook](/docs/checklists/hooks/use-checklist-persistence)
+- [Multi-tab Tours](/docs/guides/multi-tab)
 - [Storage Utilities](/docs/core/utilities/storage)
 - [Announcement Frequency Rules](/docs/announcements/configuration/frequency)

--- a/packages/adoption/src/__tests__/build/build-artifact.test.ts
+++ b/packages/adoption/src/__tests__/build/build-artifact.test.ts
@@ -5,9 +5,12 @@ describe('adoption — built artifact (post-Phase-1 minify flip)', () => {
   const dist = readDistOrSkip()
   const state = classifyDist(dist)
   const present = state !== 'missing'
+  // Once `present` is true, `dist` is guaranteed defined; capture the
+  // narrowed value once instead of asserting non-null at every use.
+  const distContent = dist ?? ''
 
   it.runIf(present)('starts with a "use client" directive', () => {
-    expect(dist!.split('\n')[0]).toMatch(/^['"]use client['"];?$/)
+    expect(distContent.split('\n')[0]).toMatch(/^['"]use client['"];?$/)
   })
 
   it.runIf(present)('is minified (heuristic: under 200 lines)', () => {
@@ -15,10 +18,10 @@ describe('adoption — built artifact (post-Phase-1 minify flip)', () => {
   })
 
   it.runIf(present)('has no JSDoc blocks remaining (minify removed them)', () => {
-    expect(dist!).not.toMatch(/\/\*\*[\s\S]+?\*\//)
+    expect(distContent).not.toMatch(/\/\*\*[\s\S]+?\*\//)
   })
 
   it.runIf(present)('gzipped size is positive (recorded for size-limit gate)', () => {
-    expect(gzippedBytes(dist!)).toBeGreaterThan(0)
+    expect(gzippedBytes(distContent)).toBeGreaterThan(0)
   })
 })

--- a/packages/core/src/__tests__/context/tour-provider-flow-session.test.tsx
+++ b/packages/core/src/__tests__/context/tour-provider-flow-session.test.tsx
@@ -53,6 +53,37 @@ describe('TourProvider — flowSession reload (US-1)', () => {
     expect(second.result.current.isActive).toBe(true)
     expect(second.result.current.currentStepIndex).toBe(1)
     expect(second.result.current.currentStep?.id).toBe('s2')
+    // Regression for clear-on-mount bug: the blob must still exist after the
+    // restored mount. Previously the clear effect fired on initial mount
+    // (state.isActive=false) and wiped the blob right after restore — only
+    // saved by the leading-edge throttle re-write on the next render.
+    expect(sessionStorage.getItem('tourkit:flow:active')).not.toBeNull()
+  })
+
+  it('clears the persisted blob when the tour is explicitly stopped', async () => {
+    function makeWrapper() {
+      return function Wrapper({ children }: { children: React.ReactNode }) {
+        return (
+          <TourProvider
+            tours={[tour]}
+            routePersistence={{ enabled: false, flowSession: { storage: 'sessionStorage' } }}
+          >
+            {children}
+          </TourProvider>
+        )
+      }
+    }
+
+    const { result } = renderHook(() => useTour(), { wrapper: makeWrapper() })
+    await act(async () => {
+      result.current.start('onboarding')
+    })
+    expect(sessionStorage.getItem('tourkit:flow:active')).not.toBeNull()
+
+    await act(async () => {
+      result.current.stop()
+    })
+    expect(sessionStorage.getItem('tourkit:flow:active')).toBeNull()
   })
 })
 

--- a/packages/core/src/__tests__/context/tour-provider-flow-session.test.tsx
+++ b/packages/core/src/__tests__/context/tour-provider-flow-session.test.tsx
@@ -1,0 +1,180 @@
+import { act, render, renderHook } from '@testing-library/react'
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTourContext } from '../../context/tour-context'
+import { TourProvider } from '../../context/tour-provider'
+import { useTour } from '../../hooks/use-tour'
+import type { Tour } from '../../types'
+
+const tour: Tour = {
+  id: 'onboarding',
+  steps: [
+    { id: 's1', target: '#t1', content: 'Step 1' },
+    { id: 's2', target: '#t2', content: 'Step 2' },
+    { id: 's3', target: '#t3', content: 'Step 3' },
+  ],
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+})
+
+describe('TourProvider — flowSession reload (US-1)', () => {
+  it('restores at the persisted stepIndex after unmount/remount', async () => {
+    function makeWrapper() {
+      return function Wrapper({ children }: { children: React.ReactNode }) {
+        return (
+          <TourProvider
+            tours={[tour]}
+            routePersistence={{ enabled: false, flowSession: { storage: 'sessionStorage' } }}
+          >
+            {children}
+          </TourProvider>
+        )
+      }
+    }
+
+    const first = renderHook(() => useTour(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      first.result.current.start('onboarding')
+    })
+    await act(async () => {
+      first.result.current.next()
+    })
+    expect(first.result.current.currentStepIndex).toBe(1)
+
+    // Verify blob exists
+    expect(sessionStorage.getItem('tourkit:flow:active')).not.toBeNull()
+    first.unmount()
+
+    const second = renderHook(() => useTour(), { wrapper: makeWrapper() })
+    expect(second.result.current.isActive).toBe(true)
+    expect(second.result.current.currentStepIndex).toBe(1)
+    expect(second.result.current.currentStep?.id).toBe('s2')
+  })
+})
+
+describe('TourProvider — flowSession TTL expiry (US-1)', () => {
+  it('does not auto-restore when persisted blob is older than ttlMs', () => {
+    sessionStorage.setItem(
+      'tourkit:flow:active',
+      JSON.stringify({
+        schemaVersion: 1,
+        tourId: 'onboarding',
+        stepIndex: 2,
+        startedAt: 1,
+        lastUpdatedAt: 1,
+      })
+    )
+
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      return (
+        <TourProvider
+          tours={[tour]}
+          routePersistence={{
+            enabled: false,
+            flowSession: { storage: 'sessionStorage', ttlMs: 1_000 },
+          }}
+        >
+          {children}
+        </TourProvider>
+      )
+    }
+    const { result } = renderHook(() => useTour(), { wrapper: Wrapper })
+    expect(result.current.isActive).toBe(false)
+    expect(sessionStorage.getItem('tourkit:flow:active')).toBeNull()
+  })
+})
+
+describe('TourProvider — cross-tab pause (US-2)', () => {
+  it('fires onTourPaused and stops the local tour when another tab posts tour:active', async () => {
+    const channel = `tk-cross-tab-${Math.random().toString(36).slice(2)}`
+    const onTourPausedA = vi.fn()
+    const onTourPausedB = vi.fn()
+
+    function makeWrapper(spy: typeof onTourPausedA) {
+      return function Wrapper({ children }: { children: React.ReactNode }) {
+        return (
+          <TourProvider
+            tours={[tour]}
+            routePersistence={{ enabled: false, crossTab: { enabled: true, channel } }}
+            onTourPaused={spy}
+          >
+            {children}
+          </TourProvider>
+        )
+      }
+    }
+
+    const tabA = renderHook(() => useTour(), { wrapper: makeWrapper(onTourPausedA) })
+    const tabB = renderHook(() => useTour(), { wrapper: makeWrapper(onTourPausedB) })
+
+    // Tab B starts a tour first.
+    await act(async () => {
+      tabB.result.current.start('onboarding')
+    })
+    expect(tabB.result.current.isActive).toBe(true)
+
+    // Tab A starts → posts tour:active on the shared channel.
+    await act(async () => {
+      tabA.result.current.start('onboarding')
+    })
+
+    // Allow MessageChannel microtasks to flush; jsdom dispatches BroadcastChannel
+    // events asynchronously (microtask queue).
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(onTourPausedB).toHaveBeenCalledWith('onboarding', 'cross-tab')
+    expect(tabB.result.current.isActive).toBe(false)
+    // Tab A is unaffected (filters self by tabId).
+    expect(tabA.result.current.isActive).toBe(true)
+    expect(onTourPausedA).not.toHaveBeenCalled()
+
+    tabA.unmount()
+    tabB.unmount()
+  })
+})
+
+describe('TourProvider — graceful when BroadcastChannel is unavailable (US-3)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('starts and runs without throwing when BroadcastChannel is undefined', async () => {
+    vi.stubGlobal('BroadcastChannel', undefined as unknown as typeof BroadcastChannel)
+
+    function ActiveProbe() {
+      const ctx = useTourContext()
+      const startedRef = React.useRef(false)
+      React.useEffect(() => {
+        if (!startedRef.current) {
+          startedRef.current = true
+          void ctx.start('onboarding')
+        }
+      }, [ctx])
+      return <div data-testid="active">{String(ctx.isActive)}</div>
+    }
+
+    expect(() =>
+      render(
+        <TourProvider
+          tours={[tour]}
+          routePersistence={{
+            enabled: false,
+            crossTab: { enabled: true, channel: 'tk-bc-undef' },
+          }}
+        >
+          <ActiveProbe />
+        </TourProvider>
+      )
+    ).not.toThrow()
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  })
+})

--- a/packages/core/src/__tests__/hooks/use-broadcast.test.ts
+++ b/packages/core/src/__tests__/hooks/use-broadcast.test.ts
@@ -1,0 +1,106 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useBroadcast } from '../../hooks/use-broadcast'
+
+interface TestMsg {
+  type: 'test'
+  value: number
+}
+
+describe('useBroadcast: round-trip (US-2)', () => {
+  it('post → subscribe round-trips a message between two channel instances', async () => {
+    const channelName = `tk-test-${Math.random().toString(36).slice(2)}`
+    const sender = renderHook(() => useBroadcast<TestMsg>(channelName))
+    const receiver = renderHook(() => useBroadcast<TestMsg>(channelName))
+
+    const received = new Promise<TestMsg>((resolve) => {
+      receiver.result.current.subscribe((msg) => resolve(msg))
+    })
+
+    sender.result.current.post({ type: 'test', value: 42 })
+
+    const msg = await received
+    expect(msg.value).toBe(42)
+
+    sender.unmount()
+    receiver.unmount()
+  })
+})
+
+describe('useBroadcast: cleanup', () => {
+  it('closes the channel on unmount', () => {
+    const closeSpy = vi.spyOn(BroadcastChannel.prototype, 'close')
+    const { unmount } = renderHook(() => useBroadcast<TestMsg>('tk-cleanup-test'))
+    unmount()
+    expect(closeSpy).toHaveBeenCalled()
+    closeSpy.mockRestore()
+  })
+})
+
+describe('useBroadcast: BroadcastChannel undefined fallback (US-3)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns no-op post / subscribe when BroadcastChannel is unavailable', () => {
+    vi.stubGlobal('BroadcastChannel', undefined as unknown as typeof BroadcastChannel)
+    const { result } = renderHook(() => useBroadcast<TestMsg>('tk-fallback'))
+    const handler = vi.fn()
+    expect(() => result.current.post({ type: 'test', value: 1 })).not.toThrow()
+    const cleanup = result.current.subscribe(handler)
+    expect(typeof cleanup).toBe('function')
+    expect(() => cleanup()).not.toThrow()
+    expect(handler).not.toHaveBeenCalled()
+  })
+})
+
+describe('useBroadcast: disabled by options.enabled = false', () => {
+  it('returns no-op post and subscribe when enabled is false', () => {
+    const channelName = `tk-disabled-${Math.random().toString(36).slice(2)}`
+    const sender = renderHook(() =>
+      useBroadcast<TestMsg>(channelName, { enabled: false })
+    )
+
+    // A second instance with enabled=true to receive (would fire if the
+    // disabled instance posted anything).
+    const receiver = renderHook(() => useBroadcast<TestMsg>(channelName))
+    const handler = vi.fn()
+    const cleanup = receiver.result.current.subscribe(handler)
+
+    sender.result.current.post({ type: 'test', value: 99 })
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(handler).not.toHaveBeenCalled()
+        cleanup()
+        sender.unmount()
+        receiver.unmount()
+        resolve()
+      }, 30)
+    })
+  })
+})
+
+describe('useBroadcast: channel name passthrough', () => {
+  it('routes messages by channel name (different names → no cross-talk)', async () => {
+    const sender = renderHook(() => useBroadcast<TestMsg>('tk-name-A'))
+    const receiverSame = renderHook(() => useBroadcast<TestMsg>('tk-name-A'))
+    const receiverOther = renderHook(() => useBroadcast<TestMsg>('tk-name-B'))
+
+    const sameHandler = vi.fn()
+    const otherHandler = vi.fn()
+    receiverSame.result.current.subscribe(sameHandler)
+    receiverOther.result.current.subscribe(otherHandler)
+
+    sender.result.current.post({ type: 'test', value: 7 })
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    expect(sameHandler).toHaveBeenCalledWith({ type: 'test', value: 7 })
+    expect(otherHandler).not.toHaveBeenCalled()
+
+    sender.unmount()
+    receiverSame.unmount()
+    receiverOther.unmount()
+  })
+})

--- a/packages/core/src/__tests__/hooks/use-broadcast.test.ts
+++ b/packages/core/src/__tests__/hooks/use-broadcast.test.ts
@@ -57,9 +57,7 @@ describe('useBroadcast: BroadcastChannel undefined fallback (US-3)', () => {
 describe('useBroadcast: disabled by options.enabled = false', () => {
   it('returns no-op post and subscribe when enabled is false', () => {
     const channelName = `tk-disabled-${Math.random().toString(36).slice(2)}`
-    const sender = renderHook(() =>
-      useBroadcast<TestMsg>(channelName, { enabled: false })
-    )
+    const sender = renderHook(() => useBroadcast<TestMsg>(channelName, { enabled: false }))
 
     // A second instance with enabled=true to receive (would fire if the
     // disabled instance posted anything).

--- a/packages/core/src/__tests__/hooks/use-flow-session.test.ts
+++ b/packages/core/src/__tests__/hooks/use-flow-session.test.ts
@@ -59,9 +59,7 @@ describe('useFlowSession: TTL expiry (US-3 / US-1)', () => {
 
 describe('useFlowSession: clear (US-3)', () => {
   it('clear() removes the persisted blob', () => {
-    const { result } = renderHook(() =>
-      useFlowSession('onboarding', { storage: 'sessionStorage' })
-    )
+    const { result } = renderHook(() => useFlowSession('onboarding', { storage: 'sessionStorage' }))
     act(() => {
       result.current.save(1)
     })
@@ -89,9 +87,7 @@ describe('useFlowSession: throttle (US-5)', () => {
 
   it('coalesces 5 saves in 100ms into a single setItem call', () => {
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
-    const { result } = renderHook(() =>
-      useFlowSession('onboarding', { storage: 'sessionStorage' })
-    )
+    const { result } = renderHook(() => useFlowSession('onboarding', { storage: 'sessionStorage' }))
     act(() => {
       for (let i = 0; i < 5; i++) {
         result.current.save(i)
@@ -125,9 +121,7 @@ describe('useFlowSession: fail-safe (US-3)', () => {
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw Object.assign(new DOMException('quota'), { name: 'QuotaExceededError' })
     })
-    const { result } = renderHook(() =>
-      useFlowSession('onboarding', { storage: 'sessionStorage' })
-    )
+    const { result } = renderHook(() => useFlowSession('onboarding', { storage: 'sessionStorage' }))
     expect(() => {
       act(() => {
         result.current.save(1)

--- a/packages/core/src/__tests__/hooks/use-flow-session.test.ts
+++ b/packages/core/src/__tests__/hooks/use-flow-session.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFlowSession } from '../../hooks/use-flow-session'
+import { parse } from '../../lib/flow-session'
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+})
+
+describe('useFlowSession: round-trip (US-1)', () => {
+  it('save → load returns the same session on remount', () => {
+    const { result, unmount } = renderHook(() =>
+      useFlowSession('onboarding', { storage: 'sessionStorage' })
+    )
+    act(() => {
+      result.current.save(2)
+    })
+    // Force the trailing-edge throttle to flush; without timers we rely on
+    // setTimeout actually firing — use real microtask flush via re-render.
+    // The first save with a fresh throttle (lastCallTime=0 vs Date.now()=large)
+    // executes immediately, so the storage already has the blob.
+    const raw = sessionStorage.getItem('tourkit:flow:active')
+    expect(raw).not.toBeNull()
+    const stored = parse(raw)
+    expect(stored?.tourId).toBe('onboarding')
+    expect(stored?.stepIndex).toBe(2)
+    unmount()
+
+    // Fresh mount reads the persisted session.
+    const { result: result2 } = renderHook(() =>
+      useFlowSession('onboarding', { storage: 'sessionStorage' })
+    )
+    expect(result2.current.session?.tourId).toBe('onboarding')
+    expect(result2.current.session?.stepIndex).toBe(2)
+  })
+})
+
+describe('useFlowSession: TTL expiry (US-3 / US-1)', () => {
+  it('returns null AND clears the blob when expired', () => {
+    // Pre-write a stale blob (lastUpdatedAt very old).
+    const stale = JSON.stringify({
+      schemaVersion: 1,
+      tourId: 'onboarding',
+      stepIndex: 1,
+      startedAt: 1,
+      lastUpdatedAt: 1, // 1970 → very stale
+    })
+    sessionStorage.setItem('tourkit:flow:active', stale)
+
+    const { result } = renderHook(() =>
+      useFlowSession('onboarding', { storage: 'sessionStorage', ttlMs: 1_000 })
+    )
+
+    expect(result.current.session).toBeNull()
+    expect(sessionStorage.getItem('tourkit:flow:active')).toBeNull()
+  })
+})
+
+describe('useFlowSession: clear (US-3)', () => {
+  it('clear() removes the persisted blob', () => {
+    const { result } = renderHook(() =>
+      useFlowSession('onboarding', { storage: 'sessionStorage' })
+    )
+    act(() => {
+      result.current.save(1)
+    })
+    expect(sessionStorage.getItem('tourkit:flow:active')).not.toBeNull()
+    act(() => {
+      result.current.clear()
+    })
+    expect(sessionStorage.getItem('tourkit:flow:active')).toBeNull()
+    expect(result.current.session).toBeNull()
+  })
+})
+
+describe('useFlowSession: throttle (US-5)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Fresh fake clock — Date.now()=0. Without this, the throttle's
+    // lastCallTime=0 vs Date.now()=large would make the leading call
+    // fire immediately, defeating the coalesce assertion.
+    vi.setSystemTime(0)
+  })
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('coalesces 5 saves in 100ms into a single setItem call', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+    const { result } = renderHook(() =>
+      useFlowSession('onboarding', { storage: 'sessionStorage' })
+    )
+    act(() => {
+      for (let i = 0; i < 5; i++) {
+        result.current.save(i)
+        vi.advanceTimersByTime(20) // total 100ms across 5 calls
+      }
+      vi.advanceTimersByTime(200) // flush trailing edge
+    })
+    expect(setItemSpy).toHaveBeenCalledTimes(1)
+    setItemSpy.mockRestore()
+  })
+})
+
+describe('useFlowSession: SSR-safe (US-3)', () => {
+  // The SSR `typeof window === 'undefined'` early return shares its no-op
+  // shape with the config-omitted path (covered below). True SSR rendering
+  // can't be exercised through @testing-library/react because React DOM
+  // requires `window`; the structural guarantee is asserted by the
+  // config-omitted assertions on `session === null` and non-throwing save.
+  it('exposes a stable no-op shape (same as the SSR fallback) when storage backend is missing', () => {
+    const { result } = renderHook(() => useFlowSession('onboarding'))
+    expect(result.current.session).toBeNull()
+    expect(typeof result.current.save).toBe('function')
+    expect(typeof result.current.clear).toBe('function')
+    expect(() => result.current.save(1)).not.toThrow()
+    expect(() => result.current.clear()).not.toThrow()
+  })
+})
+
+describe('useFlowSession: fail-safe (US-3)', () => {
+  it('does not throw when setItem throws QuotaExceededError', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw Object.assign(new DOMException('quota'), { name: 'QuotaExceededError' })
+    })
+    const { result } = renderHook(() =>
+      useFlowSession('onboarding', { storage: 'sessionStorage' })
+    )
+    expect(() => {
+      act(() => {
+        result.current.save(1)
+      })
+    }).not.toThrow()
+    setItemSpy.mockRestore()
+  })
+
+  it('does nothing when config is omitted', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+    const { result } = renderHook(() => useFlowSession('onboarding'))
+    act(() => {
+      result.current.save(1)
+    })
+    expect(setItemSpy).not.toHaveBeenCalled()
+    expect(result.current.session).toBeNull()
+    setItemSpy.mockRestore()
+  })
+})

--- a/packages/core/src/__tests__/hooks/use-persistence.test.tsx
+++ b/packages/core/src/__tests__/hooks/use-persistence.test.tsx
@@ -1,6 +1,10 @@
 import { act, renderHook } from '@testing-library/react'
+import type * as React from 'react'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { TourProvider } from '../../context/tour-provider'
 import { usePersistence } from '../../hooks/use-persistence'
+import { useTour } from '../../hooks/use-tour'
+import type { Tour } from '../../types'
 
 describe('usePersistence', () => {
   beforeEach(() => {
@@ -231,5 +235,47 @@ describe('usePersistence', () => {
     })
 
     expect(result.current.getLastStep('tour-1')).toBe(3)
+  })
+})
+
+// Backward-compat (US-4 — Phase 1.1): omitting flowSession/crossTab must
+// produce the same storage write set as before. We snapshot the sorted
+// localStorage keys after a 3-step provider run; any new key written by
+// the new code path will fail this snapshot.
+describe('TourProvider — backward-compat: no flowSession / crossTab opt-in (US-4)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  const tour: Tour = {
+    id: 'tour-1',
+    steps: [
+      { id: 's1', target: '#t1', content: 'Step 1' },
+      { id: 's2', target: '#t2', content: 'Step 2' },
+      { id: 's3', target: '#t3', content: 'Step 3' },
+    ],
+  }
+
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <TourProvider tours={[tour]}>{children}</TourProvider>
+  }
+
+  it('writes no localStorage keys when routePersistence is unset', async () => {
+    const { result } = renderHook(() => useTour(), { wrapper: Wrapper })
+    await act(async () => {
+      result.current.start('tour-1')
+    })
+    await act(async () => {
+      result.current.next()
+    })
+    await act(async () => {
+      result.current.next()
+    })
+
+    const keys = Object.keys(localStorage).sort()
+    expect(keys).toEqual([])
+    const sessionKeys = Object.keys(sessionStorage).sort()
+    expect(sessionKeys).toEqual([])
   })
 })

--- a/packages/core/src/__tests__/lib/flow-session.test.ts
+++ b/packages/core/src/__tests__/lib/flow-session.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import {
-  type FlowSessionV1,
-  isExpired,
-  parse,
-  serialize,
-} from '../../lib/flow-session'
+import { type FlowSessionV1, isExpired, parse, serialize } from '../../lib/flow-session'
 
 const validSession: FlowSessionV1 = {
   schemaVersion: 1,

--- a/packages/core/src/__tests__/lib/flow-session.test.ts
+++ b/packages/core/src/__tests__/lib/flow-session.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  type FlowSessionV1,
+  isExpired,
+  parse,
+  serialize,
+} from '../../lib/flow-session'
+
+const validSession: FlowSessionV1 = {
+  schemaVersion: 1,
+  tourId: 'onboarding',
+  stepIndex: 2,
+  startedAt: 1_700_000_000_000,
+  lastUpdatedAt: 1_700_000_005_000,
+}
+
+describe('flow-session: serialize / parse', () => {
+  it('round-trips a valid session', () => {
+    const raw = serialize(validSession)
+    const parsed = parse(raw)
+    expect(parsed).toEqual(validSession)
+  })
+
+  it.each<[label: string, raw: string | null]>([
+    ['null raw', null],
+    ['empty string', ''],
+    ['invalid JSON', '{not-json'],
+    ['missing tourId', JSON.stringify({ ...validSession, tourId: undefined })],
+    ['negative stepIndex', JSON.stringify({ ...validSession, stepIndex: -1 })],
+    ['wrong schemaVersion', JSON.stringify({ ...validSession, schemaVersion: 99 })],
+  ])('parse(%s) returns null without throwing', (_label, raw) => {
+    expect(() => parse(raw)).not.toThrow()
+    expect(parse(raw)).toBeNull()
+  })
+})
+
+describe('flow-session: isExpired', () => {
+  it('returns false when ttlMs <= 0 (never expires)', () => {
+    expect(isExpired(validSession, 0)).toBe(false)
+    expect(isExpired(validSession, -1)).toBe(false)
+  })
+
+  it('returns false when lastUpdatedAt is fresh', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(validSession.lastUpdatedAt + 100))
+    try {
+      expect(isExpired(validSession, 60 * 60 * 1000)).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns true when lastUpdatedAt is older than ttlMs', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(validSession.lastUpdatedAt + 10_000))
+    try {
+      expect(isExpired(validSession, 1_000)).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -458,12 +458,13 @@ export function TourProvider({
   // Mount-only: read whatever flow:active blob exists and start that tour.
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only flow restore
   React.useEffect(() => {
-    if (!flow.session || flow.isStale) return
-    if (!tours.some((t) => t.id === flow.session!.tourId)) return
+    const restored = flow.session
+    if (!restored || flow.isStale) return
+    if (!tours.some((t) => t.id === restored.tourId)) return
     dispatch({
       type: 'START_TOUR',
-      tourId: flow.session.tourId,
-      stepIndex: flow.session.stepIndex,
+      tourId: restored.tourId,
+      stepIndex: restored.stepIndex,
     })
   }, [])
 
@@ -509,8 +510,8 @@ export function TourProvider({
     }
   }, [state.tourId, state.currentStepIndex, state.isActive, save, routePersistence.enabled])
 
-  // Throttled flowSession save on step change while active.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: only save on tracked state transitions
+  // Throttled flowSession save on step change while active. Deps are
+  // exhaustive — the throttle inside `flow.save` handles coalescing.
   React.useEffect(() => {
     if (state.isActive && state.tourId && routePersistence.flowSession) {
       flow.save(state.currentStepIndex)

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import { useAdvanceOn } from '../hooks/use-advance-on'
+import { useBroadcast } from '../hooks/use-broadcast'
+import { useFlowSession } from '../hooks/use-flow-session'
 import { useRoutePersistence } from '../hooks/use-route-persistence'
 import type {
   BranchContext,
@@ -351,6 +353,19 @@ export interface TourProviderProps {
   autoNavigate?: boolean
   /** Callback when navigation is needed but autoNavigate is false */
   onNavigationRequired?: (route: string, stepId: string) => void
+  /**
+   * Called when the active tour is paused by an external signal.
+   * Currently the only `reason` is `'cross-tab'` (another tab posted
+   * `tour:active` on the cross-tab `BroadcastChannel`).
+   */
+  onTourPaused?: (tourId: string, reason: 'cross-tab') => void
+}
+
+interface CrossTabActiveMessage {
+  type: 'tour:active'
+  tourId: string
+  tabId: string
+  ts: number
 }
 
 export function TourProvider({
@@ -360,6 +375,7 @@ export function TourProvider({
   routePersistence = { enabled: false },
   autoNavigate = true,
   onNavigationRequired,
+  onTourPaused,
 }: TourProviderProps) {
   const tourKitContext = React.useContext(TourKitContext)
   const [data, setDataState] = React.useState<Record<string, unknown>>({})
@@ -383,6 +399,40 @@ export function TourProvider({
 
   const [state, dispatch] = React.useReducer(tourReducer, initialState)
 
+  // flowSession-restore: tour-scoped resume after reload. The hook uses a
+  // single fixed key (`flow:active`) so we discover the persisted tourId on
+  // mount without needing to know it up front; subsequent saves write the
+  // current state.tourId.
+  const flow = useFlowSession(
+    state.tourId ?? '',
+    routePersistence.flowSession
+      ? { ...routePersistence.flowSession, keyPrefix: routePersistence.key }
+      : undefined
+  )
+
+  const tabId = React.useMemo(
+    () => (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : 'ssr'),
+    []
+  )
+  const broadcast = useBroadcast<CrossTabActiveMessage>(
+    routePersistence.crossTab?.channel ?? 'tourkit:active-flow',
+    { enabled: !!routePersistence.crossTab?.enabled }
+  )
+
+  // Stable callback ref for cross-tab pause notification
+  const onTourPausedRef = React.useRef(onTourPaused)
+  React.useEffect(() => {
+    onTourPausedRef.current = onTourPaused
+  })
+
+  // Latest-state ref consumed by the cross-tab subscribe handler so it can
+  // read isActive/tourId at fire time without re-subscribing on every state
+  // change (which would risk dropping in-flight messages).
+  const currentActiveRef = React.useRef<{ isActive: boolean; tourId: string | null }>({
+    isActive: false,
+    tourId: null,
+  })
+
   // Idempotency guards: track the last tour for which the terminal callback
   // (onComplete / onSkip) has already fired. Prevents double-firing inside the
   // same React commit phase, where reducer state is still closure-stale.
@@ -398,10 +448,27 @@ export function TourProvider({
   // Get current tour
   const currentTour = state.tourId ? (state.tours.get(state.tourId) ?? null) : null
 
+  // flowSession-restore: takes precedence over useRoutePersistence — it's
+  // tour-scoped (single active tour) vs the route-state's multi-tour scope.
+  // Mount-only: read whatever flow:active blob exists and start that tour.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only flow restore
+  React.useEffect(() => {
+    if (!flow.session || flow.isStale) return
+    if (!tours.some((t) => t.id === flow.session!.tourId)) return
+    dispatch({
+      type: 'START_TOUR',
+      tourId: flow.session.tourId,
+      stepIndex: flow.session.stepIndex,
+    })
+  }, [])
+
   // Restore persisted state on mount — and re-run when another tab writes
   // (externalVersion bumps whenever `syncTabs` is on and the storage key changes).
   // biome-ignore lint/correctness/useExhaustiveDependencies: Only run on mount / external sync
   React.useEffect(() => {
+    // flowSession restore (above) wins — skip route restore if it already
+    // dispatched START_TOUR.
+    if (flow.session && !flow.isStale) return
     const persisted = load()
     if (persisted?.tourId && tours.some((t) => t.id === persisted.tourId)) {
       dispatch({
@@ -417,6 +484,7 @@ export function TourProvider({
   // so we don't double-dispatch in the same mount batch.
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only autoStart trigger
   React.useEffect(() => {
+    if (flow.session && !flow.isStale) return
     const persisted = load()
     if (persisted?.tourId && tours.some((t) => t.id === persisted.tourId)) return
     const auto = tours.find((t) => t.autoStart)
@@ -435,6 +503,64 @@ export function TourProvider({
       save(state)
     }
   }, [state.tourId, state.currentStepIndex, state.isActive, save, routePersistence.enabled])
+
+  // Throttled flowSession save on step change while active.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only save on tracked state transitions
+  React.useEffect(() => {
+    if (state.isActive && state.tourId && routePersistence.flowSession) {
+      flow.save(state.currentStepIndex)
+    }
+  }, [
+    state.currentStepIndex,
+    state.isActive,
+    state.tourId,
+    flow.save,
+    routePersistence.flowSession,
+  ])
+
+  // Clear flowSession blob when tour ends.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only react to isActive flip
+  React.useEffect(() => {
+    if (!state.isActive && routePersistence.flowSession) {
+      flow.clear()
+    }
+  }, [state.isActive])
+
+  // Keep the latest-state ref in sync (read by the cross-tab subscriber).
+  React.useEffect(() => {
+    currentActiveRef.current = { isActive: state.isActive, tourId: state.tourId }
+  })
+
+  // Cross-tab announce: whenever this tab activates a tour, post to the channel.
+  React.useEffect(() => {
+    if (state.isActive && state.tourId) {
+      broadcast.post({
+        type: 'tour:active',
+        tourId: state.tourId,
+        tabId,
+        ts: Date.now(),
+      })
+    }
+  }, [state.isActive, state.tourId, tabId, broadcast])
+
+  // Cross-tab subscribe: pause our active tour when another tab announces.
+  React.useEffect(() => {
+    return broadcast.subscribe((msg) => {
+      if (msg.type !== 'tour:active') return
+      if (msg.tabId === tabId) return
+      // Use functional access to current state via a ref-like read isn't
+      // available here; instead defer the pause condition to the dispatch
+      // by checking via a separate "is currently active" guard at fire time.
+      // We close over the latest state via the effect's identity (it
+      // re-subscribes when state.isActive flips), so this snapshot is
+      // sufficient for the pause-on-active gate.
+      const pausedTourId = currentActiveRef.current.tourId
+      if (currentActiveRef.current.isActive && pausedTourId) {
+        dispatch({ type: 'STOP_TOUR' })
+        onTourPausedRef.current?.(pausedTourId, 'cross-tab')
+      }
+    })
+  }, [broadcast, tabId])
 
   // Route-aware step navigation helper
   const navigateToStep = React.useCallback(

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -410,10 +410,15 @@ export function TourProvider({
       : undefined
   )
 
-  const tabId = React.useMemo(
-    () => (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : 'ssr'),
-    []
-  )
+  const tabId = React.useMemo(() => {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+      return crypto.randomUUID()
+    }
+    // Random-enough fallback for runtimes without crypto.randomUUID.
+    // A literal sentinel like 'ssr' would collide between tabs and silently
+    // disable the cross-tab self-message filter.
+    return `tab-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+  }, [])
   const broadcast = useBroadcast<CrossTabActiveMessage>(
     routePersistence.crossTab?.channel ?? 'tourkit:active-flow',
     { enabled: !!routePersistence.crossTab?.enabled }
@@ -518,12 +523,18 @@ export function TourProvider({
     routePersistence.flowSession,
   ])
 
-  // Clear flowSession blob when tour ends.
+  // Clear flowSession blob ONLY on a true → false transition (tour ended).
+  // The initial mount has `state.isActive === false`; without this guard
+  // we would wipe a freshly restored blob right after the restore effect
+  // dispatched START_TOUR (saved by the leading-edge throttle re-write,
+  // but fragile and an unnecessary storage churn).
+  const wasActiveRef = React.useRef(false)
   // biome-ignore lint/correctness/useExhaustiveDependencies: only react to isActive flip
   React.useEffect(() => {
-    if (!state.isActive && routePersistence.flowSession) {
+    if (wasActiveRef.current && !state.isActive && routePersistence.flowSession) {
       flow.clear()
     }
+    wasActiveRef.current = state.isActive
   }, [state.isActive])
 
   // Keep the latest-state ref in sync (read by the cross-tab subscriber).
@@ -531,14 +542,20 @@ export function TourProvider({
     currentActiveRef.current = { isActive: state.isActive, tourId: state.tourId }
   })
 
+  // Last-announce timestamp — also used as tie-breaker when two tabs
+  // simultaneously announce (e.g., both restoring from the same persisted
+  // session at cold start). The later announce wins; the earlier one yields.
+  const announceTsRef = React.useRef<number | null>(null)
+
   // Cross-tab announce: whenever this tab activates a tour, post to the channel.
   React.useEffect(() => {
     if (state.isActive && state.tourId) {
+      announceTsRef.current = Date.now()
       broadcast.post({
         type: 'tour:active',
         tourId: state.tourId,
         tabId,
-        ts: Date.now(),
+        ts: announceTsRef.current,
       })
     }
   }, [state.isActive, state.tourId, tabId, broadcast])
@@ -548,17 +565,16 @@ export function TourProvider({
     return broadcast.subscribe((msg) => {
       if (msg.type !== 'tour:active') return
       if (msg.tabId === tabId) return
-      // Use functional access to current state via a ref-like read isn't
-      // available here; instead defer the pause condition to the dispatch
-      // by checking via a separate "is currently active" guard at fire time.
-      // We close over the latest state via the effect's identity (it
-      // re-subscribes when state.isActive flips), so this snapshot is
-      // sufficient for the pause-on-active gate.
       const pausedTourId = currentActiveRef.current.tourId
-      if (currentActiveRef.current.isActive && pausedTourId) {
-        dispatch({ type: 'STOP_TOUR' })
-        onTourPausedRef.current?.(pausedTourId, 'cross-tab')
-      }
+      if (!currentActiveRef.current.isActive || !pausedTourId) return
+      // Tie-break: if we announced AFTER the incoming message, we are the
+      // newer owner and should keep running. Otherwise yield. Without this,
+      // two tabs cold-restoring the same flow.session at the same instant
+      // pause each other and the user sees no tour anywhere.
+      const myTs = announceTsRef.current
+      if (myTs !== null && myTs > msg.ts) return
+      dispatch({ type: 'STOP_TOUR' })
+      onTourPausedRef.current?.(pausedTourId, 'cross-tab')
     })
   }, [broadcast, tabId])
 

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -8,6 +8,12 @@ export { usePersistence, type UsePersistenceReturn } from './use-persistence'
 export { useMediaQuery, usePrefersReducedMotion } from './use-media-query'
 export { useRoutePersistence, type UseRoutePersistenceReturn } from './use-route-persistence'
 export {
+  useFlowSession,
+  type UseFlowSessionConfig,
+  type UseFlowSessionReturn,
+} from './use-flow-session'
+export { useBroadcast, type UseBroadcastReturn } from './use-broadcast'
+export {
   useAdvanceOn,
   dispatchAdvanceEvent,
   type UseAdvanceOnOptions,

--- a/packages/core/src/hooks/use-broadcast.ts
+++ b/packages/core/src/hooks/use-broadcast.ts
@@ -1,0 +1,69 @@
+import * as React from 'react'
+
+export interface UseBroadcastReturn<TMsg> {
+  /** Post a message to all other tabs subscribing to the same channel name. */
+  post: (msg: TMsg) => void
+  /**
+   * Subscribe to messages on the channel.
+   * @returns Cleanup function — call on unmount to remove the listener.
+   */
+  subscribe: (handler: (msg: TMsg) => void) => () => void
+}
+
+const NOOP_RETURN: UseBroadcastReturn<unknown> = {
+  post: () => {},
+  subscribe: () => () => {},
+}
+
+/**
+ * Typed wrapper around `BroadcastChannel` for cross-tab pub/sub.
+ *
+ * Lazy-initializes the channel and closes it on unmount. When the runtime
+ * does not provide `BroadcastChannel` (e.g. older Safari) or when
+ * `options.enabled === false`, both `post` and `subscribe` are no-ops so
+ * consumers do not need to branch.
+ *
+ * Self-message filtering is the consumer's responsibility — attach a
+ * `tabId` to your messages and ignore matching ones.
+ *
+ * @typeParam TMsg - Discriminated union of message shapes for this channel.
+ */
+export function useBroadcast<TMsg>(
+  channelName: string,
+  options?: { enabled?: boolean }
+): UseBroadcastReturn<TMsg> {
+  const enabled = options?.enabled ?? true
+  const isAvailable = typeof BroadcastChannel !== 'undefined'
+
+  const channel = React.useMemo(() => {
+    if (!enabled || !isAvailable) return null
+    return new BroadcastChannel(channelName)
+  }, [enabled, isAvailable, channelName])
+
+  React.useEffect(() => {
+    return () => channel?.close()
+  }, [channel])
+
+  const post = React.useCallback(
+    (msg: TMsg) => {
+      channel?.postMessage(msg)
+    },
+    [channel]
+  )
+
+  const subscribe = React.useCallback(
+    (handler: (msg: TMsg) => void) => {
+      if (!channel) return () => {}
+      const wrapped = (e: MessageEvent) => handler(e.data as TMsg)
+      channel.addEventListener('message', wrapped)
+      return () => channel.removeEventListener('message', wrapped)
+    },
+    [channel]
+  )
+
+  if (!enabled || !isAvailable) {
+    return NOOP_RETURN as UseBroadcastReturn<TMsg>
+  }
+
+  return { post, subscribe }
+}

--- a/packages/core/src/hooks/use-broadcast.ts
+++ b/packages/core/src/hooks/use-broadcast.ts
@@ -61,9 +61,16 @@ export function useBroadcast<TMsg>(
     [channel]
   )
 
+  // Memoize return value so consumers can safely use the hook result in
+  // effect dep arrays without re-running on every render.
+  const value = React.useMemo<UseBroadcastReturn<TMsg>>(
+    () => ({ post, subscribe }),
+    [post, subscribe]
+  )
+
   if (!enabled || !isAvailable) {
     return NOOP_RETURN as UseBroadcastReturn<TMsg>
   }
 
-  return { post, subscribe }
+  return value
 }

--- a/packages/core/src/hooks/use-flow-session.ts
+++ b/packages/core/src/hooks/use-flow-session.ts
@@ -1,0 +1,178 @@
+import * as React from 'react'
+import {
+  type FlowSessionV1,
+  isExpired,
+  parse,
+  serialize,
+} from '../lib/flow-session'
+import type { FlowSessionConfig } from '../types/config'
+import { logger } from '../utils/logger'
+import { createPrefixedStorage, createStorageAdapter } from '../utils/storage'
+import { throttleTime } from '../utils/throttle'
+
+const DEFAULT_TTL_MS_SESSION = 60 * 60 * 1000 // 1 hour
+const DEFAULT_TTL_MS_LOCAL = 24 * 60 * 60 * 1000 // 24 hours
+const SAVE_THROTTLE_MS = 200
+const ACTIVE_KEY_SUFFIX = 'flow:active'
+
+export interface UseFlowSessionReturn {
+  session: FlowSessionV1 | null
+  save: (stepIndex: number) => void
+  clear: () => void
+  isStale: boolean
+}
+
+export interface UseFlowSessionConfig extends FlowSessionConfig {
+  /** Storage key prefix (default: `tourkit`). Full key is `${keyPrefix}:flow:active`. */
+  keyPrefix?: string
+}
+
+const NOOP_RETURN: UseFlowSessionReturn = {
+  session: null,
+  save: () => {},
+  clear: () => {},
+  isStale: false,
+}
+
+function getDefaultTtl(storage: FlowSessionConfig['storage']): number {
+  return storage === 'localStorage' ? DEFAULT_TTL_MS_LOCAL : DEFAULT_TTL_MS_SESSION
+}
+
+/**
+ * Persist the active tour's session so a hard reload resumes it in place.
+ *
+ * Uses a single fixed storage key (`${keyPrefix}:flow:active` by default) — the
+ * blob itself carries the `tourId`, so on a fresh mount the hook can discover
+ * which tour was active without the caller needing to know it up front.
+ *
+ * The `tourId` argument identifies the tour for which `save()` writes new
+ * snapshots; pass `''` to disable writes (loads still work).
+ *
+ * Throttle: `save()` is trailing-edge throttled at 200ms via the existing
+ * `throttleTime` util — a burst of step changes coalesces into 1 storage write
+ * per window.
+ *
+ * SSR-safe: returns no-op shape when `window` is undefined.
+ * Quota-safe: `setItem` failures (`QuotaExceededError`) are logged and swallowed.
+ */
+export function useFlowSession(
+  tourId: string,
+  config?: UseFlowSessionConfig
+): UseFlowSessionReturn {
+  const isSSR = typeof window === 'undefined'
+  const enabled = !!config && !isSSR
+
+  const ttlMs = config?.ttlMs ?? (config ? getDefaultTtl(config.storage) : 0)
+  const keyPrefix = config?.keyPrefix ?? 'tourkit'
+  const storageType = config?.storage
+
+  const storage = React.useMemo(() => {
+    if (!enabled || !storageType) return null
+    return createPrefixedStorage(createStorageAdapter(storageType), keyPrefix)
+  }, [enabled, storageType, keyPrefix])
+
+  const storageKey = config?.key ?? ACTIVE_KEY_SUFFIX
+
+  const readSession = React.useCallback((): FlowSessionV1 | null => {
+    if (!storage) return null
+    try {
+      const raw = storage.getItem(storageKey)
+      if (typeof raw !== 'string' && raw !== null) return null
+      const parsed = parse(raw as string | null)
+      if (!parsed) {
+        if (raw) storage.removeItem(storageKey)
+        return null
+      }
+      if (isExpired(parsed, ttlMs)) {
+        storage.removeItem(storageKey)
+        return null
+      }
+      return parsed
+    } catch {
+      return null
+    }
+  }, [storage, storageKey, ttlMs])
+
+  const [session, setSession] = React.useState<FlowSessionV1 | null>(() => readSession())
+
+  // Re-read when storage identity changes (e.g. config.storage swap)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only re-load on storage identity change
+  React.useEffect(() => {
+    setSession(readSession())
+  }, [storage])
+
+  // Latest values ref — keeps the throttled callback identity stable while
+  // still writing the most recent tourId / startedAt.
+  const latestRef = React.useRef({
+    tourId,
+    storage,
+    storageKey,
+    enabled,
+    startedAt: session?.startedAt ?? null,
+  })
+  React.useEffect(() => {
+    latestRef.current = {
+      tourId,
+      storage,
+      storageKey,
+      enabled,
+      startedAt: session?.startedAt ?? null,
+    }
+  })
+
+  const throttledSave = React.useMemo(
+    () =>
+      throttleTime((...args: unknown[]) => {
+        const stepIndex = args[0] as number
+        const ctx = latestRef.current
+        if (!ctx.enabled || !ctx.storage || !ctx.tourId) return
+        const now = Date.now()
+        const next: FlowSessionV1 = {
+          schemaVersion: 1,
+          tourId: ctx.tourId,
+          stepIndex,
+          startedAt: ctx.startedAt ?? now,
+          lastUpdatedAt: now,
+        }
+        try {
+          ctx.storage.setItem(ctx.storageKey, serialize(next))
+          setSession(next)
+        } catch (err) {
+          logger.warn('useFlowSession: setItem failed', err)
+        }
+      }, SAVE_THROTTLE_MS),
+    []
+  )
+
+  // On unmount, flush any pending throttled save so the most recent
+  // stepIndex is persisted before teardown (otherwise a fast unmount loses
+  // the trailing-edge write).
+  React.useEffect(() => () => throttledSave.flush(), [throttledSave])
+
+  const save = React.useCallback(
+    (stepIndex: number) => {
+      throttledSave(stepIndex)
+    },
+    [throttledSave]
+  )
+
+  const clear = React.useCallback(() => {
+    if (!storage) return
+    try {
+      throttledSave.cancel()
+      storage.removeItem(storageKey)
+      setSession(null)
+    } catch (err) {
+      logger.warn('useFlowSession: clear failed', err)
+    }
+  }, [storage, storageKey, throttledSave])
+
+  if (!enabled) return NOOP_RETURN
+
+  return {
+    session,
+    save,
+    clear,
+    isStale: session ? isExpired(session, ttlMs) : false,
+  }
+}

--- a/packages/core/src/hooks/use-flow-session.ts
+++ b/packages/core/src/hooks/use-flow-session.ts
@@ -1,10 +1,5 @@
 import * as React from 'react'
-import {
-  type FlowSessionV1,
-  isExpired,
-  parse,
-  serialize,
-} from '../lib/flow-session'
+import { type FlowSessionV1, isExpired, parse, serialize } from '../lib/flow-session'
 import type { FlowSessionConfig } from '../types/config'
 import { logger } from '../utils/logger'
 import { createPrefixedStorage, createStorageAdapter } from '../utils/storage'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,8 @@ export type {
   SpotlightConfig,
   Storage,
   PersistenceConfig,
+  FlowSessionConfig,
+  CrossTabConfig,
   A11yConfig,
   ScrollConfig,
   Direction,
@@ -76,6 +78,8 @@ export {
   useMediaQuery,
   usePrefersReducedMotion,
   useRoutePersistence,
+  useFlowSession,
+  useBroadcast,
   useAdvanceOn,
   dispatchAdvanceEvent,
   useBranch,
@@ -88,6 +92,9 @@ export type {
   UseFocusTrapReturn,
   UsePersistenceReturn,
   UseRoutePersistenceReturn,
+  UseFlowSessionConfig,
+  UseFlowSessionReturn,
+  UseBroadcastReturn,
   UseAdvanceOnOptions,
 } from './hooks'
 

--- a/packages/core/src/lib/flow-session.ts
+++ b/packages/core/src/lib/flow-session.ts
@@ -1,0 +1,68 @@
+/**
+ * Flow session — represents the active tour's `(tourId, stepIndex)` so a
+ * hard reload can resume it. Stored as JSON in `sessionStorage` (default)
+ * or `localStorage`.
+ *
+ * Validation strategy: hand-rolled type guard rather than Zod. `@tour-kit/core`
+ * does not depend on Zod, and adding it for a 5-field plain-object schema
+ * would add bundle weight + a runtime dep. The schema here is the single
+ * source of truth for storage shape v1.
+ */
+
+export interface FlowSessionV1 {
+  schemaVersion: 1
+  tourId: string
+  stepIndex: number
+  /** epoch ms */
+  startedAt: number
+  /** epoch ms */
+  lastUpdatedAt: number
+}
+
+function isFlowSessionV1(value: unknown): value is FlowSessionV1 {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    v.schemaVersion === 1 &&
+    typeof v.tourId === 'string' &&
+    v.tourId.length > 0 &&
+    typeof v.stepIndex === 'number' &&
+    Number.isInteger(v.stepIndex) &&
+    v.stepIndex >= 0 &&
+    typeof v.startedAt === 'number' &&
+    Number.isInteger(v.startedAt) &&
+    v.startedAt > 0 &&
+    typeof v.lastUpdatedAt === 'number' &&
+    Number.isInteger(v.lastUpdatedAt) &&
+    v.lastUpdatedAt > 0
+  )
+}
+
+export function serialize(session: FlowSessionV1): string {
+  return JSON.stringify(session)
+}
+
+/**
+ * Parse a raw storage value into a `FlowSessionV1`.
+ * Returns `null` on any failure (null/empty input, invalid JSON, wrong shape,
+ * wrong schemaVersion). Never throws — callers should remove the blob and
+ * continue.
+ */
+export function parse(raw: string | null): FlowSessionV1 | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    return isFlowSessionV1(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Returns true when `session.lastUpdatedAt` is older than `ttlMs`.
+ * `ttlMs <= 0` disables expiry (returns false).
+ */
+export function isExpired(session: FlowSessionV1, ttlMs: number): boolean {
+  if (ttlMs <= 0) return false
+  return Date.now() - session.lastUpdatedAt > ttlMs
+}

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -76,7 +76,12 @@ export interface FlowSessionConfig {
   storage: 'sessionStorage' | 'localStorage'
   /** TTL in ms. Default: 1h for sessionStorage, 24h for localStorage. */
   ttlMs?: number
-  /** Storage key suffix (full key is `${keyPrefix}:flow:${tourId}`). */
+  /**
+   * Storage key (under the configured `keyPrefix`).
+   * Default: `'flow:active'` — full key shape `${keyPrefix}:flow:active`.
+   * The persisted blob carries its own `tourId`, so a single fixed key is
+   * sufficient for the active-tour resume case (one active tour per tab).
+   */
   key?: string
 }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -65,6 +65,36 @@ export interface Storage {
 }
 
 /**
+ * Active flow session configuration — single tour at a time, scoped to one tab.
+ * Differs from `useRoutePersistence`, which is multi-tour cross-route state.
+ *
+ * @remarks
+ * Opt-in: undefined by default. When set, `useFlowSession` will persist the
+ * active tour's `(tourId, stepIndex)` so a hard reload resumes it in place.
+ */
+export interface FlowSessionConfig {
+  storage: 'sessionStorage' | 'localStorage'
+  /** TTL in ms. Default: 1h for sessionStorage, 24h for localStorage. */
+  ttlMs?: number
+  /** Storage key suffix (full key is `${keyPrefix}:flow:${tourId}`). */
+  key?: string
+}
+
+/**
+ * Cross-tab pause/resume gate (BroadcastChannel-based).
+ * Pauses the tour in this tab when another tab posts `tour:active`.
+ *
+ * @remarks
+ * Opt-in: undefined by default. Recommended when using `flowSession.storage = 'localStorage'`
+ * so a tour started in tab A doesn't double-show after the user closed it in tab B.
+ */
+export interface CrossTabConfig {
+  enabled: boolean
+  /** Channel name. Default: `'tourkit:active-flow'`. */
+  channel?: string
+}
+
+/**
  * Persistence configuration
  */
 export interface PersistenceConfig {
@@ -74,6 +104,16 @@ export interface PersistenceConfig {
   rememberStep?: boolean
   trackCompleted?: boolean
   dontShowAgain?: boolean
+  /**
+   * Active flow session — single tour at a time, scoped to one tab.
+   * Differs from `useRoutePersistence`, which is multi-tour cross-route state.
+   */
+  flowSession?: FlowSessionConfig
+  /**
+   * Cross-tab pause/resume gate (BroadcastChannel-based).
+   * Pauses tour in this tab when another tab posts `tour:active`.
+   */
+  crossTab?: CrossTabConfig
 }
 
 /**
@@ -140,8 +180,12 @@ export const defaultSpotlightConfig: Required<SpotlightConfig> = {
   clickToExit: false,
 }
 
-export const defaultPersistenceConfig: Required<Omit<PersistenceConfig, 'storage'>> & {
+export const defaultPersistenceConfig: Required<
+  Omit<PersistenceConfig, 'storage' | 'flowSession' | 'crossTab'>
+> & {
   storage: 'localStorage'
+  flowSession?: FlowSessionConfig
+  crossTab?: CrossTabConfig
 } = {
   enabled: true,
   storage: 'localStorage',

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -21,6 +21,8 @@ export type {
   SpotlightConfig,
   Storage,
   PersistenceConfig,
+  FlowSessionConfig,
+  CrossTabConfig,
   A11yConfig,
   ScrollConfig,
   Direction,

--- a/packages/core/src/types/router.ts
+++ b/packages/core/src/types/router.ts
@@ -39,6 +39,8 @@ export interface RouterAdapter {
   onRouteChange(callback: (route: string) => void): () => void
 }
 
+import type { CrossTabConfig, FlowSessionConfig } from './config'
+
 /**
  * Multi-page persistence configuration.
  * Extends base PersistenceConfig with route-specific options.
@@ -54,4 +56,14 @@ export interface MultiPagePersistenceConfig {
   syncTabs?: boolean
   /** Expiry time in milliseconds (default: 24 hours) */
   expiryMs?: number
+  /**
+   * Active flow session — single tour at a time, scoped to one tab.
+   * When set, a hard reload resumes the active tour at its persisted step.
+   */
+  flowSession?: FlowSessionConfig
+  /**
+   * Cross-tab pause/resume gate (BroadcastChannel-based).
+   * Pauses the tour in this tab when another tab posts `tour:active`.
+   */
+  crossTab?: CrossTabConfig
 }


### PR DESCRIPTION
## Phase 1.1 — Flow Session Persistence + Cross-Tab Sync

Implements the first slice of the client-only-gaps roadmap (`plan/phase-1-1-flow-session-and-cross-tab.md`). Both new capabilities are **opt-in** and produce zero behavior change for apps that don't pass them.

### Summary
- **`useFlowSession`** — persists the active tour's `(tourId, stepIndex)` so a hard refresh resumes at the same step. Defaults: `sessionStorage` with 1h TTL, throttled writes (200ms trailing edge), `QuotaExceededError` swallowed, **flush-on-unmount** so a fast tab close doesn't lose the latest step.
- **`useBroadcast`** — typed `BroadcastChannel` wrapper with a no-op fallback for browsers/SSR that lack the API. Powers a new `crossTab` gate that pauses an active tour in tab B when tab A starts the same flow. New `onTourPaused(tourId, 'cross-tab')` prop on `<TourProvider>` reports it.
- **`PersistenceConfig` + `MultiPagePersistenceConfig`** extended with optional `flowSession` and `crossTab` fields.

### Why hand-rolled validation over zod
`@tour-kit/core` doesn't depend on zod (only the workspace root does). The schema is 5 plain fields — a hand-rolled `isFlowSessionV1` type guard adds zero deps and minimal bundle weight while still rejecting stale-shape blobs from older app versions. The plan permits this fallback explicitly.

### Test plan
- [x] 8 cases for `lib/flow-session.ts` (serialize/parse/isExpired, including 6 invalid-input cases)
- [x] 6 cases for `useFlowSession` (round-trip, TTL expiry, clear, throttle, no-op shape, quota-error)
- [x] 5 cases for `useBroadcast` (round-trip, cleanup, BC undefined, disabled, channel name routing)
- [x] 4 integration cases for `<TourProvider>` (reload restore, TTL expiry, cross-tab pause, BC-undefined graceful)
- [x] 1 backward-compat snapshot case in `use-persistence.test.tsx` — TourProvider without `flowSession`/`crossTab` writes zero localStorage keys
- [x] Full core suite: **549/549 pass**
- [x] All workspace packages: pass (react 378, hints 237, adoption 174, announcements 90, surveys 190, etc.)
- [x] `pnpm typecheck` green across all 26 packages

### Docs
- `apps/docs/content/docs/guides/persistence.mdx` — new "Flow Session" H2 with the `useRoutePersistence` vs `useFlowSession` distinction table, quick-start, storage trade-offs, TTL/quota semantics
- `apps/docs/content/docs/guides/multi-tab.mdx` (new) — when-to-enable matrix, API ref, browser support table (Chrome 54+, Firefox 38+, Safari 15.4+), failure-mode and testing patterns
- Sidebar (`meta.json`) updated

### Out of scope
Cross-page (route-aware) flow continuation lands in Phase 3. Bundle delta verification via `size-limit` is a separate post-merge gate.

🤖 Generated with run-phase skill