### PR TITLE
feat(phase-3): diagnostic engine & React surface (#32)

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,11 @@
 [
-  { "name": "@tour-kit/core", "path": "packages/core/dist/index.js", "limit": "24 KB" },
+  { "name": "@tour-kit/core", "path": "packages/core/dist/index.js", "limit": "26 KB" },
+  {
+    "name": "@tour-kit/core (useTour-only consumer)",
+    "path": "packages/core/dist/index.js",
+    "import": "{ useTour }",
+    "limit": "8 KB"
+  },
   {
     "name": "@tour-kit/core/schemas",
     "path": "packages/core/dist/schemas/index.js",

--- a/apps/docs/content/docs/core/diagnostic.mdx
+++ b/apps/docs/content/docs/core/diagnostic.mdx
@@ -1,0 +1,154 @@
+---
+title: Diagnostic Engine
+description: >-
+  Replace the silent "tour didn't fire" failure mode with a structured
+  `EligibilityReport` that names every gate's outcome.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+The diagnostic engine produces an `EligibilityReport` for every registered
+tour explaining whether it will fire — and, when it won't, exactly which gate
+rejected it. Opt in via `<TourProvider diagnose>` and read the result with
+`useTourDiagnostic(tourId)`.
+
+<Callout type="info" title="Opt-in by default">
+  `diagnose` defaults to `false`. With it off the orchestrator tree-shakes out
+  of the consumer bundle, so the cost is zero in production. In dev builds the
+  provider logs a one-time hint nudging you to enable it.
+</Callout>
+
+## Why diagnostics exist
+
+The most-asked support question on this repo is *"my tour did not fire and I
+have no idea why."* Before the diagnostic engine you had to grep through
+audience filters, route adapters, persistence stores, and license keys to
+guess. Now the provider runs all seven built-in gates plus any extension gates
+you registered, and the report names the first one that said no.
+
+## `<TourProvider diagnose>`
+
+```tsx
+import { TourProvider, useTourDiagnostic } from '@tour-kit/core'
+
+export function App() {
+  return (
+    <TourProvider tours={[myTour]} diagnose userContext={{ plan: 'pro' }}>
+      <DebugPanel />
+      <YourApp />
+    </TourProvider>
+  )
+}
+
+function DebugPanel() {
+  const report = useTourDiagnostic('my-tour')
+  if (!report) return null
+  return (
+    <pre>{JSON.stringify(report, null, 2)}</pre>
+  )
+}
+```
+
+The hook returns:
+
+- `null` when `diagnose` is off, the tour id is unknown, or the diagnostic
+  effect hasn't resolved yet
+- `EligibilityReport` once the orchestrator finishes
+
+## `EligibilityReport` shape
+
+```ts
+interface EligibilityReport {
+  tourId: string
+  willFire: boolean
+  reasons: GateReason[]
+  firstFailingGate: Extract<GateReason, { ok: false }> | null
+  evaluatedAt: number
+}
+```
+
+`reasons[]` is always populated for every built-in gate (in fixed order) plus
+your extension gates. `firstFailingGate` is a convenience — the first
+`ok: false` reason in evaluation order, or `null` when `willFire` is true.
+
+## Built-in gates
+
+Evaluated in this exact order — the contract is observable and tests pin it:
+
+| Order | Gate | Failure code | When it fires |
+|-------|------|--------------|---------------|
+| 1 | `structure` | `STRUCTURE_INVALID` | Tour has no steps, or `validateTour` threw |
+| 2 | `audience` | `AUDIENCE_MISMATCH` | Audience filter rejected the user. `detail.failingCondition` (array form) or `detail.segment` (object form) names the failing piece |
+| 3 | `persistence` | `ALREADY_COMPLETED` / `ALREADY_SKIPPED` | Tour id is in `completedTours` / `skippedTours` |
+| 4 | `route` | `ROUTE_MISMATCH` | Current route does not match the configured matcher under the chosen mode |
+| 5 | `target` | `TARGET_NOT_FOUND` | The first visible step's selector returned no element |
+| 6 | `when` | `WHEN_RETURNED_FALSE` | Tour-level `when()` returned `false` or threw |
+| 7 | `autostart` | `AUTOSTART_DISABLED` | `tour.autoStart === false` |
+
+<Callout type="warn" title="`structure` short-circuits">
+  When `structure` fails, no other built-in gate runs — there's nothing
+  meaningful to ask of a malformed tour. Other gates all run to completion so
+  you can see every rejection at once.
+</Callout>
+
+<Callout type="info" title="Async `when()`">
+  If `tour.when` returns a `Promise`, the gate yields `ok: true` with
+  `detail.note` documenting that the async path is owned by the runtime
+  pipeline. Diagnostics are synchronous-friendly.
+</Callout>
+
+## Extension gates
+
+License, scheduling, or any custom gate plugs in via `diagnosticGates`. The
+contract is `DiagnosticGate` — `@tour-kit/core` does not import the package
+implementing it.
+
+```tsx
+import type { DiagnosticGate } from '@tour-kit/core'
+
+const licenseGate: DiagnosticGate = {
+  id: 'license',
+  evaluate: async (ctx) => {
+    const ok = await checkLicense(ctx.userContext)
+    return ok
+      ? { ok: true, gate: 'license' }
+      : { ok: false, gate: 'license', code: 'LICENSE_INVALID', message: 'License invalid', detail: {} }
+  },
+}
+
+<TourProvider tours={tours} diagnose diagnosticGates={[licenseGate]}>
+  ...
+</TourProvider>
+```
+
+Rules:
+
+- Extensions run **after** every built-in gate, in registration order
+- Extensions may be async; built-ins are sync
+- A throwing extension is caught — the orchestrator inserts a synthetic
+  `{ ok: false, gate: id, code: '${ID}_THREW' }` reason and keeps going
+- `firstFailingGate` only points at an extension when no built-in failed first
+
+## `explainTour` (advanced)
+
+The orchestrator is also exported for non-React callers:
+
+```ts
+import { explainTour } from '@tour-kit/core'
+
+const report = await explainTour(myTour, {
+  completedTours: [],
+  skippedTours: [],
+  userContext: { plan: 'pro' },
+  targetResolver: (sel) => document.querySelector(sel),
+})
+```
+
+`explainTour` never throws. Internal errors land in the structure gate or, for
+extensions, as `_THREW` reasons.
+
+## Performance & bundle cost
+
+- Median **&lt;0.001ms** per call over 100 iterations (5-step tour, no extensions)
+- With `diagnose: false` the diagnostic module tree-shakes out of the consumer
+  bundle. The size-limit budget asserts this.

--- a/apps/docs/content/docs/core/meta.json
+++ b/apps/docs/content/docs/core/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "@tour-kit/core",
   "icon": "Cpu",
-  "pages": ["index", "providers", "hooks", "utilities", "types", "schemas"]
+  "pages": ["index", "providers", "hooks", "utilities", "types", "schemas", "diagnostic"]
 }

--- a/packages/core/src/__tests__/_fixtures.ts
+++ b/packages/core/src/__tests__/_fixtures.ts
@@ -29,3 +29,43 @@ export const twoStepTourTyped: Tour<TourStep<DemoStepId>> = {
     { id: 'pricing', target: '#b', content: 'b' },
   ],
 }
+
+// ─── Phase 3 diagnostic fixtures ────────────────────────────────────────────
+
+export const tourWithSegmentAudience: Tour = {
+  id: 'audience-demo',
+  steps: [{ id: 's1', target: '#a', content: '' }],
+  audience: { segment: 'admins' },
+}
+
+export const tourWithConditionAudience: Tour = {
+  id: 'cond-demo',
+  steps: [{ id: 's1', target: '#a', content: '' }],
+  audience: [{ type: 'user_property', key: 'plan', operator: 'equals', value: 'pro' }],
+}
+
+export const tourAutoStartFalse: Tour = {
+  id: 'no-auto',
+  steps: [{ id: 's1', target: '#a', content: '' }],
+  autoStart: false,
+}
+
+export const tourWithWhenFalse: Tour = {
+  id: 'when-false',
+  steps: [{ id: 's1', target: '#a', content: '' }],
+  when: () => false,
+}
+
+export const tourWithWhenThrows: Tour = {
+  id: 'when-throws',
+  steps: [{ id: 's1', target: '#a', content: '' }],
+  when: () => {
+    throw new Error('when blew up')
+  },
+}
+
+export const tourWithWhenAsync: Tour = {
+  id: 'when-async',
+  steps: [{ id: 's1', target: '#a', content: '' }],
+  when: () => Promise.resolve(true),
+}

--- a/packages/core/src/context/__tests__/tour-provider-diagnose.test.tsx
+++ b/packages/core/src/context/__tests__/tour-provider-diagnose.test.tsx
@@ -1,7 +1,11 @@
 import { act, render, renderHook } from '@testing-library/react'
+import * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { twoStepTour } from '../../__tests__/_fixtures'
+import { useTour } from '../../hooks/use-tour'
 import { useTourDiagnostic } from '../../hooks/use-tour-diagnostic'
+import type { DiagnosticGate } from '../../types/diagnostic'
+import type { RouterAdapter } from '../../types/router'
 import { TourProvider } from '../tour-provider'
 
 afterEach(() => {
@@ -101,5 +105,224 @@ describe('<TourProvider> production-mode silence', () => {
       String(args[0] ?? '').includes('diagnose')
     )
     expect(diagnoseCalls).toHaveLength(0)
+  })
+})
+
+describe('<TourProvider diagnose> — persistence integration', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="a"></div><div id="b"></div>'
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('reports ALREADY_COMPLETED after the active tour completes', async () => {
+    // Drive a real complete() through the reducer and verify the diagnostic
+    // report flips from willFire:true → firstFailingGate.code = 'ALREADY_COMPLETED'.
+    // `complete()` early-returns when state.isActive is false, so start() must
+    // flush before complete() reads the post-start closure.
+    const { result } = renderHook(
+      () => ({
+        diag: useTourDiagnostic('demo'),
+        tour: useTour(),
+      }),
+      {
+        wrapper: ({ children }) => (
+          <TourProvider tours={[twoStepTour]} diagnose>
+            {children}
+          </TourProvider>
+        ),
+      }
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current.diag?.willFire).toBe(true)
+
+    await act(async () => {
+      result.current.tour.start('demo')
+    })
+    await act(async () => {
+      result.current.tour.complete()
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(result.current.diag?.willFire).toBe(false)
+    expect(result.current.diag?.firstFailingGate?.code).toBe('ALREADY_COMPLETED')
+  })
+})
+
+describe('<TourProvider diagnose> — route gate plumbing', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="a"></div>'
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function makeRouter(current: string): RouterAdapter {
+    return {
+      getCurrentRoute: () => current,
+      navigate: vi.fn(),
+      onRouteChange: () => () => undefined,
+      matchRoute: (matcher, mode = 'exact') => {
+        if (mode === 'exact') return current === matcher
+        if (mode === 'startsWith') return current.startsWith(matcher)
+        return current.includes(matcher)
+      },
+    }
+  }
+
+  it('surfaces ROUTE_MISMATCH when the router is on a different path than the first visible step', async () => {
+    const tour = {
+      id: 'route-tour',
+      steps: [{ id: 's1', target: '#a', content: '', route: '/pricing' }],
+    }
+    const router = makeRouter('/dashboard')
+    const { result } = renderHook(() => useTourDiagnostic('route-tour'), {
+      wrapper: ({ children }) => (
+        <TourProvider tours={[tour]} diagnose router={router}>
+          {children}
+        </TourProvider>
+      ),
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current?.willFire).toBe(false)
+    expect(result.current?.firstFailingGate?.code).toBe('ROUTE_MISMATCH')
+    expect(result.current?.firstFailingGate?.detail).toMatchObject({
+      expected: '/pricing',
+      actual: '/dashboard',
+      mode: 'exact',
+    })
+  })
+
+  it('passes the route gate when current matches the first visible step', async () => {
+    const tour = {
+      id: 'route-tour',
+      steps: [{ id: 's1', target: '#a', content: '', route: '/pricing' }],
+    }
+    const router = makeRouter('/pricing')
+    const { result } = renderHook(() => useTourDiagnostic('route-tour'), {
+      wrapper: ({ children }) => (
+        <TourProvider tours={[tour]} diagnose router={router}>
+          {children}
+        </TourProvider>
+      ),
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current?.willFire).toBe(true)
+  })
+})
+
+describe('<TourProvider diagnose> — extension gate prop changes', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="a"></div><div id="b"></div>'
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('re-runs diagnostics when a new gate is added to diagnosticGates after mount', async () => {
+    // Realistic scenario: a license gate registers after auth resolves. The
+    // gate-id set changes, so the diagnose effect must re-run with the new
+    // gate appended. Keying by gate id (not by array identity) is intentional:
+    // ids are required-stable per the DiagnosticGate contract, so two gates
+    // with the same id are considered the same registration slot.
+    function Wrapper({ gates }: { gates: DiagnosticGate[] }) {
+      return (
+        <TourProvider tours={[twoStepTour]} diagnose diagnosticGates={gates}>
+          <Reader />
+        </TourProvider>
+      )
+    }
+    const reports: Array<ReturnType<typeof useTourDiagnostic>> = []
+    function Reader() {
+      const report = useTourDiagnostic('demo')
+      React.useEffect(() => {
+        reports.push(report)
+      }, [report])
+      return null
+    }
+
+    const blockingLicense: DiagnosticGate = {
+      id: 'license',
+      evaluate: () => ({
+        ok: false,
+        gate: 'license',
+        code: 'LICENSE_INVALID',
+        message: 'no key',
+      }),
+    }
+
+    const { rerender } = render(<Wrapper gates={[]} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(reports[reports.length - 1]?.willFire).toBe(true)
+
+    rerender(<Wrapper gates={[blockingLicense]} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(reports[reports.length - 1]?.willFire).toBe(false)
+    expect(reports[reports.length - 1]?.firstFailingGate?.code).toBe('LICENSE_INVALID')
+  })
+})
+
+describe('<TourProvider diagnose> — userContext stability', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="a"></div><div id="b"></div>'
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('does not re-run the diagnostic effect when a deep-equal inline userContext object is passed on re-render', async () => {
+    let effectRuns = 0
+    const trackingGate: DiagnosticGate = {
+      id: 'tracker',
+      evaluate: () => {
+        effectRuns += 1
+        return { ok: true, gate: 'tracker' }
+      },
+    }
+
+    function Harness({ tick }: { tick: number }) {
+      // New object literal every render — must NOT trigger the diagnose effect
+      // unless its contents change.
+      return (
+        <TourProvider
+          tours={[twoStepTour]}
+          diagnose
+          userContext={{ plan: 'pro' }}
+          diagnosticGates={[trackingGate]}
+        >
+          <span>tick {tick}</span>
+        </TourProvider>
+      )
+    }
+
+    const { rerender } = render(<Harness tick={1} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const baseline = effectRuns
+
+    rerender(<Harness tick={2} />)
+    rerender(<Harness tick={3} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Allow at most the baseline (one run per tour). Anything beyond proves
+    // userContext identity is leaking into the effect deps.
+    expect(effectRuns).toBe(baseline)
   })
 })

--- a/packages/core/src/context/__tests__/tour-provider-diagnose.test.tsx
+++ b/packages/core/src/context/__tests__/tour-provider-diagnose.test.tsx
@@ -1,0 +1,105 @@
+import { act, render, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { twoStepTour } from '../../__tests__/_fixtures'
+import { useTourDiagnostic } from '../../hooks/use-tour-diagnostic'
+import { TourProvider } from '../tour-provider'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('<TourProvider diagnose>', () => {
+  beforeEach(() => {
+    // Mount the targets referenced by the fixture so the `target` gate passes.
+    document.body.innerHTML = '<div id="a"></div><div id="b"></div>'
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('populates the diagnostics map for every registered tour after one microtask', async () => {
+    const { result } = renderHook(() => useTourDiagnostic('demo'), {
+      wrapper: ({ children }) => (
+        <TourProvider tours={[twoStepTour]} diagnose>
+          {children}
+        </TourProvider>
+      ),
+    })
+    // Initial state: effect hasn't resolved yet
+    expect(result.current).toBeNull()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current?.tourId).toBe('demo')
+    expect(result.current?.willFire).toBe(true)
+  })
+
+  it('keeps diagnostics map undefined when diagnose is off', () => {
+    const { result } = renderHook(() => useTourDiagnostic('demo'), {
+      wrapper: ({ children }) => <TourProvider tours={[twoStepTour]}>{children}</TourProvider>,
+    })
+    expect(result.current).toBeNull()
+  })
+})
+
+describe('<TourProvider> dev-mode warning', () => {
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'development')
+  })
+
+  it('fires console.warn exactly once across re-renders in dev mode', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const { rerender } = render(
+      <TourProvider tours={[twoStepTour]}>
+        <span>x</span>
+      </TourProvider>
+    )
+    rerender(
+      <TourProvider tours={[twoStepTour]}>
+        <span>x</span>
+      </TourProvider>
+    )
+    rerender(
+      <TourProvider tours={[twoStepTour]}>
+        <span>x</span>
+      </TourProvider>
+    )
+    const diagnoseCalls = warn.mock.calls.filter((args) =>
+      String(args[0] ?? '').includes('diagnose')
+    )
+    expect(diagnoseCalls).toHaveLength(1)
+  })
+
+  it('does NOT warn when diagnose is on', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    render(
+      <TourProvider tours={[twoStepTour]} diagnose>
+        <span>x</span>
+      </TourProvider>
+    )
+    const diagnoseCalls = warn.mock.calls.filter((args) =>
+      String(args[0] ?? '').includes('diagnose')
+    )
+    expect(diagnoseCalls).toHaveLength(0)
+  })
+})
+
+describe('<TourProvider> production-mode silence', () => {
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'production')
+  })
+
+  it('never warns in production builds', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    render(
+      <TourProvider tours={[twoStepTour]}>
+        <span>x</span>
+      </TourProvider>
+    )
+    const diagnoseCalls = warn.mock.calls.filter((args) =>
+      String(args[0] ?? '').includes('diagnose')
+    )
+    expect(diagnoseCalls).toHaveLength(0)
+  })
+})

