### PR TITLE
feat(announcements): UserGuiding parity Phase 3c — wire announcements

### DIFF
--- a/packages/announcements/src/__tests__/announcement-category.test.tsx
+++ b/packages/announcements/src/__tests__/announcement-category.test.tsx
@@ -1,0 +1,56 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { AnnouncementModal } from '../components/announcement-modal'
+import { AnnouncementsProvider } from '../context/announcements-provider'
+import type { AnnouncementConfig } from '../types/announcement'
+
+describe('AnnouncementConfig.category', () => {
+  it('round-trips through the AnnouncementConfig type', () => {
+    // Compile-time assertion: `category?: string` is accepted on the public type.
+    // If this file fails to typecheck, the field has been dropped or renamed.
+    const config: AnnouncementConfig = {
+      id: 'feat-1',
+      variant: 'modal',
+      title: 'New feature',
+      category: 'feature',
+    }
+    expect(config.category).toBe('feature')
+    expect(config).toMatchObject({ id: 'feat-1', category: 'feature' })
+  })
+
+  it('produces DOM identical to the no-category baseline (presentation-layer only)', async () => {
+    const baseline: AnnouncementConfig = {
+      id: 'feat-1',
+      variant: 'modal',
+      title: 'New feature',
+      description: 'Try it out',
+    }
+    const withCategory: AnnouncementConfig = { ...baseline, category: 'feature' }
+
+    const baselineRender = render(
+      <AnnouncementsProvider announcements={[baseline]}>
+        <AnnouncementModal id="feat-1" />
+      </AnnouncementsProvider>
+    )
+    await waitFor(() => {
+      expect(baselineRender.queryByText('New feature')).toBeInTheDocument()
+    })
+    const baselineHtml = baselineRender.container.innerHTML
+    baselineRender.unmount()
+
+    const withCatRender = render(
+      <AnnouncementsProvider announcements={[withCategory]}>
+        <AnnouncementModal id="feat-1" />
+      </AnnouncementsProvider>
+    )
+    await waitFor(() => {
+      expect(withCatRender.queryByText('New feature')).toBeInTheDocument()
+    })
+    const withCatHtml = withCatRender.container.innerHTML
+    withCatRender.unmount()
+
+    // 3c declares `category` is presentation-layer metadata only — no
+    // rendering changes. Phase 5a's changelog feed will read the field.
+    expect(withCatHtml).toBe(baselineHtml)
+  })
+})

--- a/packages/announcements/src/__tests__/announcement-i18n.test.tsx
+++ b/packages/announcements/src/__tests__/announcement-i18n.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { AnnouncementBanner } from '../components/announcement-banner'
+import { AnnouncementModal } from '../components/announcement-modal'
+import { AnnouncementSlideout } from '../components/announcement-slideout'
+import { AnnouncementSpotlight } from '../components/announcement-spotlight'
+import { AnnouncementToast } from '../components/announcement-toast'
+import { AnnouncementsProvider } from '../context/announcements-provider'
+import type { AnnouncementConfig, AnnouncementVariant } from '../types/announcement'
+import { renderWithProviders } from './render-with-providers'
+
+const SPOTLIGHT_TARGET_ID = '__spotlight-target__'
+
+interface VariantSpec {
+  name: AnnouncementVariant
+  Component: React.ComponentType<{ id: string }>
+}
+
+const VARIANTS: ReadonlyArray<VariantSpec> = [
+  { name: 'modal', Component: AnnouncementModal },
+  { name: 'banner', Component: AnnouncementBanner },
+  { name: 'toast', Component: AnnouncementToast },
+  { name: 'slideout', Component: AnnouncementSlideout },
+  { name: 'spotlight', Component: AnnouncementSpotlight },
+]
+
+function makeConfig(
+  variant: AnnouncementVariant,
+  overrides: Partial<AnnouncementConfig> = {}
+): AnnouncementConfig {
+  const base: AnnouncementConfig = {
+    id: `announcement-${variant}`,
+    variant,
+    title: 'Default title',
+    description: 'Default description',
+    // Disable toast auto-dismiss so the timer never fires during the test
+    toastOptions: { autoDismiss: false, showProgress: false },
+    spotlightOptions: { targetSelector: `#${SPOTLIGHT_TARGET_ID}` },
+  }
+  return { ...base, ...overrides }
+}
+
+beforeEach(() => {
+  // Spotlight queries `document.querySelector(targetSelector)` for its anchor.
+  const target = document.createElement('div')
+  target.id = SPOTLIGHT_TARGET_ID
+  document.body.appendChild(target)
+})
+
+afterEach(() => {
+  const target = document.getElementById(SPOTLIGHT_TARGET_ID)
+  if (target) target.remove()
+})
+
+describe.each(VARIANTS)('$name i18n', ({ name, Component }) => {
+  it('interpolates {{user.name}} from userContext into a string title', async () => {
+    const config = makeConfig(name, { title: 'Hi {{user.name | there}}' })
+    renderWithProviders(
+      <AnnouncementsProvider announcements={[config]}>
+        <Component id={config.id} />
+      </AnnouncementsProvider>,
+      { userContext: { user: { name: 'Domi' } } }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Hi Domi/)).toBeInTheDocument()
+    })
+  })
+
+  it('resolves an i18n key title via the messages dictionary', async () => {
+    const config = makeConfig(name, { title: { key: 'announcement.welcome.title' } })
+    renderWithProviders(
+      <AnnouncementsProvider announcements={[config]}>
+        <Component id={config.id} />
+      </AnnouncementsProvider>,
+      { messages: { 'announcement.welcome.title': 'Hello there' } }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello there')).toBeInTheDocument()
+    })
+  })
+
+  it('interpolates the description with userContext vars', async () => {
+    const config = makeConfig(name, {
+      title: 'Title',
+      description: 'Welcome {{user.name | friend}}',
+    })
+    renderWithProviders(
+      <AnnouncementsProvider announcements={[config]}>
+        <Component id={config.id} />
+      </AnnouncementsProvider>,
+      { userContext: { user: { name: 'Ada' } } }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Welcome Ada/)).toBeInTheDocument()
+    })
+  })
+
+  it('falls back to the literal string when no LocaleProvider is mounted', async () => {
+    // Render WITHOUT renderWithProviders — bare render, no LocaleProvider/SegmentationProvider
+    // in scope. interpolate() with no vars + no `{{x}}` tokens returns the input unchanged.
+    const config = makeConfig(name, {
+      title: 'Plain title',
+      description: 'Plain description',
+    })
+    render(
+      <AnnouncementsProvider announcements={[config]}>
+        <Component id={config.id} />
+      </AnnouncementsProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Plain title')).toBeInTheDocument()
+    })
+  })
+})
+
+// ReactNode descriptions only render losslessly in modal / slideout / spotlight
+// (banner / toast wrap description in <span> / <div> which collapse JSX
+// children when given a fragment, so they render but without preserving tag
+// structure as cleanly). Mirror the test plan's narrower scope here.
+describe('description ReactNode passthrough', () => {
+  it.each([
+    { name: 'modal' as const, Component: AnnouncementModal },
+    { name: 'slideout' as const, Component: AnnouncementSlideout },
+    { name: 'spotlight' as const, Component: AnnouncementSpotlight },
+  ])('$name renders ReactNode descriptions unchanged', async ({ name, Component }) => {
+    const config = makeConfig(name, {
+      title: 'Title',
+      description: <strong data-testid="rn-body">Body</strong>,
+    })
+    renderWithProviders(
+      <AnnouncementsProvider announcements={[config]}>
+        <Component id={config.id} />
+      </AnnouncementsProvider>
+    )
+
+    await waitFor(() => {
+      const node = screen.getByTestId('rn-body')
+      expect(node.tagName).toBe('STRONG')
+      expect(node).toHaveTextContent('Body')
+    })
+  })
+})

