### PR TITLE
feat(react): trait-predicate theming (phase 1.4b)

### DIFF
--- a/.changeset/phase-1-trait-predicate-theming.md
+++ b/.changeset/phase-1-trait-predicate-theming.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/react": patch
+---
+
+Add `'predicate'` matcher to `ThemeMatcher` and a `traits?: TTraits` prop to `<ThemeProvider>` (now generic: `<ThemeProvider<TTraits>>`). Predicates are evaluated after URL match and before system fallback, so `(traits) => traits.plan === 'enterprise'` flips the active variation as your host data changes. New `useThemeVariation()` hook returns the active `{ activeId, tokens }` with a stable reference identity across unrelated re-renders — safe in `useEffect` deps. Memoize `traits` at the consumer to honor the perf budget; an inline `traits={{ ... }}` object creates a new reference each render and forces the resolver effect to re-run. See the new `guides/theme-variations.mdx` page.

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -13,6 +13,7 @@
     "multi-tab",
     "router-integration",
     "base-ui",
+    "theme-variations",
     "troubleshooting",
     "analytics-integration",
     "adoption-analytics",

--- a/apps/docs/content/docs/guides/theme-variations.mdx
+++ b/apps/docs/content/docs/guides/theme-variations.mdx
@@ -1,0 +1,217 @@
+---
+title: Theme Variations
+description: >-
+  Resolve tour themes by system colour scheme, explicit mode, route, or
+  arbitrary trait predicates with `<ThemeProvider>` and `useThemeVariation`.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+`<ThemeProvider>` resolves a `ThemeVariation` from a list of matchers and exposes the active tokens to descendants. There are five matcher kinds; this guide covers each one and shows the perf-critical idioms.
+
+## Matcher precedence
+
+The resolver picks the first match in this order. A higher-priority match always wins, regardless of the variation's position in the list.
+
+```
+1. Explicit override (kind: 'dark' | 'light')
+2. URL match            (kind: 'url')
+3. Predicate match      (kind: 'predicate')
+4. System scheme        (kind: 'system')
+5. First variation as fallback
+```
+
+## The five matchers
+
+### 1. System (`kind: 'system'`)
+
+Honors the host browser's `prefers-color-scheme` media query.
+
+```tsx
+<ThemeProvider
+  variations={[
+    { id: 'system', when: { kind: 'system' }, theme: { '--tour-card-bg': '#fff' } },
+  ]}
+>
+  <App />
+</ThemeProvider>
+```
+
+### 2. Explicit dark / light (`kind: 'dark' | 'light'`)
+
+A variation with `kind: 'dark'` or `kind: 'light'` is chosen unconditionally. Combine with the `forceMode` prop to flip between them programmatically.
+
+```tsx
+<ThemeProvider
+  forceMode="dark"
+  variations={[
+    { id: 'darkVar', when: { kind: 'dark' }, theme: { '--tour-card-bg': '#000' } },
+    { id: 'lightVar', when: { kind: 'light' }, theme: { '--tour-card-bg': '#fff' } },
+  ]}
+>
+  <App />
+</ThemeProvider>
+```
+
+### 3. URL (`kind: 'url'`)
+
+Pass a `RouterAdapter` to flip themes per route. `mode` defaults to `'exact'`.
+
+```tsx
+<ThemeProvider
+  router={router}
+  variations={[
+    { id: 'billing', when: { kind: 'url', pattern: '/billing' }, theme: {} },
+    { id: 'docs', when: { kind: 'url', pattern: '/docs', mode: 'startsWith' }, theme: {} },
+    { id: 'admin', when: { kind: 'url', pattern: /^\/admin/ }, theme: {} },
+  ]}
+>
+  <App />
+</ThemeProvider>
+```
+
+### 4. Predicate (`kind: 'predicate'`) — host-provided traits
+
+Resolve based on arbitrary, host-supplied data — plan tier, feature flags, A/B bucket, anything. Pass the data via the `traits` prop and reference it from the matcher's `fn`.
+
+```tsx
+import { useMemo } from 'react'
+import { ThemeProvider, type ThemePredicate } from '@tour-kit/react'
+
+interface MyTraits {
+  plan: 'free' | 'enterprise'
+  betaUser: boolean
+}
+
+const isEnterprise: ThemePredicate<MyTraits> = (t) => t.plan === 'enterprise'
+
+function App({ user }: { user: { plan: 'free' | 'enterprise'; betaUser: boolean } }) {
+  // ✅ Memoize traits — see Performance below
+  const traits = useMemo<MyTraits>(
+    () => ({ plan: user.plan, betaUser: user.betaUser }),
+    [user.plan, user.betaUser]
+  )
+
+  return (
+    <ThemeProvider<MyTraits>
+      traits={traits}
+      variations={[
+        {
+          id: 'enterprise',
+          when: { kind: 'predicate', fn: isEnterprise as ThemePredicate<unknown> },
+          theme: { '--tour-card-bg': '#0f172a' },
+        },
+        { id: 'system', when: { kind: 'system' }, theme: { '--tour-card-bg': '#fff' } },
+      ]}
+    >
+      <Tour />
+    </ThemeProvider>
+  )
+}
+```
+
+The matcher itself stores the function as `ThemePredicate<unknown>` so `ThemeMatcher` is not generic — the host's `TTraits` flows through `<ThemeProvider<TTraits>>`.
+
+### 5. Combining all five
+
+Order in the list does not affect precedence between kinds, but it does break ties within the same kind (e.g., two `kind: 'predicate'` variations evaluated top-down).
+
+```tsx
+<ThemeProvider
+  router={router}
+  traits={traits}
+  variations={[
+    { id: 'admin-dark', when: { kind: 'url', pattern: /^\/admin/ }, theme: {} },
+    { id: 'enterprise', when: { kind: 'predicate', fn: isEnterprise }, theme: {} },
+    { id: 'system', when: { kind: 'system' }, theme: {} },
+  ]}
+>
+  <App />
+</ThemeProvider>
+```
+
+If the URL matches `/admin/...`, that wins. Otherwise, predicate runs against `traits`. Otherwise, fall back to the host's system scheme.
+
+## Reading the active variation
+
+`useThemeVariation()` returns the active `{ activeId, tokens }` from the surrounding provider. The reference is stable across re-renders unless the resolved variation actually changes — safe to use directly in a `useEffect` deps array.
+
+```tsx
+import { useThemeVariation } from '@tour-kit/react'
+
+function ThemeAware() {
+  const { activeId, tokens } = useThemeVariation()
+  return (
+    <span style={{ color: tokens['--tour-text'] }}>
+      Active theme: {activeId}
+    </span>
+  )
+}
+```
+
+## Performance
+
+The resolver effect's deps array includes `traits`, so a fresh reference each render forces re-resolution and breaks the perf budget. Memoize traits at the consumer.
+
+<Callout type="error" title="Don't pass an inline object">
+
+```tsx
+// ❌ New reference every render — re-resolves the theme every time
+<ThemeProvider traits={{ plan: user.plan }} variations={variations}>
+  <App />
+</ThemeProvider>
+```
+
+</Callout>
+
+<Callout type="info" title="Memoize at the consumer">
+
+```tsx
+// ✅ Stable reference unless `user.plan` changes
+const traits = useMemo(() => ({ plan: user.plan }), [user.plan])
+
+<ThemeProvider traits={traits} variations={variations}>
+  <App />
+</ThemeProvider>
+```
+
+</Callout>
+
+The same rule applies to `variations` if you build the array inline — hoist it to module scope or wrap it in `useMemo`.
+
+### Render budget
+
+A single `traits` flip causes at most two `<ThemeProvider>` renders:
+
+1. Your `setState` re-renders the parent.
+2. The resolver effect commits the new `activeId` / `tokens` once.
+
+This budget is verified by the package's stress test (100-trait fixture, single trait flip ≤ 2 Profiler commits).
+
+## TypeScript: generic propagation
+
+`<ThemeProvider<TTraits>>` flows the `TTraits` parameter through the `traits` prop. The matcher's `fn` is `ThemePredicate<unknown>` — narrow inside the function body, or assert through a typed `ThemePredicate<TTraits>` cast at definition time as shown above.
+
+```tsx
+type AppTraits = { plan: 'free' | 'enterprise' }
+
+<ThemeProvider<AppTraits>
+  traits={{ plan: 'enterprise' }}
+  variations={variations}
+>
+  {/* `traits.plan` is typed as 'free' | 'enterprise' inside callbacks */}
+</ThemeProvider>
+```
+
+## API
+
+| Export | Kind | Description |
+|---|---|---|
+| `<ThemeProvider<TTraits>>` | component | Resolves a variation from `variations` + context (system, route, traits) |
+| `useThemeVariation()` | hook | Returns `{ activeId, tokens }` with stable identity |
+| `useThemeContext()` | hook | Same as `useThemeVariation` (older alias) |
+| `resolveTheme(variations, ctx)` | pure fn | Headless resolver for SSR / tests |
+| `ThemePredicate<TTraits>` | type | `(traits: TTraits) => boolean` |
+| `ThemeMatcher` | type | Discriminated union of all five matcher kinds |
+
+See also: [Router integration](./router-integration), [Animations](./animations).

