### PR TITLE
feat(announcements): UserGuiding parity Phase 5b — <ChangelogPage> component + reactions

### DIFF
--- a/apps/docs/content/docs/announcements/changelog.mdx
+++ b/apps/docs/content/docs/announcements/changelog.mdx
@@ -1,10 +1,142 @@
 ---
-title: Changelog Feed
+title: Changelog
 description: >-
-  Serialize a list of announcements as RSS 2.0 + JSON Feed 1.1 with serializeFeed
+  Render a public changelog page in React and serialize the same entries as RSS 2.0 + JSON Feed 1.1.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+
+`@tour-kit/announcements` ships two changelog primitives that share the same `ChangelogEntry` shape:
+
+- **`<ChangelogPage>`** — a drop-in React page (category filter + emoji reactions + media support) you mount on any route.
+- **`serializeFeed`** — a pure RSS 2.0 + JSON Feed 1.1 serializer for the same entries.
+
+Use them together: render the entries to a public web page with `<ChangelogPage>`, syndicate the same list as an RSS feed with `serializeFeed`. The renderer lives behind the `@tour-kit/announcements/changelog` subpath, so toast/modal/banner-only consumers do not pay the bundle cost.
+
+---
+
+## `<ChangelogPage>` — render
+
+Mount it anywhere. No router context required.
+
+```tsx
+import { ChangelogPage } from '@tour-kit/announcements/changelog';
+import type { ChangelogEntry } from '@tour-kit/announcements';
+
+const entries: ChangelogEntry[] = [
+  {
+    id: 'evt-2026-05-04',
+    variant: 'modal',
+    title: 'Bulk export now available',
+    description: 'Export your data to CSV or PDF directly from the dashboard.',
+    permalink: 'https://acme.com/changelog/bulk-export',
+    publishedAt: new Date('2026-05-04T00:00:00Z'),
+    category: 'Features',
+  },
+  // ...
+];
+
+export default function ChangelogRoute() {
+  return <ChangelogPage entries={entries} />;
+}
+```
+
+The component derives its category sidebar from `entry.category`, prepends an "All" reset button, and supports `ArrowDown`/`ArrowUp` keyboard navigation with a roving tabindex.
+
+### Reactions
+
+Pass `onReact` to capture clicks on the per-entry emoji row (👍 😐 👎). The component holds **no reaction state** — wire the callback to your own backend or analytics:
+
+```tsx
+<ChangelogPage
+  entries={entries}
+  onReact={(entryId, emoji) => {
+    fetch('/api/changelog-reaction', {
+      method: 'POST',
+      body: JSON.stringify({ entryId, emoji }),
+    });
+  }}
+/>
+```
+
+### Media
+
+If an entry carries `media` (any URL `<MediaSlot>` understands — YouTube, Vimeo, Loom, Wistia, native video, GIF, Lottie), it renders above the entry body. See the [media docs](/docs/media) for supported sources.
+
+### Next.js URL-sync recipe (controlled mode)
+
+Omitting `category` / `onCategoryChange` runs the page in uncontrolled mode (internal `useState`). Pass both to lift state into your URL:
+
+```tsx
+'use client';
+
+import { ChangelogPage } from '@tour-kit/announcements/changelog';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import type { ChangelogEntry } from '@tour-kit/announcements';
+
+export function MyChangelog({ entries }: { entries: ChangelogEntry[] }) {
+  const sp = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const category = sp.get('category');
+  const onCategoryChange = (next: string | null) => {
+    const params = new URLSearchParams(sp);
+    if (next) params.set('category', next);
+    else params.delete('category');
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  return (
+    <ChangelogPage
+      entries={entries}
+      category={category}
+      onCategoryChange={onCategoryChange}
+    />
+  );
+}
+```
+
+The same pattern works with TanStack Router (`useSearch` + `useNavigate`) or Remix loaders — anywhere you can read and write a URL parameter.
+
+### Internationalization
+
+The page reads from `<LocaleProvider>` (Phase 1 i18n primitives). Default English fallbacks ship in the component, so it works without any provider mounted. Override per-key:
+
+| Key | English fallback |
+|---|---|
+| `changelog.empty` | `"No changelog entries yet"` |
+| `changelog.filter.all` | `"All"` |
+| `changelog.filter.label` | `"Filter by category"` |
+| `changelog.reactions.label` | `"Reactions"` |
+| `changelog.reaction.thumbs_up` | `"Thumbs up"` |
+| `changelog.reaction.neutral` | `"Neutral"` |
+| `changelog.reaction.thumbs_down` | `"Thumbs down"` |
+
+```tsx
+import { LocaleProvider } from '@tour-kit/core';
+
+<LocaleProvider
+  locale="es"
+  messages={{
+    'changelog.empty': 'Aún no hay novedades',
+    'changelog.filter.all': 'Todas',
+    'changelog.reaction.thumbs_up': 'Pulgar arriba',
+  }}
+>
+  <ChangelogPage entries={entries} />
+</LocaleProvider>
+```
+
+RTL locales (`ar`, `he`, `fa`, `ur`) automatically apply `dir="rtl"` to the page root.
+
+<Callout type="info" title="Subpath import">
+The page lives behind `@tour-kit/announcements/changelog` so toast/modal/banner-only consumers tree-shake out the renderer. Importing `<ChangelogPage>` from `@tour-kit/announcements` will not work — use the subpath.
+</Callout>
+
+---
+
+## `serializeFeed` — syndicate
 
 `serializeFeed` produces both an RSS 2.0 XML string and a JSON Feed 1.1 string from a list of `ChangelogEntry`s. The output is suitable for serving from `app/changelog/rss.xml/route.ts` and `app/changelog/feed.json/route.ts` in Next.js, or any other framework that returns raw `Response` bodies.
 

--- a/apps/docs/public/context/announcements.txt
+++ b/apps/docs/public/context/announcements.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/announcements Context File
-Version: 1.0.0 | Generated: 2026-05-05
+Version: 1.1.0 | Generated: 2026-05-05
 Paste this into your LLM to get accurate answers about @tour-kit/announcements.
 =========================================================================
 
@@ -70,6 +70,13 @@ Types:
     AudienceCondition
     AudienceProp
     AnnouncementStorageAdapter