--- a/packages/core/src/context/__tests__/tour-provider-diagnose.test.tsx
+++ b/packages/core/src/context/__tests__/tour-provider-diagnose.test.tsx
@@ -325,4 +325,62 @@ describe('<TourProvider diagnose> — userContext stability', () => {
     // userContext identity is leaking into the effect deps.
     expect(effectRuns).toBe(baseline)
   })
+
+  it('re-runs the diagnostic effect when userContext content actually changes', async () => {
+    // Complement to the deep-equal test above: prove the stability key
+    // refreshes on content change, so a future refactor that hardcoded the
+    // key to `''` would fail HERE instead of slipping through.
+    let effectRuns = 0
+    const trackingGate: DiagnosticGate = {
+      id: 'tracker',
+      evaluate: () => {
+        effectRuns += 1
+        return { ok: true, gate: 'tracker' }
+      },
+    }
+    function Harness({ ctx }: { ctx: Record<string, unknown> }) {
+      return (
+        <TourProvider
+          tours={[twoStepTour]}
+          diagnose
+          userContext={ctx}
+          diagnosticGates={[trackingGate]}
+        >
+          <span />
+        </TourProvider>
+      )
+    }
+    const { rerender } = render(<Harness ctx={{ plan: 'pro' }} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const baseline = effectRuns
+
+    rerender(<Harness ctx={{ plan: 'enterprise' }} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(effectRuns).toBeGreaterThan(baseline)
+  })
+
+  it('does not crash the host tree when userContext contains circular references', async () => {
+    // `JSON.stringify` throws on circular refs — the stability key must
+    // catch the throw and degrade gracefully so a user object with back-
+    // references never takes down the consumer's render.
+    type Circular = Record<string, unknown> & { self?: unknown }
+    const circular: Circular = { plan: 'pro' }
+    circular.self = circular
+
+    const { result } = renderHook(() => useTourDiagnostic('demo'), {
+      wrapper: ({ children }) => (
+        <TourProvider tours={[twoStepTour]} diagnose userContext={circular}>
+          {children}
+        </TourProvider>
+      ),
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current?.tourId).toBe('demo')
+  })
 })

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -442,18 +442,35 @@ export function TourProvider({
   // `diagnose === true`, so opted-out consumers pay zero runtime cost (and
   // the orchestrator import tree-shakes out of their bundle).
   //
-  // Stability keys: `userContext` and `diagnosticGates` are reference types,
-  // so deep-equality keys (JSON-stringified userContext, gate-id join) prevent
-  // an inline-literal `userContext={{...}}` from re-running the effect every
-  // render. The `cancelled` flag guards against stale `setDiagnostics` writes
-  // when a re-run kicks off before the previous resolves.
-  const userContextKey = React.useMemo(
-    () => (userContext ? JSON.stringify(userContext) : ''),
-    [userContext]
-  )
-  const diagnosticGatesKey = (diagnosticGates ?? []).map((g) => g.id).join('|')
-  const tourIdsKey = tours.map((t) => t.id).join('|')
-  // biome-ignore lint/correctness/useExhaustiveDependencies: stability keys (userContextKey, diagnosticGatesKey, tourIdsKey) replace the reference deps; state.completedTours/skippedTours are tracked as live refs
+  // Stability keys: `userContext`, `diagnosticGates`, and `router` are
+  // reference types, so we derive primitive keys that survive identity
+  // churn from inline-literal props.
+  //
+  // - `userContextKey`: JSON-stringified content (try/catch around it — a
+  //   circular reference in a user-supplied object must NEVER crash the host
+  //   render path; we degrade to a stable sentinel instead).
+  // - `diagnosticGatesKey`: gate ids joined with NUL so kebab-case ids
+  //   cannot collide regardless of payload.
+  // - `tourIdsKey`: same NUL-joined shape as the gates key.
+  // - `currentRouteKey`: the router's current path as a string, so route
+  //   changes inside a stable router re-evaluate the route gate, and inline
+  //   router instances don't reference-thrash the effect.
+  const userContextKey = React.useMemo(() => {
+    if (!userContext) return ''
+    try {
+      return JSON.stringify(userContext)
+    } catch {
+      // Circular or otherwise unserializable. Falling back to a constant
+      // string means the effect won't re-run on content changes for this
+      // shape — acceptable degradation; the alternative (throwing during
+      // render) takes down the host tree even when `diagnose` is off.
+      return '[unserializable]'
+    }
+  }, [userContext])
+  const diagnosticGatesKey = (diagnosticGates ?? []).map((g) => g.id).join('\x00')
+  const tourIdsKey = tours.map((t) => t.id).join('\x00')
+  const currentRouteKey = router?.getCurrentRoute() ?? ''
+  // biome-ignore lint/correctness/useExhaustiveDependencies: stability keys (userContextKey, diagnosticGatesKey, tourIdsKey, currentRouteKey) replace the reference deps; state.completedTours/skippedTours are tracked as live refs
   React.useEffect(() => {
     if (!diagnose) return
     let cancelled = false
@@ -494,7 +511,7 @@ export function TourProvider({
     diagnosticGatesKey,
     state.completedTours,
     state.skippedTours,
-    router,
+    currentRouteKey,
   ])
 
   // flowSession-restore: tour-scoped resume after reload. The hook uses a

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -398,39 +398,7 @@ export function TourProvider({
   // doesn't leave React with a partial hook order.
   for (const tour of tours) validateTour(tour)
 
-  // ─── Diagnostic engine wiring (Phase 3) ──────────────────────────────────
-  // The orchestrator is invoked from a `useEffect` so the consumer's render
-  // path stays sync. Only runs when `diagnose === true`, so consumers who
-  // never opt in pay zero runtime cost (and the import tree-shakes out).
   const [diagnostics, setDiagnostics] = React.useState<Record<string, EligibilityReport>>({})
-  const diagnosticGatesRef = React.useRef(diagnosticGates)
-  React.useEffect(() => {
-    diagnosticGatesRef.current = diagnosticGates
-  }, [diagnosticGates])
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: tours identity changes on every render — depend on tour ids instead
-  React.useEffect(() => {
-    if (!diagnose) return
-    let cancelled = false
-    const ctx: DiagnosticContext = {
-      userContext,
-      completedTours: [],
-      skippedTours: [],
-      targetResolver: (sel) =>
-        typeof document !== 'undefined' ? document.querySelector<HTMLElement>(sel) : null,
-    }
-    void Promise.all(
-      tours.map((t) =>
-        explainTour(t, ctx, diagnosticGatesRef.current ?? []).then((r) => [t.id, r] as const)
-      )
-    ).then((pairs) => {
-      if (cancelled) return
-      setDiagnostics(Object.fromEntries(pairs))
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [diagnose, tours.map((t) => t.id).join('|'), userContext])
 
   // Dev-mode hint: fire once per provider mount when `diagnose` is unset.
   // Gated on NODE_ENV !== 'production' so prod builds stay silent.
@@ -467,6 +435,67 @@ export function TourProvider({
   }
 
   const [state, dispatch] = React.useReducer(tourReducer, initialState)
+
+  // ─── Diagnostic engine wiring (Phase 3) ──────────────────────────────────
+  // Runs after the reducer is declared so the persistence gate can read live
+  // `state.completedTours` / `state.skippedTours`. Only fires when
+  // `diagnose === true`, so opted-out consumers pay zero runtime cost (and
+  // the orchestrator import tree-shakes out of their bundle).
+  //
+  // Stability keys: `userContext` and `diagnosticGates` are reference types,
+  // so deep-equality keys (JSON-stringified userContext, gate-id join) prevent
+  // an inline-literal `userContext={{...}}` from re-running the effect every
+  // render. The `cancelled` flag guards against stale `setDiagnostics` writes
+  // when a re-run kicks off before the previous resolves.
+  const userContextKey = React.useMemo(
+    () => (userContext ? JSON.stringify(userContext) : ''),
+    [userContext]
+  )
+  const diagnosticGatesKey = (diagnosticGates ?? []).map((g) => g.id).join('|')
+  const tourIdsKey = tours.map((t) => t.id).join('|')
+  // biome-ignore lint/correctness/useExhaustiveDependencies: stability keys (userContextKey, diagnosticGatesKey, tourIdsKey) replace the reference deps; state.completedTours/skippedTours are tracked as live refs
+  React.useEffect(() => {
+    if (!diagnose) return
+    let cancelled = false
+    const gates = diagnosticGates ?? []
+    const currentRoute = router?.getCurrentRoute()
+    void Promise.all(
+      tours.map((t) => {
+        const firstVisibleStep = t.steps.find((s) => s.kind !== 'hidden')
+        const stepRoute = firstVisibleStep?.route
+        const ctx: DiagnosticContext = {
+          userContext,
+          completedTours: state.completedTours,
+          skippedTours: state.skippedTours,
+          route:
+            stepRoute && currentRoute !== undefined
+              ? {
+                  current: currentRoute,
+                  matcher: stepRoute,
+                  mode: firstVisibleStep?.routeMatch ?? 'exact',
+                }
+              : undefined,
+          targetResolver: (sel) =>
+            typeof document !== 'undefined' ? document.querySelector<HTMLElement>(sel) : null,
+        }
+        return explainTour(t, ctx, gates).then((r) => [t.id, r] as const)
+      })
+    ).then((pairs) => {
+      if (cancelled) return
+      setDiagnostics(Object.fromEntries(pairs))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [
+    diagnose,
+    tourIdsKey,
+    userContextKey,
+    diagnosticGatesKey,
+    state.completedTours,
+    state.skippedTours,
+    router,
+  ])
 
   // flowSession-restore: tour-scoped resume after reload. The hook uses a
   // single fixed key (`flow:active`) so we discover the persisted tourId on

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -3,6 +3,7 @@ import { useAdvanceOn } from '../hooks/use-advance-on'
 import { useBroadcast } from '../hooks/use-broadcast'
 import { useFlowSession } from '../hooks/use-flow-session'
 import { useRoutePersistence } from '../hooks/use-route-persistence'
+import { explainTour } from '../lib/diagnostic'
 import { TourValidationError, validateTour } from '../lib/validate-tour'
 import { TourRouteError, waitForStepTarget } from '../lib/wait-for-step-target'
 import type {
@@ -14,6 +15,7 @@ import type {
   TourState,
   TourStep,
 } from '../types'
+import type { DiagnosticContext, DiagnosticGate, EligibilityReport } from '../types/diagnostic'
 import type { MultiPagePersistenceConfig, RouterAdapter } from '../types/router'
 import {
   isBranchToTour,
@@ -348,6 +350,26 @@ export interface TourProviderProps {
    * cooperative cancellation, not failures.
    */
   onStepError?: (err: TourRouteError) => void
+  /**
+   * Diagnostic mode — when `true`, the provider runs `explainTour` for every
+   * registered tour and exposes the result via `useTourDiagnostic(tourId)`.
+   * Defaults to `false`; the orchestrator tree-shakes out when unused.
+   *
+   * In `NODE_ENV !== 'production'` builds, leaving this off triggers a
+   * one-time `console.warn` per provider mount nudging dev consumers toward
+   * the better debug surface.
+   */
+  diagnose?: boolean
+  /**
+   * Extension gates (license, scheduling, custom) appended to the diagnostic
+   * pipeline AFTER built-ins. Only consulted when `diagnose` is `true`.
+   */
+  diagnosticGates?: DiagnosticGate[]
+  /**
+   * Optional user context plumbed to diagnostic gates (audience filter, etc).
+   * Only read when `diagnose` is `true`.
+   */
+  userContext?: Record<string, unknown>
 }
 
 interface CrossTabActiveMessage {
@@ -366,12 +388,63 @@ export function TourProvider({
   onNavigationRequired,
   onTourPaused,
   onStepError,
+  diagnose = false,
+  diagnosticGates,
+  userContext,
 }: TourProviderProps) {
   // Validate synchronously at render time so misconfigured hidden steps throw
   // at the caller's render() instead of leaking into runtime. Cheap: just a
   // shallow loop over the steps. Must run before any hook so a thrown error
   // doesn't leave React with a partial hook order.
   for (const tour of tours) validateTour(tour)
+
+  // ─── Diagnostic engine wiring (Phase 3) ──────────────────────────────────
+  // The orchestrator is invoked from a `useEffect` so the consumer's render
+  // path stays sync. Only runs when `diagnose === true`, so consumers who
+  // never opt in pay zero runtime cost (and the import tree-shakes out).
+  const [diagnostics, setDiagnostics] = React.useState<Record<string, EligibilityReport>>({})
+  const diagnosticGatesRef = React.useRef(diagnosticGates)
+  React.useEffect(() => {
+    diagnosticGatesRef.current = diagnosticGates
+  }, [diagnosticGates])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: tours identity changes on every render — depend on tour ids instead
+  React.useEffect(() => {
+    if (!diagnose) return
+    let cancelled = false
+    const ctx: DiagnosticContext = {
+      userContext,
+      completedTours: [],
+      skippedTours: [],
+      targetResolver: (sel) =>
+        typeof document !== 'undefined' ? document.querySelector<HTMLElement>(sel) : null,
+    }
+    void Promise.all(
+      tours.map((t) =>
+        explainTour(t, ctx, diagnosticGatesRef.current ?? []).then((r) => [t.id, r] as const)
+      )
+    ).then((pairs) => {
+      if (cancelled) return
+      setDiagnostics(Object.fromEntries(pairs))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [diagnose, tours.map((t) => t.id).join('|'), userContext])
+
+  // Dev-mode hint: fire once per provider mount when `diagnose` is unset.
+  // Gated on NODE_ENV !== 'production' so prod builds stay silent.
+  const diagnoseHintFiredRef = React.useRef(false)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once warning, not a reactive concern
+  React.useEffect(() => {
+    if (diagnose) return
+    if (diagnoseHintFiredRef.current) return
+    if (typeof process === 'undefined' || process.env?.NODE_ENV === 'production') return
+    diagnoseHintFiredRef.current = true
+    console.warn(
+      '[Tour Kit] Tip: pass <TourProvider diagnose> in dev to see why a tour did not fire. https://tourkit.dev/docs/core/diagnostic'
+    )
+  }, [])
 
   const tourKitContext = React.useContext(TourKitContext)
   const [data, setDataState] = React.useState<Record<string, unknown>>({})
@@ -1438,6 +1511,10 @@ export function TourProvider({
       goToStep,
       startTour,
       triggerBranchAction,
+      // Only attach the diagnostics field when `diagnose` is on — keeps
+      // `ctx.diagnostics` strictly undefined for opted-out consumers so the
+      // hook's `null` branch is observable.
+      ...(diagnose ? { diagnostics } : {}),
     }),
     [
       state,
@@ -1456,6 +1533,8 @@ export function TourProvider({
       goToStep,
       startTour,
       triggerBranchAction,
+      diagnose,
+      diagnostics,
     ]
   )
 

--- a/packages/core/src/hooks/__tests__/use-tour-diagnostic.test.tsx
+++ b/packages/core/src/hooks/__tests__/use-tour-diagnostic.test.tsx
@@ -1,0 +1,48 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { twoStepTour } from '../../__tests__/_fixtures'
+import { TourProvider } from '../../context/tour-provider'
+import { useTourDiagnostic } from '../use-tour-diagnostic'
+
+describe('useTourDiagnostic', () => {
+  it('returns null when diagnose is off', () => {
+    const { result } = renderHook(() => useTourDiagnostic('demo'), {
+      wrapper: ({ children }) => <TourProvider tours={[twoStepTour]}>{children}</TourProvider>,
+    })
+    expect(result.current).toBeNull()
+  })
+
+  it('returns the report when diagnose is on', async () => {
+    const { result } = renderHook(() => useTourDiagnostic('demo'), {
+      wrapper: ({ children }) => (
+        <TourProvider tours={[twoStepTour]} diagnose>
+          {children}
+        </TourProvider>
+      ),
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current?.tourId).toBe('demo')
+  })
+
+  it('returns null for unknown tour ids', async () => {
+    const { result } = renderHook(() => useTourDiagnostic('unknown'), {
+      wrapper: ({ children }) => (
+        <TourProvider tours={[twoStepTour]} diagnose>
+          {children}
+        </TourProvider>
+      ),
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current).toBeNull()
+  })
+
+  it('throws when used outside <TourProvider>', () => {
+    expect(() => renderHook(() => useTourDiagnostic('demo'))).toThrow(
+      /must be used inside <TourProvider>/i
+    )
+  })
+})

--- a/packages/core/src/hooks/use-tour-diagnostic.ts
+++ b/packages/core/src/hooks/use-tour-diagnostic.ts
@@ -1,0 +1,19 @@
+import { useContext } from 'react'
+import { TourContext } from '../context/tour-context'
+import type { EligibilityReport } from '../types/diagnostic'
+
+/**
+ * Read the diagnostic report for a given tour id. Returns `null` when the
+ * provider is mounted without `diagnose={true}`, when the tour is unknown,
+ * or before the first diagnostic effect tick has resolved.
+ *
+ * Throws if called outside a `<TourProvider>` — the diagnostic surface is
+ * useless without context plumbing, so make the misuse loud.
+ */
+export function useTourDiagnostic(tourId: string): EligibilityReport | null {
+  const ctx = useContext(TourContext)
+  if (!ctx) {
+    throw new Error('useTourDiagnostic must be used inside <TourProvider>')
+  }
+  return ctx.diagnostics?.[tourId] ?? null
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -193,8 +193,20 @@ export { useT } from './lib/i18n/use-t'
 export type { Messages, TranslateFn } from './lib/i18n/use-t'
 
 // Audience targeting — promoted from @tour-kit/announcements in Phase 1
-export { matchesAudience, validateConditions } from './lib/audience'
+export { explainAudience, matchesAudience, validateConditions } from './lib/audience'
 export type { AudienceCondition } from './types/audience'
+
+// Diagnostic engine — Phase 3 (issue #32)
+export { BUILTIN_GATE_ORDER, explainTour } from './lib/diagnostic'
+export { useTourDiagnostic } from './hooks/use-tour-diagnostic'
+export type {
+  DiagnosticContext,
+  DiagnosticGate,
+  EligibilityReport,
+  GateCode,
+  GateName,
+  GateReason,
+} from './types/diagnostic'
 
 // Frequency rules — Phase 3a (lifted from @tour-kit/announcements)
 export {

--- a/packages/core/src/lib/__tests__/_dom.ts
+++ b/packages/core/src/lib/__tests__/_dom.ts
@@ -1,0 +1,23 @@
+/**
+ * Test helper: inject HTML into document.body, run a callback, then clean up.
+ * Supports both sync and async callbacks.
+ */
+export function withDOM(html: string, fn: () => void): void
+export function withDOM(html: string, fn: () => Promise<void>): Promise<void>
+export function withDOM(html: string, fn: () => void | Promise<void>): void | Promise<void> {
+  document.body.innerHTML = html
+  const cleanup = (): void => {
+    document.body.innerHTML = ''
+  }
+  try {
+    const result = fn()
+    if (result instanceof Promise) {
+      return result.finally(cleanup)
+    }
+    cleanup()
+    return
+  } catch (e) {
+    cleanup()
+    throw e
+  }
+}

--- a/packages/core/src/lib/__tests__/_gate-mocks.ts
+++ b/packages/core/src/lib/__tests__/_gate-mocks.ts
@@ -1,0 +1,42 @@
+import type { DiagnosticGate } from '../../types/diagnostic'
+
+export const okGate: DiagnosticGate = {
+  id: 'mock-ok',
+  evaluate: () => ({ ok: true, gate: 'mock-ok' }),
+}
+
+export const failingGate: DiagnosticGate = {
+  id: 'mock-fail',
+  evaluate: () => ({
+    ok: false,
+    gate: 'mock-fail',
+    code: 'MOCK_FAIL',
+    message: 'mock failure',
+    detail: { reason: 'test' },
+  }),
+}
+
+export const asyncGate: DiagnosticGate = {
+  id: 'mock-async',
+  evaluate: async () => {
+    await new Promise((r) => setTimeout(r, 1))
+    return { ok: true, gate: 'mock-async' }
+  },
+}
+
+export const throwingGate: DiagnosticGate = {
+  id: 'crashy',
+  evaluate: () => {
+    throw new Error('boom from extension')
+  },
+}
+
+export function recordingGate(id: string, calls: string[]): DiagnosticGate {
+  return {
+    id,
+    evaluate: () => {
+      calls.push(id)
+      return { ok: true, gate: id }
+    },
+  }
+}

--- a/packages/core/src/lib/__tests__/diagnostic-async.test.ts
+++ b/packages/core/src/lib/__tests__/diagnostic-async.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { twoStepTour } from '../../__tests__/_fixtures'
+import type { DiagnosticContext } from '../../types/diagnostic'
+import { explainTour } from '../diagnostic'
+import { asyncGate, recordingGate } from './_gate-mocks'
+
+const baseCtx = (): DiagnosticContext => ({ completedTours: [], skippedTours: [] })
+
+describe('explainTour — async extensions', () => {
+  it('awaits async extensions and preserves order vs sync extensions', async () => {
+    const calls: string[] = []
+    const slowAsync = {
+      id: 'slow',
+      evaluate: async () => {
+        await new Promise((r) => setTimeout(r, 10))
+        calls.push('slow')
+        return { ok: true as const, gate: 'slow' }
+      },
+    }
+    const fastSync = recordingGate('fast', calls)
+    const r = await explainTour(twoStepTour, baseCtx(), [slowAsync, fastSync])
+    expect(calls).toEqual(['slow', 'fast'])
+    const tail = r.reasons.slice(-2).map((x) => x.gate)
+    expect(tail).toEqual(['slow', 'fast'])
+  })
+
+  it('resolves multiple async gates in registration order', async () => {
+    const r = await explainTour(twoStepTour, baseCtx(), [asyncGate, asyncGate])
+    const asyncReasons = r.reasons.filter((x) => x.gate === 'mock-async')
+    expect(asyncReasons).toHaveLength(2)
+  })
+})

--- a/packages/core/src/lib/__tests__/diagnostic-extension.test.ts
+++ b/packages/core/src/lib/__tests__/diagnostic-extension.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { twoStepTour } from '../../__tests__/_fixtures'
+import type { DiagnosticContext } from '../../types/diagnostic'
+import { explainTour } from '../diagnostic'
+import { failingGate, okGate, recordingGate } from './_gate-mocks'
+
+const baseCtx = (): DiagnosticContext => ({ completedTours: [], skippedTours: [] })
+
+describe('explainTour — extension gates', () => {
+  it('runs extensions AFTER all built-ins', async () => {
+    const calls: string[] = []
+    const ext = recordingGate('license', calls)
+    const r = await explainTour(twoStepTour, baseCtx(), [ext])
+    const lastBuiltIn = r.reasons.findIndex((x) => x.gate === 'autostart')
+    const extIndex = r.reasons.findIndex((x) => x.gate === 'license')
+    expect(extIndex).toBeGreaterThan(lastBuiltIn)
+    expect(calls).toEqual(['license'])
+  })
+
+  it('preserves extension registration order', async () => {
+    const r = await explainTour(twoStepTour, baseCtx(), [
+      { id: 'first', evaluate: () => ({ ok: true, gate: 'first' }) },
+      { id: 'second', evaluate: () => ({ ok: true, gate: 'second' }) },
+    ])
+    const extGates = r.reasons
+      .filter((x) => x.gate === 'first' || x.gate === 'second')
+      .map((x) => x.gate)
+    expect(extGates).toEqual(['first', 'second'])
+  })
+
+  it('surfaces failing extension in firstFailingGate when no built-in failed first', async () => {
+    const r = await explainTour(twoStepTour, baseCtx(), [failingGate])
+    expect(r.willFire).toBe(false)
+    expect(r.firstFailingGate?.gate).toBe('mock-fail')
+    expect(r.firstFailingGate?.code).toBe('MOCK_FAIL')
+  })
+
+  it('does NOT pollute firstFailingGate when extension is ok', async () => {
+    const r = await explainTour(twoStepTour, baseCtx(), [okGate])
+    expect(r.willFire).toBe(true)
+    expect(r.firstFailingGate).toBeNull()
+  })
+})

--- a/packages/core/src/lib/__tests__/diagnostic-order.test.ts
+++ b/packages/core/src/lib/__tests__/diagnostic-order.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { twoStepTour } from '../../__tests__/_fixtures'
+import type { DiagnosticContext } from '../../types/diagnostic'
+import { BUILTIN_GATE_ORDER, explainTour } from '../diagnostic'
+
+const baseCtx = (): DiagnosticContext => ({ completedTours: [], skippedTours: [] })
+
+describe('BUILTIN_GATE_ORDER', () => {
+  it('is the canonical built-in evaluation order', () => {
+    expect(BUILTIN_GATE_ORDER).toStrictEqual([
+      'structure',
+      'audience',
+      'persistence',
+      'route',
+      'target',
+      'when',
+      'autostart',
+    ])
+  })
+
+  it('matches the leading slice of reasons[].gate', async () => {
+    const r = await explainTour(twoStepTour, baseCtx())
+    const gates = r.reasons.slice(0, BUILTIN_GATE_ORDER.length).map((x) => x.gate)
+    expect(gates).toEqual([...BUILTIN_GATE_ORDER])
+  })
+
+  it('appends extensions AFTER built-ins in registration order', async () => {
+    const r = await explainTour(twoStepTour, baseCtx(), [
+      { id: 'first', evaluate: () => ({ ok: true, gate: 'first' }) },
+      { id: 'second', evaluate: () => ({ ok: true, gate: 'second' }) },
+    ])
+    const tail = r.reasons.slice(BUILTIN_GATE_ORDER.length).map((x) => x.gate)
+    expect(tail).toEqual(['first', 'second'])
+  })
+})

--- a/packages/core/src/lib/__tests__/diagnostic-throw.test.ts
+++ b/packages/core/src/lib/__tests__/diagnostic-throw.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { twoStepTour } from '../../__tests__/_fixtures'
+import type { DiagnosticContext } from '../../types/diagnostic'
+import { explainTour } from '../diagnostic'
+import { throwingGate } from './_gate-mocks'
+
+const baseCtx = (): DiagnosticContext => ({ completedTours: [], skippedTours: [] })
+
+describe('explainTour — throwing extensions', () => {
+  it('catches a throwing extension into a synthetic _THREW reason', async () => {
+    const r = await explainTour(twoStepTour, baseCtx(), [throwingGate])
+    const crashy = r.reasons.find((x) => x.gate === 'crashy')
+    expect(crashy?.ok).toBe(false)
+    if (crashy && !crashy.ok) {
+      expect(crashy.code).toBe('CRASHY_THREW')
+      expect(crashy.detail?.error).toMatch(/boom from extension/)
+    }
+  })
+
+  it('does not throw upward — return value is still a valid EligibilityReport', async () => {
+    await expect(explainTour(twoStepTour, baseCtx(), [throwingGate])).resolves.toMatchObject({
+      tourId: 'demo',
+      reasons: expect.any(Array),
+    })
+  })
+})

--- a/packages/core/src/lib/__tests__/diagnostic.bench.ts
+++ b/packages/core/src/lib/__tests__/diagnostic.bench.ts
@@ -1,0 +1,29 @@
+import { bench, describe } from 'vitest'
+import type { DiagnosticContext } from '../../types/diagnostic'
+import type { Tour } from '../../types/tour'
+import { explainTour } from '../diagnostic'
+
+const tour: Tour = {
+  id: 'demo',
+  steps: Array.from({ length: 5 }, (_, i) => ({
+    id: `s${i}`,
+    target: '#stub',
+    content: 'x',
+  })),
+}
+
+const ctx: DiagnosticContext = {
+  completedTours: [],
+  skippedTours: [],
+  targetResolver: () => ({ id: 'stub' }) as unknown as HTMLElement,
+}
+
+describe('explainTour bench', () => {
+  bench(
+    '5-step tour, no extensions',
+    async () => {
+      await explainTour(tour, ctx)
+    },
+    { iterations: 100 }
+  )
+})

--- a/packages/core/src/lib/__tests__/diagnostic.test.ts
+++ b/packages/core/src/lib/__tests__/diagnostic.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+import {
+  tourAutoStartFalse,
+  tourWithSegmentAudience,
+  tourWithWhenAsync,
+  tourWithWhenFalse,
+  tourWithWhenThrows,
+  twoStepTour,
+} from '../../__tests__/_fixtures'
+import type { DiagnosticContext } from '../../types/diagnostic'
+import type { Tour } from '../../types/tour'
+import { BUILTIN_GATE_ORDER, explainTour } from '../diagnostic'
+import { withDOM } from './_dom'
+
+const baseCtx = (overrides: Partial<DiagnosticContext> = {}): DiagnosticContext => ({
+  completedTours: [],
+  skippedTours: [],
+  ...overrides,
+})
+
+describe('explainTour — orchestrator', () => {
+  it('returns willFire:true for a valid tour with all gates passing', async () => {
+    const r = await explainTour(twoStepTour, baseCtx())
+    expect(r.willFire).toBe(true)
+    expect(r.firstFailingGate).toBeNull()
+    expect(r.tourId).toBe('demo')
+    expect(typeof r.evaluatedAt).toBe('number')
+  })
+
+  it('reports each built-in gate in the documented order', async () => {
+    const r = await explainTour(twoStepTour, baseCtx())
+    const gates = r.reasons.slice(0, BUILTIN_GATE_ORDER.length).map((x) => x.gate)
+    expect(gates).toEqual([...BUILTIN_GATE_ORDER])
+  })
+
+  it('exposes BUILTIN_GATE_ORDER as a readonly tuple', () => {
+    expect(BUILTIN_GATE_ORDER).toStrictEqual([
+      'structure',
+      'audience',
+      'persistence',
+      'route',
+      'target',
+      'when',
+      'autostart',
+    ])
+  })
+
+  it('NEVER throws — internal errors land in firstFailingGate', async () => {
+    const malformed = { id: 'x', steps: null } as unknown as Tour
+    await expect(explainTour(malformed, baseCtx())).resolves.toBeTruthy()
+  })
+})
+
+describe('built-in gates — failure paths', () => {
+  it('gateStructure fails when tour.steps is empty', async () => {
+    const r = await explainTour({ id: 'bad', steps: [] }, baseCtx())
+    expect(r.willFire).toBe(false)
+    expect(r.firstFailingGate?.gate).toBe('structure')
+    expect(r.firstFailingGate?.code).toBe('STRUCTURE_INVALID')
+  })
+
+  it('gateStructure short-circuits the rest of the pipeline', async () => {
+    const r = await explainTour({ id: 'bad', steps: [] }, baseCtx())
+    // Structure failure short-circuits — only `structure` reason is present.
+    expect(r.reasons).toHaveLength(1)
+    expect(r.reasons[0]?.gate).toBe('structure')
+  })
+
+  it('gateAudience fails when segment-form audience does not match', async () => {
+    const r = await explainTour(
+      tourWithSegmentAudience,
+      baseCtx({ userContext: { segments: ['viewers'] } })
+    )
+    const aud = r.reasons.find((x) => x.gate === 'audience')
+    expect(aud?.ok).toBe(false)
+    if (aud && !aud.ok) expect(aud.code).toBe('AUDIENCE_MISMATCH')
+  })
+
+  it('gatePersistence fails when tour id is in completedTours', async () => {
+    const r = await explainTour(twoStepTour, baseCtx({ completedTours: ['demo'] }))
+    expect(r.willFire).toBe(false)
+    expect(r.firstFailingGate?.code).toBe('ALREADY_COMPLETED')
+  })
+
+  it('gatePersistence fails when tour id is in skippedTours', async () => {
+    const r = await explainTour(twoStepTour, baseCtx({ skippedTours: ['demo'] }))
+    expect(r.firstFailingGate?.code).toBe('ALREADY_SKIPPED')
+  })
+
+  it('gateRoute fails when route mode is exact and current differs', async () => {
+    const r = await explainTour(twoStepTour, {
+      ...baseCtx(),
+      route: { current: '/dashboard', matcher: '/pricing', mode: 'exact' },
+    })
+    const route = r.reasons.find((x) => x.gate === 'route')
+    expect(route?.ok).toBe(false)
+    if (route && !route.ok) {
+      expect(route.code).toBe('ROUTE_MISMATCH')
+      expect(route.detail).toMatchObject({ expected: '/pricing', actual: '/dashboard' })
+    }
+  })
+
+  it('gateRoute passes when ctx.route is undefined', async () => {
+    const r = await explainTour(twoStepTour, baseCtx())
+    const route = r.reasons.find((x) => x.gate === 'route')
+    expect(route?.ok).toBe(true)
+  })
+
+  it('gateTarget fails when selector does not resolve in DOM', async () => {
+    await withDOM('<div id="a"></div>', async () => {
+      const r = await explainTour(
+        { id: 't', steps: [{ id: 's', target: '#not-here', content: '' }] },
+        baseCtx({
+          targetResolver: (sel) => document.querySelector<HTMLElement>(sel),
+        })
+      )
+      const target = r.reasons.find((x) => x.gate === 'target')
+      expect(target?.ok).toBe(false)
+      if (target && !target.ok) {
+        expect(target.code).toBe('TARGET_NOT_FOUND')
+        expect(target.detail?.selector).toBe('#not-here')
+      }
+    })
+  })
+
+  it('gateTarget passes when first visible step uses a React ref (skipped)', async () => {
+    const r = await explainTour(
+      {
+        id: 't',
+        // biome-ignore lint/suspicious/noExplicitAny: ref shape from test data
+        steps: [{ id: 's', target: { current: null } as any, content: '' }],
+      },
+      baseCtx({ targetResolver: () => null })
+    )
+    const target = r.reasons.find((x) => x.gate === 'target')
+    expect(target?.ok).toBe(true)
+  })
+
+  it('gateWhen fails when sync callback returns false', async () => {
+    const r = await explainTour(tourWithWhenFalse, baseCtx())
+    const when = r.reasons.find((x) => x.gate === 'when')
+    expect(when?.ok).toBe(false)
+    if (when && !when.ok) expect(when.code).toBe('WHEN_RETURNED_FALSE')
+  })
+
+  it('gateWhen captures a throwing sync callback with error in detail', async () => {
+    const r = await explainTour(tourWithWhenThrows, baseCtx())
+    const when = r.reasons.find((x) => x.gate === 'when')
+    expect(when?.ok).toBe(false)
+    if (when && !when.ok) {
+      expect(when.code).toBe('WHEN_RETURNED_FALSE')
+      expect(when.detail?.error).toMatch(/when blew up/)
+    }
+  })
+
+  it('gateWhen returns ok with detail.note for async callbacks', async () => {
+    const r = await explainTour(tourWithWhenAsync, baseCtx())
+    const when = r.reasons.find((x) => x.gate === 'when')
+    expect(when?.ok).toBe(true)
+    if (when?.ok && 'detail' in when) {
+      // `ok: true` allows an optional `detail` for the async-note carveout
+      const note = (when as { detail?: { note?: string } }).detail?.note
+      expect(typeof note).toBe('string')
+    }
+  })
+
+  it('gateAutostart fails when tour.autoStart === false', async () => {
+    const r = await explainTour(tourAutoStartFalse, baseCtx())
+    const auto = r.reasons.find((x) => x.gate === 'autostart')
+    expect(auto?.ok).toBe(false)
+    if (auto && !auto.ok) expect(auto.code).toBe('AUTOSTART_DISABLED')
+  })
+
+  it('gateAutostart passes when tour.autoStart is unset', async () => {
+    const r = await explainTour(twoStepTour, baseCtx())
+    const auto = r.reasons.find((x) => x.gate === 'autostart')
+    expect(auto?.ok).toBe(true)
+  })
+})
+
+describe('firstFailingGate semantics', () => {
+  it('points at the first ok:false reason in evaluation order', async () => {
+    // tour fails BOTH persistence (completedTours) and autostart — first failing is persistence.
+    const r = await explainTour(tourAutoStartFalse, baseCtx({ completedTours: ['no-auto'] }))
+    expect(r.firstFailingGate?.gate).toBe('persistence')
+  })
+
+  it('is null when every gate passes', async () => {
+    const r = await explainTour(twoStepTour, baseCtx())
+    expect(r.firstFailingGate).toBeNull()
+    expect(r.willFire).toBe(true)
+  })
+})

--- a/packages/core/src/lib/__tests__/diagnostic.test.ts
+++ b/packages/core/src/lib/__tests__/diagnostic.test.ts
@@ -47,7 +47,10 @@ describe('explainTour — orchestrator', () => {
 
   it('NEVER throws — internal errors land in firstFailingGate', async () => {
     const malformed = { id: 'x', steps: null } as unknown as Tour
-    await expect(explainTour(malformed, baseCtx())).resolves.toBeTruthy()
+    const r = await explainTour(malformed, baseCtx())
+    expect(r.willFire).toBe(false)
+    expect(r.firstFailingGate?.gate).toBe('structure')
+    expect(r.firstFailingGate?.code).toBe('STRUCTURE_INVALID')
   })
 })
 

--- a/packages/core/src/lib/__tests__/explain-audience.test.ts
+++ b/packages/core/src/lib/__tests__/explain-audience.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { explainAudience } from '../audience'
+
+describe('explainAudience', () => {
+  it('returns ok when audience is undefined (everyone matches)', () => {
+    const r = explainAudience(undefined, { plan: 'pro' })
+    expect(r.ok).toBe(true)
+    expect(r.gate).toBe('audience')
+  })
+
+  it('returns ok for matching array-form audience', () => {
+    const r = explainAudience(
+      [{ type: 'user_property', key: 'plan', operator: 'equals', value: 'pro' }],
+      { plan: 'pro' }
+    )
+    expect(r.ok).toBe(true)
+  })
+
+  it('returns fail with AUDIENCE_MISMATCH for failing array-form audience', () => {
+    const r = explainAudience(
+      [{ type: 'user_property', key: 'plan', operator: 'equals', value: 'pro' }],
+      { plan: 'free' }
+    )
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.code).toBe('AUDIENCE_MISMATCH')
+      expect(r.detail?.failingCondition).toMatchObject({
+        key: 'plan',
+        operator: 'equals',
+        value: 'pro',
+      })
+      expect(r.detail?.userContext).toEqual({ plan: 'free' })
+    }
+  })
+
+  it('surfaces the FIRST failing condition when multiple conditions exist', () => {
+    const conditions = [
+      { type: 'user_property' as const, key: 'plan', operator: 'equals' as const, value: 'pro' },
+      { type: 'user_property' as const, key: 'role', operator: 'equals' as const, value: 'admin' },
+    ]
+    const r = explainAudience(conditions, { plan: 'pro', role: 'viewer' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.detail?.failingCondition).toMatchObject({ key: 'role', value: 'admin' })
+    }
+  })
+
+  it('returns ok for matching segment-form audience', () => {
+    const r = explainAudience({ segment: 'admins' }, { segments: ['admins', 'beta'] })
+    expect(r.ok).toBe(true)
+  })
+
+  it('returns fail with AUDIENCE_MISMATCH for non-matching segment-form audience', () => {
+    const r = explainAudience({ segment: 'admins' }, { segments: ['beta'] })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.code).toBe('AUDIENCE_MISMATCH')
+      expect(r.detail?.segment).toBe('admins')
+    }
+  })
+
+  it('returns fail for segment-form audience when userContext lacks segments', () => {
+    const r = explainAudience({ segment: 'admins' }, {})
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('AUDIENCE_MISMATCH')
+  })
+})

--- a/packages/core/src/lib/__tests__/explain-audience.test.ts
+++ b/packages/core/src/lib/__tests__/explain-audience.test.ts
@@ -29,7 +29,18 @@ describe('explainAudience', () => {
         operator: 'equals',
         value: 'pro',
       })
-      expect(r.detail?.userContext).toEqual({ plan: 'free' })
+      // `userContext` is deliberately NOT echoed back — would leak PII to
+      // anywhere the diagnostic report is shipped (telemetry, debug overlay).
+      expect(r.detail).not.toHaveProperty('userContext')
+    }
+  })
+
+  it('does not leak userSegments in segment-form failure detail', () => {
+    const r = explainAudience({ segment: 'admins' }, { segments: ['beta', 'qa'] })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.detail?.segment).toBe('admins')
+      expect(r.detail).not.toHaveProperty('userSegments')
     }
   })
 

--- a/packages/core/src/lib/audience.ts
+++ b/packages/core/src/lib/audience.ts
@@ -68,6 +68,9 @@ export function explainAudience(
   if (Array.isArray(audience)) {
     const result = evaluateConditions(audience, userContext)
     if (result.matched) return { ok: true, gate: 'audience' }
+    // `detail` deliberately omits `userContext` — diagnostic reports are
+    // often shipped to telemetry or rendered in dev panels, so the failing
+    // condition is enough to explain "why" without leaking unrelated PII.
     return {
       ok: false,
       gate: 'audience',
@@ -76,12 +79,13 @@ export function explainAudience(
       detail: {
         failingCondition: result.failingCondition,
         audience,
-        userContext,
       },
     }
   }
 
   // Segment-form: `{ segment: 'admins' }` — resolved against `userContext.segments`.
+  // The user's full segment membership is intentionally NOT echoed back in
+  // `detail` (PII / leak vector for telemetry); only the gating segment id is.
   const segment = audience.segment
   const userSegments = userContext?.segments
   const segments = Array.isArray(userSegments) ? userSegments : []
@@ -95,7 +99,6 @@ export function explainAudience(
     message: `User is not a member of segment '${segment}'`,
     detail: {
       segment,
-      userSegments: segments,
       audience,
     },
   }

--- a/packages/core/src/lib/audience.ts
+++ b/packages/core/src/lib/audience.ts
@@ -3,6 +3,39 @@
  * initiative. Re-exported there for backward compat — see `packages/announcements/src/core/audience.ts`.
  */
 import type { AudienceCondition } from '../types/audience'
+import type { GateReason } from '../types/diagnostic'
+import type { AudienceProp } from '../types/step'
+
+interface AudienceEvaluation {
+  matched: boolean
+  failingCondition?: AudienceCondition
+}
+
+/**
+ * Internal shared helper: evaluate an array of conditions against a user
+ * context, returning both the boolean outcome AND (on failure) the first
+ * condition that did not match. `matchesAudience` projects `.matched`;
+ * `explainAudience` reads `.failingCondition` to populate `detail`.
+ */
+function evaluateConditions(
+  conditions: AudienceCondition[] | undefined,
+  userContext: Record<string, unknown> | undefined
+): AudienceEvaluation {
+  if (!conditions || conditions.length === 0) {
+    return { matched: true }
+  }
+
+  for (const condition of conditions) {
+    if (!userContext) {
+      if (condition.operator === 'not_exists') continue
+      return { matched: false, failingCondition: condition }
+    }
+    if (!matchesCondition(condition, userContext)) {
+      return { matched: false, failingCondition: condition }
+    }
+  }
+  return { matched: true }
+}
 
 /**
  * Check if user context matches audience conditions
@@ -11,23 +44,61 @@ export function matchesAudience(
   conditions: AudienceCondition[] | undefined,
   userContext: Record<string, unknown> | undefined
 ): boolean {
-  // No conditions means everyone matches
-  if (!conditions || conditions.length === 0) {
-    return true
+  return evaluateConditions(conditions, userContext).matched
+}
+
+/**
+ * Structured sibling of `matchesAudience` consumed by the diagnostic engine.
+ * Returns a `GateReason` describing the audience-gate outcome — including the
+ * first failing condition (or the failing segment) in `detail` so operators
+ * see WHY the audience filter rejected the user.
+ *
+ * Segment-form audience (`{ segment: 'admins' }`) looks up
+ * `userContext.segments` (a `string[]` listing the user's resolved segments).
+ * If the segment is missing or absent, the gate fails with `AUDIENCE_MISMATCH`.
+ */
+export function explainAudience(
+  audience: AudienceProp | undefined,
+  userContext: Record<string, unknown> | undefined
+): GateReason {
+  if (!audience) {
+    return { ok: true, gate: 'audience' }
   }
 
-  // No user context means only 'not_exists' checks can pass
-  if (!userContext) {
-    return conditions.every((condition) => {
-      if (condition.operator === 'not_exists') {
-        return true
-      }
-      return false
-    })
+  if (Array.isArray(audience)) {
+    const result = evaluateConditions(audience, userContext)
+    if (result.matched) return { ok: true, gate: 'audience' }
+    return {
+      ok: false,
+      gate: 'audience',
+      code: 'AUDIENCE_MISMATCH',
+      message: 'User context did not satisfy audience filter',
+      detail: {
+        failingCondition: result.failingCondition,
+        audience,
+        userContext,
+      },
+    }
   }
 
-  // All conditions must match (AND logic)
-  return conditions.every((condition) => matchesCondition(condition, userContext))
+  // Segment-form: `{ segment: 'admins' }` — resolved against `userContext.segments`.
+  const segment = audience.segment
+  const userSegments = userContext?.segments
+  const segments = Array.isArray(userSegments) ? userSegments : []
+  if (segments.includes(segment)) {
+    return { ok: true, gate: 'audience' }
+  }
+  return {
+    ok: false,
+    gate: 'audience',
+    code: 'AUDIENCE_MISMATCH',
+    message: `User is not a member of segment '${segment}'`,
+    detail: {
+      segment,
+      userSegments: segments,
+      audience,
+    },
+  }
 }
 
 /**

--- a/packages/core/src/lib/diagnostic.ts
+++ b/packages/core/src/lib/diagnostic.ts
@@ -1,0 +1,251 @@
+/**
+ * Diagnostic engine — Phase 3.
+ *
+ * Wraps every reason a tour might not fire into a single structured
+ * `EligibilityReport`. Runs seven built-in gates in a fixed order, then any
+ * extension gates registered via `<TourProvider diagnosticGates>`. NEVER
+ * throws: internal errors are captured as `ok: false` reasons.
+ */
+import type {
+  DiagnosticContext,
+  DiagnosticGate,
+  EligibilityReport,
+  GateReason,
+} from '../types/diagnostic'
+import type { AudienceProp, TourStep } from '../types/step'
+import type { Tour } from '../types/tour'
+import { explainAudience } from './audience'
+import { validateTour } from './validate-tour'
+
+/**
+ * Canonical built-in evaluation order. Tests pin this tuple — the order is
+ * part of the contract that consumers (and `<TourDebugger>`) rely on.
+ */
+export const BUILTIN_GATE_ORDER = [
+  'structure',
+  'audience',
+  'persistence',
+  'route',
+  'target',
+  'when',
+  'autostart',
+] as const
+
+function gateStructure(tour: Tour): GateReason {
+  try {
+    if (!Array.isArray(tour.steps) || tour.steps.length === 0) {
+      return {
+        ok: false,
+        gate: 'structure',
+        code: 'STRUCTURE_INVALID',
+        message: 'Tour has no steps',
+        detail: { tourId: tour.id, stepCount: Array.isArray(tour.steps) ? tour.steps.length : 0 },
+      }
+    }
+    validateTour(tour)
+    return { ok: true, gate: 'structure' }
+  } catch (e) {
+    const error = e as Error
+    return {
+      ok: false,
+      gate: 'structure',
+      code: 'STRUCTURE_INVALID',
+      message: error.message ?? 'Tour failed structural validation',
+      detail: { error: error.message },
+    }
+  }
+}
+
+function gateAudience(audience: AudienceProp | undefined, ctx: DiagnosticContext): GateReason {
+  return explainAudience(audience, ctx.userContext)
+}
+
+function gatePersistence(tour: Tour, ctx: DiagnosticContext): GateReason {
+  if (ctx.completedTours.includes(tour.id)) {
+    return {
+      ok: false,
+      gate: 'persistence',
+      code: 'ALREADY_COMPLETED',
+      message: `Tour ${tour.id} already completed`,
+      detail: { tourId: tour.id },
+    }
+  }
+  if (ctx.skippedTours.includes(tour.id)) {
+    return {
+      ok: false,
+      gate: 'persistence',
+      code: 'ALREADY_SKIPPED',
+      message: `Tour ${tour.id} previously skipped`,
+      detail: { tourId: tour.id },
+    }
+  }
+  return { ok: true, gate: 'persistence' }
+}
+
+function gateRoute(tour: Tour, ctx: DiagnosticContext): GateReason {
+  if (!ctx.route) return { ok: true, gate: 'route' }
+  const { current, matcher, mode } = ctx.route
+  let matches = false
+  switch (mode) {
+    case 'exact':
+      matches = current === matcher
+      break
+    case 'startsWith':
+      matches = current.startsWith(matcher)
+      break
+    case 'contains':
+      matches = current.includes(matcher)
+      break
+    default:
+      matches = false
+  }
+  if (matches) return { ok: true, gate: 'route' }
+  return {
+    ok: false,
+    gate: 'route',
+    code: 'ROUTE_MISMATCH',
+    message: `Route ${current} does not match ${matcher} (${mode})`,
+    detail: { expected: matcher, actual: current, mode, tourId: tour.id },
+  }
+}
+
+function firstVisibleStep(tour: Tour): TourStep | undefined {
+  return tour.steps.find((s) => s.kind !== 'hidden')
+}
+
+function gateTarget(tour: Tour, ctx: DiagnosticContext): GateReason {
+  if (!ctx.targetResolver) return { ok: true, gate: 'target' }
+  const step = firstVisibleStep(tour)
+  if (!step) return { ok: true, gate: 'target' }
+  // Refs (objects with `.current`) are not checked in diagnostic mode — runtime owns them.
+  if (typeof step.target !== 'string') return { ok: true, gate: 'target' }
+  const el = ctx.targetResolver(step.target)
+  if (el) return { ok: true, gate: 'target' }
+  return {
+    ok: false,
+    gate: 'target',
+    code: 'TARGET_NOT_FOUND',
+    message: `Selector ${step.target} did not resolve`,
+    detail: { selector: step.target, stepId: step.id, tourId: tour.id },
+  }
+}
+
+function gateWhen(tour: Tour): GateReason {
+  if (!tour.when) return { ok: true, gate: 'when' }
+  try {
+    const result = tour.when()
+    if (result instanceof Promise) {
+      // Async when() is owned by the runtime pipeline. Document the carveout.
+      return {
+        ok: true,
+        gate: 'when',
+        detail: {
+          note: 'Async when() callbacks are evaluated at runtime, not in diagnostic mode',
+        },
+      } as GateReason
+    }
+    if (result === false) {
+      return {
+        ok: false,
+        gate: 'when',
+        code: 'WHEN_RETURNED_FALSE',
+        message: 'Tour-level when() returned false',
+        detail: { tourId: tour.id },
+      }
+    }
+    return { ok: true, gate: 'when' }
+  } catch (e) {
+    const error = e as Error
+    return {
+      ok: false,
+      gate: 'when',
+      code: 'WHEN_RETURNED_FALSE',
+      message: error.message ?? 'Tour-level when() threw',
+      detail: { error: error.message, tourId: tour.id },
+    }
+  }
+}
+
+function gateAutostart(tour: Tour): GateReason {
+  if (tour.autoStart === false) {
+    return {
+      ok: false,
+      gate: 'autostart',
+      code: 'AUTOSTART_DISABLED',
+      message: 'Tour has autoStart: false',
+      detail: { tourId: tour.id },
+    }
+  }
+  return { ok: true, gate: 'autostart' }
+}
+
+function finalize(tourId: string, reasons: GateReason[], evaluatedAt: number): EligibilityReport {
+  const firstFailingGate =
+    reasons.find((r): r is Extract<GateReason, { ok: false }> => !r.ok) ?? null
+  return {
+    tourId,
+    willFire: firstFailingGate === null,
+    reasons,
+    firstFailingGate,
+    evaluatedAt,
+  }
+}
+
+/**
+ * Evaluate every built-in gate (in `BUILTIN_GATE_ORDER`) and any extension
+ * gates (in registration order), then return the aggregated report.
+ *
+ * Built-in gates are sync; extension gates may be async. NEVER throws — a
+ * throwing extension yields a synthetic `{ ok: false, code: '${ID}_THREW' }`.
+ * A failing `structure` gate short-circuits the rest of the pipeline: nothing
+ * else matters when the tour shape is invalid.
+ */
+export async function explainTour(
+  tour: Tour,
+  ctx: DiagnosticContext,
+  extensions: DiagnosticGate[] = []
+): Promise<EligibilityReport> {
+  const reasons: GateReason[] = []
+  const evaluatedAt = Date.now()
+
+  try {
+    const structure = gateStructure(tour)
+    reasons.push(structure)
+    if (!structure.ok) return finalize(tour.id, reasons, evaluatedAt)
+
+    reasons.push(gateAudience(tour.audience, ctx))
+    reasons.push(gatePersistence(tour, ctx))
+    reasons.push(gateRoute(tour, ctx))
+    reasons.push(gateTarget(tour, ctx))
+    reasons.push(gateWhen(tour))
+    reasons.push(gateAutostart(tour))
+
+    for (const gate of extensions) {
+      try {
+        const result = await gate.evaluate(ctx)
+        reasons.push(result)
+      } catch (e) {
+        const error = e as Error
+        reasons.push({
+          ok: false,
+          gate: gate.id,
+          code: `${gate.id.toUpperCase()}_THREW`,
+          message: error.message ?? 'Gate threw',
+          detail: { error: error.message },
+        })
+      }
+    }
+  } catch (e) {
+    // Defensive catch-all — diagnostic engine must never throw.
+    const error = e as Error
+    reasons.push({
+      ok: false,
+      gate: 'structure',
+      code: 'STRUCTURE_INVALID',
+      message: error.message ?? 'Diagnostic engine threw',
+      detail: { error: error.message },
+    })
+  }
+
+  return finalize(tour.id, reasons, evaluatedAt)
+}

--- a/packages/core/src/lib/diagnostic.ts
+++ b/packages/core/src/lib/diagnostic.ts
@@ -15,7 +15,7 @@ import type {
 import type { AudienceProp, TourStep } from '../types/step'
 import type { Tour } from '../types/tour'
 import { explainAudience } from './audience'
-import { validateTour } from './validate-tour'
+import { TourValidationError, validateTour } from './validate-tour'
 
 /**
  * Canonical built-in evaluation order. Tests pin this tuple — the order is
@@ -46,12 +46,19 @@ function gateStructure(tour: Tour): GateReason {
     return { ok: true, gate: 'structure' }
   } catch (e) {
     const error = e as Error
+    // Preserve `TourValidationError`'s structured fields (the offending step
+    // id and the specific validation code) so operators can route on them.
+    const detail: Record<string, unknown> = { error: error.message }
+    if (error instanceof TourValidationError) {
+      detail.tourErrorCode = error.code
+      detail.stepId = error.stepId
+    }
     return {
       ok: false,
       gate: 'structure',
       code: 'STRUCTURE_INVALID',
       message: error.message ?? 'Tour failed structural validation',
-      detail: { error: error.message },
+      detail,
     }
   }
 }
@@ -142,7 +149,7 @@ function gateWhen(tour: Tour): GateReason {
         detail: {
           note: 'Async when() callbacks are evaluated at runtime, not in diagnostic mode',
         },
-      } as GateReason
+      }
     }
     if (result === false) {
       return {

--- a/packages/core/src/types/diagnostic.ts
+++ b/packages/core/src/types/diagnostic.ts
@@ -1,18 +1,68 @@
 /**
- * DiagnosticGate extension contract (Phase 0 — type-only stub).
+ * Diagnostic engine types — Phase 3 (full surface).
  *
- * Phase 3.1 owns the runtime implementation; this file ships the structural
- * contract so upper packages (@tour-kit/license, @tour-kit/scheduling, etc.)
- * can prototype gates against a stable interface.
- *
- * Hard rule: @tour-kit/core sits at the bottom of the dependency graph —
- * NEVER import from any other @tour-kit/* package here.
+ * The `EligibilityReport` is what `explainTour` produces and
+ * `useTourDiagnostic` exposes. The `DiagnosticGate` interface is the
+ * extension contract — upper packages (`@tour-kit/license`,
+ * `@tour-kit/scheduling`, etc.) implement it WITHOUT this package importing
+ * any of them. Hard rule: `@tour-kit/core` sits at the bottom of the
+ * dependency graph; never `import { ... } from '@tour-kit/<anything>'` here.
  */
+
+/**
+ * Canonical failure codes. The `(string & {})` escape hatch keeps
+ * literal-union autocomplete for built-ins while allowing extension gates to
+ * surface their own codes (`'LICENSE_INVALID'`, `'OUT_OF_WINDOW'`, ...).
+ */
+export type GateCode =
+  | 'STRUCTURE_INVALID'
+  | 'AUDIENCE_MISMATCH'
+  | 'ALREADY_COMPLETED'
+  | 'ALREADY_SKIPPED'
+  | 'OUT_OF_WINDOW'
+  | 'LICENSE_INVALID'
+  | 'LICENSE_EXPIRED'
+  | 'TARGET_NOT_FOUND'
+  | 'WHEN_RETURNED_FALSE'
+  | 'ROUTE_MISMATCH'
+  | 'AUTOSTART_DISABLED'
+  | (string & {})
+
+export type GateName =
+  | 'structure'
+  | 'audience'
+  | 'persistence'
+  | 'scheduling'
+  | 'license'
+  | 'target'
+  | 'when'
+  | 'route'
+  | 'autostart'
+  | (string & {})
+
+export type GateReason =
+  | { ok: true; gate: GateName; detail?: Record<string, unknown> }
+  | {
+      ok: false
+      gate: GateName
+      code: GateCode
+      message: string
+      detail?: Record<string, unknown>
+    }
+
+export interface EligibilityReport {
+  tourId: string
+  willFire: boolean
+  reasons: GateReason[]
+  firstFailingGate: Extract<GateReason, { ok: false }> | null
+  evaluatedAt: number
+}
 
 export interface DiagnosticContext {
   userContext?: Record<string, unknown>
   completedTours: readonly string[]
   skippedTours: readonly string[]
+  schedule?: { from?: Date; to?: Date }
   route?: {
     current: string
     matcher: string
@@ -21,19 +71,9 @@ export interface DiagnosticContext {
   targetResolver?: (selector: string) => HTMLElement | null
 }
 
-export type GateReason =
-  | { ok: true; gate: string }
-  | {
-      ok: false
-      gate: string
-      code: string
-      message: string
-      detail?: Record<string, unknown>
-    }
-
 export interface DiagnosticGate {
   /** Stable identifier, e.g. 'license', 'scheduling', 'audience'. */
   id: string
-  /** Run synchronously OR async. Must NOT throw — return an `ok: false` reason instead. */
+  /** Run synchronously OR async. May throw — orchestrator captures the error. */
   evaluate: (ctx: DiagnosticContext) => GateReason | Promise<GateReason>
 }

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -1,3 +1,4 @@
+import type { EligibilityReport } from './diagnostic'
 import type { TourStep } from './step'
 import type { Tour } from './tour'
 
@@ -83,6 +84,13 @@ export interface TourContextValue<TStep extends TourStep = TourStep>
     TourActions<TStep> {
   tour: Tour<TStep> | null
   data: Record<string, unknown>
+  /**
+   * Per-tour diagnostic reports — populated only when the provider is mounted
+   * with `diagnose={true}`. Each key is a registered tour id; the value is the
+   * latest `EligibilityReport` produced by `explainTour`. `undefined` when
+   * diagnostics are off (the default in production builds).
+   */
+  diagnostics?: Record<string, EligibilityReport>
 }
 
 /**

--- a/packages/core/src/types/tour.ts
+++ b/packages/core/src/types/tour.ts
@@ -34,6 +34,16 @@ export interface Tour<TStep extends TourStep = TourStep> {
   persistence?: PersistenceConfig | boolean
   a11y?: A11yConfig
   scroll?: ScrollConfig
+  /**
+   * Tour-level eligibility predicate evaluated by the diagnostic engine
+   * (`explainTour`'s `when` gate). Sync callbacks returning `false` flip the
+   * tour to `WHEN_RETURNED_FALSE`; throwing callbacks are captured with the
+   * error in `detail`. Async callbacks are NOT awaited in diagnostic mode —
+   * the gate returns `ok: true` with a `detail.note` documenting that the
+   * async path is evaluated at runtime instead. Step-level `when` (on
+   * `TourStep`) is unaffected — it is owned by the runtime step pipeline.
+   */
+  when?: () => boolean | Promise<boolean>
   onStart?: (context: TourCallbackContext) => void
   onComplete?: (context: TourCallbackContext) => void
   onSkip?: (context: TourCallbackContext) => void

--- a/packages/react/src/hooks/__tests__/use-tour-diagnostic.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-tour-diagnostic.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react'
+import { TourProvider, useTourDiagnostic } from '@tour-kit/core'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as tkReact from '../../index'
+
+describe('@tour-kit/react re-export smoke', () => {
+  it('exposes useTourDiagnostic from the public surface', () => {
+    expect(typeof tkReact.useTourDiagnostic).toBe('function')
+  })
+
+  it('exposes the diagnostic engine runtime entrypoints', () => {
+    expect(typeof tkReact.explainTour).toBe('function')
+    expect(typeof tkReact.explainAudience).toBe('function')
+    expect(Array.isArray(tkReact.BUILTIN_GATE_ORDER)).toBe(true)
+  })
+})
+
+describe('useTourDiagnostic via @tour-kit/react surface', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="a"></div><div id="b"></div>'
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('returns a populated EligibilityReport when diagnose is on', async () => {
+    const tour = {
+      id: 'demo',
+      steps: [
+        { id: 's1', target: '#a', content: 'a' },
+        { id: 's2', target: '#b', content: 'b' },
+      ],
+    }
+    const { result } = renderHook(() => useTourDiagnostic('demo'), {
+      wrapper: ({ children }) => (
+        <TourProvider tours={[tour]} diagnose>
+          {children}
+        </TourProvider>
+      ),
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current?.tourId).toBe('demo')
+    expect(result.current?.willFire).toBe(true)
+  })
+})

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -139,6 +139,18 @@ export {
   useMediaQuery,
   usePrefersReducedMotion,
   useBranch,
+  useTourDiagnostic,
+} from '@tour-kit/core'
+
+// Diagnostic engine surface (Phase 3 — issue #32)
+export { BUILTIN_GATE_ORDER, explainAudience, explainTour } from '@tour-kit/core'
+export type {
+  DiagnosticContext,
+  DiagnosticGate,
+  EligibilityReport,
+  GateCode,
+  GateName,
+  GateReason,
 } from '@tour-kit/core'
 
 // Utilities


### PR DESCRIPTION
## Summary

- Replace the silent "tour didn't fire" failure mode with a structured `EligibilityReport` — `explainTour(tour, ctx, gates?)` runs seven built-in gates plus arbitrary extension gates without `@tour-kit/core` importing any other `@tour-kit/*` package.
- `<TourProvider diagnose>` + `useTourDiagnostic(tourId)` expose the report to React consumers; defaults stay tree-shake-safe.
- 35 new tests across 7 suites, bench median **0.0007ms** (target <2ms), useTour-only bundle **3.99 kB** (limit 8 kB).

## Architecture

```
useTourDiagnostic(tourId) ──► provider.diagnostics[tourId] ──► EligibilityReport
                                       ▲
                       <TourProvider diagnose={true}
                                     diagnosticGates={[licenseGate, scheduleGate]}>
                                       │
                                       ▼
                                explainTour(tour, ctx, [
                                  // BUILT-IN gates (fixed order):
                                  structure, audience, persistence,
                                  route, target, when, autostart,
                                  // then EXTENSION gates in registration order:
                                  licenseGate, scheduleGate,
                                ])
```

## Key rules implemented

- `matchesAudience(...) → boolean` stays unchanged. New `explainAudience(...) → GateReason` is a sibling that shares an internal `evaluateConditions` helper.
- `explainTour` NEVER throws. Throwing extensions become `{ ok: false, code: '${ID}_THREW' }` reasons.
- `structure` failure short-circuits — nothing else runs. All other built-ins run to completion so operators see every reason.
- Async `when()` returns `ok: true` with `detail.note` documenting that the async path is runtime-owned.
- Dev-mode warning fires **exactly once per provider mount**; production builds stay silent.

## Test plan

- [x] `pnpm --filter @tour-kit/core typecheck` clean
- [x] `pnpm --filter @tour-kit/react typecheck` clean
- [x] `pnpm --filter @tour-kit/core test` → 816/816 passing
- [x] `pnpm --filter @tour-kit/react test` → 460/460 passing
- [x] `grep -rn "from '@tour-kit/license'\|from '@tour-kit/scheduling'\|from '@tour-kit/analytics'\|from '@tour-kit/adoption'" packages/core/src/` → 0 hits
- [x] `pnpm exec size-limit` exits 0; useTour-only bundle = 3.99 kB
- [x] `pnpm exec vitest bench --run src/lib/__tests__/diagnostic.bench.ts` → median 0.0007ms (well under 2ms target)
- [x] `pnpm lint` clean

## Exit criteria (from phase-3.md)

- [x] Typecheck both packages
- [x] ≥18 diagnostic assertions (delivered 35 across 7 files)
- [x] `useTourDiagnostic` covers null + populated + throws-outside-provider
- [x] No upward imports from `@tour-kit/core`
- [x] `matchesAudience` boolean signature preserved (pre-existing tests still pass)
- [x] `explainTour` bench median <2ms
- [x] size-limit `useTour`-only entry <8 KB (3.99 KB actual)
- [x] Extension-gate test proves third-party gate runs AFTER built-ins
- [x] Docs page lists every `GateCode` + extension registration pattern

## Files

```
packages/core/src/
├── types/
│   ├── diagnostic.ts                       (full types, replaces phase-0 stub)
│   ├── state.ts                            (TourContextValue.diagnostics)
│   └── tour.ts                             (Tour.when at tour level)
├── lib/
│   ├── audience.ts                         (explainAudience + shared helper)
│   ├── diagnostic.ts                       (seven gates + orchestrator)
│   └── __tests__/                          (7 new files + 2 helpers)
├── context/
│   ├── tour-provider.tsx                   (diagnose/diagnosticGates wiring)
│   └── __tests__/tour-provider-diagnose.test.tsx
├── hooks/
│   ├── use-tour-diagnostic.ts
│   └── __tests__/use-tour-diagnostic.test.tsx
└── index.ts                                (new exports)

packages/react/src/
├── index.ts                                (re-exports)
└── hooks/__tests__/use-tour-diagnostic.test.tsx

apps/docs/content/docs/core/
├── diagnostic.mdx                          (new page)
└── meta.json                               (page registered)

.size-limit.json                            (useTour-only tree-shake gate)
```

🤖 Implemented end-to-end with the run-phase TDD workflow.