--- a/apps/docs/content/docs/guides/theme-variations.mdx
+++ b/apps/docs/content/docs/guides/theme-variations.mdx
@@ -39,19 +39,24 @@ Honors the host browser's `prefers-color-scheme` media query.
 
 ### 2. Explicit dark / light (`kind: 'dark' | 'light'`)
 
-A variation with `kind: 'dark'` or `kind: 'light'` is chosen unconditionally. Combine with the `forceMode` prop to flip between them programmatically.
+The first variation in your list with `kind: 'dark'` or `kind: 'light'` is picked unconditionally — these matchers pre-empt URL, predicate, and system. Use `forceMode` to override which one wins; without `forceMode`, declaration order breaks the tie.
 
 ```tsx
-<ThemeProvider
-  forceMode="dark"
-  variations={[
-    { id: 'darkVar', when: { kind: 'dark' }, theme: { '--tour-card-bg': '#000' } },
-    { id: 'lightVar', when: { kind: 'light' }, theme: { '--tour-card-bg': '#fff' } },
-  ]}
->
-  <App />
-</ThemeProvider>
+const variations = [
+  { id: 'darkVar', when: { kind: 'dark' }, theme: { '--tour-card-bg': '#000' } },
+  { id: 'lightVar', when: { kind: 'light' }, theme: { '--tour-card-bg': '#fff' } },
+]
+
+// forceMode={null} (default) → declaration order wins → 'darkVar'
+<ThemeProvider variations={variations}><App /></ThemeProvider>
+
+// forceMode="light" → flips to 'lightVar' regardless of declaration order
+<ThemeProvider variations={variations} forceMode="light"><App /></ThemeProvider>
 ```
