### PR TITLE
feat(announcements,surveys,hints): prefers-reduced-motion plumbing (phase 1.6)

### DIFF
--- a/.changeset/phase-1-announcements-reduced-motion.md
+++ b/.changeset/phase-1-announcements-reduced-motion.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/announcements": patch
+---
+
+Honor `prefers-reduced-motion: reduce` across all five display variants (modal, slideout, banner, toast, spotlight). Every `tailwindcss-animate` utility (`animate-in`, `animate-out`, `fade-*`, `slide-in-from-*`, `slide-out-to-*`, `zoom-in-95`, `zoom-out-95`) is now gated behind Tailwind's `motion-safe:` prefix in the cva variant files and `<AnnouncementOverlay>`, so reduce-mode users never see them. Also re-exports `useReducedMotion` from `@tour-kit/core` for ergonomic in-package access. No public API changes.

--- a/.changeset/phase-1-hints-reduced-motion.md
+++ b/.changeset/phase-1-hints-reduced-motion.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/hints": patch
+---
+
+`<HintHotspot>` now reads `useReducedMotion()` from `@tour-kit/core` and skips the `animate-tour-pulse` cva variant under reduce mode (defense-in-depth on top of the existing `@media (prefers-reduced-motion: reduce)` keyframe wrapper). Re-exports `useReducedMotion` from the package for ergonomic in-package access.

--- a/.changeset/phase-1-surveys-reduced-motion.md
+++ b/.changeset/phase-1-surveys-reduced-motion.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/surveys": patch
+---
+
+Honor `prefers-reduced-motion: reduce` for `<SurveyModal>` and `<SurveySlideout>`. Every `tailwindcss-animate` utility on the modal + slideout content/overlay is now gated behind Tailwind's `motion-safe:` prefix in the cva variant files. Adds `modalContentVariants`, `modalOverlayVariants`, `slideoutContentVariants`, `slideoutOverlayVariants` to the public exports for consumer customization, and re-exports `useReducedMotion` from `@tour-kit/core` for ergonomic in-package access. No breaking API changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,14 @@ All UI packages import from `@tour-kit/core`.
 ### `cn()` utility
 Single source in `@tour-kit/core/lib/utils.ts`.
 
+### Reduced motion
+All animation-bearing packages honor `prefers-reduced-motion: reduce` via a three-tier defense:
+1. **`motion-safe:` Tailwind prefix** on every `tailwindcss-animate` utility (`animate-in`, `fade-*`, `slide-*`, `zoom-*`) in `announcements` and `surveys` cva variants. Compiles to `@media (prefers-reduced-motion: no-preference)` — under reduce, the utility never applies. Required because `tailwindcss-animate` does not auto-respect the OS pref.
+2. **`@media (prefers-reduced-motion: reduce)` keyframe wrappers** for custom keyframes we own (`tour-pulse` in `hints`, `tour-spotlight-in`/`tour-card-in` in `react`, `tk-strike`/`tk-check-pop` in `checklists`).
+3. **JS gate via `useReducedMotion()`** from `@tour-kit/core` for render-time class branches (`<HintHotspot pulse>`, `<TourCard>` docking transition, checklist `completing` phase). Re-exported from `announcements`, `surveys`, `hints` for ergonomic in-package access.
+
+When adding new animations, prefix with `motion-safe:` if it's a `tailwindcss-animate` utility, wrap custom `@keyframes` in the `@media` block, and use `useReducedMotion()` for any class chosen at render time. Cross-package guarantee documented at [`apps/docs/content/docs/guides/reduced-motion.mdx`](apps/docs/content/docs/guides/reduced-motion.mdx).
+
 ### Provider Architecture
 - `@tour-kit/core` provides base providers (TourProvider, TourKitProvider)
 - Each package wraps with its own context (AdoptionProvider, ChecklistProvider, etc.)

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -7,6 +7,7 @@
     "vite",
     "accessibility",
     "animations",
+    "reduced-motion",
     "branching",
     "hidden-steps",
     "persistence",