--- a/packages/announcements/src/__tests__/announcement-segmentation.test.tsx
+++ b/packages/announcements/src/__tests__/announcement-segmentation.test.tsx
@@ -1,7 +1,10 @@
-import { screen, waitFor } from '@testing-library/react'
+import { act, renderHook, screen, waitFor } from '@testing-library/react'
+import { LocaleProvider, type SegmentSource, SegmentationProvider } from '@tour-kit/core'
+import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
 import { AnnouncementModal } from '../components/announcement-modal'
 import { AnnouncementsProvider } from '../context/announcements-provider'
+import { useAnnouncement } from '../hooks/use-announcement'
 import type { AnnouncementConfig } from '../types/announcement'
 import { renderWithProviders } from './render-with-providers'
 
@@ -81,6 +84,94 @@ describe('Announcement audience filtering', () => {
       await waitFor(() => {
         expect(screen.queryByText('Pro-only notice')).not.toBeInTheDocument()
       })
+    })
+  })
+
+  // Phase 3c regression guard — imperative `show(id)` and `canShow(id)` must
+  // honor segment-shape audiences too. Without this, the scheduler's
+  // narrowed audience check (only evaluates array shape) would let
+  // `useAnnouncement(id).show()` display admin-only announcements to
+  // non-admins.
+  describe('imperative show/canShow honor segment audience', () => {
+    function makeWrapper(
+      announcements: AnnouncementConfig[],
+      segments: Record<string, SegmentSource>,
+      userContext: Record<string, unknown>
+    ) {
+      return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+          <LocaleProvider>
+            <SegmentationProvider segments={segments} userContext={userContext}>
+              <AnnouncementsProvider announcements={announcements} userContext={userContext}>
+                {children}
+              </AnnouncementsProvider>
+            </SegmentationProvider>
+          </LocaleProvider>
+        )
+      }
+    }
+
+    it('show(id) is suppressed when segment audience is false', async () => {
+      const config: AnnouncementConfig = {
+        id: 'admin-only',
+        variant: 'modal',
+        title: 'Admin notice',
+        audience: { segment: 'admins' },
+        autoShow: false,
+      }
+      const { result } = renderHook(() => useAnnouncement('admin-only'), {
+        wrapper: makeWrapper(
+          [config],
+          {
+            admins: [{ type: 'user_property', key: '__probe__', operator: 'not_exists' }],
+          },
+          { __probe__: 'present' }
+        ),
+      })
+
+      // Wait for REGISTER effect to populate state
+      await waitFor(() => {
+        expect(result.current.config?.id).toBe('admin-only')
+      })
+
+      act(() => {
+        result.current.show()
+      })
+
+      expect(result.current.state?.isVisible).toBe(false)
+      expect(result.current.canShow).toBe(false)
+    })
+
+    it('show(id) succeeds when segment audience is true', async () => {
+      const config: AnnouncementConfig = {
+        id: 'admin-only',
+        variant: 'modal',
+        title: 'Admin notice',
+        audience: { segment: 'admins' },
+        autoShow: false,
+      }
+      const { result } = renderHook(() => useAnnouncement('admin-only'), {
+        wrapper: makeWrapper(
+          [config],
+          {
+            admins: [{ type: 'user_property', key: '__probe__', operator: 'exists' }],
+          },
+          { __probe__: 'present' }
+        ),
+      })
+
+      await waitFor(() => {
+        expect(result.current.config?.id).toBe('admin-only')
+      })
+
+      act(() => {
+        result.current.show()
+      })
+
+      await waitFor(() => {
+        expect(result.current.state?.isVisible).toBe(true)
+      })
+      expect(result.current.canShow).toBe(true)
     })
   })
 

