### PR TITLE
feat(react): theme variation foundation (phase 1.4a)

### DIFF
--- a/.changeset/phase-1-theme-foundation.md
+++ b/.changeset/phase-1-theme-foundation.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/react": minor
+---
+
+Add `<ThemeProvider>`, `resolveTheme`, and `ThemeMatcher` (discriminated union over `'system' | 'dark' | 'light' | 'url'`). Themes are applied via a `data-tk-theme` attribute on the provider root, switching CSS variables defined in `@tour-kit/react/styles/variables.css` without React tree re-renders for non-subscribed consumers. SSR-safe: the server-rendered HTML emits a fixed neutral `data-tk-theme="default"` and no inline CSS-variable style; the first client effect resolves the active variation and applies it. Phase 4b will add trait-predicate matchers.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   { "name": "@tour-kit/core", "path": "packages/core/dist/index.js", "limit": "22 KB" },
-  { "name": "@tour-kit/react", "path": "packages/react/dist/index.js", "limit": "35 KB" },
+  { "name": "@tour-kit/react", "path": "packages/react/dist/index.js", "limit": "36 KB" },
   { "name": "@tour-kit/hints", "path": "packages/hints/dist/index.js", "limit": "30 KB" },
   { "name": "@tour-kit/adoption", "path": "packages/adoption/dist/index.js", "limit": "146 KB" },
   {

--- a/packages/react/src/__tests__/theme/theme-provider.test.tsx
+++ b/packages/react/src/__tests__/theme/theme-provider.test.tsx
@@ -1,5 +1,5 @@
-import type { RouterAdapter } from '@tour-kit/core'
 import { act, render } from '@testing-library/react'
+import type { RouterAdapter } from '@tour-kit/core'
 import * as React from 'react'
 import { renderToString } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -13,7 +13,7 @@ function createMockRouter(initial = '/'): RouterAdapter {
     getCurrentRoute: () => current,
     navigate: vi.fn((r: string) => {
       current = r
-      subs.forEach((cb) => cb(r))
+      for (const cb of subs) cb(r)
       return undefined
     }),
     matchRoute: vi.fn((p: string) => current === p),
@@ -45,7 +45,7 @@ describe('<ThemeProvider> (US-2)', () => {
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),
           dispatchEvent: vi.fn(),
-        }) as unknown as MediaQueryList,
+        }) as unknown as MediaQueryList
     )
   })
 
@@ -57,7 +57,7 @@ describe('<ThemeProvider> (US-2)', () => {
     const { getByTestId } = render(
       <ThemeProvider variations={variations}>
         <div data-testid="child">hello</div>
-      </ThemeProvider>,
+      </ThemeProvider>
     )
     expect(getByTestId('child').textContent).toBe('hello')
   })
