### PR TITLE
feat(core,react,checklists): progress variants + animations (phase 1.5)

### DIFF
--- a/.changeset/phase-1-checklist-completion.md
+++ b/.changeset/phase-1-checklist-completion.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/checklists": patch
+---
+
+Add a 200ms `pending → completing → completed` state machine to `<ChecklistTask>`. While in the `completing` phase the root element gains `data-tk-completing="true"`, which the new optional stylesheet `@tour-kit/checklists/styles/animations.css` uses to apply a strike-through label keyframe and a check-icon scale-pop keyframe. The completion phase is skipped entirely when `useReducedMotion()` returns `true`; the CSS additionally wraps the keyframes in `@media (prefers-reduced-motion: reduce) { animation: none }` for defense-in-depth.

--- a/.changeset/phase-1-core-reduced-motion-export.md
+++ b/.changeset/phase-1-core-reduced-motion-export.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/core": minor
+---
+
+Add SSR-safe `useReducedMotion()` hook (Comeau pattern). Defaults to `true` server-side and on the first client render, then flips to the actual `matchMedia('(prefers-reduced-motion: reduce)')` value after the first effect. Designed for animation classes that must default to "no animation" during SSR/first paint to avoid a one-frame motion flash for users who have requested reduced motion. The existing `usePrefersReducedMotion()` hook (defaults to `false`) is preserved for backward compatibility.

--- a/.changeset/phase-1-progress-variants.md
+++ b/.changeset/phase-1-progress-variants.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/react": minor
+---
+
+Extend `<TourProgress>` from 3 to 7 variants. New variants: `narrow` (thin progress bar), `chain` (segmented progress with completed/active/pending status), `numbered` (`"<current> / <total>"` chip), and `none` (renders `null` — useful for compound layouts that opt out). All visible aria-bearing variants expose `role="progressbar"` with `aria-valuenow={current}`, `aria-valuemin={1}`, `aria-valuemax={total}`, and `aria-label="Step N of M"`. Existing `text`, `dots`, and `bar` variants are unchanged.

--- a/.changeset/phase-1-tour-card-docking.md
+++ b/.changeset/phase-1-tour-card-docking.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/react": patch
+---
+
+Add a 150ms docking transition to `<TourCard>` so placement flips (e.g. `bottom` → `top` when the target scrolls near the viewport edge) tween smoothly instead of snapping. The transition class `transition-[transform,top,left] duration-150 ease-out` is applied to the floating element (the same element Floating UI positions via inline `transform`). The class is gated by `useReducedMotion()` from `@tour-kit/core` — users who prefer reduced motion get instant placement updates with no animation.

--- a/apps/docs/content/docs/examples/meta.json
+++ b/apps/docs/content/docs/examples/meta.json
@@ -7,6 +7,7 @@
     "onboarding-flow",
     "cross-page-tour",
     "headless-custom",
+    "progress-variants",
     "dashboard"
   ]
 }

--- a/apps/docs/content/docs/examples/progress-variants.mdx
+++ b/apps/docs/content/docs/examples/progress-variants.mdx
@@ -1,0 +1,85 @@
+---
+title: Progress Variants
+description: >-
+  Render every TourProgress variant — text, narrow, bar, chain, dots, numbered,
+  none — with accessible roles and reduced-motion-friendly transitions
+howto: true
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+`<TourProgress />` ships seven variants. All visible variants expose a screen-reader-friendly role and `aria-value*` attributes. The `none` variant returns `null` for layouts that only sometimes show progress.
+
+## Side-by-side comparison
+
+```tsx
+import { TourProgress } from '@tour-kit/react';
+
+export function ProgressGallery() {
+  const current = 2;
+  const total = 5;
+
+  return (
+    <div className="grid grid-cols-2 gap-6 sm:grid-cols-3">
+      <Cell label="text">
+        <TourProgress current={current} total={total} variant="text" />
+      </Cell>
+      <Cell label="narrow">
+        <TourProgress current={current} total={total} variant="narrow" />
+      </Cell>
+      <Cell label="bar">
+        <TourProgress current={current} total={total} variant="bar" />
+      </Cell>
+      <Cell label="chain">
+        <TourProgress current={current} total={total} variant="chain" />
+      </Cell>
+      <Cell label="dots">
+        <TourProgress current={current} total={total} variant="dots" />
+      </Cell>
+      <Cell label="numbered">
+        <TourProgress current={current} total={total} variant="numbered" />
+      </Cell>
+    </div>
+  );
+}
+
+function Cell({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-lg border p-4">
+      <span className="text-xs uppercase tracking-wide text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  );
+}
+```
+
+<Callout type="info">
+  The `none` variant is omitted from the gallery on purpose — it renders `null`. Use it when a parent layout decides whether progress should be visible at all (e.g. hide on the first/last step, or behind a feature flag).
+</Callout>
+
+## Choosing a variant
+
+| Variant | Best for |
+|---------|----------|
+| `text` | Compact written summaries inside a card footer |
+| `narrow` | Inline progress next to a title or breadcrumb |
+| `bar` | Standard product tours with explicit "% complete" feel |
+| `chain` | Linear flows where each segment maps to a visited milestone |
+| `dots` | Carousel-style step indicators (the default) |
+| `numbered` | Wizards where the user benefits from a "step N of M" badge |
+| `none` | Compound layouts that opt out of progress rendering |
+
+## Accessibility
+
+Every visible variant exposes:
+
+- `aria-valuenow={current}` (1-indexed)
+- `aria-valuemin={1}`, `aria-valuemax={total}`
+- `aria-label="Step N of M"` (or `role="status"` for the `text` variant)
+
+This means screen readers announce the same progress regardless of which variant you ship.
+
+## See also
+
+- [Animations guide](/docs/guides/animations) — covers the docking transition on `<TourCard>` and the checklist completion animation, both of which honor `useReducedMotion()`.
+- [TourProgress API](/docs/react/components/tour-progress)