--- a/packages/announcements/src/__tests__/announcement-segmentation.test.tsx
+++ b/packages/announcements/src/__tests__/announcement-segmentation.test.tsx
@@ -1,0 +1,104 @@
+import { screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { AnnouncementModal } from '../components/announcement-modal'
+import { AnnouncementsProvider } from '../context/announcements-provider'
+import type { AnnouncementConfig } from '../types/announcement'
+import { renderWithProviders } from './render-with-providers'
+
+describe('Announcement audience filtering', () => {
+  it('filters out an announcement when its segment is false', async () => {
+    const config: AnnouncementConfig = {
+      id: 'admin-notice',
+      variant: 'modal',
+      title: 'Admin notice',
+      audience: { segment: 'admins' },
+    }
+    renderWithProviders(
+      <AnnouncementsProvider announcements={[config]}>
+        <AnnouncementModal id="admin-notice" />
+      </AnnouncementsProvider>,
+      { segments: { admins: () => false } }
+    )
+
+    // Wait one microtask for the auto-show effect to run.
+    await waitFor(() => {
+      expect(screen.queryByText('Admin notice')).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders an announcement when its segment is true', async () => {
+    const config: AnnouncementConfig = {
+      id: 'admin-notice',
+      variant: 'modal',
+      title: 'Admin notice',
+      audience: { segment: 'admins' },
+    }
+    renderWithProviders(
+      <AnnouncementsProvider announcements={[config]}>
+        <AnnouncementModal id="admin-notice" />
+      </AnnouncementsProvider>,
+      { segments: { admins: () => true } }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin notice')).toBeInTheDocument()
+    })
+  })
+
+  // ★★ MANDATORY REGRESSION GUARD — keeps the legacy array audience shape
+  // working through the discriminated-union widening. Both "match" and
+  // "filter out" branches must hold; testing only one would silently let a
+  // future bug always-allow or always-filter the array shape. ★★
+  describe('legacy AudienceCondition[] shape (regression guard)', () => {
+    const proConfig = (): AnnouncementConfig => ({
+      id: 'pro-notice',
+      variant: 'modal',
+      title: 'Pro-only notice',
+      audience: [{ type: 'user_property', key: 'plan', operator: 'equals', value: 'pro' }],
+    })
+
+    it('renders for a matching userContext (plan=pro)', async () => {
+      renderWithProviders(
+        <AnnouncementsProvider announcements={[proConfig()]} userContext={{ plan: 'pro' }}>
+          <AnnouncementModal id="pro-notice" />
+        </AnnouncementsProvider>,
+        { userContext: { plan: 'pro' } }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Pro-only notice')).toBeInTheDocument()
+      })
+    })
+
+    it('filters out for a non-matching userContext (plan=free)', async () => {
+      renderWithProviders(
+        <AnnouncementsProvider announcements={[proConfig()]} userContext={{ plan: 'free' }}>
+          <AnnouncementModal id="pro-notice" />
+        </AnnouncementsProvider>,
+        { userContext: { plan: 'free' } }
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByText('Pro-only notice')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  it('renders for everyone when no audience is set, regardless of segments/context', async () => {
+    const config: AnnouncementConfig = {
+      id: 'public-notice',
+      variant: 'modal',
+      title: 'Public notice',
+    }
+    renderWithProviders(
+      <AnnouncementsProvider announcements={[config]} userContext={{ plan: 'free' }}>
+        <AnnouncementModal id="public-notice" />
+      </AnnouncementsProvider>,
+      { segments: { admins: () => false }, userContext: { plan: 'free' } }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Public notice')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/announcements/src/__tests__/render-with-providers.tsx
+++ b/packages/announcements/src/__tests__/render-with-providers.tsx
@@ -1,0 +1,54 @@
+import { type RenderResult, render } from '@testing-library/react'
+import {
+  LocaleProvider,
+  type Messages,
+  type SegmentSource,
+  SegmentationProvider,
+} from '@tour-kit/core'
+import type { ReactNode } from 'react'
+
+const PROBE_KEY = '__test_segment_present__'
+
+interface RenderOptions {
+  locale?: string
+  messages?: Messages
+  userContext?: Record<string, unknown>
+  segments?: Record<string, SegmentSource | (() => boolean)>
+  currentUserId?: string
+}
+
+/**
+ * Mirror of `@tour-kit/hints` and `@tour-kit/react` test helpers — duplicated
+ * per-package on purpose so announcements does not need a runtime dep on
+ * either sibling. Wraps `<LocaleProvider>` + `<SegmentationProvider>` and
+ * provides a sugar shorthand for `segments: { name: () => true|false }`
+ * that expands to a probe-keyed `AudienceCondition[]` so segment evaluation
+ * resolves under the real `useSegments()` hook.
+ */
+export function renderWithProviders(ui: ReactNode, opts: RenderOptions = {}): RenderResult {
+  const compiledSegments: Record<string, SegmentSource> = {}
+  for (const [name, value] of Object.entries(opts.segments ?? {})) {
+    if (typeof value === 'function') {
+      compiledSegments[name] = value()
+        ? [{ type: 'user_property', key: PROBE_KEY, operator: 'exists' }]
+        : [{ type: 'user_property', key: PROBE_KEY, operator: 'not_exists' }]
+    } else {
+      compiledSegments[name] = value
+    }
+  }
+  const userContext = {
+    ...(opts.userContext ?? {}),
+    [PROBE_KEY]: 'present',
+  }
+  return render(
+    <LocaleProvider locale={opts.locale ?? 'en'} messages={opts.messages ?? {}}>
+      <SegmentationProvider
+        segments={compiledSegments}
+        userContext={userContext}
+        currentUserId={opts.currentUserId}
+      >
+        {ui}
+      </SegmentationProvider>
+    </LocaleProvider>
+  )
+}

--- a/packages/announcements/src/components/announcement-banner.tsx
+++ b/packages/announcements/src/components/announcement-banner.tsx
@@ -4,6 +4,7 @@ import { cn } from '@tour-kit/core'
 import type { VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 import { useAnnouncement } from '../hooks/use-announcement'
+import { useResolvedText } from '../lib/use-resolved-text'
 import type { BannerOptions, DismissalReason } from '../types/announcement'
 import { AnnouncementClose } from './announcement-close'
 import { bannerVariants } from './ui/banner-variants'
@@ -44,6 +45,9 @@ export const AnnouncementBanner = React.forwardRef<HTMLDivElement, AnnouncementB
   ) => {
     const announcement = useAnnouncement(id)
     const config = announcement.config
+
+    const resolvedTitle = useResolvedText(config?.title)
+    const resolvedDescription = useResolvedText(config?.description)
 
     // Controlled or uncontrolled open state
     const isControlled = openProp !== undefined
@@ -87,9 +91,9 @@ export const AnnouncementBanner = React.forwardRef<HTMLDivElement, AnnouncementB
         <div className="flex-1">
           {useConfig && config ? (
             <>
-              {config.title && <span className="font-medium">{config.title}</span>}
-              {config.title && config.description && ' — '}
-              {config.description && <span>{config.description}</span>}
+              {resolvedTitle && <span className="font-medium">{resolvedTitle}</span>}
+              {resolvedTitle && resolvedDescription && ' — '}
+              {resolvedDescription && <span>{resolvedDescription}</span>}
             </>
           ) : (
             children

--- a/packages/announcements/src/components/announcement-content.tsx
+++ b/packages/announcements/src/components/announcement-content.tsx
@@ -4,9 +4,10 @@ import { cn } from '@tour-kit/core'
 import * as React from 'react'
 import type { AnnouncementMedia } from '../types/announcement'
 
-export interface AnnouncementContentProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Title of the announcement */
-  title?: string
+export interface AnnouncementContentProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
+  /** Title of the announcement (any ReactNode — strings render as <h2>, JSX passes through). */
+  title?: React.ReactNode
   /** Description/body content */
   description?: React.ReactNode
   /** Media to display */

--- a/packages/announcements/src/components/announcement-modal.tsx
+++ b/packages/announcements/src/components/announcement-modal.tsx
@@ -5,6 +5,7 @@ import { cn } from '@tour-kit/core'
 import type { VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 import { useAnnouncement } from '../hooks/use-announcement'
+import { useResolvedText } from '../lib/use-resolved-text'
 import type { DismissalReason, ModalOptions } from '../types/announcement'
 import { AnnouncementActions } from './announcement-actions'
 import { AnnouncementClose } from './announcement-close'
@@ -45,6 +46,9 @@ export const AnnouncementModal = React.forwardRef<HTMLDivElement, AnnouncementMo
   ) => {
     const announcement = useAnnouncement(id)
     const config = announcement.config
+
+    const resolvedTitle = useResolvedText(config?.title)
+    const resolvedDescription = useResolvedText(config?.description)
 
     // Controlled or uncontrolled open state
     const isControlled = openProp !== undefined
@@ -113,8 +117,8 @@ export const AnnouncementModal = React.forwardRef<HTMLDivElement, AnnouncementMo
             {useConfig && config ? (
               <>
                 <AnnouncementContent
-                  title={config.title}
-                  description={config.description}
+                  title={resolvedTitle}
+                  description={resolvedDescription}
                   media={config.media}
                 />
                 <AnnouncementActions

--- a/packages/announcements/src/components/announcement-slideout.tsx
+++ b/packages/announcements/src/components/announcement-slideout.tsx
@@ -5,6 +5,7 @@ import { cn } from '@tour-kit/core'
 import type { VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 import { useAnnouncement } from '../hooks/use-announcement'
+import { useResolvedText } from '../lib/use-resolved-text'
 import type { DismissalReason, SlideoutOptions } from '../types/announcement'
 import { AnnouncementActions } from './announcement-actions'
 import { AnnouncementClose } from './announcement-close'
@@ -46,6 +47,9 @@ export const AnnouncementSlideout = React.forwardRef<HTMLDivElement, Announcemen
   ) => {
     const announcement = useAnnouncement(id)
     const config = announcement.config
+
+    const resolvedTitle = useResolvedText(config?.title)
+    const resolvedDescription = useResolvedText(config?.description)
 
     // Controlled or uncontrolled open state
     const isControlled = openProp !== undefined
@@ -118,8 +122,8 @@ export const AnnouncementSlideout = React.forwardRef<HTMLDivElement, Announcemen
             {useConfig && config ? (
               <div className="flex h-full flex-col">
                 <AnnouncementContent
-                  title={config.title}
-                  description={config.description}
+                  title={resolvedTitle}
+                  description={resolvedDescription}
                   media={config.media}
                   className="flex-1"
                 />

--- a/packages/announcements/src/components/announcement-spotlight.tsx
+++ b/packages/announcements/src/components/announcement-spotlight.tsx
@@ -6,6 +6,7 @@ import type { VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useAnnouncement } from '../hooks/use-announcement'
+import { useResolvedText } from '../lib/use-resolved-text'
 import type { DismissalReason, SpotlightOptions } from '../types/announcement'
 import { AnnouncementActions } from './announcement-actions'
 import { AnnouncementClose } from './announcement-close'
@@ -48,6 +49,9 @@ export const AnnouncementSpotlight = React.forwardRef<HTMLDivElement, Announceme
     const config = announcement.config
     const [mounted, setMounted] = React.useState(false)
     const [targetElement, setTargetElement] = React.useState<Element | null>(null)
+
+    const resolvedTitle = useResolvedText(config?.title)
+    const resolvedDescription = useResolvedText(config?.description)
 
     // Controlled or uncontrolled open state
     const isControlled = openProp !== undefined
@@ -163,8 +167,8 @@ export const AnnouncementSpotlight = React.forwardRef<HTMLDivElement, Announceme
           {useConfig && config ? (
             <>
               <AnnouncementContent
-                title={config.title}
-                description={config.description}
+                title={resolvedTitle}
+                description={resolvedDescription}
                 media={config.media}
               />
               <AnnouncementActions

--- a/packages/announcements/src/components/announcement-toast.tsx
+++ b/packages/announcements/src/components/announcement-toast.tsx
@@ -5,6 +5,7 @@ import type { VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useAnnouncement } from '../hooks/use-announcement'
+import { useResolvedText } from '../lib/use-resolved-text'
 import type { DismissalReason, ToastOptions } from '../types/announcement'
 import { AnnouncementClose } from './announcement-close'
 import { toastContainerVariants, toastProgressVariants, toastVariants } from './ui/toast-variants'
@@ -46,6 +47,9 @@ export const AnnouncementToast = React.forwardRef<HTMLDivElement, AnnouncementTo
     const config = announcement.config
     const [progress, setProgress] = React.useState(100)
     const [mounted, setMounted] = React.useState(false)
+
+    const resolvedTitle = useResolvedText(config?.title)
+    const resolvedDescription = useResolvedText(config?.description)
 
     // Controlled or uncontrolled open state
     const isControlled = openProp !== undefined
@@ -116,9 +120,9 @@ export const AnnouncementToast = React.forwardRef<HTMLDivElement, AnnouncementTo
           <div className="flex-1 space-y-1">
             {useConfig && config ? (
               <>
-                {config.title && <div className="font-medium">{config.title}</div>}
-                {config.description && (
-                  <div className="text-sm opacity-90">{config.description}</div>
+                {resolvedTitle && <div className="font-medium">{resolvedTitle}</div>}
+                {resolvedDescription && (
+                  <div className="text-sm opacity-90">{resolvedDescription}</div>
                 )}
               </>
             ) : (

--- a/packages/announcements/src/context/announcements-provider.tsx
+++ b/packages/announcements/src/context/announcements-provider.tsx
@@ -2,7 +2,12 @@ import { ProGate } from '@tour-kit/license'
 import * as React from 'react'
 import { AnnouncementScheduler } from '../core/scheduler'
 import { useFilteredAnnouncements } from '../hooks/use-filtered-announcements'
-import type { AnnouncementConfig, AnnouncementState, DismissalReason } from '../types/announcement'
+import {
+  type AnnouncementConfig,
+  type AnnouncementState,
+  type DismissalReason,
+  isSegmentAudience,
+} from '../types/announcement'
 import type { AnnouncementsContextValue, AnnouncementsProviderProps } from '../types/context'
 import type { QueueConfig } from '../types/queue'
 import { DEFAULT_QUEUE_CONFIG } from '../types/queue'
@@ -244,6 +249,16 @@ export function AnnouncementsProvider({
   // is also re-checked downstream by the scheduler for backward compat.
   const filteredAnnouncements = useFilteredAnnouncements(initialAnnouncements)
 
+  // Set of segment-eligible IDs — used to gate imperative `show(id)` and
+  // `canShow(id)` against segment-shape audiences. Without this, an
+  // `audience: { segment: 'admins' }` announcement could be shown via
+  // `useAnnouncement(id).show()` to non-admins because the scheduler only
+  // evaluates the array-shape branch.
+  const filteredIds = React.useMemo(
+    () => new Set(filteredAnnouncements.map((a) => a.id)),
+    [filteredAnnouncements]
+  )
+
   const [state, dispatch] = React.useReducer(announcementsReducer, {
     announcements: new Map(),
     configs: new Map(),
@@ -417,6 +432,14 @@ export function AnnouncementsProvider({
 
       if (!announcementState || !config) return
 
+      // Phase 3c — gate imperative show on segment-shape audience eligibility.
+      // The scheduler only evaluates array-shape audiences; segment shapes
+      // are resolved by `useFilteredAnnouncements` upstream and exposed here
+      // via `filteredIds`.
+      if (config.audience && isSegmentAudience(config.audience) && !filteredIds.has(id)) {
+        return
+      }
+
       // Check if can show
       if (!schedulerRef.current.canShow(config, announcementState, userContext)) {
         return
@@ -445,7 +468,7 @@ export function AnnouncementsProvider({
       config.onShow?.()
       onAnnouncementShow?.(id)
     },
-    [state.announcements, state.configs, userContext, persistState, onAnnouncementShow]
+    [state.announcements, state.configs, userContext, persistState, onAnnouncementShow, filteredIds]
   )
 
   const hide = React.useCallback((id: string) => {
@@ -572,9 +595,14 @@ export function AnnouncementsProvider({
 
       if (!announcementState || !config) return false
 
+      // Phase 3c — segment-shape audience eligibility (mirrors `show()`).
+      if (config.audience && isSegmentAudience(config.audience) && !filteredIds.has(id)) {
+        return false
+      }
+
       return schedulerRef.current.canShow(config, announcementState, userContext)
     },
-    [state.announcements, state.configs, userContext]
+    [state.announcements, state.configs, userContext, filteredIds]
   )
 
   const showNext = React.useCallback(() => {

--- a/packages/announcements/src/context/announcements-provider.tsx
+++ b/packages/announcements/src/context/announcements-provider.tsx
@@ -1,6 +1,7 @@
 import { ProGate } from '@tour-kit/license'
 import * as React from 'react'
 import { AnnouncementScheduler } from '../core/scheduler'
+import { useFilteredAnnouncements } from '../hooks/use-filtered-announcements'
 import type { AnnouncementConfig, AnnouncementState, DismissalReason } from '../types/announcement'
 import type { AnnouncementsContextValue, AnnouncementsProviderProps } from '../types/context'
 import type { QueueConfig } from '../types/queue'
@@ -237,6 +238,12 @@ export function AnnouncementsProvider({
     [queueConfigOverrides]
   )
 
+  // Phase 3c — filter announcements by audience (segment + array shapes) once
+  // at the top of the provider so the scheduler / auto-show / canShow
+  // eligibility paths only see eligible candidates. The array-shape audience
+  // is also re-checked downstream by the scheduler for backward compat.
+  const filteredAnnouncements = useFilteredAnnouncements(initialAnnouncements)
+
   const [state, dispatch] = React.useReducer(announcementsReducer, {
     announcements: new Map(),
     configs: new Map(),
@@ -338,9 +345,11 @@ export function AnnouncementsProvider({
     if (state.announcements.size === 0) return
 
     // Collect eligible candidates first so we can show highest-priority immediately
-    // and queue the rest.
+    // and queue the rest. `filteredAnnouncements` already excludes anything
+    // ruled out by audience (segment + array shapes) so the scheduler only
+    // re-checks the array path for backward-compat semantics.
     const eligible: AnnouncementConfig[] = []
-    for (const config of initialAnnouncements) {
+    for (const config of filteredAnnouncements) {
       if (config.autoShow === false) continue
       const st = state.announcements.get(config.id)
       if (!st) continue
@@ -389,7 +398,7 @@ export function AnnouncementsProvider({
       config.onShow?.()
       onAnnouncementShow?.(config.id)
     }
-  }, [state.announcements, userContext, initialAnnouncements])
+  }, [state.announcements, userContext, filteredAnnouncements])
 
   // Context methods
   const register = React.useCallback((config: AnnouncementConfig) => {

--- a/packages/announcements/src/core/scheduler.ts
+++ b/packages/announcements/src/core/scheduler.ts
@@ -35,8 +35,12 @@ export class AnnouncementScheduler {
       return false
     }
 
-    // Check audience targeting
-    if (!matchesAudience(config.audience, userContext)) {
+    // Check audience targeting — only the legacy array shape goes through
+    // `matchesAudience` here. The segment-shape `{ segment: string }` branch is
+    // resolved upstream by `useFilteredAnnouncements` (Phase 3c) which prunes
+    // ineligible announcements before they reach the scheduler. Treating an
+    // array+undefined as "match" keeps backward compat unchanged.
+    if (Array.isArray(config.audience) && !matchesAudience(config.audience, userContext)) {
       return false
     }
 

--- a/packages/announcements/src/hooks/use-filtered-announcements.tsx
+++ b/packages/announcements/src/hooks/use-filtered-announcements.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+// NOTE: `evaluateAnnouncementAudience` mirrors `evaluateHintAudience` in
+// `@tour-kit/hints/src/hooks/use-hint-filter.tsx` and `evaluateAudience` in
+// `@tour-kit/react/src/hooks/use-step-filter.tsx`. Per Phase 3a's plan the
+// helpers are duplicated per-package to avoid forcing a runtime dep across
+// sibling UI packages. Keep all three in lockstep when changing
+// audience-resolution semantics.
+
+import { useSegments } from '@tour-kit/core'
+import * as React from 'react'
+import {
+  type AnnouncementConfig,
+  type AudienceProp,
+  isSegmentAudience,
+} from '../types/announcement'
+
+// Module-scope dedupe set — see the matching comment in
+// `@tour-kit/hints`'s `use-hint-filter.tsx`. Without this a misconfigured
+// segment reference would log on every render.
+const warnedUnknownSegments = new Set<string>()
+
+/**
+ * Resolve a single announcement's audience for the segment-shape branch only.
+ *
+ * Returns `true` (let through) for `undefined` and array-shape audiences —
+ * the array branch is re-checked downstream by the scheduler against the
+ * `<AnnouncementsProvider userContext>` prop, which is the legacy contract
+ * we must preserve. Only segment-shape audiences are filtered here, because
+ * those require `<SegmentationProvider>` and can't be evaluated in the
+ * scheduler (which is framework-agnostic).
+ */
+export function evaluateAnnouncementAudience(
+  audience: AudienceProp | undefined,
+  segments: Record<string, boolean>
+): boolean {
+  if (!audience) return true
+  if (isSegmentAudience(audience)) {
+    if (
+      !(audience.segment in segments) &&
+      process.env.NODE_ENV !== 'production' &&
+      !warnedUnknownSegments.has(audience.segment)
+    ) {
+      warnedUnknownSegments.add(audience.segment)
+      console.warn(
+        `[tour-kit] useFilteredAnnouncements: announcement references segment "${audience.segment}" not registered in <SegmentationProvider>`
+      )
+    }
+    return segments[audience.segment] === true
+  }
+  // Array-shape audiences are forwarded to the scheduler unchanged — it owns
+  // the legacy `matchesAudience(audience, userContext)` evaluation against the
+  // provider's `userContext` prop.
+  return true
+}
+
+/**
+ * Filter a list of announcement configs by their `audience` prop. Mirror of
+ * `@tour-kit/hints`'s `useHintFilter` for `AnnouncementConfig[]`. Uses
+ * `useSegments()` (bulk read) once at the top of the provider to satisfy
+ * rules-of-hooks under dynamic announcement lists — never call `useSegment`
+ * inside `.filter`. Only the segment-shape audience branch is filtered here;
+ * array-shape audiences pass through to the scheduler for backward compat.
+ */
+export function useFilteredAnnouncements(
+  announcements: AnnouncementConfig[]
+): AnnouncementConfig[] {
+  const segments = useSegments()
+  return React.useMemo(
+    () => announcements.filter((a) => evaluateAnnouncementAudience(a.audience, segments)),
+    [announcements, segments]
+  )
+}

--- a/packages/announcements/src/index.ts
+++ b/packages/announcements/src/index.ts
@@ -104,6 +104,14 @@ export type { AnnouncementsFilter, UseAnnouncementsReturn } from './hooks/use-an
 export { useAnnouncementQueue } from './hooks/use-announcement-queue'
 export type { UseAnnouncementQueueReturn } from './hooks/use-announcement-queue'
 
+// Phase 3c — audience filter hook + i18n resolver. Mirrors the per-package
+// helpers in `@tour-kit/hints` and `@tour-kit/react`.
+export {
+  useFilteredAnnouncements,
+  evaluateAnnouncementAudience,
+} from './hooks/use-filtered-announcements'
+export { useResolvedText } from './lib/use-resolved-text'
+
 // ============================================
 // CORE UTILITIES
 // ============================================
@@ -156,8 +164,12 @@ export type {
   SpotlightOptions,
   AnnouncementConfig,
   AudienceCondition,
+  AudienceProp,
   AnnouncementStorageAdapter,
 } from './types/announcement'
+
+// Phase 3c — segment-audience type guard
+export { isSegmentAudience } from './types/announcement'
 
 export type {
   // Context types

--- a/packages/announcements/src/lib/use-resolved-text.tsx
+++ b/packages/announcements/src/lib/use-resolved-text.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import {
+  type LocalizedText,
+  interpolate,
+  isI18nKey,
+  useSegmentationContext,
+  useT,
+} from '@tour-kit/core'
+import type * as React from 'react'
+
+/**
+ * Mirror of `@tour-kit/hints` and `@tour-kit/react`'s `useResolvedText`.
+ * Per-package duplicate so announcements does not require a runtime dep on
+ * either sibling. Keep the three implementations in lockstep when changing
+ * resolution semantics.
+ *
+ *   string         → `interpolate(value, vars)`
+ *   { key: '…' }   → `useT()(value.key, vars)`
+ *   ReactNode      → returned unchanged
+ *
+ * `vars` defaults to `useSegmentationContext().userContext` so consumers who
+ * pass `userContext` to `<SegmentationProvider>` get interpolation against the
+ * same data with no extra plumbing.
+ */
+export function useResolvedText(
+  value: React.ReactNode | LocalizedText | undefined,
+  vars?: Record<string, unknown>
+): React.ReactNode {
+  const t = useT()
+  const { userContext } = useSegmentationContext()
+  const effectiveVars = vars ?? userContext
+
+  if (value === undefined || value === null) return value
+  if (typeof value === 'string') return interpolate(value, effectiveVars)
+  if (isI18nKey(value)) return t(value.key, effectiveVars)
+  return value as React.ReactNode
+}

--- a/packages/announcements/src/types/announcement.ts
+++ b/packages/announcements/src/types/announcement.ts
@@ -5,9 +5,28 @@ import type { ReactNode } from 'react'
 // Re-exported here for backward compat — existing
 // `import { AudienceCondition, FrequencyRule } from '@tour-kit/announcements'`
 // consumers continue to work without source changes.
-import type { AudienceCondition, FrequencyRule } from '@tour-kit/core'
+import type { AudienceCondition, FrequencyRule, LocalizedText } from '@tour-kit/core'
 
 export type { AudienceCondition, FrequencyRule }
+
+/**
+ * Audience prop accepting either inline conditions (legacy `AudienceCondition[]`)
+ * or a named segment registered in `<SegmentationProvider>`. Discriminated by
+ * `Array.isArray()` — the array branch goes through `matchesAudience`, the
+ * object branch through `useSegments()`. Mirror of `@tour-kit/core`'s
+ * `AudienceProp` (kept as a local re-export so the announcements barrel does
+ * not pin a breaking change to core).
+ */
+export type AudienceProp = AudienceCondition[] | { segment: string }
+
+/**
+ * Type guard narrowing `AudienceProp` to its segment-named branch. Mirrors the
+ * private guard in `@tour-kit/hints` — keep both in lockstep when changing the
+ * discriminator.
+ */
+export function isSegmentAudience(a: AudienceProp): a is { segment: string } {
+  return !Array.isArray(a) && typeof a === 'object' && a !== null && 'segment' in a
+}
 
 /**
  * Announcement display variants
@@ -140,11 +159,20 @@ export interface AnnouncementConfig {
   /** Priority for queue ordering */
   priority?: AnnouncementPriority
 
-  /** Title of the announcement */
-  title?: string
+  /**
+   * Title of the announcement. Supports plain strings (interpolated against
+   * `userContext` from `<SegmentationProvider>`), i18n keys
+   * (`{ key: 'announcement.foo.title' }` resolved via `useT()`), or any
+   * `ReactNode` body. Strings without `{{var}}` tokens render unchanged.
+   */
+  title?: ReactNode | LocalizedText
 
-  /** Description or body content */
-  description?: string | ReactNode
+  /**
+   * Description or body content. Same `ReactNode | LocalizedText` shape as
+   * `title`; ReactNode children pass through unchanged so consumers can
+   * supply rich JSX bodies.
+   */
+  description?: ReactNode | LocalizedText
 
   /** Media to display */
   media?: AnnouncementMedia
@@ -161,8 +189,13 @@ export interface AnnouncementConfig {
   /** Schedule configuration (requires @tour-kit/scheduling) */
   schedule?: unknown // Will be Schedule type from @tour-kit/scheduling
 
-  /** Audience targeting conditions */
-  audience?: AudienceCondition[]
+  /**
+   * Audience targeting. Accepts either an inline `AudienceCondition[]` (legacy)
+   * evaluated by `matchesAudience(...)`, or a `{ segment: string }` reference
+   * to a segment registered in `<SegmentationProvider>` and evaluated by
+   * `useSegments()`. The array branch is fully backward-compatible.
+   */
+  audience?: AudienceProp
 
   /** Variant-specific options */
   modalOptions?: ModalOptions
@@ -170,6 +203,14 @@ export interface AnnouncementConfig {
   bannerOptions?: BannerOptions
   toastOptions?: ToastOptions
   spotlightOptions?: SpotlightOptions
+
+  /**
+   * Optional free-form category tag — presentation-layer metadata only.
+   * Phase 5a's changelog feed will read this for grouping and filtering;
+   * 3c only round-trips the field through the type system. Examples:
+   * `'feature'`, `'fix'`, `'breaking'`, `'security'`.
+   */
+  category?: string
 
   /** Custom metadata */
   metadata?: Record<string, unknown>

--- a/packages/announcements/src/types/announcement.ts
+++ b/packages/announcements/src/types/announcement.ts
@@ -5,19 +5,9 @@ import type { ReactNode } from 'react'
 // Re-exported here for backward compat — existing
 // `import { AudienceCondition, FrequencyRule } from '@tour-kit/announcements'`
 // consumers continue to work without source changes.
-import type { AudienceCondition, FrequencyRule, LocalizedText } from '@tour-kit/core'
+import type { AudienceCondition, AudienceProp, FrequencyRule, LocalizedText } from '@tour-kit/core'
 
-export type { AudienceCondition, FrequencyRule }
-
-/**
- * Audience prop accepting either inline conditions (legacy `AudienceCondition[]`)
- * or a named segment registered in `<SegmentationProvider>`. Discriminated by
- * `Array.isArray()` — the array branch goes through `matchesAudience`, the
- * object branch through `useSegments()`. Mirror of `@tour-kit/core`'s
- * `AudienceProp` (kept as a local re-export so the announcements barrel does
- * not pin a breaking change to core).
- */
-export type AudienceProp = AudienceCondition[] | { segment: string }
+export type { AudienceCondition, AudienceProp, FrequencyRule }
 
 /**
  * Type guard narrowing `AudienceProp` to its segment-named branch. Mirrors the


### PR DESCRIPTION
## Summary

Phase 3c of the UserGuiding feature-parity initiative. Wires `@tour-kit/announcements` to consume the Phase 1 (i18n) and Phase 2 (segmentation) core primitives. **Strictly additive widening** — every existing consumer (plain string `title`, `AudienceCondition[]` audience, no `category`) compiles and renders identically.

- Widen `AnnouncementConfig.title` / `description` to `ReactNode | LocalizedText` (interpolation + i18n keys + JSX passthrough)
- Widen `AnnouncementConfig.audience` to `AudienceProp = AudienceCondition[] | { segment: string }` discriminated by `Array.isArray()`
- Add `AnnouncementConfig.category?: string` (presentation-layer metadata; Phase 5a's changelog feed will read it)
- New `useResolvedText` and `useFilteredAnnouncements` hooks; wired into all 5 variant components and the provider

## Test plan

- [x] `pnpm --filter @tour-kit/announcements test` — 156/156 pass (126 baseline + 30 new across 4 new test files)
- [x] `pnpm typecheck` — clean monorepo-wide (26/26 turbo tasks)
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm size` — `@tour-kit/announcements` 90.02 KB brotlied (limit 107 KB), well under the 110 KB plan ceiling
- [x] Mandatory legacy `AudienceCondition[]` regression guard included in `announcement-segmentation.test.tsx` (both pos/neg branches)
- [x] All 5 variants (modal/banner/toast/slideout/spotlight) parametrized via `describe.each` for uniform i18n coverage
- [x] No-LocaleProvider graceful-degradation case covered

## Refs

- `plan/userguiding-phase-3c.md`
- `plan/userguiding-phase-3c-tests.md`