@@ -66,7 +66,7 @@ describe('<ThemeProvider> (US-2)', () => {
     const { container } = render(
       <ThemeProvider variations={variations} forceMode="dark">
         <span>x</span>
-      </ThemeProvider>,
+      </ThemeProvider>
     )
     // Effects flush synchronously inside render with @testing-library; the
     // attribute should be present after the initial mount cycle.
@@ -86,7 +86,7 @@ describe('<ThemeProvider> (US-2)', () => {
     const { container } = render(
       <ThemeProvider variations={urlVariations} router={router}>
         <span>x</span>
-      </ThemeProvider>,
+      </ThemeProvider>
     )
 
     // Initial route '/' matches nothing → falls back to first variation.
@@ -115,7 +115,7 @@ describe('<ThemeProvider> (US-2)', () => {
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),
           dispatchEvent: vi.fn(),
-        }) as unknown as MediaQueryList,
+        }) as unknown as MediaQueryList
     )
 
     const sysVariations: ThemeVariation[] = [
@@ -125,7 +125,7 @@ describe('<ThemeProvider> (US-2)', () => {
     const { container } = render(
       <ThemeProvider variations={sysVariations}>
         <span>x</span>
-      </ThemeProvider>,
+      </ThemeProvider>
     )
     // Effect resolves systemColorScheme = 'dark' → matches system variation.
     expect(container.querySelector('[data-tk-theme="systemDark"]')).not.toBeNull()
@@ -137,7 +137,7 @@ describe('<ThemeProvider> SSR safety (US-3)', () => {
     const html = renderToString(
       <ThemeProvider variations={variations} forceMode="dark">
         <span>x</span>
-      </ThemeProvider>,
+      </ThemeProvider>
     )
     expect(html).not.toContain('data-tk-theme="dark"')
     // Acceptable: neutral default attribute (no per-variation theme leak).
@@ -150,7 +150,7 @@ describe('<ThemeProvider> SSR safety (US-3)', () => {
     const html = renderToString(
       <ThemeProvider variations={variations} forceMode="dark">
         <span>x</span>
-      </ThemeProvider>,
+      </ThemeProvider>
     )
     expect(html).not.toMatch(/style="[^"]*--tour-card-bg/)
   })
@@ -183,7 +183,7 @@ describe('<ThemeProvider> render budget (US-2)', () => {
         <ThemeProvider variations={urlVariations} router={router}>
           <ContextConsumer />
         </ThemeProvider>
-      </React.Profiler>,
+      </React.Profiler>
     )
 
     // Reset render count after initial mount; we only measure the cost of one
@@ -207,7 +207,7 @@ describe('useThemeContext', () => {
     // Suppress React's expected error output for this negative-path test.
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     expect(() => render(<Consumer />)).toThrow(
-      /useThemeContext must be used inside <ThemeProvider>/,
+      /useThemeContext must be used inside <ThemeProvider>/
     )
     spy.mockRestore()
   })
@@ -220,7 +220,7 @@ describe('useThemeContext', () => {
     const { getByTestId } = render(
       <ThemeProvider variations={variations} forceMode="light">
         <Consumer />
-      </ThemeProvider>,
+      </ThemeProvider>
     )
     expect(getByTestId('active').textContent).toBe('light')
   })

--- a/packages/react/src/__tests__/theme/theme-provider.test.tsx
+++ b/packages/react/src/__tests__/theme/theme-provider.test.tsx
@@ -1,0 +1,227 @@
+import type { RouterAdapter } from '@tour-kit/core'
+import { act, render } from '@testing-library/react'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ThemeProvider, useThemeContext } from '../../components/theme/theme-provider'
+import type { ThemeVariation } from '../../components/theme/types'
+
+function createMockRouter(initial = '/'): RouterAdapter {
+  let current = initial
+  const subs = new Set<(r: string) => void>()
+  return {
+    getCurrentRoute: () => current,
+    navigate: vi.fn((r: string) => {
+      current = r
+      subs.forEach((cb) => cb(r))
+      return undefined
+    }),
+    matchRoute: vi.fn((p: string) => current === p),
+    onRouteChange: vi.fn((cb: (r: string) => void) => {
+      subs.add(cb)
+      return () => {
+        subs.delete(cb)
+      }
+    }),
+  }
+}
+
+const variations: ThemeVariation[] = [
+  { id: 'dark', when: { kind: 'dark' }, theme: { '--tour-card-bg': '#000' } },
+  { id: 'light', when: { kind: 'light' }, theme: { '--tour-card-bg': '#fff' } },
+]
+
+describe('<ThemeProvider> (US-2)', () => {
+  beforeEach(() => {
+    // Reset matchMedia to "light" by default for each test.
+    vi.mocked(window.matchMedia).mockImplementation(
+      (query: string) =>
+        ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList,
+    )
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders children', () => {
+    const { getByTestId } = render(
+      <ThemeProvider variations={variations}>
+        <div data-testid="child">hello</div>
+      </ThemeProvider>,
+    )
+    expect(getByTestId('child').textContent).toBe('hello')
+  })
+
+  it('forceMode="dark" flips data-tk-theme to "dark" after mount', () => {
+    const { container } = render(
+      <ThemeProvider variations={variations} forceMode="dark">
+        <span>x</span>
+      </ThemeProvider>,
+    )
+    // Effects flush synchronously inside render with @testing-library; the
+    // attribute should be present after the initial mount cycle.
+    expect(container.querySelector('[data-tk-theme="dark"]')).not.toBeNull()
+  })
+
+  it('flips attribute when router navigates to a URL-matched route', () => {
+    const urlVariations: ThemeVariation[] = [
+      { id: 'billing', when: { kind: 'url', pattern: '/billing' }, theme: {} },
+      {
+        id: 'docs',
+        when: { kind: 'url', pattern: '/docs', mode: 'startsWith' },
+        theme: {},
+      },
+    ]
+    const router = createMockRouter('/')
+    const { container } = render(
+      <ThemeProvider variations={urlVariations} router={router}>
+        <span>x</span>
+      </ThemeProvider>,
+    )
+
+    // Initial route '/' matches nothing → falls back to first variation.
+    expect(container.querySelector('[data-tk-theme="billing"]')).not.toBeNull()
+
+    act(() => {
+      router.navigate('/docs/start')
+    })
+    expect(container.querySelector('[data-tk-theme="docs"]')).not.toBeNull()
+
+    act(() => {
+      router.navigate('/billing')
+    })
+    expect(container.querySelector('[data-tk-theme="billing"]')).not.toBeNull()
+  })
+
+  it('reflects system colour scheme via matchMedia mock', () => {
+    vi.mocked(window.matchMedia).mockImplementation(
+      (query: string) =>
+        ({
+          matches: query.includes('prefers-color-scheme: dark'),
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList,
+    )
+
+    const sysVariations: ThemeVariation[] = [
+      { id: 'systemDark', when: { kind: 'system' }, theme: {} },
+      { id: 'fallback', when: { kind: 'url', pattern: '/never-match' }, theme: {} },
+    ]
+    const { container } = render(
+      <ThemeProvider variations={sysVariations}>
+        <span>x</span>
+      </ThemeProvider>,
+    )
+    // Effect resolves systemColorScheme = 'dark' → matches system variation.
+    expect(container.querySelector('[data-tk-theme="systemDark"]')).not.toBeNull()
+  })
+})
+
+describe('<ThemeProvider> SSR safety (US-3)', () => {
+  it('renderToString output does NOT contain data-tk-theme="dark"', () => {
+    const html = renderToString(
+      <ThemeProvider variations={variations} forceMode="dark">
+        <span>x</span>
+      </ThemeProvider>,
+    )
+    expect(html).not.toContain('data-tk-theme="dark"')
+    // Acceptable: neutral default attribute (no per-variation theme leak).
+    expect(html).toContain('data-tk-theme="default"')
+  })
+
+  it('renderToString does not emit inline style on the wrapper', () => {
+    // Inline style is computed client-side; emitting it server-side would
+    // diverge from the first client render and trip hydration warnings.
+    const html = renderToString(
+      <ThemeProvider variations={variations} forceMode="dark">
+        <span>x</span>
+      </ThemeProvider>,
+    )
+    expect(html).not.toMatch(/style="[^"]*--tour-card-bg/)
+  })
+})
+
+describe('<ThemeProvider> render budget (US-2)', () => {
+  it('renders the provider subtree at most twice per route change', () => {
+    const counter = vi.fn()
+
+    const urlVariations: ThemeVariation[] = [
+      { id: 'home', when: { kind: 'url', pattern: '/' }, theme: {} },
+      { id: 'billing', when: { kind: 'url', pattern: '/billing' }, theme: {} },
+      { id: 'docs', when: { kind: 'url', pattern: '/docs', mode: 'startsWith' }, theme: {} },
+      {
+        id: 'admin',
+        when: { kind: 'url', pattern: /^\/admin/ },
+        theme: {},
+      },
+    ]
+
+    const router = createMockRouter('/')
+
+    function ContextConsumer() {
+      const ctx = useThemeContext()
+      return <span data-testid="ctx">{ctx.activeId}</span>
+    }
+
+    render(
+      <React.Profiler id="theme" onRender={counter}>
+        <ThemeProvider variations={urlVariations} router={router}>
+          <ContextConsumer />
+        </ThemeProvider>
+      </React.Profiler>,
+    )
+
+    // Reset render count after initial mount; we only measure the cost of one
+    // route change (the budget set in Phase 0 spike 0.3).
+    counter.mockClear()
+
+    act(() => {
+      router.navigate('/billing')
+    })
+
+    expect(counter.mock.calls.length).toBeLessThanOrEqual(2)
+  })
+})
+
+describe('useThemeContext', () => {
+  it('throws when used outside <ThemeProvider>', () => {
+    function Consumer() {
+      useThemeContext()
+      return null
+    }
+    // Suppress React's expected error output for this negative-path test.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<Consumer />)).toThrow(
+      /useThemeContext must be used inside <ThemeProvider>/,
+    )
+    spy.mockRestore()
+  })
+
+  it('returns active theme context inside <ThemeProvider>', () => {
+    function Consumer() {
+      const ctx = useThemeContext()
+      return <span data-testid="active">{ctx.activeId}</span>
+    }
+    const { getByTestId } = render(
+      <ThemeProvider variations={variations} forceMode="light">
+        <Consumer />
+      </ThemeProvider>,
+    )
+    expect(getByTestId('active').textContent).toBe('light')
+  })
+})

--- a/packages/react/src/__tests__/theme/theme-resolver.test.ts
+++ b/packages/react/src/__tests__/theme/theme-resolver.test.ts
@@ -56,9 +56,7 @@ describe('resolveTheme: priority order (US-1)', () => {
   })
 
   it('returns null when variations is empty', () => {
-    expect(
-      resolveTheme([], { systemColorScheme: 'light', route: '/anywhere' }),
-    ).toBeNull()
+    expect(resolveTheme([], { systemColorScheme: 'light', route: '/anywhere' })).toBeNull()
   })
 })
 
@@ -100,7 +98,7 @@ describe('matchUrl modes (US-1)', () => {
 describe('resolver purity (US-4)', () => {
   const resolverPath = resolve(
     dirname(fileURLToPath(import.meta.url)),
-    '../../components/theme/theme-resolver.ts',
+    '../../components/theme/theme-resolver.ts'
   )
   const source = readFileSync(resolverPath, 'utf-8')
 

--- a/packages/react/src/__tests__/theme/theme-resolver.test.ts
+++ b/packages/react/src/__tests__/theme/theme-resolver.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { matchUrl, resolveTheme } from '../../components/theme/theme-resolver'
+import type { ThemeVariation } from '../../components/theme/types'
+
+const dark: ThemeVariation = { id: 'dark', when: { kind: 'dark' }, theme: {} }
+const light: ThemeVariation = { id: 'light', when: { kind: 'light' }, theme: {} }
+const system: ThemeVariation = { id: 'system', when: { kind: 'system' }, theme: {} }
+const billing: ThemeVariation = {
+  id: 'billing',
+  when: { kind: 'url', pattern: '/billing' },
+  theme: {},
+}
+
+describe('resolveTheme: priority order (US-1)', () => {
+  it('explicit dark wins over URL match', () => {
+    const result = resolveTheme([dark, billing], {
+      systemColorScheme: 'light',
+      route: '/billing',
+    })
+    expect(result?.id).toBe('dark')
+  })
+
+  it('explicit light wins over URL match in declaration order', () => {
+    const result = resolveTheme([light, billing], {
+      systemColorScheme: 'dark',
+      route: '/billing',
+    })
+    expect(result?.id).toBe('light')
+  })
+
+  it('URL match wins over system fallback', () => {
+    const result = resolveTheme([billing, system], {
+      systemColorScheme: 'light',
+      route: '/billing',
+    })
+    expect(result?.id).toBe('billing')
+  })
+
+  it('system fallback when no URL match', () => {
+    const result = resolveTheme([billing, system], {
+      systemColorScheme: 'dark',
+      route: '/unmatched',
+    })
+    expect(result?.id).toBe('system')
+  })
+
+  it('falls back to first variation when nothing matches', () => {
+    const result = resolveTheme([billing, system], {
+      systemColorScheme: null,
+      route: null,
+    })
+    expect(result?.id).toBe('billing')
+  })
+
+  it('returns null when variations is empty', () => {
+    expect(
+      resolveTheme([], { systemColorScheme: 'light', route: '/anywhere' }),
+    ).toBeNull()
+  })
+})
+
+describe('matchUrl modes (US-1)', () => {
+  it.each([
+    ['exact match', { kind: 'url' as const, pattern: '/billing' }, '/billing', true],
+    ['exact non-match', { kind: 'url' as const, pattern: '/billing' }, '/dashboard', false],
+    [
+      'startsWith hit',
+      { kind: 'url' as const, pattern: '/admin', mode: 'startsWith' as const },
+      '/admin/users',
+      true,
+    ],
+    [
+      'startsWith miss',
+      { kind: 'url' as const, pattern: '/admin', mode: 'startsWith' as const },
+      '/billing',
+      false,
+    ],
+    [
+      'contains hit',
+      { kind: 'url' as const, pattern: 'billing', mode: 'contains' as const },
+      '/v2/billing/details',
+      true,
+    ],
+    [
+      'contains miss',
+      { kind: 'url' as const, pattern: 'billing', mode: 'contains' as const },
+      '/v2/dashboard',
+      false,
+    ],
+    ['regex hit', { kind: 'url' as const, pattern: /^\/admin/ }, '/admin/users', true],
+    ['regex miss', { kind: 'url' as const, pattern: /^\/admin/ }, '/billing', false],
+  ])('%s', (_label, matcher, route, expected) => {
+    expect(matchUrl(matcher, route as string)).toBe(expected)
+  })
+})
+
+describe('resolver purity (US-4)', () => {
+  const resolverPath = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../components/theme/theme-resolver.ts',
+  )
+  const source = readFileSync(resolverPath, 'utf-8')
+
+  it('does not import react or react-dom', () => {
+    expect(source).not.toMatch(/from\s+['"]react['"]/)
+    expect(source).not.toMatch(/from\s+['"]react-dom['"]/)
+  })
+
+  it('does not reference window or document', () => {
+    expect(source).not.toMatch(/\bwindow\b/)
+    expect(source).not.toMatch(/\bdocument\b/)
+  })
+})

--- a/packages/react/src/components/theme/index.ts
+++ b/packages/react/src/components/theme/index.ts
@@ -1,0 +1,9 @@
+export { ThemeProvider, useThemeContext, type ThemeProviderProps } from './theme-provider'
+export type {
+  ThemeContextValue,
+  ThemeMatcher,
+  ThemeResolveContext,
+  ThemeTokens,
+  ThemeVariation,
+} from './types'
+export { matchUrl, resolveTheme } from './theme-resolver'

--- a/packages/react/src/components/theme/theme-provider.tsx
+++ b/packages/react/src/components/theme/theme-provider.tsx
@@ -23,33 +23,24 @@ export function ThemeProvider({
   defaultId = 'default',
   children,
 }: ThemeProviderProps) {
-  // SSR-safe initial state — never compute on server. The first client effect
-  // resolves and applies the active theme to avoid hydration mismatches.
+  // Server render and first client render both emit `defaultId` because state
+  // is initialized to it and no effect has run yet — so hydration matches.
+  // The effect below flips it to the resolved variation after mount.
   const [activeId, setActiveId] = React.useState<string>(defaultId)
   const [tokens, setTokens] = React.useState<ThemeTokens>({})
   const [route, setRoute] = React.useState<string | null>(null)
-  const [mounted, setMounted] = React.useState(false)
 
   const isDark = useMediaQuery('(prefers-color-scheme: dark)')
-  const systemColorScheme: 'light' | 'dark' | null = mounted
-    ? isDark
-      ? 'dark'
-      : 'light'
-    : null
-
-  React.useEffect(() => {
-    setMounted(true)
-  }, [])
+  const systemColorScheme: 'light' | 'dark' | null =
+    typeof window === 'undefined' ? null : isDark ? 'dark' : 'light'
 
   React.useEffect(() => {
     if (!router) return
     setRoute(router.getCurrentRoute())
-    const unsubscribe = router.onRouteChange((next) => setRoute(next))
-    return unsubscribe
+    return router.onRouteChange((next) => setRoute(next))
   }, [router])
 
   React.useEffect(() => {
-    if (!mounted) return
     if (forceMode) {
       const forced = variations.find((v) => v.when.kind === forceMode)
       if (forced) {
@@ -63,20 +54,13 @@ export function ThemeProvider({
       setActiveId(match.id)
       setTokens(match.theme)
     }
-  }, [variations, systemColorScheme, route, forceMode, mounted])
+  }, [variations, systemColorScheme, route, forceMode])
 
-  const value = React.useMemo<ThemeContextValue>(
-    () => ({ activeId, tokens }),
-    [activeId, tokens],
-  )
-
-  // Server render and first client render emit the same `defaultId` attribute,
-  // so hydration matches. The effect above flips it to the resolved variation.
-  const styleProp = mounted ? (tokens as React.CSSProperties) : undefined
+  const value = React.useMemo<ThemeContextValue>(() => ({ activeId, tokens }), [activeId, tokens])
 
   return (
     <ThemeContext.Provider value={value}>
-      <div data-tk-theme={mounted ? activeId : defaultId} style={styleProp}>
+      <div data-tk-theme={activeId} style={tokens as React.CSSProperties}>
         {children}
       </div>
     </ThemeContext.Provider>

--- a/packages/react/src/components/theme/theme-provider.tsx
+++ b/packages/react/src/components/theme/theme-provider.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useMediaQuery } from '@tour-kit/core'
+import type { RouterAdapter } from '@tour-kit/core'
+import * as React from 'react'
+import { resolveTheme } from './theme-resolver'
+import type { ThemeContextValue, ThemeTokens, ThemeVariation } from './types'
+
+const ThemeContext = React.createContext<ThemeContextValue | null>(null)
+
+export interface ThemeProviderProps {
+  variations: ThemeVariation[]
+  router?: RouterAdapter
+  forceMode?: 'dark' | 'light' | null
+  defaultId?: string
+  children: React.ReactNode
+}
+
+export function ThemeProvider({
+  variations,
+  router,
+  forceMode = null,
+  defaultId = 'default',
+  children,
+}: ThemeProviderProps) {
+  // SSR-safe initial state — never compute on server. The first client effect
+  // resolves and applies the active theme to avoid hydration mismatches.
+  const [activeId, setActiveId] = React.useState<string>(defaultId)
+  const [tokens, setTokens] = React.useState<ThemeTokens>({})
+  const [route, setRoute] = React.useState<string | null>(null)
+  const [mounted, setMounted] = React.useState(false)
+
+  const isDark = useMediaQuery('(prefers-color-scheme: dark)')
+  const systemColorScheme: 'light' | 'dark' | null = mounted
+    ? isDark
+      ? 'dark'
+      : 'light'
+    : null
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  React.useEffect(() => {
+    if (!router) return
+    setRoute(router.getCurrentRoute())
+    const unsubscribe = router.onRouteChange((next) => setRoute(next))
+    return unsubscribe
+  }, [router])
+
+  React.useEffect(() => {
+    if (!mounted) return
+    if (forceMode) {
+      const forced = variations.find((v) => v.when.kind === forceMode)
+      if (forced) {
+        setActiveId(forced.id)
+        setTokens(forced.theme)
+        return
+      }
+    }
+    const match = resolveTheme(variations, { systemColorScheme, route })
+    if (match) {
+      setActiveId(match.id)
+      setTokens(match.theme)
+    }
+  }, [variations, systemColorScheme, route, forceMode, mounted])
+
+  const value = React.useMemo<ThemeContextValue>(
+    () => ({ activeId, tokens }),
+    [activeId, tokens],
+  )
+
+  // Server render and first client render emit the same `defaultId` attribute,
+  // so hydration matches. The effect above flips it to the resolved variation.
+  const styleProp = mounted ? (tokens as React.CSSProperties) : undefined
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <div data-tk-theme={mounted ? activeId : defaultId} style={styleProp}>
+        {children}
+      </div>
+    </ThemeContext.Provider>
+  )
+}
+
+export function useThemeContext(): ThemeContextValue {
+  const ctx = React.useContext(ThemeContext)
+  if (!ctx) {
+    throw new Error('useThemeContext must be used inside <ThemeProvider>')
+  }
+  return ctx
+}

--- a/packages/react/src/components/theme/theme-resolver.ts
+++ b/packages/react/src/components/theme/theme-resolver.ts
@@ -1,0 +1,39 @@
+import type { ThemeMatcher, ThemeResolveContext, ThemeVariation } from './types'
+
+export function matchUrl(
+  matcher: Extract<ThemeMatcher, { kind: 'url' }>,
+  route: string,
+): boolean {
+  const { pattern, mode = 'exact' } = matcher
+  if (pattern instanceof RegExp) return pattern.test(route)
+  switch (mode) {
+    case 'exact':
+      return route === pattern
+    case 'startsWith':
+      return route.startsWith(pattern)
+    case 'contains':
+      return route.includes(pattern)
+    default:
+      return route === pattern
+  }
+}
+
+export function resolveTheme(
+  variations: ThemeVariation[],
+  ctx: ThemeResolveContext,
+): ThemeVariation | null {
+  for (const v of variations) {
+    if (v.when.kind === 'dark' || v.when.kind === 'light') return v
+  }
+  if (ctx.route) {
+    for (const v of variations) {
+      if (v.when.kind === 'url' && matchUrl(v.when, ctx.route)) return v
+    }
+  }
+  if (ctx.systemColorScheme) {
+    for (const v of variations) {
+      if (v.when.kind === 'system') return v
+    }
+  }
+  return variations[0] ?? null
+}

--- a/packages/react/src/components/theme/theme-resolver.ts
+++ b/packages/react/src/components/theme/theme-resolver.ts
@@ -1,9 +1,6 @@
 import type { ThemeMatcher, ThemeResolveContext, ThemeVariation } from './types'
 
-export function matchUrl(
-  matcher: Extract<ThemeMatcher, { kind: 'url' }>,
-  route: string,
-): boolean {
+export function matchUrl(matcher: Extract<ThemeMatcher, { kind: 'url' }>, route: string): boolean {
   const { pattern, mode = 'exact' } = matcher
   if (pattern instanceof RegExp) return pattern.test(route)
   switch (mode) {
@@ -18,22 +15,32 @@ export function matchUrl(
   }
 }
 
+function findExplicit(variations: ThemeVariation[]): ThemeVariation | undefined {
+  return variations.find((v) => v.when.kind === 'dark' || v.when.kind === 'light')
+}
+
+function findUrl(variations: ThemeVariation[], route: string | null): ThemeVariation | undefined {
+  if (!route) return undefined
+  return variations.find((v) => v.when.kind === 'url' && matchUrl(v.when, route))
+}
+
+function findSystem(
+  variations: ThemeVariation[],
+  scheme: 'light' | 'dark' | null
+): ThemeVariation | undefined {
+  if (!scheme) return undefined
+  return variations.find((v) => v.when.kind === 'system')
+}
+
 export function resolveTheme(
   variations: ThemeVariation[],
-  ctx: ThemeResolveContext,
+  ctx: ThemeResolveContext
 ): ThemeVariation | null {
-  for (const v of variations) {
-    if (v.when.kind === 'dark' || v.when.kind === 'light') return v
-  }
-  if (ctx.route) {
-    for (const v of variations) {
-      if (v.when.kind === 'url' && matchUrl(v.when, ctx.route)) return v
-    }
-  }
-  if (ctx.systemColorScheme) {
-    for (const v of variations) {
-      if (v.when.kind === 'system') return v
-    }
-  }
-  return variations[0] ?? null
+  return (
+    findExplicit(variations) ??
+    findUrl(variations, ctx.route) ??
+    findSystem(variations, ctx.systemColorScheme) ??
+    variations[0] ??
+    null
+  )
 }

--- a/packages/react/src/components/theme/types.ts
+++ b/packages/react/src/components/theme/types.ts
@@ -1,0 +1,27 @@
+export type ThemeTokens = Record<string, string>
+
+export type ThemeMatcher =
+  | { kind: 'system' }
+  | { kind: 'dark' }
+  | { kind: 'light' }
+  | {
+      kind: 'url'
+      pattern: string | RegExp
+      mode?: 'exact' | 'startsWith' | 'contains'
+    }
+
+export interface ThemeVariation {
+  id: string
+  when: ThemeMatcher
+  theme: ThemeTokens
+}
+
+export interface ThemeResolveContext {
+  systemColorScheme: 'light' | 'dark' | null
+  route: string | null
+}
+
+export interface ThemeContextValue {
+  activeId: string
+  tokens: ThemeTokens
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -32,6 +32,20 @@ export {
   type MultiTourKitProviderProps,
 } from './components/provider/tourkit-provider'
 
+// Theme
+export {
+  ThemeProvider,
+  useThemeContext,
+  resolveTheme,
+  matchUrl,
+  type ThemeProviderProps,
+  type ThemeContextValue,
+  type ThemeMatcher,
+  type ThemeResolveContext,
+  type ThemeTokens,
+  type ThemeVariation,
+} from './components/theme'
+
 // ============================================
 // UI VARIANTS (for customization)
 // ============================================

--- a/packages/react/src/styles/variables.css
+++ b/packages/react/src/styles/variables.css
@@ -86,6 +86,42 @@
   }
 }
 
+/* ==========================================================================
+   Theme variations
+   --------------------------------------------------------------------------
+   Tour Kit uses an attribute-swap pattern (data-tk-theme) rather than the
+   next-themes "render both UIs and CSS-hide one" approach. Because the tour
+   UI is a small controlled portal with no nested host content, swapping the
+   attribute is correct and far cheaper. Do NOT change this without revisiting
+   plan/phase-1-4a-theme-foundation.md § Key design decisions.
+
+   These attribute selectors live OUTSIDE @layer base intentionally so that
+   they win over the @media (prefers-color-scheme: dark) block above when a
+   <ThemeProvider> explicitly forces a theme.
+   ========================================================================== */
+
+[data-tk-theme="dark"] {
+  --tour-card-bg: #0a0a0a;
+  --tour-card-fg: #fafafa;
+  --tour-card-border: #262626;
+  --tour-overlay-bg: rgba(0, 0, 0, 0.7);
+  --tour-secondary-fg: #fafafa;
+  --tour-secondary-border: #262626;
+  --tour-secondary-hover: #262626;
+  --tour-muted-fg: #a3a3a3;
+}
+
+[data-tk-theme="light"] {
+  --tour-card-bg: #ffffff;
+  --tour-card-fg: #171717;
+  --tour-card-border: #e5e7eb;
+  --tour-overlay-bg: rgba(0, 0, 0, 0.5);
+  --tour-secondary-fg: #171717;
+  --tour-secondary-border: #e5e7eb;
+  --tour-secondary-hover: #f5f5f5;
+  --tour-muted-fg: #737373;
+}
+
 /* ===== Keyframes (for non-Tailwind projects) ===== */
 @keyframes tour-pulse {
   0%,


### PR DESCRIPTION
## Summary
- Adds `<ThemeProvider>` to `@tour-kit/react` that resolves a theme dynamically at render time from `dark` / `light` / `system` / URL match, with no remount and **no React tree re-render outside the provider's own subtree**.
- Themes are applied via a `data-tk-theme` attribute on the provider root + CSS attribute selectors in `variables.css`. 90% of components don't subscribe to React context — they read `var(--tour-*)` and the browser swaps styles when the attribute flips.
- SSR-safe via the Comeau pattern: the server-rendered HTML emits a fixed neutral `data-tk-theme="default"` (and no inline CSS-variable style); the first client effect resolves and applies the active variation. No hydration warnings.

## Public API additions (all from `@tour-kit/react`)
- `ThemeProvider`, `useThemeContext`, `resolveTheme`, `matchUrl`
- `ThemeProviderProps`, `ThemeContextValue`, `ThemeMatcher`, `ThemeResolveContext`, `ThemeTokens`, `ThemeVariation`

`ThemeMatcher` is a closed discriminated union over `'system' | 'dark' | 'light' | 'url'`. Phase 4b will extend it with `'predicate'`; `resolveTheme` already uses pattern-based priority resolution that is forward-compatible.

## Tests
- 6 resolver cases (priority order: explicit `dark`/`light` → URL → system → first; empty → null).
- 8 `matchUrl` cases (`exact`/`startsWith`/`contains` hit & miss + `RegExp` hit & miss).
- 2 resolver-purity static checks (no `react`/`react-dom` import; no `window`/`document`).
- 4 provider component cases (renders children, `forceMode='dark'`, URL flip via mock router, system flip via `matchMedia` mock).
- 2 SSR safety cases (`renderToString` does NOT contain `data-tk-theme="dark"`; emits no inline `--tour-*` style).
- 1 render-budget perf gate (≤ 2 React renders per route change, per Phase 0 spike 0.3 budget).
- 2 `useThemeContext` cases (throws outside provider; returns active context inside).

Total: **25 new tests**, all green. Full `@tour-kit/react` suite: **418/418 passing**.

## Test plan
- [x] `pnpm --filter @tour-kit/react test src/__tests__/theme` → 25/25 passing
- [x] `pnpm --filter @tour-kit/react test` → 418/418 passing
- [x] `pnpm typecheck` (full monorepo) → 26/26 turbo tasks green
- [x] `pnpm --filter @tour-kit/react build` → success (ESM + CJS + DTS)
- [x] Changeset: `@tour-kit/react: minor`
- [ ] Manual: `cd apps/docs && pnpm dev` with a `<ThemeProvider>`-wrapped tour shows zero hydration warnings

## Out of scope
- Trait/predicate matchers — Phase 4b
- `useThemeVariation` consumer hook — Phase 4b (use `useThemeContext` until then)
- Theming the docs site itself

Refs: `plan/phase-1-4a-theme-foundation.md`, `plan/phase-1-4a-theme-foundation-tests.md`.