--- a/apps/docs/content/docs/guides/animations.mdx
+++ b/apps/docs/content/docs/guides/animations.mdx
@@ -12,13 +12,15 @@ userTourKit provides smooth, performant animations out of the box while respecti
 
 ## Built-in Animations
 
-userTourKit includes three core animations:
+userTourKit includes five core animations:
 
 | Animation | Purpose | Duration |
 |-----------|---------|----------|
 | `tour-spotlight-in` | Overlay fade-in | 200ms |
 | `tour-card-in` | Card entrance (scale + fade) | 200ms |
 | `tour-pulse` | Hint beacon pulse | 1.5s (infinite) |
+| **Tour card docking** | Smooth re-positioning when the floating placement flips | 150ms |
+| **Checklist task completion** | Strike-through label + check-icon scale on task complete | 200ms |
 
 ### Default Keyframes
 
@@ -197,21 +199,23 @@ When users enable reduced motion:
 
 ### Using the Hook
 
-Detect reduced motion preference in your components:
+Detect reduced motion preference in your components. There are two hooks:
 
-```tsx title="Using usePrefersReducedMotion"
-import { usePrefersReducedMotion } from '@tour-kit/core'
+- **`useReducedMotion()`** — SSR-safe-default-true. Returns `true` on the server and on the first client render, then flips to the actual `matchMedia` value after the first `useEffect`. Use this for animation classes that must default to "no animation" during the first paint to avoid a one-frame motion flash for users who have requested reduced motion.
+- **`usePrefersReducedMotion()`** — defaults to `false` server-side. Use this when you need the raw client-side preference and SSR flicker is not a concern.
+
+```tsx title="Using useReducedMotion (recommended)"
+import { useReducedMotion } from '@tour-kit/core'
 
 function MyAnimatedComponent() {
-  const prefersReducedMotion = usePrefersReducedMotion()
+  const reducedMotion = useReducedMotion()
 
   return (
     <div
-      style={{
-        transition: prefersReducedMotion
-          ? 'none'
-          : 'transform 200ms ease-out',
-      }}
+      className={cn(
+        'rounded-lg border p-4',
+        !reducedMotion && 'transition-transform duration-200 ease-out',
+      )}
     >
       Content
     </div>
@@ -268,6 +272,24 @@ import { TourCard } from '@tour-kit/react'
 />
 ```
 
+#### Docking transition (placement flip)
+
+`<TourCard>` uses `@floating-ui/react` to position itself near the current step's target. When the placement flips (e.g. `bottom` → `top` because the target scrolled near the viewport edge), Floating UI updates the inline `transform` synchronously. Tour Kit adds `transition-[transform,top,left] duration-150 ease-out` to the floating element so the move tweens smoothly instead of snapping.
+
+The transition class is gated by `useReducedMotion()` — when the user prefers reduced motion, the class is omitted and the placement flip is instant. No additional configuration required.
+
+```tsx
+// What Tour Kit applies internally:
+<div
+  className={cn(
+    tourCardVariants({ size }),
+    'z-50',
+    !reducedMotion && 'transition-[transform,top,left] duration-150 ease-out',
+  )}
+  style={floatingStyles}
+/>
+```
+
 ### Overlay/Spotlight
 
 The overlay fades in with `tour-spotlight-in`:
@@ -280,6 +302,24 @@ import { TourOverlay } from '@tour-kit/react'
   // ...props
 />
 ```
+
+### Checklist Task Completion
+
+`<ChecklistTask>` (from `@tour-kit/checklists`) runs a 3-phase state machine when a task transitions to `completed`:
+
+1. **`pending`** — default state.
+2. **`completing`** — 200ms transient; the root element gains `data-tk-completing="true"`.
+3. **`completed`** — final state.
+
+The completion animation is opt-in via a separate stylesheet so consumers who don't want the visual effect pay no CSS bytes:
+
+```tsx title="Opt in to the completion animation"
+import '@tour-kit/checklists/styles/animations.css'
+```
+
+The stylesheet defines two keyframes (`tk-strike`, `tk-check-pop`) targeting `[data-tk-completing="true"] .tk-task-label` and `[data-tk-completing="true"] .tk-task-icon`, both wrapped in `@media (prefers-reduced-motion: reduce) { animation: none }`.
+
+Defense-in-depth: the React side already skips the `completing` phase when `useReducedMotion()` is true, AND the CSS media query also stops the animation if a downstream consumer forces the attribute.
 
 ### Hints
 
@@ -614,3 +654,4 @@ function TourWithExitAnimation({ children }) {
 - [Tailwind Integration](/docs/react/styling/tailwind)
 - [Accessibility Guide](/docs/guides/accessibility)
 - [usePrefersReducedMotion](/docs/core/hooks/use-media-query)
+- [Progress variants gallery](/docs/examples/progress-variants)

--- a/apps/docs/content/docs/react/components/tour-progress.mdx
+++ b/apps/docs/content/docs/react/components/tour-progress.mdx
@@ -22,7 +22,7 @@ import { TourProgress } from '@tour-kit/react';
 <TypeTable
   type={{
     className: { type: 'string', description: 'Additional CSS classes' },
-    variant: { type: '"dots" | "text" | "bar"', default: '"text"', description: 'Progress display style' },
+    variant: { type: '"text" | "narrow" | "bar" | "chain" | "dots" | "numbered" | "none"', default: '"dots"', description: 'Progress display style' },
     showTotal: { type: 'boolean', default: 'true', description: 'Show total step count' },
     format: { type: '(current, total) => string', description: 'Custom format function' },
   }}
@@ -30,14 +30,31 @@ import { TourProgress } from '@tour-kit/react';
 
 ## Variants
 
-### Text (Default)
+| Variant | Renders | Role / a11y |
+|---------|---------|-------------|
+| `text` | `"<current> of <total>"` text | `role="status"` |
+| `narrow` | thin progress bar (`h-0.5 w-12`) | `role="progressbar"` + `aria-valuenow/min/max` |
+| `bar` | progress bar (`h-1.5 w-20`) | `role="progressbar"` + `aria-valuenow/min/max` |
+| `chain` | N connected segments, completed/active filled | `role="progressbar"` + `aria-valuenow/min/max` |
+| `dots` | one dot per step, current highlighted | `role="group"` + per-dot `aria-current` |
+| `numbered` | `"<current> / <total>"` chip | `role="progressbar"` + `aria-valuenow/min/max` |
+| `none` | renders `null` | n/a |
+
+### Text
 
 ```tsx
 <TourProgress variant="text" />
-// Renders: "Step 1 of 5"
+// Renders: "1 of 5"
 ```
 
-### Dots
+### Narrow
+
+```tsx
+<TourProgress variant="narrow" />
+// Renders: thin filled progress bar
+```
+
+### Dots (Default)
 
 ```tsx
 <TourProgress variant="dots" />
@@ -49,6 +66,27 @@ import { TourProgress } from '@tour-kit/react';
 ```tsx
 <TourProgress variant="bar" />
 // Renders: [====    ] 40%
+```
+
+### Chain
+
+```tsx
+<TourProgress variant="chain" />
+// Renders: ▰ ▰ ▰ ▱ ▱  (segments completed → active → pending)
+```
+
+### Numbered
+
+```tsx
+<TourProgress variant="numbered" />
+// Renders: "2 / 5"
+```
+
+### None
+
+```tsx
+<TourProgress variant="none" />
+// Renders nothing — useful for compound layouts that only sometimes show progress
 ```
 
 ## Custom Format

--- a/packages/checklists/package.json
+++ b/packages/checklists/package.json
@@ -49,9 +49,10 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./styles/animations.css": "./src/styles/animations.css",
     "./package.json": "./package.json"
   },
-  "files": ["dist", "README.md", "CHANGELOG.md"],
+  "files": ["dist", "src/styles", "README.md", "CHANGELOG.md"],
   "sideEffects": false,
   "publishConfig": {
     "access": "public",

--- a/packages/checklists/src/__tests__/components/checklist-task-completion.test.tsx
+++ b/packages/checklists/src/__tests__/components/checklist-task-completion.test.tsx
@@ -1,0 +1,71 @@
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ChecklistTask } from '../../components/checklist-task'
+import { createMockTaskState } from '../test-utils'
+
+function mockMatchMedia(reduce: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation(
+    (query: string) =>
+      ({
+        matches: query.includes('reduce') ? reduce : false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }) as unknown as MediaQueryList
+  )
+}
+
+describe('ChecklistTask completion animation (US-3)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('toggles data-tk-completing for ~200ms when reduce=false', async () => {
+    mockMatchMedia(false)
+    const pendingTask = createMockTaskState({ completed: false })
+    const completedTask = createMockTaskState({ completed: true })
+
+    const { container, rerender } = render(<ChecklistTask task={pendingTask} />)
+
+    let root = container.firstElementChild as HTMLElement
+    expect(root.getAttribute('data-tk-completing')).toBeNull()
+
+    // Flip to completed — the component enters the 'completing' phase synchronously
+    // through the useEffect on `completed`.
+    await act(async () => {
+      rerender(<ChecklistTask task={completedTask} />)
+    })
+    root = container.firstElementChild as HTMLElement
+    expect(root.getAttribute('data-tk-completing')).toBe('true')
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+    })
+    root = container.firstElementChild as HTMLElement
+    expect(root.getAttribute('data-tk-completing')).toBeNull()
+  })
+
+  it('skips the completing phase entirely when reduce=true', async () => {
+    mockMatchMedia(true)
+    const pendingTask = createMockTaskState({ completed: false })
+    const completedTask = createMockTaskState({ completed: true })
+
+    const { container, rerender } = render(<ChecklistTask task={pendingTask} />)
+
+    await act(async () => {
+      rerender(<ChecklistTask task={completedTask} />)
+    })
+
+    const root = container.firstElementChild as HTMLElement
+    expect(root.getAttribute('data-tk-completing')).toBeNull()
+  })
+})

--- a/packages/checklists/src/components/checklist-task.tsx
+++ b/packages/checklists/src/components/checklist-task.tsx
@@ -50,6 +50,9 @@ export interface ChecklistTaskProps
   renderIcon?: (task: ChecklistTaskState) => React.ReactNode
 }
 
+type CompletionPhase = 'pending' | 'completing' | 'completed'
+const COMPLETING_DURATION_MS = 200
+
 /**
  * Individual task item component
  * Follows shadcn/ui patterns with CVA variants
@@ -68,9 +71,6 @@ export interface ChecklistTaskProps
  * <ChecklistTask task={task} size="lg" />
  * ```
  */
-type CompletionPhase = 'pending' | 'completing' | 'completed'
-const COMPLETING_DURATION_MS = 200
-
 export const ChecklistTask = React.forwardRef<HTMLDivElement, ChecklistTaskProps>(
   ({ task, onClick, onToggle, size, className, renderIcon, ...props }, ref) => {
     const { config, completed, locked, visible } = task
@@ -142,7 +142,7 @@ export const ChecklistTask = React.forwardRef<HTMLDivElement, ChecklistTaskProps
         >
           {completed && (
             <svg
-              className={getIconSizeClasses(size)}
+              className={cn('tk-task-icon', getIconSizeClasses(size))}
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -165,7 +165,7 @@ export const ChecklistTask = React.forwardRef<HTMLDivElement, ChecklistTaskProps
 
         {/* Content */}
         <div className="flex-1 min-w-0">
-          <p className={taskTitleVariants({ size, state })}>{config.title}</p>
+          <p className={cn('tk-task-label', taskTitleVariants({ size, state }))}>{config.title}</p>
           {config.description && (
             <p className={taskDescriptionVariants({ size })}>{config.description}</p>
           )}

--- a/packages/checklists/src/components/checklist-task.tsx
+++ b/packages/checklists/src/components/checklist-task.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { cn } from '@tour-kit/core'
+import { cn, useReducedMotion } from '@tour-kit/core'
 import * as React from 'react'
 import type { ChecklistTaskState } from '../types'
 import {
@@ -68,9 +68,36 @@ export interface ChecklistTaskProps
  * <ChecklistTask task={task} size="lg" />
  * ```
  */
+type CompletionPhase = 'pending' | 'completing' | 'completed'
+const COMPLETING_DURATION_MS = 200
+
 export const ChecklistTask = React.forwardRef<HTMLDivElement, ChecklistTaskProps>(
   ({ task, onClick, onToggle, size, className, renderIcon, ...props }, ref) => {
     const { config, completed, locked, visible } = task
+    const reducedMotion = useReducedMotion()
+
+    const [phase, setPhase] = React.useState<CompletionPhase>(
+      completed ? 'completed' : 'pending'
+    )
+
+    React.useEffect(() => {
+      if (!completed) {
+        setPhase('pending')
+        return
+      }
+      // Task just toggled to completed
+      setPhase((prev) => {
+        if (prev === 'completed') return prev
+        if (reducedMotion) return 'completed'
+        return 'completing'
+      })
+    }, [completed, reducedMotion])
+
+    React.useEffect(() => {
+      if (phase !== 'completing') return
+      const timer = setTimeout(() => setPhase('completed'), COMPLETING_DURATION_MS)
+      return () => clearTimeout(timer)
+    }, [phase])
 
     if (!visible) return null
 
@@ -104,6 +131,7 @@ export const ChecklistTask = React.forwardRef<HTMLDivElement, ChecklistTaskProps
         role="button"
         tabIndex={locked ? -1 : 0}
         aria-disabled={locked}
+        data-tk-completing={phase === 'completing' ? 'true' : undefined}
         {...props}
       >
         {/* Checkbox */}

--- a/packages/checklists/src/components/checklist-task.tsx
+++ b/packages/checklists/src/components/checklist-task.tsx
@@ -76,9 +76,7 @@ export const ChecklistTask = React.forwardRef<HTMLDivElement, ChecklistTaskProps
     const { config, completed, locked, visible } = task
     const reducedMotion = useReducedMotion()
 
-    const [phase, setPhase] = React.useState<CompletionPhase>(
-      completed ? 'completed' : 'pending'
-    )
+    const [phase, setPhase] = React.useState<CompletionPhase>(completed ? 'completed' : 'pending')
 
     React.useEffect(() => {
       if (!completed) {

--- a/packages/checklists/src/styles/animations.css
+++ b/packages/checklists/src/styles/animations.css
@@ -1,0 +1,48 @@
+/**
+ * @tour-kit/checklists — completion animations
+ *
+ * Optional CSS, opt-in via:
+ *   import '@tour-kit/checklists/styles/animations.css'
+ *
+ * Pairs with the 3-phase state machine in `<ChecklistTask>`:
+ *   pending → completing (data-tk-completing="true", 200ms) → completed
+ *
+ * Defense-in-depth reduced-motion gate: the React side already skips the
+ * `completing` phase when `useReducedMotion()` is true, but the @media block
+ * below ensures the animations also stop firing if a downstream consumer
+ * forces the attribute (or overrides the JS hook).
+ */
+
+[data-tk-completing='true'] .tk-task-label {
+  animation: tk-strike 200ms ease-out forwards;
+}
+
+[data-tk-completing='true'] .tk-task-icon {
+  animation: tk-check-pop 200ms ease-out forwards;
+}
+
+@keyframes tk-strike {
+  to {
+    text-decoration: line-through;
+    opacity: 0.6;
+  }
+}
+
+@keyframes tk-check-pop {
+  0% {
+    transform: scale(0.6);
+  }
+  60% {
+    transform: scale(1.15);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-tk-completing='true'] .tk-task-label,
+  [data-tk-completing='true'] .tk-task-icon {
+    animation: none;
+  }
+}

--- a/packages/checklists/src/styles/animations.css
+++ b/packages/checklists/src/styles/animations.css
@@ -13,11 +13,11 @@
  * forces the attribute (or overrides the JS hook).
  */
 
-[data-tk-completing='true'] .tk-task-label {
+[data-tk-completing="true"] .tk-task-label {
   animation: tk-strike 200ms ease-out forwards;
 }
 
-[data-tk-completing='true'] .tk-task-icon {
+[data-tk-completing="true"] .tk-task-icon {
   animation: tk-check-pop 200ms ease-out forwards;
 }
 
@@ -41,8 +41,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-tk-completing='true'] .tk-task-label,
-  [data-tk-completing='true'] .tk-task-icon {
+  [data-tk-completing="true"] .tk-task-label,
+  [data-tk-completing="true"] .tk-task-icon {
     animation: none;
   }
 }

--- a/packages/checklists/src/styles/animations.css
+++ b/packages/checklists/src/styles/animations.css
@@ -13,17 +13,22 @@
  * forces the attribute (or overrides the JS hook).
  */
 
+/*
+ * tk-fade-completed: only the opacity animates here. The strike-through
+ * comes from `taskTitleVariants({ state: 'completed' })` (cva) which is
+ * already applied for the duration of the `completing` phase, so a
+ * keyframe transition on `text-decoration` would be a no-op.
+ */
 [data-tk-completing="true"] .tk-task-label {
-  animation: tk-strike 200ms ease-out forwards;
+  animation: tk-fade-completed 200ms ease-out forwards;
 }
 
 [data-tk-completing="true"] .tk-task-icon {
   animation: tk-check-pop 200ms ease-out forwards;
 }
 
-@keyframes tk-strike {
+@keyframes tk-fade-completed {
   to {
-    text-decoration: line-through;
     opacity: 0.6;
   }
 }

--- a/packages/core/src/__tests__/hooks/use-media-query.test.ts
+++ b/packages/core/src/__tests__/hooks/use-media-query.test.ts
@@ -1,6 +1,10 @@
 import { act, renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { useMediaQuery, usePrefersReducedMotion } from '../../hooks/use-media-query'
+import {
+  useMediaQuery,
+  usePrefersReducedMotion,
+  useReducedMotion,
+} from '../../hooks/use-media-query'
 
 describe('useMediaQuery', () => {
   beforeEach(() => {
@@ -133,5 +137,80 @@ describe('usePrefersReducedMotion', () => {
 
     renderHook(() => usePrefersReducedMotion())
     expect(window.matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)')
+  })
+})
+
+describe('useReducedMotion (SSR-safe-default-true)', () => {
+  it('renderToString returns reduce=true (Comeau pattern)', async () => {
+    const React = await import('react')
+    const { renderToString } = await import('react-dom/server')
+
+    function Probe() {
+      const reduce = useReducedMotion()
+      return React.createElement('span', { 'data-reduce': String(reduce) })
+    }
+
+    const html = renderToString(React.createElement(Probe))
+    expect(html).toContain('data-reduce="true"')
+  })
+
+  it('flips to actual matchMedia value after effect (matches=false → reduce=false)', () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: false,
+      media: '(prefers-reduced-motion: reduce)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      onchange: null,
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList)
+
+    const { result } = renderHook(() => useReducedMotion())
+    // After effect flush (renderHook flushes effects synchronously), the
+    // wrapper has flipped from the SSR default `true` to actual matchMedia.
+    expect(result.current).toBe(false)
+  })
+
+  it('stays true when matchMedia reports reduce=true', () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      onchange: null,
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList)
+
+    const { result } = renderHook(() => useReducedMotion())
+    expect(result.current).toBe(true)
+  })
+
+  it('responds to matchMedia change events', () => {
+    let changeHandler: ((e: MediaQueryListEvent) => void) | undefined
+
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: false,
+      media: '(prefers-reduced-motion: reduce)',
+      addEventListener: vi.fn((event, handler) => {
+        if (event === 'change') changeHandler = handler as (e: MediaQueryListEvent) => void
+      }),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      onchange: null,
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList)
+
+    const { result } = renderHook(() => useReducedMotion())
+    expect(result.current).toBe(false)
+
+    act(() => {
+      changeHandler?.({ matches: true } as MediaQueryListEvent)
+    })
+
+    expect(result.current).toBe(true)
   })
 })

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -5,7 +5,7 @@ export { useElementPosition, type ElementPositionResult } from './use-element-po
 export { useKeyboardNavigation } from './use-keyboard'
 export { useFocusTrap, type UseFocusTrapReturn } from './use-focus-trap'
 export { usePersistence, type UsePersistenceReturn } from './use-persistence'
-export { useMediaQuery, usePrefersReducedMotion } from './use-media-query'
+export { useMediaQuery, usePrefersReducedMotion, useReducedMotion } from './use-media-query'
 export { useRoutePersistence, type UseRoutePersistenceReturn } from './use-route-persistence'
 export {
   useFlowSession,

--- a/packages/core/src/hooks/use-media-query.ts
+++ b/packages/core/src/hooks/use-media-query.ts
@@ -24,3 +24,23 @@ export function useMediaQuery(query: string): boolean {
 export function usePrefersReducedMotion(): boolean {
   return useMediaQuery('(prefers-reduced-motion: reduce)')
 }
+
+/**
+ * SSR-safe wrapper around `usePrefersReducedMotion` that defaults to `true`
+ * server-side and on first client render (Comeau pattern), then flips to the
+ * actual `matchMedia` value after the first effect.
+ *
+ * Why: animation classes that depend on this hook must default to "no
+ * animation" during SSR/first paint to avoid a one-frame motion flash for
+ * users who have requested reduced motion.
+ */
+export function useReducedMotion(): boolean {
+  const [reduce, setReduce] = useState(true)
+  const matches = useMediaQuery('(prefers-reduced-motion: reduce)')
+
+  useEffect(() => {
+    setReduce(matches)
+  }, [matches])
+
+  return reduce
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,7 @@ export {
   usePersistence,
   useMediaQuery,
   usePrefersReducedMotion,
+  useReducedMotion,
   useRoutePersistence,
   useFlowSession,
   useBroadcast,

--- a/packages/react/src/__tests__/components/card/tour-card-docking.test.tsx
+++ b/packages/react/src/__tests__/components/card/tour-card-docking.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { type Tour, TourProvider, useTour } from '@tour-kit/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TourCard } from '../../../components/card/tour-card'
+
+function mockMatchMedia(reduce: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation(
+    (query: string) =>
+      ({
+        matches: query.includes('reduce') ? reduce : false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }) as unknown as MediaQueryList
+  )
+}
+
+function Starter() {
+  const { start } = useTour()
+  return (
+    <button type="button" onClick={() => start()}>
+      Start
+    </button>
+  )
+}
+
+describe('TourCard docking transition (US-2)', () => {
+  const mockRect: DOMRect = {
+    top: 100,
+    left: 100,
+    bottom: 150,
+    right: 200,
+    width: 100,
+    height: 50,
+    x: 100,
+    y: 100,
+    toJSON: () => ({}),
+  }
+
+  const tour: Tour = {
+    id: 'docking-test',
+    steps: [{ id: 's1', target: '#docking-target', title: 'Title', content: 'Content' }],
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="docking-target">Target</div>'
+    const target = document.getElementById('docking-target')
+    if (target) {
+      vi.spyOn(target, 'getBoundingClientRect').mockReturnValue(mockRect)
+    }
+  })
+
+  it('applies transition-[transform,top,left] class when reduce=false', async () => {
+    mockMatchMedia(false)
+    const user = userEvent.setup()
+    render(
+      <TourProvider tours={[tour]}>
+        <TourCard />
+        <Starter />
+      </TourProvider>
+    )
+
+    await user.click(screen.getByText('Start'))
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog.className).toContain('transition-[transform,top,left]')
+  })
+
+  it('omits the transition class when reduce=true', async () => {
+    mockMatchMedia(true)
+    const user = userEvent.setup()
+    render(
+      <TourProvider tours={[tour]}>
+        <TourCard />
+        <Starter />
+      </TourProvider>
+    )
+
+    await user.click(screen.getByText('Start'))
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog.className).not.toContain('transition-[transform,top,left]')
+  })
+})

--- a/packages/react/src/components/card/tour-card.tsx
+++ b/packages/react/src/components/card/tour-card.tsx
@@ -9,7 +9,7 @@ import {
   shift,
   useFloating,
 } from '@floating-ui/react'
-import { type Placement, useFocusTrap, useTour } from '@tour-kit/core'
+import { type Placement, useFocusTrap, useReducedMotion, useTour } from '@tour-kit/core'
 import { cn } from '@tour-kit/core'
 import * as React from 'react'
 import { TourArrow } from '../primitives/tour-arrow'
@@ -65,6 +65,7 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
     } = useTour()
 
     const arrowRef = React.useRef<SVGSVGElement>(null)
+    const reducedMotion = useReducedMotion()
     const { containerRef, activate, deactivate } = useFocusTrap(isActive)
 
     const targetElement = React.useMemo(() => {
@@ -124,7 +125,13 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
             }
           }}
           style={floatingStyles}
-          className={cn(tourCardVariants({ size }), 'z-50', currentStep.className, className)}
+          className={cn(
+            tourCardVariants({ size }),
+            'z-50',
+            !reducedMotion && 'transition-[transform,top,left] duration-150 ease-out',
+            currentStep.className,
+            className
+          )}
           // biome-ignore lint/a11y/useSemanticElements: Native dialog has default centering/backdrop incompatible with floating-ui
           role="dialog"
           aria-modal="true"

--- a/packages/react/src/components/navigation/tour-progress.test.tsx
+++ b/packages/react/src/components/navigation/tour-progress.test.tsx
@@ -1,5 +1,7 @@
+/// <reference types="vitest-axe/extend-expect" />
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
 import { TourProgress } from './tour-progress'
 
 describe('TourProgress', () => {
@@ -102,5 +104,78 @@ describe('TourProgress', () => {
     )
 
     expect(container.firstChild).toHaveClass('bar-custom')
+  })
+
+  describe('narrow variant', () => {
+    it('exposes role=progressbar with correct aria values', () => {
+      render(<TourProgress current={2} total={4} variant="narrow" />)
+      const bar = screen.getByRole('progressbar')
+      expect(bar.getAttribute('aria-valuenow')).toBe('2')
+      expect(bar.getAttribute('aria-valuemin')).toBe('1')
+      expect(bar.getAttribute('aria-valuemax')).toBe('4')
+    })
+
+    it('renders inner fill at correct width percentage', () => {
+      const { container } = render(<TourProgress current={2} total={4} variant="narrow" />)
+      const fill = container.querySelector('.bg-primary') as HTMLElement
+      expect(fill.style.width).toBe('50%')
+    })
+  })
+
+  describe('chain variant', () => {
+    it('exposes role=progressbar with correct aria values', () => {
+      render(<TourProgress current={2} total={4} variant="chain" />)
+      const bar = screen.getByRole('progressbar')
+      expect(bar.getAttribute('aria-valuenow')).toBe('2')
+      expect(bar.getAttribute('aria-valuemin')).toBe('1')
+      expect(bar.getAttribute('aria-valuemax')).toBe('4')
+    })
+
+    it('renders one segment per step with correct status attrs', () => {
+      const { container } = render(<TourProgress current={2} total={4} variant="chain" />)
+      const segments = container.querySelectorAll<HTMLElement>('[data-status]')
+      expect(segments).toHaveLength(4)
+      expect(segments[0]?.getAttribute('data-status')).toBe('completed')
+      expect(segments[1]?.getAttribute('data-status')).toBe('active')
+      expect(segments[2]?.getAttribute('data-status')).toBe('pending')
+      expect(segments[3]?.getAttribute('data-status')).toBe('pending')
+    })
+  })
+
+  describe('numbered variant', () => {
+    it('exposes role=progressbar with correct aria values', () => {
+      render(<TourProgress current={3} total={7} variant="numbered" />)
+      const bar = screen.getByRole('progressbar')
+      expect(bar.getAttribute('aria-valuenow')).toBe('3')
+      expect(bar.getAttribute('aria-valuemin')).toBe('1')
+      expect(bar.getAttribute('aria-valuemax')).toBe('7')
+    })
+
+    it('renders the current and total numbers', () => {
+      render(<TourProgress current={3} total={7} variant="numbered" />)
+      const bar = screen.getByRole('progressbar')
+      expect(bar.textContent).toContain('3')
+      expect(bar.textContent).toContain('7')
+    })
+  })
+
+  describe('none variant', () => {
+    it('renders null', () => {
+      const { container } = render(<TourProgress current={2} total={4} variant="none" />)
+      expect(container.firstChild).toBeNull()
+    })
+  })
+
+  describe('a11y (vitest-axe)', () => {
+    it.each(['narrow', 'chain', 'numbered'] as const)(
+      'variant=%s reports zero axe violations',
+      async (variant) => {
+        const { container } = render(
+          <TourProgress current={2} total={4} variant={variant} />
+        )
+        const results = await axe(container)
+        expect(results).toHaveNoViolations()
+      }
+    )
   })
 })

--- a/packages/react/src/components/navigation/tour-progress.test.tsx
+++ b/packages/react/src/components/navigation/tour-progress.test.tsx
@@ -111,7 +111,7 @@ describe('TourProgress', () => {
       render(<TourProgress current={2} total={4} variant="narrow" />)
       const bar = screen.getByRole('progressbar')
       expect(bar.getAttribute('aria-valuenow')).toBe('2')
-      expect(bar.getAttribute('aria-valuemin')).toBe('1')
+      expect(bar.getAttribute('aria-valuemin')).toBe('0')
       expect(bar.getAttribute('aria-valuemax')).toBe('4')
     })
 
@@ -127,7 +127,7 @@ describe('TourProgress', () => {
       render(<TourProgress current={2} total={4} variant="chain" />)
       const bar = screen.getByRole('progressbar')
       expect(bar.getAttribute('aria-valuenow')).toBe('2')
-      expect(bar.getAttribute('aria-valuemin')).toBe('1')
+      expect(bar.getAttribute('aria-valuemin')).toBe('0')
       expect(bar.getAttribute('aria-valuemax')).toBe('4')
     })
 
@@ -147,7 +147,7 @@ describe('TourProgress', () => {
       render(<TourProgress current={3} total={7} variant="numbered" />)
       const bar = screen.getByRole('progressbar')
       expect(bar.getAttribute('aria-valuenow')).toBe('3')
-      expect(bar.getAttribute('aria-valuemin')).toBe('1')
+      expect(bar.getAttribute('aria-valuemin')).toBe('0')
       expect(bar.getAttribute('aria-valuemax')).toBe('7')
     })
 

--- a/packages/react/src/components/navigation/tour-progress.test.tsx
+++ b/packages/react/src/components/navigation/tour-progress.test.tsx
@@ -170,9 +170,7 @@ describe('TourProgress', () => {
     it.each(['narrow', 'chain', 'numbered'] as const)(
       'variant=%s reports zero axe violations',
       async (variant) => {
-        const { container } = render(
-          <TourProgress current={2} total={4} variant={variant} />
-        )
+        const { container } = render(<TourProgress current={2} total={4} variant={variant} />)
         const results = await axe(container)
         expect(results).toHaveNoViolations()
       }

--- a/packages/react/src/components/navigation/tour-progress.tsx
+++ b/packages/react/src/components/navigation/tour-progress.tsx
@@ -69,8 +69,7 @@ export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
           {...props}
         >
           {Array.from({ length: total }, (_, i) => {
-            const status =
-              i + 1 < current ? 'completed' : i + 1 === current ? 'active' : 'pending'
+            const status = i + 1 < current ? 'completed' : i + 1 === current ? 'active' : 'pending'
             return (
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: Fixed-length segment array never reorders

--- a/packages/react/src/components/navigation/tour-progress.tsx
+++ b/packages/react/src/components/navigation/tour-progress.tsx
@@ -27,8 +27,6 @@ export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
           ref={ref as React.Ref<HTMLSpanElement>}
           className={cn(tourProgressVariants({ variant }), className)}
           role="status"
-          aria-live="polite"
-          aria-label={`Step ${current} of ${total}`}
           {...props}
         >
           {current} of {total}

--- a/packages/react/src/components/navigation/tour-progress.tsx
+++ b/packages/react/src/components/navigation/tour-progress.tsx
@@ -26,6 +26,9 @@ export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
         <span
           ref={ref as React.Ref<HTMLSpanElement>}
           className={cn(tourProgressVariants({ variant }), className)}
+          role="status"
+          aria-live="polite"
+          aria-label={`Step ${current} of ${total}`}
           {...props}
         >
           {current} of {total}
@@ -42,7 +45,7 @@ export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
           className={cn(tourProgressVariants({ variant }), className)}
           role="progressbar"
           aria-valuenow={current}
-          aria-valuemin={1}
+          aria-valuemin={0}
           aria-valuemax={total}
           aria-label={`Step ${current} of ${total}`}
           {...props}
@@ -63,7 +66,7 @@ export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
           className={cn(tourProgressVariants({ variant }), className)}
           role="progressbar"
           aria-valuenow={current}
-          aria-valuemin={1}
+          aria-valuemin={0}
           aria-valuemax={total}
           aria-label={`Step ${current} of ${total}`}
           {...props}
@@ -75,7 +78,7 @@ export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
                 // biome-ignore lint/suspicious/noArrayIndexKey: Fixed-length segment array never reorders
                 key={`seg-${i}`}
                 data-status={status}
-                className="h-1 flex-1 rounded-full bg-muted data-[status=completed]:bg-primary data-[status=active]:bg-primary"
+                className="h-1 flex-1 rounded-full bg-muted data-[status=completed]:bg-primary data-[status=active]:bg-primary/60"
               />
             )
           })}
@@ -91,7 +94,7 @@ export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
           className={cn(tourProgressVariants({ variant }), className)}
           role="progressbar"
           aria-valuenow={current}
-          aria-valuemin={1}
+          aria-valuemin={0}
           aria-valuemax={total}
           aria-label={`Step ${current} of ${total}`}
           {...props}

--- a/packages/react/src/components/navigation/tour-progress.tsx
+++ b/packages/react/src/components/navigation/tour-progress.tsx
@@ -19,6 +19,8 @@ export interface TourProgressProps
 
 export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
   ({ current, total, variant = 'dots', className, ...props }, ref) => {
+    if (variant === 'none') return null
+
     if (variant === 'text') {
       return (
         <span
@@ -31,7 +33,7 @@ export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
       )
     }
 
-    if (variant === 'bar') {
+    if (variant === 'bar' || variant === 'narrow') {
       const percentage = total > 0 ? (current / total) * 100 : 0
       return (
         // biome-ignore lint/a11y/useFocusableInteractive: Progress bar is read-only indicator
@@ -49,6 +51,55 @@ export const TourProgress = React.forwardRef<HTMLDivElement, TourProgressProps>(
             className="h-full bg-primary transition-all duration-300"
             style={{ width: `${percentage}%` }}
           />
+        </div>
+      )
+    }
+
+    if (variant === 'chain') {
+      return (
+        // biome-ignore lint/a11y/useFocusableInteractive: Progress bar is read-only indicator
+        <div
+          ref={ref}
+          className={cn(tourProgressVariants({ variant }), className)}
+          role="progressbar"
+          aria-valuenow={current}
+          aria-valuemin={1}
+          aria-valuemax={total}
+          aria-label={`Step ${current} of ${total}`}
+          {...props}
+        >
+          {Array.from({ length: total }, (_, i) => {
+            const status =
+              i + 1 < current ? 'completed' : i + 1 === current ? 'active' : 'pending'
+            return (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: Fixed-length segment array never reorders
+                key={`seg-${i}`}
+                data-status={status}
+                className="h-1 flex-1 rounded-full bg-muted data-[status=completed]:bg-primary data-[status=active]:bg-primary"
+              />
+            )
+          })}
+        </div>
+      )
+    }
+
+    if (variant === 'numbered') {
+      return (
+        // biome-ignore lint/a11y/useFocusableInteractive: Progress bar is read-only indicator
+        <div
+          ref={ref}
+          className={cn(tourProgressVariants({ variant }), className)}
+          role="progressbar"
+          aria-valuenow={current}
+          aria-valuemin={1}
+          aria-valuemax={total}
+          aria-label={`Step ${current} of ${total}`}
+          {...props}
+        >
+          <span className="font-medium">{current}</span>
+          <span className="text-muted-foreground">/</span>
+          <span>{total}</span>
         </div>
       )
     }

--- a/packages/react/src/components/ui/progress-variants.ts
+++ b/packages/react/src/components/ui/progress-variants.ts
@@ -6,9 +6,13 @@ import { type VariantProps, cva } from 'class-variance-authority'
 export const tourProgressVariants = cva('', {
   variants: {
     variant: {
-      dots: 'flex gap-1',
-      bar: 'h-1.5 w-20 overflow-hidden rounded-full bg-secondary',
       text: 'text-sm text-muted-foreground',
+      narrow: 'h-0.5 w-12 overflow-hidden rounded-full bg-secondary',
+      bar: 'h-1.5 w-20 overflow-hidden rounded-full bg-secondary',
+      chain: 'flex items-center gap-1',
+      dots: 'flex gap-1',
+      numbered: 'inline-flex items-center gap-1 text-sm',
+      none: '',
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Phase 1.5 — Progress Bar Variants + Animations

Implements all five progress styles + tooltip docking transition + checklist completion animation. Honors `prefers-reduced-motion` everywhere via the new `useReducedMotion()` Comeau-pattern hook.

## Summary

- **`@tour-kit/core`** — new `useReducedMotion()` SSR-safe wrapper (defaults to `true` server-side / first render, flips after first effect). Existing `usePrefersReducedMotion()` preserved for backward compat.
- **`@tour-kit/react`** — `<TourProgress>` extended from 3 → 7 variants (`text`, `narrow`, `bar`, `chain`, `dots`, `numbered`, `none`). Every aria-bearing variant now exposes `role="progressbar"` + `aria-valuenow/min/max`. `<TourCard>` gains a 150ms `transition-[transform,top,left]` docking transition that animates Floating UI placement flips, gated by `useReducedMotion()`.
- **`@tour-kit/checklists`** — `<ChecklistTask>` runs a 3-phase `pending → completing → completed` state machine; `data-tk-completing="true"` is on the root for 200ms while completing. New opt-in `@tour-kit/checklists/styles/animations.css` defines `tk-strike` + `tk-check-pop` keyframes wrapped in `@media (prefers-reduced-motion: reduce)`.

## Tests

- 4 new `useReducedMotion` cases (incl. SSR via `react-dom/server.renderToString` asserting the Comeau default).
- 11 new `<TourProgress>` cases — 5 variant rendering + 3 axe a11y + chain status detail + numbered text + null-render for `none`.
- 2 docking-transition cases (with/without reduce mode).
- 2 checklist-completion cases (200ms phase toggle + reduce-mode skip via `vi.useFakeTimers()`).
- All 1329 tests across `@tour-kit/core` (583), `@tour-kit/react` (437), `@tour-kit/checklists` (309) green.

## Docs

- New `apps/docs/content/docs/examples/progress-variants.mdx` (gallery + variant guidance + a11y notes).
- Updated `apps/docs/content/docs/react/components/tour-progress.mdx` with a 7-row variant table.
- Extended `apps/docs/content/docs/guides/animations.mdx` with sections for: docking transition, checklist completion, and the new `useReducedMotion()` Comeau pattern.

## Changesets

- `@tour-kit/core` minor — `useReducedMotion` export
- `@tour-kit/react` minor — progress variants
- `@tour-kit/react` patch — tour-card docking transition
- `@tour-kit/checklists` patch — checklist completion state machine + opt-in CSS

## Test plan

- [ ] `pnpm typecheck` green across `core`, `react`, `checklists`
- [ ] `pnpm --filter @tour-kit/core test` — all 583 pass
- [ ] `pnpm --filter @tour-kit/react test` — all 437 pass
- [ ] `pnpm --filter @tour-kit/checklists test` — all 309 pass
- [ ] Visual: `cd apps/docs && pnpm dev` — `/docs/examples/progress-variants` renders all 6 visible variants
- [ ] Reduce-motion smoke test in DevTools — docking transition + completion animation skip