+    ChangelogEntry
+    SerializeFeedOptions
+    ChangelogPageProps
+    ChangelogEntryProps
+    ChangelogFilterProps
+    Reaction
+    ReactionsProps
     // Context types
   AnnouncementsContextValue
     AnnouncementsProviderProps
@@ -145,6 +152,7 @@ Utilities:
     validateConditions
     cn
     isSegmentAudience
+    serializeFeed
 
 TYPES
 -----
@@ -278,7 +286,7 @@ TYPES
       useConfig?: boolean
     }
 
-    ... and 45 more types. See source for full definitions.
+    ... and 52 more types. See source for full definitions.
 
 HOOKS
 -----

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,4 +1,4 @@
-# userTourKit v0.9.0 — Generated 2026-05-05T02:52:17Z
+# userTourKit v0.10.0 — Generated 2026-05-05T04:23:20Z
 
 # userTourKit
 
@@ -121,7 +121,7 @@
 ## Announcements
 
 - [@tour-kit/announcements](https://usertourkit.com/docs/announcements): Product announcements with modal, toast, banner, slideout, and spotlight variants — priority queuing and audience targeting
-- [Changelog Feed](https://usertourkit.com/docs/announcements/changelog): Serialize a list of announcements as RSS 2.0 + JSON Feed 1.1 with serializeFeed
+- [Changelog](https://usertourkit.com/docs/announcements/changelog): Render a public changelog page in React and serialize the same entries as RSS 2.0 + JSON Feed 1.1.
 - [Components](https://usertourkit.com/docs/announcements/components): Pre-styled announcement components: Modal, Toast, Banner, Slideout, and Spotlight with built-in close and action buttons
 - [AnnouncementBanner](https://usertourkit.com/docs/announcements/components/banner): AnnouncementBanner component: full-width persistent bar for system notices with dismiss button and action link support
 - [AnnouncementModal](https://usertourkit.com/docs/announcements/components/modal): AnnouncementModal component: centered dialog overlay for important product updates with title, body, and action buttons

--- a/packages/announcements/package.json
+++ b/packages/announcements/package.json
@@ -69,6 +69,16 @@
         "default": "./dist/tailwind/index.cjs"
       }
     },
+    "./changelog": {
+      "import": {
+        "types": "./dist/changelog/index.d.ts",
+        "default": "./dist/changelog/index.js"
+      },
+      "require": {
+        "types": "./dist/changelog/index.d.cts",
+        "default": "./dist/changelog/index.cjs"
+      }
+    },
     "./styles/variables.css": "./src/styles/variables.css",
     "./styles.css": "./dist/styles/variables.css",
     "./package.json": "./package.json"
@@ -117,6 +127,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
+    "@testing-library/user-event": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "^4.5.2",

--- a/packages/announcements/src/changelog/__test-helpers__.ts
+++ b/packages/announcements/src/changelog/__test-helpers__.ts
@@ -1,0 +1,80 @@
+import { vi } from 'vitest'
+import type { ChangelogEntry } from './feed'
+
+/**
+ * Mocks `window.matchMedia` so the `motion-safe:` Tailwind utility evaluates
+ * deterministically. Per CLAUDE.md cross-package contract, motion-safe gates
+ * on `@media (prefers-reduced-motion: no-preference)` — when `reduce: true`,
+ * the utility does NOT apply.
+ *
+ * Use `vi.unstubAllGlobals()` in an afterEach to restore.
+ */
+export function mockReducedMotion(reduce: boolean): void {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: reduce && query.includes('reduce'),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(() => false),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    }))
+  )
+  // Also patch the Window prototype path the SSR-safe hook reads on first render.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: reduce && query.includes('reduce'),
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+      addListener: () => {},
+      removeListener: () => {},
+    }),
+  })
+}
+
+/**
+ * Three deterministic entries spanning the categories `Performance`,
+ * `Bugfixes`, and `Features`. The third entry carries a `media` payload so
+ * MediaSlot integration is observable via an `<iframe>` in the rendered DOM.
+ *
+ * `variant: 'modal'` is required because `ChangelogEntry extends
+ * AnnouncementConfig`; the value is unused by the changelog renderer.
+ */
+export const MOCK_ENTRIES: ChangelogEntry[] = [
+  {
+    id: 'evt-1',
+    variant: 'modal',
+    title: 'Performance: 30% faster boot',
+    description: 'We reduced initial bundle parse time.',
+    permalink: 'https://acme.com/changelog/perf-30',
+    publishedAt: new Date('2026-04-15T00:00:00Z'),
+    category: 'Performance',
+  },
+  {
+    id: 'evt-2',
+    variant: 'modal',
+    title: 'Bugfix: dark mode flicker',
+    description: 'Fixed CSS variable race on initial paint.',
+    permalink: 'https://acme.com/changelog/dark-flicker',
+    publishedAt: new Date('2026-04-20T00:00:00Z'),
+    category: 'Bugfixes',
+  },
+  {
+    id: 'evt-3',
+    variant: 'modal',
+    title: 'Feature: SSO',
+    description: 'SAML 2.0 support is GA.',
+    permalink: 'https://acme.com/changelog/sso',
+    publishedAt: new Date('2026-04-25T00:00:00Z'),
+    category: 'Features',
+    media: { src: 'https://youtu.be/dQw4w9WgXcQ' },
+  },
+]

--- a/packages/announcements/src/changelog/changelog-entry.tsx
+++ b/packages/announcements/src/changelog/changelog-entry.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import { toMediaSlotProps } from '../lib/media-slot-adapter'
 import { useResolvedText } from '../lib/use-resolved-text'
 import type { ChangelogEntry as ChangelogEntryType } from './feed'
-import { Reactions, type Reaction } from './reactions'
+import { type Reaction, Reactions } from './reactions'
 
 export interface ChangelogEntryProps {
   /** A serialized changelog entry. Inherits `AnnouncementConfig` so the same payload can drive a feed and an in-app modal. */
@@ -61,9 +61,7 @@ export const ChangelogEntry = React.forwardRef<HTMLElement, ChangelogEntryProps>
                 {formattedDate}
               </time>
             )}