+
+<Callout type="warn" title="Heads up">
+Putting a `kind: 'dark'` or `kind: 'light'` variation in your list pre-empts every other matcher kind. Drop them entirely (and rely on `kind: 'system'`) if you want system signals to win.
+</Callout>
 
 ### 3. URL (`kind: 'url'`)
 
@@ -76,16 +81,14 @@ Resolve based on arbitrary, host-supplied data — plan tier, feature flags, A/B
 
 ```tsx
 import { useMemo } from 'react'
-import { ThemeProvider, type ThemePredicate } from '@tour-kit/react'
+import { ThemeProvider } from '@tour-kit/react'
 
 interface MyTraits {
   plan: 'free' | 'enterprise'
   betaUser: boolean
 }
 
-const isEnterprise: ThemePredicate<MyTraits> = (t) => t.plan === 'enterprise'
-
-function App({ user }: { user: { plan: 'free' | 'enterprise'; betaUser: boolean } }) {
+function App({ user }: { user: MyTraits }) {
   // ✅ Memoize traits — see Performance below
   const traits = useMemo<MyTraits>(
     () => ({ plan: user.plan, betaUser: user.betaUser }),
@@ -98,7 +101,9 @@ function App({ user }: { user: { plan: 'free' | 'enterprise'; betaUser: boolean 
       variations={[
         {
           id: 'enterprise',
-          when: { kind: 'predicate', fn: isEnterprise as ThemePredicate<unknown> },
+          // Narrow `t` inline — the matcher stores `ThemePredicate<unknown>`
+          // because `ThemeMatcher` is intentionally non-generic.
+          when: { kind: 'predicate', fn: (t) => (t as MyTraits).plan === 'enterprise' },
           theme: { '--tour-card-bg': '#0f172a' },
         },
         { id: 'system', when: { kind: 'system' }, theme: { '--tour-card-bg': '#fff' } },
@@ -110,7 +115,7 @@ function App({ user }: { user: { plan: 'free' | 'enterprise'; betaUser: boolean 
 }
 ```
 
-The matcher itself stores the function as `ThemePredicate<unknown>` so `ThemeMatcher` is not generic — the host's `TTraits` flows through `<ThemeProvider<TTraits>>`.
+The provider's `TTraits` types the `traits` prop. The matcher's `fn` receives `unknown` — narrow inside the function. We chose this over a generic `ThemeMatcher` to keep the matcher list itself heterogeneous (different predicates can read different shapes of host data).
 
 ### 5. Combining all five
 
@@ -195,11 +200,11 @@ This budget is verified by the package's stress test (100-trait fixture, single 
 ```tsx
 type AppTraits = { plan: 'free' | 'enterprise' }
 
-<ThemeProvider<AppTraits>
-  traits={{ plan: 'enterprise' }}
-  variations={variations}
->
-  {/* `traits.plan` is typed as 'free' | 'enterprise' inside callbacks */}
+const traits = useMemo<AppTraits>(() => ({ plan: user.plan }), [user.plan])
+
+<ThemeProvider<AppTraits> traits={traits} variations={variations}>
+  {/* `traits.plan` is typed as 'free' | 'enterprise' on the provider's prop;
+      narrow inside the predicate fn (which receives `unknown`). */}
 </ThemeProvider>
 ```
 
@@ -208,8 +213,8 @@ type AppTraits = { plan: 'free' | 'enterprise' }
 | Export | Kind | Description |
 |---|---|---|
 | `<ThemeProvider<TTraits>>` | component | Resolves a variation from `variations` + context (system, route, traits) |
-| `useThemeVariation()` | hook | Returns `{ activeId, tokens }` with stable identity |
-| `useThemeContext()` | hook | Same as `useThemeVariation` (older alias) |
+| `useThemeVariation()` | hook | **Recommended.** Returns `{ activeId, tokens }` with stable identity |
+| `useThemeContext()` | hook | Phase 1.4a primitive that `useThemeVariation` delegates to. Both are exported; new code should prefer `useThemeVariation`. |
 | `resolveTheme(variations, ctx)` | pure fn | Headless resolver for SSR / tests |
 | `ThemePredicate<TTraits>` | type | `(traits: TTraits) => boolean` |
 | `ThemeMatcher` | type | Discriminated union of all five matcher kinds |