--- a/apps/docs/content/docs/guides/reduced-motion.mdx
+++ b/apps/docs/content/docs/guides/reduced-motion.mdx
@@ -1,0 +1,130 @@
+---
+title: Reduced Motion
+description: >-
+  How Tour Kit honors prefers-reduced-motion across announcements, surveys,
+  hints, checklists, and the core tour runtime
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+Users who set their OS-level "reduce motion" preference are signalling a real accessibility need (vestibular disorders, motion sensitivity, attention regulation). Tour Kit takes this seriously: every animation in every Tour Kit package is gated, by either CSS, JS, or both — so reduce-mode users never see one slide, fade, pulse, or zoom from us.
+
+This page documents the cross-package guarantee. If you're customizing or extending Tour Kit, follow the same pattern.
+
+## What is `prefers-reduced-motion`?
+
+A CSS media query exposing the user's OS-level setting (macOS: System Settings → Accessibility → Display → Reduce Motion; Windows: Settings → Accessibility → Visual Effects → Animation Effects). Browsers expose it as `window.matchMedia('(prefers-reduced-motion: reduce)')`. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) for the spec.
+
+## Three-tier defense
+
+Tour Kit uses three layers, each catching what the next one might miss:
+
+1. **OS pref → CSS `motion-safe:` prefix.** Every `tailwindcss-animate` utility (`animate-in`, `animate-out`, `fade-in-0`, `slide-in-from-*`, `zoom-in-95`, …) is prefixed with Tailwind's `motion-safe:` variant, which compiles to `@media (prefers-reduced-motion: no-preference)`. Under reduce mode, none of these utilities apply. Zero JS, zero bundle cost, no first-frame motion flash.
+2. **CSS keyframe wrappers.** Custom keyframes that we own (`tour-pulse`, `tour-spotlight-in`, `tour-card-in`, `tk-strike`, `tk-check-pop`) are wrapped in `@media (prefers-reduced-motion: reduce) { animation: none }` blocks in their stylesheets. This catches any consumer who applies the class outside a `motion-safe:` context.
+3. **JS gate via `useReducedMotion()`.** For animations driven by render branches (a `pulse` prop on a hotspot, a Floating UI `transform` transition that we add programmatically), the React component reads `useReducedMotion()` from `@tour-kit/core` and omits the animation class entirely under reduce mode. This is the only layer that can react to runtime config (e.g., a future `A11yConfig.reducedMotion: 'always-animate'` override).
+
+<Callout type="info">
+**Why three layers?** `tailwindcss-animate` does **not** auto-respect `prefers-reduced-motion` ([upstream discussion](https://github.com/tailwindlabs/tailwindcss/discussions/12864)) — the `motion-safe:` prefix is the contract. CSS keyframe wrappers handle classes added by consumers outside our control. The JS gate handles render-time conditional classes and exposes a hook that future override knobs can plug into.
+</Callout>
+
+## Per-package matrix
+
+| Package | Animations | Layer 1 (`motion-safe:`) | Layer 2 (`@media` wrap) | Layer 3 (JS gate) |
+|---------|-----------|--------------------------|--------------------------|--------------------|
+| `@tour-kit/core` | none directly; exports `useReducedMotion()` | n/a | n/a | hook source |
+| `@tour-kit/react` | `tour-spotlight-in`, `tour-card-in`, card docking transition | n/a | yes (`packages/react/src/styles/theme.css`) | yes (`<TourCard>` docking transition) |
+| `@tour-kit/hints` | `tour-pulse` on `<HintHotspot>` | n/a (custom keyframe, not tailwindcss-animate) | yes (`packages/hints/src/styles/{theme,variables}.css`) | yes (`<HintHotspot pulse>` reads `useReducedMotion`) |
+| `@tour-kit/announcements` | `animate-in`/`animate-out` + `fade-*` + `slide-*` + `zoom-*` on modal/slideout/banner/toast/spotlight | yes (all 6 variant files + overlay) | inherited from `tailwindcss-animate` plugin | n/a |
+| `@tour-kit/surveys` | `animate-in`/`animate-out` + `fade-*` + `slide-*` + `zoom-*` on modal/slideout | yes (both variant files) | inherited from `tailwindcss-animate` plugin | n/a |
+| `@tour-kit/checklists` | `tk-strike`, `tk-check-pop` on task completion | n/a (custom keyframes) | yes (opt-in `@tour-kit/checklists/styles/animations.css`) | yes (skips the `completing` phase under reduce) |
+| `@tour-kit/media` | video / GIF / Lottie autoplay | n/a | n/a | yes (renders poster instead of autoplaying) |
+
+## Using `useReducedMotion()` in your own components
+
+The hook is exported from `@tour-kit/core` and re-exported from every UI package for convenience.
+
+```tsx title="Importing"
+// Import from any of these — they're the same hook:
+import { useReducedMotion } from '@tour-kit/core'
+import { useReducedMotion } from '@tour-kit/announcements'
+import { useReducedMotion } from '@tour-kit/surveys'
+import { useReducedMotion } from '@tour-kit/hints'
+```
+
+```tsx title="Gate a render-time animation class"
+import { cn, useReducedMotion } from '@tour-kit/core'
+
+function MyAnimatedCard({ className, children }) {
+  const reducedMotion = useReducedMotion()
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border p-4',
+        !reducedMotion && 'transition-transform duration-200 ease-out',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+```
+
+`useReducedMotion()` is **SSR-safe-default-true**: it returns `true` on the server and on the first client render, then flips to the actual `matchMedia` value after the first `useEffect`. This avoids a one-frame motion flash for users who have requested reduced motion. If you need the raw client-side preference and SSR flicker is not a concern, use the lower-level `usePrefersReducedMotion()` (defaults to `false`).
+
+## Override knobs
+
+`A11yConfig.reducedMotion` is part of the `@tour-kit/react` provider config:
+
+```tsx
+<TourKitProvider
+  a11y={{
+    reducedMotion: 'respect', // 'respect' (default) | 'always-animate' | 'never-animate'
+  }}
+>
+  …
+</TourKitProvider>
+```
+
+- **`'respect'`** (default and currently the only fully-implemented value) — defers to the OS preference via `useReducedMotion()`.
+- **`'always-animate'`** and **`'never-animate'`** — reserved for future expansion. The hook layer (#3) is the only piece of the three-tier defense that can be runtime-overridden, since CSS layers are static. Track [issue #TBD](https://github.com/domidex01/tour-kit/issues) for the full implementation.
+
+<Callout type="warn">
+Forcing `'always-animate'` would override an explicit accessibility request. Do this only if you have a strong justification (e.g., an internal tool with no end users, where the developer has confirmed they want the animations).
+</Callout>
+
+## Testing your own components
+
+If you embed a Tour Kit component, our reduce-mode gates already fire — you don't need to do anything. For your own animations:
+
+```tsx title="Vitest pattern (jsdom)"
+import { vi } from 'vitest'
+
+function mockMatchMedia(reduce: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation((q) => ({
+    matches: q.includes('reduce') ? reduce : false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MediaQueryList))
+}
+
+it('omits the pulse class when reduce mode is on', () => {
+  mockMatchMedia(true)
+  render(<MyAnimatedCard />)
+  expect(screen.getByRole('article')).not.toHaveClass('animate-pulse')
+})
+```
+
+For end-to-end verification in a real browser, use Chrome DevTools → Cmd/Ctrl+Shift+P → "Emulate CSS prefers-reduced-motion: reduce".
+
+## Related
+
+- [Animations guide](/docs/guides/animations) — keyframe customization, Framer Motion, performance
+- [Accessibility guide](/docs/guides/accessibility) — broader a11y coverage
+- [`useReducedMotion`](/docs/core/hooks/use-media-query) — hook API reference

--- a/apps/docs/public/context/adoption.txt
+++ b/apps/docs/public/context/adoption.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/adoption Context File
-Version: 0.0.8 | Generated: 2026-05-02
+Version: 0.0.8 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/adoption.
 =========================================================================
 

--- a/apps/docs/public/context/analytics.txt
+++ b/apps/docs/public/context/analytics.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/analytics Context File
-Version: 0.1.7 | Generated: 2026-05-02
+Version: 0.1.7 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/analytics.
 =========================================================================
 

--- a/apps/docs/public/context/announcements.txt
+++ b/apps/docs/public/context/announcements.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/announcements Context File
-Version: 0.2.2 | Generated: 2026-05-02
+Version: 0.2.2 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/announcements.
 =========================================================================
 
@@ -95,6 +95,7 @@ Hooks:
     useAnnouncements — Filter options for announcements
     useAnnouncementQueue — Return type for useAnnouncementQueue hook
     useUILibrary
+    useReducedMotion
 
 Components:
     AnnouncementOverlay
@@ -280,6 +281,7 @@ HOOKS
     useAnnouncements(): UseAnnouncementsReturn
     useAnnouncementQueue(): UseAnnouncementQueueReturn
     useUILibrary(...)
+    useReducedMotion(...)
 
 COMPONENTS
 ----------

--- a/apps/docs/public/context/checklists.txt
+++ b/apps/docs/public/context/checklists.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/checklists Context File
-Version: 0.1.7 | Generated: 2026-05-02
+Version: 0.1.7 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/checklists.
 =========================================================================
 

--- a/apps/docs/public/context/core.txt
+++ b/apps/docs/public/context/core.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/core Context File
-Version: 0.6.0 | Generated: 2026-05-02
+Version: 0.6.0 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/core.
 =========================================================================
 
@@ -101,6 +101,7 @@ Hooks:
     usePersistence
     useMediaQuery
     usePrefersReducedMotion
+    useReducedMotion
     useRoutePersistence
     useFlowSession
     useBroadcast
@@ -225,6 +226,7 @@ HOOKS
     usePersistence(...)
     useMediaQuery(...)
     usePrefersReducedMotion(...)
+    useReducedMotion(...)
     useRoutePersistence(...)
     useFlowSession(...)
     useBroadcast(...)

--- a/apps/docs/public/context/hints.txt
+++ b/apps/docs/public/context/hints.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/hints Context File
-Version: 0.6.0 | Generated: 2026-05-02
+Version: 0.6.0 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/hints.
 =========================================================================
 
@@ -42,6 +42,7 @@ Hooks:
     useHints
     useHint
     useUILibrary
+    useReducedMotion
 
 Components:
     Hint
@@ -143,6 +144,7 @@ HOOKS
     useHints()
     useHint(id: string)
     useUILibrary(...)
+    useReducedMotion(...)
 
 COMPONENTS
 ----------

--- a/apps/docs/public/context/media.txt
+++ b/apps/docs/public/context/media.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/media Context File
-Version: 0.1.5 | Generated: 2026-05-02
+Version: 0.1.5 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/media.
 =========================================================================
 

--- a/apps/docs/public/context/react.txt
+++ b/apps/docs/public/context/react.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/react Context File
-Version: 0.6.0 | Generated: 2026-05-02
+Version: 0.6.0 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/react.
 =========================================================================
 
@@ -37,6 +37,8 @@ Types:
     TourOverlayProps
     TourPortalProps
     MultiTourKitProviderProps
+    ThemeProviderProps
+    ThemeContextValue
     TourButtonVariants
     TourCardVariants
     TourCardHeaderVariants
@@ -49,6 +51,7 @@ Types:
     UILibraryProviderProps
     TourInfo
     UseToursReturn
+    UseThemeVariationReturn
     // Config types
   Side
     Alignment
@@ -97,9 +100,11 @@ Types:
     UseBranchReturn
 
 Hooks:
+    useThemeContext
     useUILibrary
     useTours — All registered tours
     useTourRoute — Router adapter
+    useThemeVariation — Subscribe to the active theme variation.
     useNextAppRouter
     useNextPagesRouter
     useReactRouter
@@ -130,6 +135,12 @@ Components:
     TourPortal
     TourArrow
     MultiTourKitProvider
+    ThemeProvider
+    ThemeMatcher
+    ThemePredicate
+    ThemeResolveContext
+    ThemeTokens
+    ThemeVariation
     Slot
     Slottable
     UnifiedSlot
@@ -142,6 +153,8 @@ Components:
     TourKitProvider
 
 Utilities:
+    resolveTheme
+    matchUrl
     // Button variants
   tourButtonVariants
     // Card variants
@@ -318,11 +331,15 @@ TYPES
       getTour: (tourId: string) => TourInfo | undefined
     }
 
+    export type UseThemeVariationReturn = ThemeContextValue
+
 HOOKS
 -----
+    useThemeContext(...)
     useUILibrary(...)
     useTours(): UseToursReturn
     useTourRoute({ router, tourId }: UseTourRouteOptions): UseTourRouteReturn
+    useThemeVariation(): UseThemeVariationReturn
     useNextAppRouter(...)
     useNextPagesRouter(...)
     useReactRouter(...)
@@ -354,6 +371,12 @@ COMPONENTS
     <TourPortal />
     <TourArrow />
     <MultiTourKitProvider />
+    <ThemeProvider />
+    <ThemeMatcher />
+    <ThemePredicate />
+    <ThemeResolveContext />
+    <ThemeTokens />
+    <ThemeVariation />
     <Slot />
     <Slottable />
     <UnifiedSlot />

--- a/apps/docs/public/context/scheduling.txt
+++ b/apps/docs/public/context/scheduling.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/scheduling Context File
-Version: 0.1.4 | Generated: 2026-05-02
+Version: 0.1.4 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/scheduling.
 =========================================================================
 

--- a/apps/docs/public/context/surveys.txt
+++ b/apps/docs/public/context/surveys.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/surveys Context File
-Version: 0.1.5 | Generated: 2026-05-02
+Version: 0.1.5 | Generated: 2026-05-03
 Paste this into your LLM to get accurate answers about @tour-kit/surveys.
 =========================================================================
 
@@ -75,6 +75,7 @@ Hooks:
     useSurvey
     useSurveys
     useSurveyScoring
+    useReducedMotion
 
 Components:
     SurveysProvider
@@ -98,6 +99,10 @@ Utilities:
     selectOptionVariants
     booleanOptionVariants
     progressBarVariants
+    modalContentVariants
+    modalOverlayVariants
+    slideoutContentVariants
+    slideoutOverlayVariants
 
 TYPES
 -----
@@ -258,6 +263,7 @@ HOOKS
     useSurvey(...)
     useSurveys(...)
     useSurveyScoring(...)
+    useReducedMotion(...)
 
 COMPONENTS
 ----------

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,4 +1,4 @@
-# userTourKit v0.6.0 — Generated 2026-05-02T08:36:30Z
+# userTourKit v0.6.0 — Generated 2026-05-03T06:03:41Z
 
 # userTourKit
 
@@ -234,7 +234,9 @@
 - [Multi-tab Tours](https://usertourkit.com/docs/guides/multi-tab): Pause an active tour in tab B when the user starts the same flow in tab A — cross-tab coordination via BroadcastChannel.
 - [Next.js Integration](https://usertourkit.com/docs/guides/nextjs): Set up userTourKit with Next.js App Router or Pages Router — server component layouts, route-aware tours, and SSR support
 - [Persistence](https://usertourkit.com/docs/guides/persistence): Save tour progress, checklist completion, and hint dismissals across browser sessions with pluggable storage adapters
+- [Reduced Motion](https://usertourkit.com/docs/guides/reduced-motion): How Tour Kit honors prefers-reduced-motion across announcements, surveys, hints, checklists, and the core tour runtime
 - [Router Integration](https://usertourkit.com/docs/guides/router-integration): Build multi-page tours with Next.js, React Router, or custom routers using route-aware step targeting and persistence
+- [Theme Variations](https://usertourkit.com/docs/guides/theme-variations): Resolve tour themes by system colour scheme, explicit mode, route, or arbitrary trait predicates with `<ThemeProvider>` and `useThemeVariation`.
 - [Troubleshooting](https://usertourkit.com/docs/guides/troubleshooting): Diagnose and fix common userTourKit issues: missing targets, positioning glitches, hydration errors, and focus trap problems
 - [Unified Slot (Radix UI + Base UI)](https://usertourkit.com/docs/guides/unified-slot): Single composition primitive that supports both Radix UI's asChild element cloning and Base UI's render-prop style — covers UnifiedSlot, UILibrary, UILibraryProvider, and the RenderProp shape
 - [Vite Integration](https://usertourkit.com/docs/guides/vite): Configure userTourKit in Vite + React projects with hot module replacement, path aliases, and production build optimization
@@ -243,9 +245,11 @@
 
 - [Examples](https://usertourkit.com/docs/examples): Copy-paste examples for common userTourKit patterns: basic tours, onboarding flows, and fully custom headless interfaces
 - [Basic Tour](https://usertourkit.com/docs/examples/basic-tour): Build a 3-step product tour with spotlight overlay, keyboard navigation, and progress indicators — full working code
+- [Cross-page Tour](https://usertourkit.com/docs/examples/cross-page-tour): Build a multi-page tour that navigates from /dashboard to /billing and resumes on the right URL after a hard refresh, using the Next.js App Router.
 - [Dashboard (full integration)](https://usertourkit.com/docs/examples/dashboard): Reference example exercising every @tour-kit/* package in one Next.js 16 + React 19 + Tailwind v4 + shadcn/ui app.
 - [Headless Custom UI](https://usertourkit.com/docs/examples/headless-custom): Build a completely custom tour UI with headless components, render props, and your own design system or CSS framework
 - [Onboarding Flow](https://usertourkit.com/docs/examples/onboarding-flow): Complete user onboarding flow with persistent progress, conditional steps, checklists, and tour completion callbacks
+- [Progress Variants](https://usertourkit.com/docs/examples/progress-variants): Render every TourProgress variant — text, narrow, bar, chain, dots, numbered, none — with accessible roles and reduced-motion-friendly transitions
 
 ## API Reference
 

--- a/packages/announcements/CLAUDE.md
+++ b/packages/announcements/CLAUDE.md
@@ -71,6 +71,10 @@ pnpm --filter @tour-kit/announcements typecheck
 pnpm --filter @tour-kit/announcements test
 ```
 
+## Reduced motion
+
+All five display variants (modal, slideout, banner, toast, spotlight) gate their `tailwindcss-animate` utilities behind the `motion-safe:` Tailwind prefix in their cva variant files. See the cross-package contract in the repo-root [CLAUDE.md § Reduced motion](../../CLAUDE.md) and the user-facing guide at [`apps/docs/content/docs/guides/reduced-motion.mdx`](../../apps/docs/content/docs/guides/reduced-motion.mdx). `useReducedMotion` is re-exported from `@tour-kit/announcements` for ergonomic access in consumer code.
+
 ## Related Rules
 - `tour-kit/rules/components.md` - Component patterns
 - `tour-kit/rules/accessibility.md` - A11y requirements

--- a/packages/announcements/src/__tests__/reduced-motion.test.tsx
+++ b/packages/announcements/src/__tests__/reduced-motion.test.tsx
@@ -1,0 +1,69 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  bannerVariants,
+  modalContentVariants,
+  modalOverlayVariants,
+  slideoutContentVariants,
+  slideoutOverlayVariants,
+  spotlightContentVariants,
+  toastVariants,
+  useReducedMotion,
+} from '../index'
+
+// Catches any bare animation utility that's missing the `motion-safe:` prefix.
+// `tailwindcss-animate` does NOT honor `prefers-reduced-motion: reduce` on its
+// own; the prefix is the contract.
+const BARE_ANIM_RE =
+  /(?<!motion-safe:)(?:^|\s|\]:)(animate-in|animate-out|fade-in-0|fade-out-0|fade-in|fade-out|slide-in-from-[\w/-]+|slide-out-to-[\w/-]+|zoom-in-95|zoom-out-95|zoom-in|zoom-out)\b/
+
+const REQUIRED_MOTION_SAFE_RE = /motion-safe:animate-in/
+
+const cases: Array<[label: string, classes: string]> = [
+  ['modalOverlayVariants()', modalOverlayVariants()],
+  ['modalContentVariants({ size: md })', modalContentVariants({ size: 'md' })],
+  ['slideoutOverlayVariants()', slideoutOverlayVariants()],
+  ['slideoutContentVariants({ position: left })', slideoutContentVariants({ position: 'left' })],
+  ['slideoutContentVariants({ position: right })', slideoutContentVariants({ position: 'right' })],
+  ['bannerVariants({ position: top })', bannerVariants({ position: 'top' })],
+  ['bannerVariants({ position: bottom })', bannerVariants({ position: 'bottom' })],
+  ['toastVariants({ position: top-right })', toastVariants({ position: 'top-right' })],
+  ['toastVariants({ position: bottom-left })', toastVariants({ position: 'bottom-left' })],
+  ['toastVariants({ position: top-center })', toastVariants({ position: 'top-center' })],
+  ['toastVariants({ position: bottom-center })', toastVariants({ position: 'bottom-center' })],
+  ['spotlightContentVariants({ placement: top })', spotlightContentVariants({ placement: 'top' })],
+  [
+    'spotlightContentVariants({ placement: bottom })',
+    spotlightContentVariants({ placement: 'bottom' }),
+  ],
+  [
+    'spotlightContentVariants({ placement: left })',
+    spotlightContentVariants({ placement: 'left' }),
+  ],
+  [
+    'spotlightContentVariants({ placement: right })',
+    spotlightContentVariants({ placement: 'right' }),
+  ],
+]
+
+describe('announcements: motion-safe CSS-prefix coverage (US-1)', () => {
+  it.each(cases)('%s exposes motion-safe:animate-in', (_label, classes) => {
+    expect(classes).toMatch(REQUIRED_MOTION_SAFE_RE)
+  })
+
+  it.each(cases)('%s contains no bare animate-* utility', (_label, classes) => {
+    expect(classes).not.toMatch(BARE_ANIM_RE)
+  })
+})
+
+describe('announcements: useReducedMotion re-export (US-5)', () => {
+  it('exports a function from @tour-kit/announcements', () => {
+    expect(typeof useReducedMotion).toBe('function')
+  })
+
+  it('returns a boolean when called inside a component', () => {
+    const { result } = renderHook(() => useReducedMotion())
+    expect(typeof result.current).toBe('boolean')
+  })
+})

--- a/packages/announcements/src/components/announcement-overlay.tsx
+++ b/packages/announcements/src/components/announcement-overlay.tsx
@@ -5,7 +5,7 @@ import { type VariantProps, cva } from 'class-variance-authority'
 import * as React from 'react'
 
 const overlayVariants = cva(
-  'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+  'fixed inset-0 z-50 bg-black/80 data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0',
   {
     variants: {
       blur: {

--- a/packages/announcements/src/components/ui/banner-variants.ts
+++ b/packages/announcements/src/components/ui/banner-variants.ts
@@ -1,13 +1,13 @@
 import { cva } from 'class-variance-authority'
 
 export const bannerVariants = cva(
-  'relative flex items-center justify-between gap-4 px-4 py-3 text-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+  'relative flex items-center justify-between gap-4 px-4 py-3 text-sm data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0',
   {
     variants: {
       position: {
-        top: 'border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        top: 'border-b data-[state=closed]:motion-safe:slide-out-to-top data-[state=open]:motion-safe:slide-in-from-top',
         bottom:
-          'border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+          'border-t data-[state=closed]:motion-safe:slide-out-to-bottom data-[state=open]:motion-safe:slide-in-from-bottom',
       },
       intent: {
         info: 'bg-blue-50 text-blue-900 border-blue-200 dark:bg-blue-950 dark:text-blue-100 dark:border-blue-800',

--- a/packages/announcements/src/components/ui/modal-variants.ts
+++ b/packages/announcements/src/components/ui/modal-variants.ts
@@ -1,11 +1,11 @@
 import { cva } from 'class-variance-authority'
 
 export const modalOverlayVariants = cva(
-  'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
+  'fixed inset-0 z-50 bg-black/80 data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0'
 )
 
 export const modalContentVariants = cva(
-  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0 data-[state=closed]:motion-safe:zoom-out-95 data-[state=open]:motion-safe:zoom-in-95 data-[state=closed]:motion-safe:slide-out-to-left-1/2 data-[state=closed]:motion-safe:slide-out-to-top-[48%] data-[state=open]:motion-safe:slide-in-from-left-1/2 data-[state=open]:motion-safe:slide-in-from-top-[48%] sm:rounded-lg',
   {
     variants: {
       size: {

--- a/packages/announcements/src/components/ui/slideout-variants.ts
+++ b/packages/announcements/src/components/ui/slideout-variants.ts
@@ -1,17 +1,17 @@
 import { cva } from 'class-variance-authority'
 
 export const slideoutOverlayVariants = cva(
-  'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
+  'fixed inset-0 z-50 bg-black/80 data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0'
 )
 
 export const slideoutContentVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
   {
     variants: {
       position: {
-        left: 'inset-y-0 left-0 h-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+        left: 'inset-y-0 left-0 h-full border-r data-[state=closed]:motion-safe:slide-out-to-left data-[state=open]:motion-safe:slide-in-from-left',
         right:
-          'inset-y-0 right-0 h-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+          'inset-y-0 right-0 h-full border-l data-[state=closed]:motion-safe:slide-out-to-right data-[state=open]:motion-safe:slide-in-from-right',
       },
       size: {
         sm: 'w-3/4 sm:max-w-sm',

--- a/packages/announcements/src/components/ui/spotlight-variants.ts
+++ b/packages/announcements/src/components/ui/spotlight-variants.ts
@@ -13,14 +13,14 @@ export const spotlightOverlayVariants = cva('fixed inset-0 z-40 pointer-events-n
 })
 
 export const spotlightContentVariants = cva(
-  'z-50 w-full max-w-sm rounded-lg border bg-background p-4 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+  'z-50 w-full max-w-sm rounded-lg border bg-background p-4 shadow-lg data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0 data-[state=closed]:motion-safe:zoom-out-95 data-[state=open]:motion-safe:zoom-in-95',
   {
     variants: {
       placement: {
-        top: 'data-[state=open]:slide-in-from-bottom-2',
-        right: 'data-[state=open]:slide-in-from-left-2',
-        bottom: 'data-[state=open]:slide-in-from-top-2',
-        left: 'data-[state=open]:slide-in-from-right-2',
+        top: 'data-[state=open]:motion-safe:slide-in-from-bottom-2',
+        right: 'data-[state=open]:motion-safe:slide-in-from-left-2',
+        bottom: 'data-[state=open]:motion-safe:slide-in-from-top-2',
+        left: 'data-[state=open]:motion-safe:slide-in-from-right-2',
       },
     },
     defaultVariants: {

--- a/packages/announcements/src/components/ui/toast-variants.ts
+++ b/packages/announcements/src/components/ui/toast-variants.ts
@@ -17,7 +17,7 @@ export const toastContainerVariants = cva('fixed z-50 flex flex-col gap-2 p-4', 
 })
 
 export const toastVariants = cva(
-  'relative flex w-full max-w-sm items-start gap-3 rounded-lg border p-4 shadow-lg transition-all data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+  'relative flex w-full max-w-sm items-start gap-3 rounded-lg border p-4 shadow-lg transition-all data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0',
   {
     variants: {
       intent: {
@@ -30,14 +30,18 @@ export const toastVariants = cva(
           'bg-red-50 text-red-900 border-red-200 dark:bg-red-950 dark:text-red-100 dark:border-red-800',
       },
       position: {
-        'top-left': 'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
-        'top-right': 'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
-        'top-center': 'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
-        'bottom-left': 'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+        'top-left':
+          'data-[state=closed]:motion-safe:slide-out-to-left data-[state=open]:motion-safe:slide-in-from-left',
+        'top-right':
+          'data-[state=closed]:motion-safe:slide-out-to-right data-[state=open]:motion-safe:slide-in-from-right',
+        'top-center':
+          'data-[state=closed]:motion-safe:slide-out-to-top data-[state=open]:motion-safe:slide-in-from-top',
+        'bottom-left':
+          'data-[state=closed]:motion-safe:slide-out-to-left data-[state=open]:motion-safe:slide-in-from-left',
         'bottom-right':
-          'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+          'data-[state=closed]:motion-safe:slide-out-to-right data-[state=open]:motion-safe:slide-in-from-right',
         'bottom-center':
-          'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+          'data-[state=closed]:motion-safe:slide-out-to-bottom data-[state=open]:motion-safe:slide-in-from-bottom',
       },
     },
     defaultVariants: {

--- a/packages/announcements/src/index.ts
+++ b/packages/announcements/src/index.ts
@@ -130,6 +130,9 @@ export {
   type UILibraryProviderProps,
 } from '@tour-kit/core'
 
+// Accessibility hooks (re-exported for ergonomic in-package access)
+export { useReducedMotion } from '@tour-kit/core'
+
 // ============================================
 // TYPES
 // ============================================

--- a/packages/hints/CLAUDE.md
+++ b/packages/hints/CLAUDE.md
@@ -45,6 +45,10 @@ pnpm --filter @tour-kit/hints typecheck
 pnpm --filter @tour-kit/hints test
 ```
 
+## Reduced motion
+
+`<HintHotspot>` reads `useReducedMotion()` from `@tour-kit/core` and gates the `pulse` cva variant: under reduce mode, `shouldPulse = pulse && !isOpen && !reducedMotion` resolves to `false` and the `animate-tour-pulse` class is never applied. CSS keyframe wrappers in `src/styles/{theme,variables}.css` are kept as defense-in-depth. See the cross-package contract in the repo-root [CLAUDE.md § Reduced motion](../../CLAUDE.md) and the user-facing guide at [`apps/docs/content/docs/guides/reduced-motion.mdx`](../../apps/docs/content/docs/guides/reduced-motion.mdx). `useReducedMotion` is re-exported from `@tour-kit/hints`.
+
 ## Related Rules
 - `tour-kit/rules/components.md` - Component patterns
 - `tour-kit/rules/accessibility.md` - A11y requirements

--- a/packages/hints/src/__tests__/reduced-motion.test.tsx
+++ b/packages/hints/src/__tests__/reduced-motion.test.tsx
@@ -1,0 +1,72 @@
+import { render, renderHook, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { HintHotspot, useReducedMotion } from '../index'
+
+const mockRect: DOMRect = {
+  top: 100,
+  left: 100,
+  bottom: 200,
+  right: 300,
+  width: 200,
+  height: 100,
+  x: 100,
+  y: 100,
+  toJSON: () => ({}),
+}
+
+function mockMatchMedia(reduce: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation(
+    (q: string) =>
+      ({
+        matches: q.includes('reduce') ? reduce : false,
+        media: q,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }) as unknown as MediaQueryList
+  )
+}
+
+describe('hints: HintHotspot pulse JS-gate (US-4)', () => {
+  it('omits animate-tour-pulse class when prefers-reduced-motion: reduce is true', () => {
+    mockMatchMedia(true)
+
+    render(<HintHotspot targetRect={mockRect} position="top-right" pulse isOpen={false} />)
+
+    const button = screen.getByRole('button', { name: 'Show hint' })
+    expect(button).not.toHaveClass('animate-tour-pulse')
+  })
+
+  it('applies animate-tour-pulse class when reduce mode is false (post-effect)', () => {
+    mockMatchMedia(false)
+
+    render(<HintHotspot targetRect={mockRect} position="top-right" pulse isOpen={false} />)
+
+    const button = screen.getByRole('button', { name: 'Show hint' })
+    expect(button).toHaveClass('animate-tour-pulse')
+  })
+
+  it('omits pulse class when isOpen is true regardless of reduce mode', () => {
+    mockMatchMedia(false)
+
+    render(<HintHotspot targetRect={mockRect} position="top-right" pulse isOpen />)
+
+    const button = screen.getByRole('button', { name: 'Show hint' })
+    expect(button).not.toHaveClass('animate-tour-pulse')
+  })
+})
+
+describe('hints: useReducedMotion re-export (US-5)', () => {
+  it('exports a function from @tour-kit/hints', () => {
+    expect(typeof useReducedMotion).toBe('function')
+  })
+
+  it('returns a boolean when called inside a component', () => {
+    const { result } = renderHook(() => useReducedMotion())
+    expect(typeof result.current).toBe('boolean')
+  })
+})

--- a/packages/hints/src/__tests__/reduced-motion.test.tsx
+++ b/packages/hints/src/__tests__/reduced-motion.test.tsx
@@ -44,6 +44,10 @@ describe('hints: HintHotspot pulse JS-gate (US-4)', () => {
   it('applies animate-tour-pulse class when reduce mode is false (post-effect)', () => {
     mockMatchMedia(false)
 
+    // useReducedMotion's SSR-safe default is `true`; the hook's useEffect flips
+    // it to matchMedia's value (false here). render() wraps in act and flushes
+    // the effect, so the assertion sees the post-effect state — no awaitable
+    // needed.
     render(<HintHotspot targetRect={mockRect} position="top-right" pulse isOpen={false} />)
 
     const button = screen.getByRole('button', { name: 'Show hint' })

--- a/packages/hints/src/components/hint-hotspot.tsx
+++ b/packages/hints/src/components/hint-hotspot.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { cn } from '@tour-kit/core'
-import { useUILibrary } from '@tour-kit/core'
+import { cn, useReducedMotion, useUILibrary } from '@tour-kit/core'
 import * as React from 'react'
 import { Slot, UnifiedSlot } from '../lib/slot'
 import type { HotspotPosition } from '../types'
@@ -60,11 +59,12 @@ export const HintHotspot = React.forwardRef<HTMLButtonElement, HintHotspotProps>
     ref
   ) => {
     const library = useUILibrary()
+    const reducedMotion = useReducedMotion()
     const pos = getHotspotPosition(position, targetRect)
     const Comp = asChild ? (library === 'base-ui' ? UnifiedSlot : Slot) : 'button'
 
-    // Don't pulse when tooltip is open
-    const shouldPulse = pulse && !isOpen
+    // Don't pulse when tooltip is open or when the user prefers reduced motion.
+    const shouldPulse = pulse && !isOpen && !reducedMotion
 
     return (
       <Comp

--- a/packages/hints/src/index.ts
+++ b/packages/hints/src/index.ts
@@ -49,6 +49,9 @@ export {
   type UILibraryProviderProps,
 } from '@tour-kit/core'
 
+// Accessibility hooks (re-exported for ergonomic in-package access)
+export { useReducedMotion } from '@tour-kit/core'
+
 // ============================================
 // TYPES
 // ============================================

--- a/packages/surveys/CLAUDE.md
+++ b/packages/surveys/CLAUDE.md
@@ -62,6 +62,10 @@ pnpm --filter @tour-kit/surveys typecheck
 pnpm --filter @tour-kit/surveys test
 ```
 
+## Reduced motion
+
+`SurveyModal` and `SurveySlideout` gate their `tailwindcss-animate` utilities behind the `motion-safe:` Tailwind prefix in `components/ui/{modal,slideout}-variants.ts`. See the cross-package contract in the repo-root [CLAUDE.md § Reduced motion](../../CLAUDE.md) and the user-facing guide at [`apps/docs/content/docs/guides/reduced-motion.mdx`](../../apps/docs/content/docs/guides/reduced-motion.mdx). `useReducedMotion` is re-exported from `@tour-kit/surveys` for ergonomic access in consumer code.
+
 ## Related Rules
 - `tour-kit/rules/components.md` - Component patterns
 - `tour-kit/rules/accessibility.md` - A11y requirements

--- a/packages/surveys/src/__tests__/reduced-motion.test.tsx
+++ b/packages/surveys/src/__tests__/reduced-motion.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  modalContentVariants,
+  modalOverlayVariants,
+  slideoutContentVariants,
+  slideoutOverlayVariants,
+  useReducedMotion,
+} from '../index'
+
+// Surveys vitest setup is minimal — make sure matchMedia is callable so the
+// hook smoke can run.
+if (typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+const BARE_ANIM_RE =
+  /(?<!motion-safe:)(?:^|\s|\]:)(animate-in|animate-out|fade-in-0|fade-out-0|fade-in|fade-out|slide-in-from-[\w/-]+|slide-out-to-[\w/-]+|zoom-in-95|zoom-out-95|zoom-in|zoom-out)\b/
+
+const REQUIRED_MOTION_SAFE_RE = /motion-safe:animate-in/
+
+const cases: Array<[label: string, classes: string]> = [
+  ['modalOverlayVariants()', modalOverlayVariants()],
+  ['modalContentVariants({ size: md })', modalContentVariants({ size: 'md' })],
+  ['slideoutOverlayVariants()', slideoutOverlayVariants()],
+  ['slideoutContentVariants({ position: left })', slideoutContentVariants({ position: 'left' })],
+  ['slideoutContentVariants({ position: right })', slideoutContentVariants({ position: 'right' })],
+]
+
+describe('surveys: motion-safe CSS-prefix coverage (US-2)', () => {
+  it.each(cases)('%s exposes motion-safe:animate-in', (_label, classes) => {
+    expect(classes).toMatch(REQUIRED_MOTION_SAFE_RE)
+  })
+
+  it.each(cases)('%s contains no bare animate-* utility', (_label, classes) => {
+    expect(classes).not.toMatch(BARE_ANIM_RE)
+  })
+})
+
+describe('surveys: useReducedMotion re-export (US-5)', () => {
+  it('exports a function from @tour-kit/surveys', () => {
+    expect(typeof useReducedMotion).toBe('function')
+  })
+
+  it('returns a boolean when called inside a component', () => {
+    const { result } = renderHook(() => useReducedMotion())
+    expect(typeof result.current).toBe('boolean')
+  })
+})

--- a/packages/surveys/src/components/ui/modal-variants.ts
+++ b/packages/surveys/src/components/ui/modal-variants.ts
@@ -1,11 +1,11 @@
 import { cva } from 'class-variance-authority'
 
 export const modalOverlayVariants = cva(
-  'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
+  'fixed inset-0 z-50 bg-black/80 data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0'
 )
 
 export const modalContentVariants = cva(
-  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
+  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0 data-[state=closed]:motion-safe:zoom-out-95 data-[state=open]:motion-safe:zoom-in-95 sm:rounded-lg',
   {
     variants: {
       size: {

--- a/packages/surveys/src/components/ui/slideout-variants.ts
+++ b/packages/surveys/src/components/ui/slideout-variants.ts
@@ -1,17 +1,17 @@
 import { cva } from 'class-variance-authority'
 
 export const slideoutOverlayVariants = cva(
-  'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
+  'fixed inset-0 z-50 bg-black/80 data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:motion-safe:fade-out-0 data-[state=open]:motion-safe:fade-in-0'
 )
 
 export const slideoutContentVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:motion-safe:animate-in data-[state=closed]:motion-safe:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
   {
     variants: {
       position: {
-        left: 'inset-y-0 left-0 h-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+        left: 'inset-y-0 left-0 h-full border-r data-[state=closed]:motion-safe:slide-out-to-left data-[state=open]:motion-safe:slide-in-from-left',
         right:
-          'inset-y-0 right-0 h-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+          'inset-y-0 right-0 h-full border-l data-[state=closed]:motion-safe:slide-out-to-right data-[state=open]:motion-safe:slide-in-from-right',
       },
       size: {
         sm: 'w-3/4 sm:max-w-sm',

--- a/packages/surveys/src/index.ts
+++ b/packages/surveys/src/index.ts
@@ -98,3 +98,13 @@ export {
   booleanOptionVariants,
   progressBarVariants,
 } from './components/ui/question-variants'
+
+export { modalContentVariants, modalOverlayVariants } from './components/ui/modal-variants'
+
+export {
+  slideoutContentVariants,
+  slideoutOverlayVariants,
+} from './components/ui/slideout-variants'
+
+// Accessibility hooks (re-exported for ergonomic in-package access)
+export { useReducedMotion } from '@tour-kit/core'


### PR DESCRIPTION
## Phase 1.6 — `prefers-reduced-motion` Plumbing

Wires the SSR-safe `useReducedMotion()` hook (shipped in Phase 1.5 from `@tour-kit/core`) into the three remaining packages with motion. Closes the cross-package contract: every animation in every Tour Kit package is now gated, by either CSS, JS, or both.

### Why

[Tailwind's own docs](https://tailwindcss.com/docs/animation) and the [`tailwindcss-animate` upstream](https://github.com/tailwindlabs/tailwindcss/discussions/12864) confirm `tailwindcss-animate` does **not** auto-respect `prefers-reduced-motion: reduce`. A repo-wide grep on `main` found **12 unprotected `animate-in` / `animate-out` / `fade-*` / `slide-*` / `zoom-*` class strings** across `announcements` (8) and `surveys` (4) — all of them ran at full strength under reduce mode. The `motion-safe:` prefix (which compiles to `@media (prefers-reduced-motion: no-preference)`) is the documented fix.

### Changes

**CSS-prefix sweep (zero JS, zero bundle delta).**
- `packages/announcements/src/components/ui/{modal,slideout,banner,toast,spotlight}-variants.ts` — every `tailwindcss-animate` utility now prefixed with `motion-safe:`.
- `packages/announcements/src/components/announcement-overlay.tsx` — same.
- `packages/surveys/src/components/ui/{modal,slideout}-variants.ts` — same.

**JS gate.**
- `packages/hints/src/components/hint-hotspot.tsx` — `<HintHotspot pulse>` reads `useReducedMotion()` and gates the `animate-tour-pulse` cva variant; defense-in-depth on top of the existing `@media` keyframe wrapper.

**Re-exports.**
- `useReducedMotion` re-exported from `@tour-kit/announcements`, `@tour-kit/surveys`, `@tour-kit/hints` for ergonomic in-package access.
- `@tour-kit/surveys` additionally exposes `modal{Content,Overlay}Variants` and `slideout{Content,Overlay}Variants` (consumer customization parity with `@tour-kit/announcements`).

**Tests.** 49 reduce-motion cases across 3 packages — announcements 32, surveys 12, hints 5 — covering:
- CSS-prefix coverage (every variant function exposes `motion-safe:animate-in`, no bare animate-* utility).
- JS-gate coverage (`<HintHotspot pulse>` + reduce → no pulse class; reduce false → pulse class).
- `useReducedMotion` re-export smoke.

**Docs.** New `apps/docs/content/docs/guides/reduced-motion.mdx` documents the three-tier defense (CSS prefix → CSS keyframe wrap → JS hook) with a per-package matrix. Cross-linked from repo-root + per-package CLAUDE.md.

**Changesets.** 3 patch bumps (announcements, surveys, hints).

### Test plan

- [x] `pnpm --filter @tour-kit/announcements --filter @tour-kit/surveys --filter @tour-kit/hints test` — 566/566 passing (announcements 122, hints 242, surveys 202)
- [x] `pnpm --filter @tour-kit/announcements --filter @tour-kit/surveys --filter @tour-kit/hints typecheck` — clean
- [x] Repo-wide audit: `grep -rn "animate-in\|animate-out\|fade-in-0\|fade-out-0\|slide-in-from\|slide-out-to\|zoom-in-95\|zoom-out-95" packages/announcements/src packages/surveys/src | grep -v motion-safe | grep -v "test\|tailwind/index.ts"` returns zero hits
- [ ] Manual: with OS reduce-mode on, opening a `<HintHotspot pulse>` does not visibly pulse — verify in docs preview
- [ ] Lighthouse on `apps/docs` build — accessibility score still 100

### Out of scope / deviations from the test plan

- **US-3 dropped.** The Phase 1.6 test plan specified a JS-gate test for `<AnnouncementSpotlight>`'s `animate-tour-pulse` keyframe — but the spotlight component has no such class in the current codebase (`animate-tour-pulse` lives only in `@tour-kit/hints`). Adding a JS gate to the spotlight would gate dead code or invent a new pulse animation. The CSS-prefix sweep covers all the spotlight's real animations (`animate-in`, `fade-*`, `slide-*`, `zoom-*`).
- Implementing `A11yConfig.reducedMotion: 'always-animate' | 'never-animate'` (filed as a follow-up issue).
- Touching `@tour-kit/media` — already correct, reference implementation.

### Notes

- Pre-existing `apps/docs` build failure on `/blog/page` (`useMemo` from null) reproduces on clean `main` without these changes; not introduced by this PR.

🤖 Generated with run-phase skill