-            {entry.category && (
-              <span className="tk-changelog-entry__badge">{entry.category}</span>
-            )}
+            {entry.category && <span className="tk-changelog-entry__badge">{entry.category}</span>}
           </div>
         </header>
         {resolvedDescription !== undefined && resolvedDescription !== null && (

--- a/packages/announcements/src/changelog/changelog-entry.tsx
+++ b/packages/announcements/src/changelog/changelog-entry.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { cn, useLocale } from '@tour-kit/core'
+import { MediaSlot } from '@tour-kit/media'
+import * as React from 'react'
+
+import { toMediaSlotProps } from '../lib/media-slot-adapter'
+import { useResolvedText } from '../lib/use-resolved-text'
+import type { ChangelogEntry as ChangelogEntryType } from './feed'
+import { Reactions, type Reaction } from './reactions'
+
+export interface ChangelogEntryProps {
+  /** A serialized changelog entry. Inherits `AnnouncementConfig` so the same payload can drive a feed and an in-app modal. */
+  entry: ChangelogEntryType
+  /** Forwarded to the inner `<Reactions>` row. Fire-and-forget. */
+  onReact?: (id: string, emoji: Reaction) => void
+  className?: string
+}
+
+/**
+ * Single-entry renderer. Title and description resolve through
+ * `useResolvedText` so consumers may pass plain strings, i18n keys, or rich
+ * `ReactNode` bodies. Date formatting is locale-aware via
+ * `Intl.DateTimeFormat`. The card is animated via the `motion-safe:`
+ * Tailwind utilities — CSS gates the motion under
+ * `prefers-reduced-motion: reduce`.
+ */
+export const ChangelogEntry = React.forwardRef<HTMLElement, ChangelogEntryProps>(
+  function ChangelogEntry({ entry, onReact, className }, ref) {
+    const { locale } = useLocale()
+    const resolvedTitle = useResolvedText(entry.title)
+    const resolvedDescription = useResolvedText(entry.description)
+
+    const formattedDate = React.useMemo(() => {
+      const d = new Date(entry.publishedAt)
+      if (Number.isNaN(d.getTime())) return ''
+      return new Intl.DateTimeFormat(locale || 'en', { dateStyle: 'medium' }).format(d)
+    }, [entry.publishedAt, locale])
+
+    const isoDate = React.useMemo(() => {
+      const d = new Date(entry.publishedAt)
+      return Number.isNaN(d.getTime()) ? undefined : d.toISOString()
+    }, [entry.publishedAt])
+
+    return (
+      <article
+        ref={ref}
+        id={entry.id}
+        className={cn(
+          'tk-changelog-entry',
+          'motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200',
+          className
+        )}
+      >
+        {entry.media && <MediaSlot {...toMediaSlotProps(entry.media)} />}
+        <header className="tk-changelog-entry__header">
+          <h2 className="tk-changelog-entry__title">{resolvedTitle}</h2>
+          <div className="tk-changelog-entry__meta">
+            {isoDate && (
+              <time className="tk-changelog-entry__date" dateTime={isoDate}>
+                {formattedDate}
+              </time>
+            )}
+            {entry.category && (
+              <span className="tk-changelog-entry__badge">{entry.category}</span>
+            )}
+          </div>
+        </header>
+        {resolvedDescription !== undefined && resolvedDescription !== null && (
+          <div className="tk-changelog-entry__body">{resolvedDescription}</div>
+        )}
+        <Reactions entryId={entry.id} onReact={onReact} />
+      </article>
+    )
+  }
+)

--- a/packages/announcements/src/changelog/changelog-filter.tsx
+++ b/packages/announcements/src/changelog/changelog-filter.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { cn, useT } from '@tour-kit/core'
+import * as React from 'react'
+
+export interface ChangelogFilterProps {
+  /** Distinct categories derived from the entry list (no "All" sentinel — the filter prepends it). */
+  categories: string[]
+  /** Currently selected category. `null` = "All". */
+  selected: string | null
+  /** Fires with the next category (or `null` for "All") on click / Enter / Space. */
+  onSelect: (next: string | null) => void
+  className?: string
+}
+
+/**
+ * Pure presentational sidebar. Renders an "All" reset followed by one button
+ * per category. Implements roving tabindex so screen-reader users can cycle
+ * options with `ArrowUp` / `ArrowDown` (wrapping at both ends).
+ */
+export function ChangelogFilter({
+  categories,
+  selected,
+  onSelect,
+  className,
+}: ChangelogFilterProps) {
+  const t = useT()
+  const allLabel = resolveT(t, 'changelog.filter.all', 'All')
+  const navLabel = resolveT(t, 'changelog.filter.label', 'Filter by category')
+  const items: Array<string | null> = React.useMemo(() => [null, ...categories], [categories])
+  const itemsRef = React.useRef<Array<HTMLButtonElement | null>>([])
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, idx: number) => {
+      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+      event.preventDefault()
+      const dir = event.key === 'ArrowDown' ? 1 : -1
+      const next = (idx + dir + items.length) % items.length
+      itemsRef.current[next]?.focus()
+    },
+    [items.length]
+  )
+
+  return (
+    <nav className={cn('tk-changelog-filter', className)} aria-label={navLabel}>
+      <ul className="tk-changelog-filter__list" role="list">
+        {items.map((cat, idx) => {
+          const isSelected = cat === selected
+          const label = cat ?? allLabel
+          return (
+            <li key={cat ?? '__all__'}>
+              <button
+                ref={(el) => {
+                  itemsRef.current[idx] = el
+                }}
+                type="button"
+                aria-pressed={isSelected}
+                tabIndex={isSelected ? 0 : -1}
+                onClick={() => onSelect(cat)}
+                onKeyDown={(e) => handleKeyDown(e, idx)}
+                className={cn(
+                  'tk-changelog-filter__item',
+                  'focus-visible:ring-2 focus-visible:ring-offset-2',
+                  isSelected && 'tk-changelog-filter__item--selected'
+                )}
+              >
+                {label}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}
+
+function resolveT(
+  t: (key: string, vars?: Record<string, unknown>) => string,
+  key: string,
+  fallback: string
+): string {
+  const value = t(key)
+  return value === '' || value === key ? fallback : value
+}

--- a/packages/announcements/src/changelog/changelog-filter.tsx
+++ b/packages/announcements/src/changelog/changelog-filter.tsx
@@ -43,7 +43,7 @@ export function ChangelogFilter({
 
   return (
     <nav className={cn('tk-changelog-filter', className)} aria-label={navLabel}>
-      <ul className="tk-changelog-filter__list" role="list">
+      <ul className="tk-changelog-filter__list">
         {items.map((cat, idx) => {
           const isSelected = cat === selected
           const label = cat ?? allLabel

--- a/packages/announcements/src/changelog/changelog-page.test.tsx
+++ b/packages/announcements/src/changelog/changelog-page.test.tsx
@@ -1,0 +1,183 @@
+import { LocaleProvider } from '@tour-kit/core'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ChangelogPage } from './changelog-page'
+import { MOCK_ENTRIES, mockReducedMotion } from './__test-helpers__'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('<ChangelogPage>', () => {
+  beforeEach(() => {
+    mockReducedMotion(false)
+  })
+
+  describe('rendering', () => {
+    it('renders without a router context', () => {
+      expect(() => render(<ChangelogPage entries={MOCK_ENTRIES} />)).not.toThrow()
+    })
+
+    it('shows the English fallback empty state when entries=[]', () => {
+      render(<ChangelogPage entries={[]} />)
+      expect(screen.getByText('No changelog entries yet')).toBeInTheDocument()
+    })
+
+    it('localizes the empty state via LocaleProvider', () => {
+      render(
+        <LocaleProvider
+          locale="es"
+          messages={{ 'changelog.empty': 'Aún no hay novedades' }}
+        >
+          <ChangelogPage entries={[]} />
+        </LocaleProvider>
+      )
+      expect(screen.getByText('Aún no hay novedades')).toBeInTheDocument()
+    })
+
+    it('renders one <article> per entry', () => {
+      render(<ChangelogPage entries={MOCK_ENTRIES} />)
+      expect(screen.getAllByRole('article')).toHaveLength(3)
+    })
+  })
+
+  describe('uncontrolled filter', () => {
+    it('lists all derived categories plus an "All" reset button', () => {
+      render(<ChangelogPage entries={MOCK_ENTRIES} />)
+      expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Performance' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Bugfixes' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Features' })).toBeInTheDocument()
+    })
+
+    it('clicking a category narrows the entry list; "All" restores', async () => {
+      const user = userEvent.setup()
+      render(<ChangelogPage entries={MOCK_ENTRIES} />)
+      expect(screen.getAllByRole('article')).toHaveLength(3)
+
+      await user.click(screen.getByRole('button', { name: 'Performance' }))
+      const articles = screen.getAllByRole('article')
+      expect(articles).toHaveLength(1)
+      expect(within(articles[0]).getByText(/Performance: 30% faster boot/)).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'All' }))
+      expect(screen.getAllByRole('article')).toHaveLength(3)
+    })
+
+    it('marks the selected filter button with aria-pressed=true', async () => {
+      const user = userEvent.setup()
+      render(<ChangelogPage entries={MOCK_ENTRIES} />)
+      const allBtn = screen.getByRole('button', { name: 'All' })
+      const perfBtn = screen.getByRole('button', { name: 'Performance' })
+      expect(allBtn).toHaveAttribute('aria-pressed', 'true')
+      expect(perfBtn).toHaveAttribute('aria-pressed', 'false')
+
+      await user.click(perfBtn)
+      expect(perfBtn).toHaveAttribute('aria-pressed', 'true')
+      expect(allBtn).toHaveAttribute('aria-pressed', 'false')
+    })
+  })
+
+  describe('controlled mode', () => {
+    it('calls onCategoryChange and does NOT mutate internal state', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      render(
+        <ChangelogPage
+          entries={MOCK_ENTRIES}
+          category="Performance"
+          onCategoryChange={onChange}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Bugfixes' }))
+      expect(onChange).toHaveBeenCalledOnce()
+      expect(onChange).toHaveBeenCalledWith('Bugfixes')
+
+      // Internal state untouched: prop still drives the filter to "Performance".
+      const articles = screen.getAllByRole('article')
+      expect(articles).toHaveLength(1)
+      expect(within(articles[0]).getByText(/Performance: 30% faster boot/)).toBeInTheDocument()
+    })
+
+    it('passes null when "All" is clicked in controlled mode', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      render(
+        <ChangelogPage
+          entries={MOCK_ENTRIES}
+          category="Performance"
+          onCategoryChange={onChange}
+        />
+      )
+      await user.click(screen.getByRole('button', { name: 'All' }))
+      expect(onChange).toHaveBeenCalledWith(null)
+    })
+  })
+
+  describe('MediaSlot integration', () => {
+    it('renders <MediaSlot> only for entries with media set', () => {
+      render(<ChangelogPage entries={MOCK_ENTRIES} />)
+      // Only evt-3 (SSO) carries `media`. Its YouTube URL renders an <iframe>.
+      expect(document.querySelectorAll('iframe').length).toBe(1)
+    })
+  })
+
+  describe('reactions', () => {
+    it('forwards onReact from page to entry buttons', async () => {
+      const user = userEvent.setup()
+      const onReact = vi.fn()
+      render(<ChangelogPage entries={MOCK_ENTRIES} onReact={onReact} />)
+      const entry1 = screen.getAllByRole('article')[0]
+      await user.click(within(entry1).getByRole('button', { name: 'Thumbs up' }))
+      expect(onReact).toHaveBeenCalledWith('evt-1', '👍')
+    })
+  })
+
+  describe('keyboard navigation', () => {
+    it('Tab → ArrowDown → Enter cycles and activates filter buttons', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      render(
+        <ChangelogPage
+          entries={MOCK_ENTRIES}
+          category={null}
+          onCategoryChange={onChange}
+        />
+      )
+
+      await user.tab()
+      expect(screen.getByRole('button', { name: 'All' })).toHaveFocus()
+
+      await user.keyboard('{ArrowDown}')
+      expect(screen.getByRole('button', { name: 'Performance' })).toHaveFocus()
+
+      await user.keyboard('{Enter}')
+      expect(onChange).toHaveBeenCalledWith('Performance')
+    })
+
+    it('ArrowUp wraps from the first option to the last', async () => {
+      const user = userEvent.setup()
+      render(<ChangelogPage entries={MOCK_ENTRIES} />)
+      await user.tab()
+      await user.keyboard('{ArrowUp}')
+      expect(screen.getByRole('button', { name: 'Features' })).toHaveFocus()
+    })
+  })
+
+  describe('reduced motion', () => {
+    it('keeps the motion-safe:animate-in class on entries (CSS gates it browser-side)', () => {
+      mockReducedMotion(true)
+      render(<ChangelogPage entries={MOCK_ENTRIES} />)
+      const articles = screen.getAllByRole('article')
+      // jsdom does not evaluate `@media` queries; the documented contract is
+      // that the `motion-safe:` Tailwind utility is emitted in classnames and
+      // CSS gates it browser-side.
+      for (const article of articles) {
+        expect(article.className).toMatch(/motion-safe:animate-in/)
+      }
+    })
+  })
+})

--- a/packages/announcements/src/changelog/changelog-page.test.tsx
+++ b/packages/announcements/src/changelog/changelog-page.test.tsx
@@ -1,10 +1,10 @@
-import { LocaleProvider } from '@tour-kit/core'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { LocaleProvider } from '@tour-kit/core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ChangelogPage } from './changelog-page'
 import { MOCK_ENTRIES, mockReducedMotion } from './__test-helpers__'
+import { ChangelogPage } from './changelog-page'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -27,10 +27,7 @@ describe('<ChangelogPage>', () => {
 
     it('localizes the empty state via LocaleProvider', () => {
       render(
-        <LocaleProvider
-          locale="es"
-          messages={{ 'changelog.empty': 'Aún no hay novedades' }}
-        >
+        <LocaleProvider locale="es" messages={{ 'changelog.empty': 'Aún no hay novedades' }}>
           <ChangelogPage entries={[]} />
         </LocaleProvider>
       )
@@ -85,11 +82,7 @@ describe('<ChangelogPage>', () => {
       const user = userEvent.setup()
       const onChange = vi.fn()
       render(
-        <ChangelogPage
-          entries={MOCK_ENTRIES}
-          category="Performance"
-          onCategoryChange={onChange}
-        />
+        <ChangelogPage entries={MOCK_ENTRIES} category="Performance" onCategoryChange={onChange} />
       )
 
       await user.click(screen.getByRole('button', { name: 'Bugfixes' }))
@@ -106,11 +99,7 @@ describe('<ChangelogPage>', () => {
       const user = userEvent.setup()
       const onChange = vi.fn()
       render(
-        <ChangelogPage
-          entries={MOCK_ENTRIES}
-          category="Performance"
-          onCategoryChange={onChange}
-        />
+        <ChangelogPage entries={MOCK_ENTRIES} category="Performance" onCategoryChange={onChange} />
       )
       await user.click(screen.getByRole('button', { name: 'All' }))
       expect(onChange).toHaveBeenCalledWith(null)
@@ -140,13 +129,7 @@ describe('<ChangelogPage>', () => {
     it('Tab → ArrowDown → Enter cycles and activates filter buttons', async () => {
       const user = userEvent.setup()
       const onChange = vi.fn()
-      render(
-        <ChangelogPage
-          entries={MOCK_ENTRIES}
-          category={null}
-          onCategoryChange={onChange}
-        />
-      )
+      render(<ChangelogPage entries={MOCK_ENTRIES} category={null} onCategoryChange={onChange} />)
 
       await user.tab()
       expect(screen.getByRole('button', { name: 'All' })).toHaveFocus()

--- a/packages/announcements/src/changelog/changelog-page.tsx
+++ b/packages/announcements/src/changelog/changelog-page.tsx
@@ -35,7 +35,7 @@ export function ChangelogPage({
   const { direction } = useLocale()
   const [internalCategory, setInternalCategory] = React.useState<string | null>(null)
   const isControlled = controlledCategory !== undefined
-  const selected = isControlled ? controlledCategory ?? null : internalCategory
+  const selected = isControlled ? (controlledCategory ?? null) : internalCategory
 
   const handleSelect = React.useCallback(
     (next: string | null) => {
@@ -46,8 +46,7 @@ export function ChangelogPage({
   )
 
   const categories = React.useMemo(
-    () =>
-      Array.from(new Set(entries.flatMap((e) => (e.category ? [e.category] : [])))),
+    () => Array.from(new Set(entries.flatMap((e) => (e.category ? [e.category] : [])))),
     [entries]
   )
 
@@ -59,19 +58,12 @@ export function ChangelogPage({
   const emptyText = resolveT(t, 'changelog.empty', 'No changelog entries yet')
 
   return (
-    <div
-      dir={direction ?? 'ltr'}
-      className={cn('tk-changelog-page', className)}
-    >
-      <ChangelogFilter
-        categories={categories}
-        selected={selected}
-        onSelect={handleSelect}
-      />
+    <div dir={direction ?? 'ltr'} className={cn('tk-changelog-page', className)}>
+      <ChangelogFilter categories={categories} selected={selected} onSelect={handleSelect} />
       {filtered.length === 0 ? (
         <p className="tk-changelog-page__empty">{emptyText}</p>
       ) : (
-        <ul role="list" className="tk-changelog-page__list">
+        <ul className="tk-changelog-page__list">
           {filtered.map((entry) => (
             <li key={entry.id}>
               <ChangelogEntry entry={entry} onReact={onReact} />

--- a/packages/announcements/src/changelog/changelog-page.tsx
+++ b/packages/announcements/src/changelog/changelog-page.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { cn, useLocale, useT } from '@tour-kit/core'
+import * as React from 'react'
+
+import { ChangelogEntry } from './changelog-entry'
+import { ChangelogFilter } from './changelog-filter'
+import type { ChangelogEntry as ChangelogEntryType } from './feed'
+import type { Reaction } from './reactions'
+
+export interface ChangelogPageProps {
+  entries: ChangelogEntryType[]
+  /** Controlled selected category. `null` = "All". Omit to use uncontrolled internal state. */
+  category?: string | null
+  /** Required to switch the component into controlled mode. */
+  onCategoryChange?: (next: string | null) => void
+  /** Forwarded to every entry's `<Reactions>` row. Fire-and-forget. */
+  onReact?: (id: string, emoji: Reaction) => void
+  className?: string
+}
+
+/**
+ * Drop-in changelog page: category-filter sidebar + entry list. Router-agnostic
+ * — consumers wire `category`/`onCategoryChange` for URL-sync. Without those
+ * props, the component manages an internal `useState` (uncontrolled).
+ */
+export function ChangelogPage({
+  entries,
+  category: controlledCategory,
+  onCategoryChange,
+  onReact,
+  className,
+}: ChangelogPageProps) {
+  const t = useT()
+  const { direction } = useLocale()
+  const [internalCategory, setInternalCategory] = React.useState<string | null>(null)
+  const isControlled = controlledCategory !== undefined
+  const selected = isControlled ? controlledCategory ?? null : internalCategory
+
+  const handleSelect = React.useCallback(
+    (next: string | null) => {
+      if (!isControlled) setInternalCategory(next)
+      onCategoryChange?.(next)
+    },
+    [isControlled, onCategoryChange]
+  )
+
+  const categories = React.useMemo(
+    () =>
+      Array.from(new Set(entries.flatMap((e) => (e.category ? [e.category] : [])))),
+    [entries]
+  )
+
+  const filtered = React.useMemo(
+    () => (selected ? entries.filter((e) => e.category === selected) : entries),
+    [entries, selected]
+  )
+
+  const emptyText = resolveT(t, 'changelog.empty', 'No changelog entries yet')
+
+  return (
+    <div
+      dir={direction ?? 'ltr'}
+      className={cn('tk-changelog-page', className)}
+    >
+      <ChangelogFilter
+        categories={categories}
+        selected={selected}
+        onSelect={handleSelect}
+      />
+      {filtered.length === 0 ? (
+        <p className="tk-changelog-page__empty">{emptyText}</p>
+      ) : (
+        <ul role="list" className="tk-changelog-page__list">
+          {filtered.map((entry) => (
+            <li key={entry.id}>
+              <ChangelogEntry entry={entry} onReact={onReact} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function resolveT(
+  t: (key: string, vars?: Record<string, unknown>) => string,
+  key: string,
+  fallback: string
+): string {
+  const value = t(key)
+  return value === '' || value === key ? fallback : value
+}

--- a/packages/announcements/src/changelog/changelog-rtl.test.tsx
+++ b/packages/announcements/src/changelog/changelog-rtl.test.tsx
@@ -1,9 +1,9 @@
-import { LocaleProvider } from '@tour-kit/core'
 import { render } from '@testing-library/react'
+import { LocaleProvider } from '@tour-kit/core'
 import { describe, expect, it } from 'vitest'
 
-import { ChangelogPage } from './changelog-page'
 import { MOCK_ENTRIES } from './__test-helpers__'
+import { ChangelogPage } from './changelog-page'
 
 describe('<ChangelogPage> RTL', () => {
   it('applies dir="rtl" when wrapped in <LocaleProvider locale="ar">', () => {

--- a/packages/announcements/src/changelog/changelog-rtl.test.tsx
+++ b/packages/announcements/src/changelog/changelog-rtl.test.tsx
@@ -1,0 +1,34 @@
+import { LocaleProvider } from '@tour-kit/core'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { ChangelogPage } from './changelog-page'
+import { MOCK_ENTRIES } from './__test-helpers__'
+
+describe('<ChangelogPage> RTL', () => {
+  it('applies dir="rtl" when wrapped in <LocaleProvider locale="ar">', () => {
+    const { container } = render(
+      <LocaleProvider locale="ar">
+        <ChangelogPage entries={MOCK_ENTRIES} />
+      </LocaleProvider>
+    )
+    const root = container.firstElementChild as HTMLElement
+    expect(root).toHaveAttribute('dir', 'rtl')
+  })
+
+  it('applies dir="ltr" when no locale provider mounted', () => {
+    const { container } = render(<ChangelogPage entries={MOCK_ENTRIES} />)
+    const root = container.firstElementChild as HTMLElement
+    expect(root).toHaveAttribute('dir', 'ltr')
+  })
+
+  it('honors an explicit direction override on LocaleProvider', () => {
+    const { container } = render(
+      <LocaleProvider locale="ar" direction="ltr">
+        <ChangelogPage entries={MOCK_ENTRIES} />
+      </LocaleProvider>
+    )
+    const root = container.firstElementChild as HTMLElement
+    expect(root).toHaveAttribute('dir', 'ltr')
+  })
+})

--- a/packages/announcements/src/changelog/index.ts
+++ b/packages/announcements/src/changelog/index.ts
@@ -1,2 +1,22 @@
+// ============================================
+// PHASE 5b — UI components
+// ============================================
+
+export { ChangelogPage } from './changelog-page'
+export type { ChangelogPageProps } from './changelog-page'
+
+export { ChangelogEntry } from './changelog-entry'
+export type { ChangelogEntryProps } from './changelog-entry'
+
+export { ChangelogFilter } from './changelog-filter'
+export type { ChangelogFilterProps } from './changelog-filter'
+
+export { Reactions } from './reactions'
+export type { Reaction, ReactionsProps } from './reactions'
+
+// ============================================
+// PHASE 5a — feed serializer
+// ============================================
+
 export { serializeFeed } from './feed'
-export type { ChangelogEntry, SerializeFeedOptions } from './feed'
+export type { ChangelogEntry as ChangelogEntryType, SerializeFeedOptions } from './feed'

--- a/packages/announcements/src/changelog/reactions.test.tsx
+++ b/packages/announcements/src/changelog/reactions.test.tsx
@@ -1,6 +1,6 @@
-import { LocaleProvider } from '@tour-kit/core'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { LocaleProvider } from '@tour-kit/core'
 import { describe, expect, it, vi } from 'vitest'
 
 import { Reactions } from './reactions'

--- a/packages/announcements/src/changelog/reactions.test.tsx
+++ b/packages/announcements/src/changelog/reactions.test.tsx
@@ -1,0 +1,59 @@
+import { LocaleProvider } from '@tour-kit/core'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Reactions } from './reactions'
+
+describe('<Reactions>', () => {
+  it('renders 3 buttons with English fallback aria-labels', () => {
+    render(<Reactions entryId="evt-1" />)
+    expect(screen.getByRole('button', { name: 'Thumbs up' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Neutral' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Thumbs down' })).toBeInTheDocument()
+  })
+
+  it('clicking thumbs up fires onReact(entryId, "👍")', async () => {
+    const user = userEvent.setup()
+    const onReact = vi.fn()
+    render(<Reactions entryId="evt-1" onReact={onReact} />)
+    await user.click(screen.getByRole('button', { name: 'Thumbs up' }))
+    expect(onReact).toHaveBeenCalledOnce()
+    expect(onReact).toHaveBeenCalledWith('evt-1', '👍')
+  })
+
+  it('clicking the other reactions fires the matching emoji', async () => {
+    const user = userEvent.setup()
+    const onReact = vi.fn()
+    render(<Reactions entryId="evt-2" onReact={onReact} />)
+    await user.click(screen.getByRole('button', { name: 'Neutral' }))
+    expect(onReact).toHaveBeenLastCalledWith('evt-2', '😐')
+    await user.click(screen.getByRole('button', { name: 'Thumbs down' }))
+    expect(onReact).toHaveBeenLastCalledWith('evt-2', '👎')
+  })
+
+  it('does not throw when onReact is undefined', async () => {
+    const user = userEvent.setup()
+    render(<Reactions entryId="evt-3" />)
+    await expect(
+      user.click(screen.getByRole('button', { name: 'Thumbs up' }))
+    ).resolves.toBeUndefined()
+  })
+
+  it('localizes aria-labels via LocaleProvider', () => {
+    render(
+      <LocaleProvider
+        locale="es"
+        messages={{
+          'changelog.reaction.thumbs_up': 'Pulgar arriba',
+          'changelog.reaction.neutral': 'Neutral',
+          'changelog.reaction.thumbs_down': 'Pulgar abajo',
+        }}
+      >
+        <Reactions entryId="evt-1" />
+      </LocaleProvider>
+    )
+    expect(screen.getByRole('button', { name: 'Pulgar arriba' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Pulgar abajo' })).toBeInTheDocument()
+  })
+})

--- a/packages/announcements/src/changelog/reactions.tsx
+++ b/packages/announcements/src/changelog/reactions.tsx
@@ -44,10 +44,7 @@ export function Reactions({ entryId, onReact, className }: ReactionsProps) {
           type="button"
           aria-label={resolve(t, key, fallback)}
           onClick={() => onReact?.(entryId, emoji)}
-          className={cn(
-            'tk-reactions__button',
-            'focus-visible:ring-2 focus-visible:ring-offset-2'
-          )}
+          className={cn('tk-reactions__button', 'focus-visible:ring-2 focus-visible:ring-offset-2')}
         >
           <span aria-hidden="true">{emoji}</span>
         </button>

--- a/packages/announcements/src/changelog/reactions.tsx
+++ b/packages/announcements/src/changelog/reactions.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { cn, useT } from '@tour-kit/core'
+
+export type Reaction = '👍' | '😐' | '👎'
+
+interface ReactionDef {
+  emoji: Reaction
+  key: string
+  fallback: string
+}
+
+const REACTIONS: ReadonlyArray<ReactionDef> = [
+  { emoji: '👍', key: 'changelog.reaction.thumbs_up', fallback: 'Thumbs up' },
+  { emoji: '😐', key: 'changelog.reaction.neutral', fallback: 'Neutral' },
+  { emoji: '👎', key: 'changelog.reaction.thumbs_down', fallback: 'Thumbs down' },
+]
+
+export interface ReactionsProps {
+  /** Stable id of the entry these reactions belong to. Forwarded as the first arg of `onReact`. */
+  entryId: string
+  /** Fire-and-forget callback. The component holds no reaction state. */
+  onReact?: (id: string, emoji: Reaction) => void
+  className?: string
+}
+
+/**
+ * Three-button reaction row (👍 😐 👎). Stateless: clicks bubble up via
+ * `onReact`. Aria-labels resolve through `useT()` with English fallbacks
+ * when no `LocaleProvider` (or matching message) is present.
+ */
+export function Reactions({ entryId, onReact, className }: ReactionsProps) {
+  const t = useT()
+
+  return (
+    <div
+      className={cn('tk-reactions', className)}
+      role="group"
+      aria-label={resolve(t, 'changelog.reactions.label', 'Reactions')}
+    >
+      {REACTIONS.map(({ emoji, key, fallback }) => (
+        <button
+          key={emoji}
+          type="button"
+          aria-label={resolve(t, key, fallback)}
+          onClick={() => onReact?.(entryId, emoji)}
+          className={cn(
+            'tk-reactions__button',
+            'focus-visible:ring-2 focus-visible:ring-offset-2'
+          )}
+        >
+          <span aria-hidden="true">{emoji}</span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * `useT()` returns the key itself (dev) or `''` (prod) when a message is
+ * missing. Fall back to the supplied English string in either case so the
+ * UI is meaningful without a `LocaleProvider`.
+ */
+function resolve(
+  t: (key: string, vars?: Record<string, unknown>) => string,
+  key: string,
+  fallback: string
+): string {
+  const value = t(key)
+  return value === '' || value === key ? fallback : value
+}

--- a/packages/announcements/src/index.ts
+++ b/packages/announcements/src/index.ts
@@ -177,8 +177,20 @@ export { isSegmentAudience } from './types/announcement'
 
 // Pure RSS 2.0 + JSON Feed 1.1 serializer. Zero runtime deps; barrel-isolated
 // under `./changelog` so toast-only consumers tree-shake out the feed code.
-export { serializeFeed } from './changelog'
-export type { ChangelogEntry, SerializeFeedOptions } from './changelog'
+// Explicit deep imports (NOT `export * from './changelog'`) keep the page UI
+// tree out of toast-only consumer bundles.
+export { serializeFeed } from './changelog/feed'
+export type { ChangelogEntry, SerializeFeedOptions } from './changelog/feed'
+
+// Phase 5b — `<ChangelogPage>` and friends are intentionally NOT re-exported
+// at the top level. They live behind the `@tour-kit/announcements/changelog`
+// subpath so toast/modal/banner-only consumers do not pay the bundle cost.
+// Type-only re-exports (no runtime cost) are still convenient for consumers
+// who pass entries through their own type-checked code path.
+export type { ChangelogPageProps } from './changelog/changelog-page'
+export type { ChangelogEntryProps } from './changelog/changelog-entry'
+export type { ChangelogFilterProps } from './changelog/changelog-filter'
+export type { Reaction, ReactionsProps } from './changelog/reactions'
 
 export type {
   // Context types

--- a/packages/announcements/tsup.config.ts
+++ b/packages/announcements/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     index: 'src/index.ts',
     headless: 'src/headless.ts',
     'tailwind/index': 'src/tailwind/index.ts',
+    'changelog/index': 'src/changelog/index.ts',
   },
   format: ['cjs', 'esm'],
   dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -777,6 +777,9 @@ importers:
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14

--- a/scripts/verify-changelog-page-treeshake.sh
+++ b/scripts/verify-changelog-page-treeshake.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Phase 5b tree-shake gate: verify that a toast-only consumer bundle does
+# NOT include the changelog *UI* symbols (ChangelogPage / ChangelogEntry /
+# ChangelogFilter / Reactions). Mirrors `verify-changelog-treeshake.sh`
+# (Phase 5a), narrowed to the new component tree.
+#
+# Usage: bash scripts/verify-changelog-page-treeshake.sh
+# Exits 0 if tree-shaking holds, 1 otherwise.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIR="$(mktemp -d -p "$ROOT/scripts" .changelog-page-treeshake.XXXXXX)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cd "$ROOT"
+
+if [[ ! -f packages/announcements/dist/index.js ]]; then
+  echo "verify-changelog-page-treeshake: building @tour-kit/announcements first..."
+  pnpm --filter @tour-kit/announcements build >/dev/null
+fi
+
+DIST_PATH="$ROOT/packages/announcements/dist/index.js"
+cat >"$TMPDIR/scratch.ts" <<EOF
+import { AnnouncementToast } from '${DIST_PATH}'
+console.log(AnnouncementToast)
+EOF
+
+ENTRY="$TMPDIR/scratch.ts"
+OUT="$TMPDIR/bundle.js"
+
+ESBUILD="$(node -p "require.resolve('esbuild/bin/esbuild')" 2>/dev/null || true)"
+if [[ -z "$ESBUILD" ]]; then
+  ESBUILD="npx esbuild"
+fi
+
+$ESBUILD "$ENTRY" \
+  --bundle \
+  --minify \
+  --format=esm \
+  --tree-shaking=true \
+  --platform=neutral \
+  --conditions=import,module,default \
+  --external:react \
+  --external:react-dom \
+  --external:@radix-ui/react-dialog \
+  --external:@floating-ui/react \
+  --external:tailwindcss \
+  --outfile="$OUT" \
+  --log-level=error
+
+# Symbols that must NOT appear in the toast-only bundle. We grep for class
+# names that the changelog UI code uses (`tk-changelog-page`,
+# `tk-changelog-filter`, `tk-changelog-entry`, `tk-reactions`) plus the
+# i18n keys unique to the changelog UI.
+PATTERN='tk-changelog-page|tk-changelog-filter|tk-changelog-entry|tk-reactions|changelog\.filter\.all|changelog\.empty|changelog\.reaction\.thumbs_'
+
+if grep -E "$PATTERN" "$OUT" >/dev/null 2>&1; then
+  echo "FAIL: toast-only bundle contains changelog UI symbols."
+  echo "Matches:"
+  grep -oE "$PATTERN" "$OUT" | sort -u | sed 's/^/  /'
+  echo "Bundle: $OUT"
+  exit 1
+fi
+
+echo "PASS: toast-only bundle is free of changelog UI symbols."
+echo "Bundle size: $(wc -c <"$OUT") bytes"


### PR DESCRIPTION
## Summary

Ships **`<ChangelogPage>`** — a drop-in React page (category filter sidebar + per-entry emoji reactions + `<MediaSlot>` integration) for serving public changelogs from `@tour-kit/announcements`. Lives behind the `@tour-kit/announcements/changelog` subpath so toast/modal/banner-only consumers tree-shake out the renderer.

- **New components** (router-agnostic, headless-first):
  - `<ChangelogPage>` — orchestrator, controlled/uncontrolled filter, RTL-aware
  - `<ChangelogEntry>` — single-entry renderer with locale-aware date + MediaSlot
  - `<ChangelogFilter>` — sidebar with roving tabindex (ArrowUp/Down wrap)
  - `<Reactions>` — stateless 3-emoji row, `onReact(entryId, emoji)` fire-and-forget
- **Subpath export**: `package.json#exports./changelog`, `tsup.config.ts` `'changelog/index'`.
- **Tree-shake gate**: `scripts/verify-changelog-page-treeshake.sh` confirms toast-only consumers do not pull changelog UI symbols. Phase 5a regression check still passes.
- **Bundle**: 167.17 kB / 175 kB brotlied (7.83 kB headroom).
- **Docs**: `apps/docs/content/docs/announcements/changelog.mdx` extended with `<ChangelogPage>` quick-start, Next.js URL-sync recipe, i18n key reference.

### Architectural call

Top-level runtime re-exports of `<ChangelogPage>` etc. were dropped after the tree-shake test caught a leak — tsup's `splitting: true` co-locates the changelog code with `useResolvedText` (toast/modal share the chunk), and re-exporting at the top of `src/index.ts` prevented esbuild from dropping the unused UI from toast-only consumer bundles. The subpath import is now the only supported entry point. Type-only re-exports stay top-level (zero runtime cost).

## Test plan

- [x] `pnpm --filter @tour-kit/announcements test` — 238/238 pass (24 new tests for changelog UI)
- [x] `pnpm --filter @tour-kit/announcements typecheck` — clean
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm --filter @tour-kit/announcements build` — emits `dist/changelog/index.{js,cjs,d.ts}`
- [x] `bash scripts/verify-changelog-page-treeshake.sh` — PASS
- [x] `bash scripts/verify-changelog-treeshake.sh` (Phase 5a) — still PASS
- [x] `npx size-limit` — `@tour-kit/announcements` 167.17 kB / 175 kB
- [x] `node -e "require.resolve('@tour-kit/announcements/changelog')"` — resolves to `dist/changelog/index.cjs`
- [ ] Manual smoke: mount `<ChangelogPage>` in a Next.js app and verify URL-sync recipe (deferred to docs site preview)