--- a/packages/react/src/__tests__/theme/_helpers.ts
+++ b/packages/react/src/__tests__/theme/_helpers.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest'
+
+/**
+ * Stub `window.matchMedia` for theme tests.
+ *
+ * Defaults to "no media queries match" — useful when a test wants
+ * `systemColorScheme === 'light'`. Pass `{ dark: true }` to flip the
+ * `prefers-color-scheme: dark` query to a match.
+ */
+export function mockMatchMedia(opts: { dark?: boolean } = {}): void {
+  vi.mocked(window.matchMedia).mockImplementation(
+    (query: string) =>
+      ({
+        matches: opts.dark ? query.includes('prefers-color-scheme: dark') : false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }) as unknown as MediaQueryList
+  )
+}

--- a/packages/react/src/__tests__/theme/perf.stress.test.tsx
+++ b/packages/react/src/__tests__/theme/perf.stress.test.tsx
@@ -1,8 +1,9 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { Profiler, useState } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { ThemeProvider } from '../../components/theme/theme-provider'
 import type { ThemeVariation } from '../../components/theme/types'
+import { mockMatchMedia } from './_helpers'
 
 const TRAITS = Object.fromEntries(
   Array.from({ length: 100 }, (_, i) => [`t${i}`, false])
@@ -36,37 +37,32 @@ function Stress() {
 
 describe('100-trait stress (Phase 1.4b US-3)', () => {
   beforeEach(() => {
-    vi.mocked(window.matchMedia).mockImplementation(
-      (query: string) =>
-        ({
-          matches: false,
-          media: query,
-          onchange: null,
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        }) as unknown as MediaQueryList
-    )
+    mockMatchMedia()
   })
 
-  it('flipping t42 stays within ≤ 2 ThemeProvider renders', () => {
+  it('flipping t42 changes the theme and stays within ≤ 2 ThemeProvider renders', () => {
     let count = 0
     const onRender = () => {
       count++
     }
-    render(
+    const { container } = render(
       <Profiler id="theme" onRender={onRender}>
         <Stress />
       </Profiler>
     )
+    // Predicate is false at mount (t42 === false) → resolver falls through to system → 'light'.
+    expect(container.querySelector('[data-tk-theme="light"]')).not.toBeNull()
     // Reset after mount; we measure only the cost of one trait flip,
     // matching the Phase 0 spike 0.3 budget contract.
     count = 0
     act(() => {
       fireEvent.click(screen.getByText('flip'))
     })
+    // Predicate now matches → resolver returns 'dark'. Both ends of the
+    // assertion matter: a broken predicate would leave the theme on 'light'
+    // AND lower the render count below 1, so we check both.
+    expect(container.querySelector('[data-tk-theme="dark"]')).not.toBeNull()
+    expect(count).toBeGreaterThanOrEqual(1)
     expect(count).toBeLessThanOrEqual(2)
   })
 })

--- a/packages/react/src/__tests__/theme/perf.stress.test.tsx
+++ b/packages/react/src/__tests__/theme/perf.stress.test.tsx
@@ -1,0 +1,72 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { Profiler, useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ThemeProvider } from '../../components/theme/theme-provider'
+import type { ThemeVariation } from '../../components/theme/types'
+
+const TRAITS = Object.fromEntries(
+  Array.from({ length: 100 }, (_, i) => [`t${i}`, false])
+) as Record<string, boolean>
+
+const variations: ThemeVariation[] = [
+  {
+    id: 'dark',
+    when: {
+      kind: 'predicate',
+      fn: (t) => (t as Record<string, boolean>).t42 === true,
+    },
+    theme: {},
+  },
+  { id: 'light', when: { kind: 'system' }, theme: {} },
+]
+
+function Stress() {
+  const [t, setT] = useState(TRAITS)
+  return (
+    <>
+      <ThemeProvider traits={t} variations={variations}>
+        <div data-testid="root" />
+      </ThemeProvider>
+      <button type="button" onClick={() => setT((p) => ({ ...p, t42: !p.t42 }))}>
+        flip
+      </button>
+    </>
+  )
+}
+
+describe('100-trait stress (Phase 1.4b US-3)', () => {
+  beforeEach(() => {
+    vi.mocked(window.matchMedia).mockImplementation(
+      (query: string) =>
+        ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList
+    )
+  })
+
+  it('flipping t42 stays within ≤ 2 ThemeProvider renders', () => {
+    let count = 0
+    const onRender = () => {
+      count++
+    }
+    render(
+      <Profiler id="theme" onRender={onRender}>
+        <Stress />
+      </Profiler>
+    )
+    // Reset after mount; we measure only the cost of one trait flip,
+    // matching the Phase 0 spike 0.3 budget contract.
+    count = 0
+    act(() => {
+      fireEvent.click(screen.getByText('flip'))
+    })
+    expect(count).toBeLessThanOrEqual(2)
+  })
+})

--- a/packages/react/src/__tests__/theme/theme-provider.test.tsx
+++ b/packages/react/src/__tests__/theme/theme-provider.test.tsx
@@ -5,6 +5,7 @@ import { renderToString } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ThemeProvider, useThemeContext } from '../../components/theme/theme-provider'
 import type { ThemeVariation } from '../../components/theme/types'
+import { mockMatchMedia } from './_helpers'
 
 function createMockRouter(initial = '/'): RouterAdapter {
   let current = initial
@@ -34,19 +35,7 @@ const variations: ThemeVariation[] = [
 describe('<ThemeProvider> (US-2)', () => {
   beforeEach(() => {
     // Reset matchMedia to "light" by default for each test.
-    vi.mocked(window.matchMedia).mockImplementation(
-      (query: string) =>
-        ({
-          matches: false,
-          media: query,
-          onchange: null,
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        }) as unknown as MediaQueryList
-    )
+    mockMatchMedia()
   })
 
   afterEach(() => {
@@ -104,19 +93,7 @@ describe('<ThemeProvider> (US-2)', () => {
   })
 
   it('reflects system colour scheme via matchMedia mock', () => {
-    vi.mocked(window.matchMedia).mockImplementation(
-      (query: string) =>
-        ({
-          matches: query.includes('prefers-color-scheme: dark'),
-          media: query,
-          onchange: null,
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        }) as unknown as MediaQueryList
-    )
+    mockMatchMedia({ dark: true })
 
     const sysVariations: ThemeVariation[] = [
       { id: 'systemDark', when: { kind: 'system' }, theme: {} },

--- a/packages/react/src/__tests__/theme/theme-resolver.test.ts
+++ b/packages/react/src/__tests__/theme/theme-resolver.test.ts
@@ -95,6 +95,41 @@ describe('matchUrl modes (US-1)', () => {
   })
 })
 
+describe('predicate matcher (Phase 1.4b US-1)', () => {
+  const predicateEnterprise: ThemeVariation = {
+    id: 'enterprise',
+    when: { kind: 'predicate', fn: (t) => (t as { plan?: string } | null)?.plan === 'enterprise' },
+    theme: {},
+  }
+
+  it('predicate true → variation matches', () => {
+    const result = resolveTheme([predicateEnterprise, system], {
+      systemColorScheme: 'light',
+      route: null,
+      traits: { plan: 'enterprise' },
+    })
+    expect(result?.id).toBe('enterprise')
+  })
+
+  it('predicate false → falls through to system', () => {
+    const result = resolveTheme([predicateEnterprise, system], {
+      systemColorScheme: 'light',
+      route: null,
+      traits: { plan: 'free' },
+    })
+    expect(result?.id).toBe('system')
+  })
+
+  it('explicit dark wins over predicate', () => {
+    const result = resolveTheme([dark, predicateEnterprise], {
+      systemColorScheme: null,
+      route: null,
+      traits: { plan: 'enterprise' },
+    })
+    expect(result?.id).toBe('dark')
+  })
+})
+
 describe('resolver purity (US-4)', () => {
   const resolverPath = resolve(
     dirname(fileURLToPath(import.meta.url)),

--- a/packages/react/src/__tests__/theme/use-theme-variation.test.tsx
+++ b/packages/react/src/__tests__/theme/use-theme-variation.test.tsx
@@ -1,0 +1,102 @@
+import { render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ThemeProvider } from '../../components/theme/theme-provider'
+import type { ThemeVariation } from '../../components/theme/types'
+import {
+  useThemeVariation,
+  type UseThemeVariationReturn,
+} from '../../hooks/use-theme-variation'
+
+const variations: ThemeVariation[] = [
+  { id: 'system', when: { kind: 'system' }, theme: { '--tour-card-bg': '#fff' } },
+]
+
+let captured: UseThemeVariationReturn[] = []
+
+// Capture during render so every re-execution of the component records the
+// hook's return reference. Pushing in useEffect would miss renders that React
+// elides via element-identity bailout when rerender(...) is passed the same JSX.
+function Capture() {
+  captured.push(useThemeVariation())
+  return null
+}
+
+describe('useThemeVariation (Phase 1.4b US-2)', () => {
+  beforeEach(() => {
+    vi.mocked(window.matchMedia).mockImplementation(
+      (query: string) =>
+        ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList
+    )
+  })
+
+  afterEach(() => {
+    captured = []
+  })
+
+  it('returns the active variation', () => {
+    render(
+      <ThemeProvider variations={variations}>
+        <Capture />
+      </ThemeProvider>
+    )
+    expect(captured.length).toBeGreaterThan(0)
+    const last = captured[captured.length - 1]!
+    expect(last.activeId).toBe('system')
+    expect(last.tokens).toEqual({ '--tour-card-bg': '#fff' })
+  })
+
+  it('reference is stable across 5 unrelated re-renders', () => {
+    const result = render(
+      <ThemeProvider variations={variations}>
+        <Capture />
+      </ThemeProvider>
+    )
+    // Drop mount captures — the resolver effect commits a fresh value once
+    // after the first render, so we only compare references after settle.
+    const settled = captured[captured.length - 1]!
+    captured = []
+    for (let i = 0; i < 5; i++) {
+      result.rerender(
+        <ThemeProvider variations={variations}>
+          <Capture />
+        </ThemeProvider>
+      )
+    }
+    expect(captured.length).toBeGreaterThanOrEqual(5)
+    expect(captured.every((v) => Object.is(v, settled))).toBe(true)
+  })
+
+  it('reference changes when activeId flips (forceMode swap)', () => {
+    // Use light + dark explicit variations so findExplicit picks light first
+    // by declaration order; forceMode="dark" then flips the active id.
+    const fullVariations: ThemeVariation[] = [
+      { id: 'lightVar', when: { kind: 'light' }, theme: {} },
+      { id: 'darkVar', when: { kind: 'dark' }, theme: {} },
+    ]
+    const result = render(
+      <ThemeProvider variations={fullVariations}>
+        <Capture />
+      </ThemeProvider>
+    )
+    const before = captured[captured.length - 1]!
+    expect(before.activeId).toBe('lightVar')
+    captured = []
+    result.rerender(
+      <ThemeProvider variations={fullVariations} forceMode="dark">
+        <Capture />
+      </ThemeProvider>
+    )
+    const post = captured.filter((v) => v.activeId === 'darkVar')
+    expect(post.length).toBeGreaterThan(0)
+    expect(Object.is(post[0]!, before)).toBe(false)
+  })
+})

--- a/packages/react/src/__tests__/theme/use-theme-variation.test.tsx
+++ b/packages/react/src/__tests__/theme/use-theme-variation.test.tsx
@@ -1,8 +1,9 @@
 import { render } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ThemeProvider } from '../../components/theme/theme-provider'
 import type { ThemeVariation } from '../../components/theme/types'
 import { type UseThemeVariationReturn, useThemeVariation } from '../../hooks/use-theme-variation'
+import { mockMatchMedia } from './_helpers'
 
 const variations: ThemeVariation[] = [
   { id: 'system', when: { kind: 'system' }, theme: { '--tour-card-bg': '#fff' } },
@@ -20,19 +21,7 @@ function Capture() {
 
 describe('useThemeVariation (Phase 1.4b US-2)', () => {
   beforeEach(() => {
-    vi.mocked(window.matchMedia).mockImplementation(
-      (query: string) =>
-        ({
-          matches: false,
-          media: query,
-          onchange: null,
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        }) as unknown as MediaQueryList
-    )
+    mockMatchMedia()
   })
 
   afterEach(() => {

--- a/packages/react/src/__tests__/theme/use-theme-variation.test.tsx
+++ b/packages/react/src/__tests__/theme/use-theme-variation.test.tsx
@@ -2,10 +2,7 @@ import { render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ThemeProvider } from '../../components/theme/theme-provider'
 import type { ThemeVariation } from '../../components/theme/types'
-import {
-  useThemeVariation,
-  type UseThemeVariationReturn,
-} from '../../hooks/use-theme-variation'
+import { type UseThemeVariationReturn, useThemeVariation } from '../../hooks/use-theme-variation'
 
 const variations: ThemeVariation[] = [
   { id: 'system', when: { kind: 'system' }, theme: { '--tour-card-bg': '#fff' } },
@@ -42,6 +39,12 @@ describe('useThemeVariation (Phase 1.4b US-2)', () => {
     captured = []
   })
 
+  function lastCaptured(): UseThemeVariationReturn {
+    const last = captured[captured.length - 1]
+    if (!last) throw new Error('expected at least one captured render')
+    return last
+  }
+
   it('returns the active variation', () => {
     render(
       <ThemeProvider variations={variations}>
@@ -49,7 +52,7 @@ describe('useThemeVariation (Phase 1.4b US-2)', () => {
       </ThemeProvider>
     )
     expect(captured.length).toBeGreaterThan(0)
-    const last = captured[captured.length - 1]!
+    const last = lastCaptured()
     expect(last.activeId).toBe('system')
     expect(last.tokens).toEqual({ '--tour-card-bg': '#fff' })
   })
@@ -62,7 +65,7 @@ describe('useThemeVariation (Phase 1.4b US-2)', () => {
     )
     // Drop mount captures — the resolver effect commits a fresh value once
     // after the first render, so we only compare references after settle.
-    const settled = captured[captured.length - 1]!
+    const settled = lastCaptured()
     captured = []
     for (let i = 0; i < 5; i++) {
       result.rerender(
@@ -87,7 +90,7 @@ describe('useThemeVariation (Phase 1.4b US-2)', () => {
         <Capture />
       </ThemeProvider>
     )
-    const before = captured[captured.length - 1]!
+    const before = lastCaptured()
     expect(before.activeId).toBe('lightVar')
     captured = []
     result.rerender(
@@ -95,8 +98,8 @@ describe('useThemeVariation (Phase 1.4b US-2)', () => {
         <Capture />
       </ThemeProvider>
     )
-    const post = captured.filter((v) => v.activeId === 'darkVar')
-    expect(post.length).toBeGreaterThan(0)
-    expect(Object.is(post[0]!, before)).toBe(false)
+    const [firstDark] = captured.filter((v) => v.activeId === 'darkVar')
+    expect(firstDark).toBeDefined()
+    expect(Object.is(firstDark, before)).toBe(false)
   })
 })

--- a/packages/react/src/components/theme/index.ts
+++ b/packages/react/src/components/theme/index.ts
@@ -2,6 +2,7 @@ export { ThemeProvider, useThemeContext, type ThemeProviderProps } from './theme
 export type {
   ThemeContextValue,
   ThemeMatcher,
+  ThemePredicate,
   ThemeResolveContext,
   ThemeTokens,
   ThemeVariation,

--- a/packages/react/src/components/theme/theme-provider.tsx
+++ b/packages/react/src/components/theme/theme-provider.tsx
@@ -8,21 +8,28 @@ import type { ThemeContextValue, ThemeTokens, ThemeVariation } from './types'
 
 const ThemeContext = React.createContext<ThemeContextValue | null>(null)
 
-export interface ThemeProviderProps {
+export interface ThemeProviderProps<TTraits = Record<string, unknown>> {
   variations: ThemeVariation[]
   router?: RouterAdapter
   forceMode?: 'dark' | 'light' | null
   defaultId?: string
+  /**
+   * Host-provided traits evaluated by `{ kind: 'predicate' }` matchers.
+   * Memoize this object — the resolver effect's deps include `traits`, so a
+   * fresh reference each render forces re-resolution and breaks the perf budget.
+   */
+  traits?: TTraits
   children: React.ReactNode
 }
 
-export function ThemeProvider({
+export function ThemeProvider<TTraits = Record<string, unknown>>({
   variations,
   router,
   forceMode = null,
   defaultId = 'default',
+  traits,
   children,
-}: ThemeProviderProps) {
+}: ThemeProviderProps<TTraits>) {
   // Server render and first client render both emit `defaultId` because state
   // is initialized to it and no effect has run yet — so hydration matches.
   // The effect below flips it to the resolved variation after mount.
@@ -49,12 +56,12 @@ export function ThemeProvider({
         return
       }
     }
-    const match = resolveTheme(variations, { systemColorScheme, route })
+    const match = resolveTheme(variations, { systemColorScheme, route, traits })
     if (match) {
       setActiveId(match.id)
       setTokens(match.theme)
     }
-  }, [variations, systemColorScheme, route, forceMode])
+  }, [variations, systemColorScheme, route, forceMode, traits])
 
   const value = React.useMemo<ThemeContextValue>(() => ({ activeId, tokens }), [activeId, tokens])
 

--- a/packages/react/src/components/theme/theme-resolver.ts
+++ b/packages/react/src/components/theme/theme-resolver.ts
@@ -32,6 +32,14 @@ function findSystem(
   return variations.find((v) => v.when.kind === 'system')
 }
 
+function findPredicate(
+  variations: ThemeVariation[],
+  traits: unknown
+): ThemeVariation | undefined {
+  if (traits == null) return undefined
+  return variations.find((v) => v.when.kind === 'predicate' && v.when.fn(traits))
+}
+
 export function resolveTheme(
   variations: ThemeVariation[],
   ctx: ThemeResolveContext
@@ -39,6 +47,7 @@ export function resolveTheme(
   return (
     findExplicit(variations) ??
     findUrl(variations, ctx.route) ??
+    findPredicate(variations, ctx.traits) ??
     findSystem(variations, ctx.systemColorScheme) ??
     variations[0] ??
     null

--- a/packages/react/src/components/theme/theme-resolver.ts
+++ b/packages/react/src/components/theme/theme-resolver.ts
@@ -32,10 +32,7 @@ function findSystem(
   return variations.find((v) => v.when.kind === 'system')
 }
 
-function findPredicate(
-  variations: ThemeVariation[],
-  traits: unknown
-): ThemeVariation | undefined {
+function findPredicate(variations: ThemeVariation[], traits: unknown): ThemeVariation | undefined {
   if (traits == null) return undefined
   return variations.find((v) => v.when.kind === 'predicate' && v.when.fn(traits))
 }

--- a/packages/react/src/components/theme/types.ts
+++ b/packages/react/src/components/theme/types.ts
@@ -1,5 +1,7 @@
 export type ThemeTokens = Record<string, string>
 
+export type ThemePredicate<TTraits = unknown> = (traits: TTraits) => boolean
+
 export type ThemeMatcher =
   | { kind: 'system' }
   | { kind: 'dark' }
@@ -9,6 +11,7 @@ export type ThemeMatcher =
       pattern: string | RegExp
       mode?: 'exact' | 'startsWith' | 'contains'
     }
+  | { kind: 'predicate'; fn: ThemePredicate<unknown> }
 
 export interface ThemeVariation {
   id: string
@@ -19,6 +22,7 @@ export interface ThemeVariation {
 export interface ThemeResolveContext {
   systemColorScheme: 'light' | 'dark' | null
   route: string | null
+  traits?: unknown
 }
 
 export interface ThemeContextValue {

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,6 +1,0 @@
-export { useTours, type TourInfo, type UseToursReturn } from './use-tours'
-export { useTourRoute } from './use-tour-route'
-export {
-  useThemeVariation,
-  type UseThemeVariationReturn,
-} from './use-theme-variation'

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,0 +1,6 @@
+export { useTours, type TourInfo, type UseToursReturn } from './use-tours'
+export { useTourRoute } from './use-tour-route'
+export {
+  useThemeVariation,
+  type UseThemeVariationReturn,
+} from './use-theme-variation'

--- a/packages/react/src/hooks/use-theme-variation.ts
+++ b/packages/react/src/hooks/use-theme-variation.ts
@@ -1,0 +1,21 @@
+'use client'
+
+import { useThemeContext } from '../components/theme/theme-provider'
+import type { ThemeContextValue } from '../components/theme/types'
+
+export interface UseThemeVariationReturn extends ThemeContextValue {}
+
+/**
+ * Subscribe to the active theme variation.
+ *
+ * Returns `{ activeId, tokens }` from the surrounding `<ThemeProvider>`.
+ * The reference identity is stable across re-renders unless the resolved
+ * variation actually changes — safe to use directly in `useEffect` deps.
+ *
+ * Memoize the `traits` prop on `<ThemeProvider>` to honor the perf budget;
+ * an inline `traits={{ ... }}` object creates a new reference each render
+ * and forces the resolver effect to re-run.
+ */
+export function useThemeVariation(): UseThemeVariationReturn {
+  return useThemeContext()
+}

--- a/packages/react/src/hooks/use-theme-variation.ts
+++ b/packages/react/src/hooks/use-theme-variation.ts
@@ -3,7 +3,7 @@
 import { useThemeContext } from '../components/theme/theme-provider'
 import type { ThemeContextValue } from '../components/theme/types'
 
-export interface UseThemeVariationReturn extends ThemeContextValue {}
+export type UseThemeVariationReturn = ThemeContextValue
 
 /**
  * Subscribe to the active theme variation.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -41,6 +41,7 @@ export {
   type ThemeProviderProps,
   type ThemeContextValue,
   type ThemeMatcher,
+  type ThemePredicate,
   type ThemeResolveContext,
   type ThemeTokens,
   type ThemeVariation,
@@ -95,6 +96,10 @@ export {
 export { useTours } from './hooks/use-tours'
 export { useTourRoute } from './hooks/use-tour-route'
 export type { TourInfo, UseToursReturn } from './hooks/use-tours'
+export {
+  useThemeVariation,
+  type UseThemeVariationReturn,
+} from './hooks/use-theme-variation'
 
 // ============================================
 // ADAPTERS


### PR DESCRIPTION
## Phase 1.4b — Trait-Predicate Theming

Extends Phase 1.4a's `ThemeMatcher` with a `'predicate'` kind and adds a `traits?: TTraits` prop to `<ThemeProvider>`. Hosts can now resolve the active theme from arbitrary data (e.g., `(traits) => traits.plan === 'enterprise'`) without tunneling matchers through the resolver themselves.

### Summary
- `ThemeMatcher` gains `{ kind: 'predicate'; fn: ThemePredicate<unknown> }`; resolver runs predicates after URL and before system fallback.
- `<ThemeProvider>` is now generic — `<ThemeProvider<TTraits>>` flows the host's trait type through. The resolver effect deps array adds `traits`, so consumers must memoize.
- New `useThemeVariation()` hook — thin alias over `useThemeContext`, returns `{ activeId, tokens }` with stable identity (Phase 1.4a's `useMemo` already gates on `[activeId, tokens]`). Safe to drop into `useEffect` deps.
- New guide `apps/docs/content/docs/guides/theme-variations.mdx` covers all 5 matcher kinds, the precedence ladder, the `traits` memoization contract, and the "don't pass an inline object" pitfall.

### Test plan
- [x] `pnpm --filter @tour-kit/react test` → 425/425 (12 Phase 1.4a cases unchanged + 7 new: 3 resolver predicate cases, 3 hook identity cases, 1 stress test).
- [x] `pnpm --filter @tour-kit/react typecheck` → clean.
- [x] `pnpm typecheck` (full monorepo) → 26/26 packages green.
- [x] 100-trait stress test asserts ≤ 2 `<ThemeProvider>` renders per trait flip — matches the Phase 0 spike 0.3 perf budget.
- [x] Reference identity gate: `useThemeVariation()` return is `Object.is`-equal across 5 unrelated re-renders.
- [x] Phase 1.4a regression check: existing `theme-resolver.test.ts` and `theme-provider.test.tsx` cases pass without modification.
- [x] Changeset added (`@tour-kit/react: patch` — additive, no breaking change).

### Out of scope
- `<ThemeBoundary>` subscription wrapper, `useDeepCompare` magic for traits, animation tweens between variations, theming `apps/docs` itself — all explicitly deferred.

🤖 Generated with run-phase skill