### PR TITLE
feat(phase-4): AdoptionFunnel widget (#1)

### DIFF
--- a/apps/docs/content/docs/adoption/dashboard/funnel.mdx
+++ b/apps/docs/content/docs/adoption/dashboard/funnel.mdx
@@ -53,7 +53,7 @@ import {
 } from '@tour-kit/adoption'
 
 function OnboardingFunnel() {
-  const { steps } = useFunnelData({
+  const steps = useFunnelData({
     featureIds: ['view-pricing', 'start-trial', 'invite-team'],
     labels: {
       'view-pricing': 'Viewed Pricing',
@@ -156,9 +156,9 @@ function OnboardingFunnel() {
   }}
 />
 
-Returns `{ steps: FunnelStep[]; loading: boolean; error: Error | null }`. The
-`loading`/`error` slots are reserved for future async sources — the
-in-memory provider always returns `false`/`null`.
+Returns `FunnelStep[]` ready to pass to `<AdoptionFunnel steps={...}>`. The
+source data is in-memory and synchronous, so the hook returns the steps
+directly — no `loading`/`error` envelope.
 
 ## Accessibility
 

--- a/apps/docs/content/docs/adoption/dashboard/funnel.mdx
+++ b/apps/docs/content/docs/adoption/dashboard/funnel.mdx
@@ -1,0 +1,207 @@
+---
+title: Adoption Funnel
+description: >-
+  Step-by-step adoption funnel with drop-off percentages — Pendo/Userpilot
+  parity, native CSS, no chart peer dependency.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { TypeTable } from 'fumadocs-ui/components/type-table'
+
+`<AdoptionFunnel>` renders a vertical funnel chart with retention and
+drop-off between adjacent steps. It is **data-first**: hand it pre-computed
+`steps` and it works without any provider. Inside an
+`<AdoptionProvider>`, pair it with `useFunnelData({ featureIds })` for a
+one-line in-provider integration.
+
+<Callout type="info">
+  The funnel is rendered with native CSS — no `recharts`, `d3`, or other chart
+  peer dependency. Bundle delta is &lt;2 KB gzipped.
+</Callout>
+
+## Provider-less Usage (Recommended)
+
+Compute funnel data from your analytics layer and pass it in directly:
+
+```tsx
+import { AdoptionFunnel } from '@tour-kit/adoption'
+import '@tour-kit/adoption/styles/funnel.css'
+
+const steps = [
+  { id: 'view', label: 'Viewed', entered: 1000, completed: 720 },
+  { id: 'click', label: 'Clicked CTA', entered: 720, completed: 380 },
+  { id: 'signup', label: 'Signed Up', entered: 380, completed: 240 },
+]
+
+<AdoptionFunnel
+  steps={steps}
+  title="Sign-up funnel"
+  onStepClick={(step, index) => console.log('drilldown:', step, index)}
+/>
+```
+
+This path needs no provider, so the funnel can live in any tree —
+admin dashboards, server-rendered reports, etc.
+
+## In-provider Usage with `useFunnelData`
+
+```tsx
+import {
+  AdoptionFunnel,
+  AdoptionProvider,
+  useFunnelData,
+} from '@tour-kit/adoption'
+
+function OnboardingFunnel() {
+  const { steps } = useFunnelData({
+    featureIds: ['view-pricing', 'start-trial', 'invite-team'],
+    labels: {
+      'view-pricing': 'Viewed Pricing',
+      'start-trial': 'Started Trial',
+      'invite-team': 'Invited Team',
+    },
+  })
+  return <AdoptionFunnel steps={steps} title="Activation funnel" />
+}
+
+<AdoptionProvider features={features}>
+  <OnboardingFunnel />
+</AdoptionProvider>
+```
+
+<Callout type="warn">
+  **Current-state, not historical.** `useFunnelData` derives a per-user
+  snapshot from `useAdoptionStats` — `entered` is the user's `useCount` and
+  `completed` is `useCount` when the feature status is `'adopted'`, else `0`.
+  For aggregated cohort funnels with date ranges, compute them in your
+  analytics layer and hand the result to `<AdoptionFunnel steps={...}>`
+  directly.
+</Callout>
+
+## `<AdoptionFunnel>` Props
+
+<TypeTable
+  type={{
+    steps: {
+      type: 'readonly FunnelStep[]',
+      required: true,
+      description: 'Pre-computed funnel data in display order.',
+    },
+    title: {
+      type: 'React.ReactNode',
+      description: 'Optional header rendered above the bars.',
+    },
+    onStepClick: {
+      type: '(step: FunnelStep, index: number) => void',
+      description:
+        'Click/keyboard activation handler. Steps become focusable (role="button", tabIndex=0) when provided; Enter and Space both fire the callback.',
+    },
+    emptyState: {
+      type: 'React.ReactNode',
+      description:
+        'Replaces the default "No funnel data yet." message when `steps` is empty.',
+    },
+    ariaLabel: {
+      type: 'string',
+      description:
+        'Overrides the auto-generated summary on the `role="img"` chart element.',
+    },
+    className: {
+      type: 'string',
+      description: 'Extra class merged onto the root.',
+    },
+  }}
+/>
+
+## `FunnelStep` Shape
+
+<TypeTable
+  type={{
+    id: {
+      type: 'string',
+      required: true,
+      description: 'Stable identifier (React key + onClick payload).',
+    },
+    label: {
+      type: 'string',
+      required: true,
+      description: 'Visible label rendered next to the bar.',
+    },
+    entered: {
+      type: 'number',
+      required: true,
+      description: 'Subjects that reached this step.',
+    },
+    completed: {
+      type: 'number',
+      description: 'Subjects that completed this step. Defaults to 0.',
+    },
+  }}
+/>
+
+## `useFunnelData` Input/Output
+
+<TypeTable
+  type={{
+    featureIds: {
+      type: 'readonly string[]',
+      required: true,
+      description: 'Feature IDs in funnel order.',
+    },
+    labels: {
+      type: 'Partial<Record<string, string>>',
+      description:
+        'Override the visible label per feature ID. Falls back to `feature.name` then the raw id.',
+    },
+  }}
+/>
+
+Returns `{ steps: FunnelStep[]; loading: boolean; error: Error | null }`. The
+`loading`/`error` slots are reserved for future async sources — the
+in-memory provider always returns `false`/`null`.
+
+## Accessibility
+
+- The chart is exposed to assistive tech as a single `role="img"` element with
+  an auto-generated `aria-label` summarizing the funnel
+  (`Adoption funnel: 100 → 60 → 30, 30% end-to-end retention`). Override via
+  the `ariaLabel` prop.
+- Each bar carries `aria-hidden="true"` — screen readers receive the same
+  numbers through a visually-hidden `<table>` mirror placed alongside the
+  visual list.
+- Clickable steps are keyboard-activatable. **Enter** and **Space** both
+  fire `onStepClick`; tab order matches visual order.
+- Honors `prefers-reduced-motion: reduce` — the hover-transition is disabled
+  under the OS preference. See the
+  [reduced-motion guide](/docs/guides/reduced-motion).
+
+## Styling
+
+Import the base stylesheet once at your app root:
+
+```ts
+import '@tour-kit/adoption/styles/funnel.css'
+```
+
+CSS custom properties for theming:
+
+```css
+:root {
+  --tour-funnel-gap: 0.5rem;
+  --tour-funnel-step-gap: 0.5rem;
+  --tour-funnel-bar-bg: hsl(220 90% 56%);
+  --tour-funnel-bar-fg: #fff;
+  --tour-funnel-retention-fg: hsl(0 0% 40%);
+  --tour-funnel-step-hover: rgba(0, 0, 0, 0.04);
+  --tour-funnel-focus-ring: hsl(220 90% 56%);
+}
+```
+
+## Next Steps
+
+- [AdoptionDashboard](/docs/adoption/dashboard/adoption-dashboard) — full
+  dashboard component
+- [useAdoptionStats](/docs/adoption/hooks/use-adoption-stats) — underlying
+  per-feature stats hook
+- [Reduced-motion guide](/docs/guides/reduced-motion) — cross-package
+  motion contract

--- a/apps/docs/content/docs/adoption/dashboard/meta.json
+++ b/apps/docs/content/docs/adoption/dashboard/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Dashboard",
-  "pages": ["index", "adoption-dashboard", "stats", "table", "charts"]
+  "pages": ["index", "adoption-dashboard", "stats", "table", "charts", "funnel"]
 }

--- a/apps/docs/content/docs/adoption/hooks/meta.json
+++ b/apps/docs/content/docs/adoption/hooks/meta.json
@@ -1,4 +1,10 @@
 {
   "title": "Hooks",
-  "pages": ["use-feature", "use-adoption-stats", "use-funnel-data", "use-nudge", "use-adoption-context"]
+  "pages": [
+    "use-feature",
+    "use-adoption-stats",
+    "use-funnel-data",
+    "use-nudge",
+    "use-adoption-context"
+  ]
 }

--- a/apps/docs/content/docs/adoption/hooks/meta.json
+++ b/apps/docs/content/docs/adoption/hooks/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Hooks",
-  "pages": ["use-feature", "use-adoption-stats", "use-nudge", "use-adoption-context"]
+  "pages": ["use-feature", "use-adoption-stats", "use-funnel-data", "use-nudge", "use-adoption-context"]
 }

--- a/apps/docs/content/docs/adoption/hooks/use-funnel-data.mdx
+++ b/apps/docs/content/docs/adoption/hooks/use-funnel-data.mdx
@@ -29,7 +29,7 @@ import {
 } from '@tour-kit/adoption'
 
 function ActivationFunnel() {
-  const { steps } = useFunnelData({
+  const steps = useFunnelData({
     featureIds: ['view-pricing', 'start-trial', 'invite-team'],
     labels: {
       'view-pricing': 'Viewed Pricing',
@@ -64,25 +64,8 @@ function ActivationFunnel() {
 
 ## Output
 
-<TypeTable
-  type={{
-    steps: {
-      type: 'FunnelStep[]',
-      description:
-        'Funnel steps ready for `<AdoptionFunnel>`. One step per `featureIds` entry, in input order.',
-    },
-    loading: {
-      type: 'boolean',
-      description:
-        'Reserved for future async sources. Always `false` for the in-memory provider.',
-    },
-    error: {
-      type: 'Error | null',
-      description:
-        'Reserved for future async sources. Always `null` for the in-memory provider.',
-    },
-  }}
-/>
+Returns `FunnelStep[]` directly — one step per `featureIds` entry, in input
+order. Pass straight to `<AdoptionFunnel steps={...}>`.
 
 ## Mapping Semantics
 

--- a/apps/docs/content/docs/adoption/hooks/use-funnel-data.mdx
+++ b/apps/docs/content/docs/adoption/hooks/use-funnel-data.mdx
@@ -1,0 +1,104 @@
+---
+title: useFunnelData
+description: >-
+  Derive a current-state adoption funnel from useAdoptionStats — feed straight
+  into AdoptionFunnel.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { TypeTable } from 'fumadocs-ui/components/type-table'
+
+`useFunnelData` is a convenience selector that projects the current user's
+adoption state — read via `useAdoptionStats` — into a `FunnelStep[]` ready
+to hand to `<AdoptionFunnel>`. Must be used inside `<AdoptionProvider>`.
+
+<Callout type="warn">
+  **Current-state, not historical.** This hook describes the *current user*'s
+  progress at this moment. It does NOT support date-ranged cohort funnels.
+  For aggregated multi-user funnels, compute the data in your analytics
+  pipeline and pass it directly to `<AdoptionFunnel steps={data} />`.
+</Callout>
+
+## Usage
+
+```tsx
+import {
+  AdoptionFunnel,
+  AdoptionProvider,
+  useFunnelData,
+} from '@tour-kit/adoption'
+
+function ActivationFunnel() {
+  const { steps } = useFunnelData({
+    featureIds: ['view-pricing', 'start-trial', 'invite-team'],
+    labels: {
+      'view-pricing': 'Viewed Pricing',
+      'start-trial': 'Started Trial',
+      'invite-team': 'Invited Team',
+    },
+  })
+  return <AdoptionFunnel steps={steps} title="Activation funnel" />
+}
+
+<AdoptionProvider features={features}>
+  <ActivationFunnel />
+</AdoptionProvider>
+```
+
+## Input
+
+<TypeTable
+  type={{
+    featureIds: {
+      type: 'readonly string[]',
+      required: true,
+      description: 'Feature IDs in funnel order.',
+    },
+    labels: {
+      type: 'Partial<Record<string, string>>',
+      description:
+        'Override the visible label per feature ID. Falls back to `feature.name`, then the raw id.',
+    },
+  }}
+/>
+
+## Output
+
+<TypeTable
+  type={{
+    steps: {
+      type: 'FunnelStep[]',
+      description:
+        'Funnel steps ready for `<AdoptionFunnel>`. One step per `featureIds` entry, in input order.',
+    },
+    loading: {
+      type: 'boolean',
+      description:
+        'Reserved for future async sources. Always `false` for the in-memory provider.',
+    },
+    error: {
+      type: 'Error | null',
+      description:
+        'Reserved for future async sources. Always `null` for the in-memory provider.',
+    },
+  }}
+/>
+
+## Mapping Semantics
+
+For each `featureIds[i]`, the hook reads the matching `FeatureWithUsage`
+from `useAdoptionStats()` and produces:
+
+- `entered` = `usage.useCount` — number of times the current user has touched
+  the feature.
+- `completed` = `usage.useCount` when `usage.status === 'adopted'`, else `0` —
+  100% per-user conversion once adopted; 0% before.
+
+Unknown feature IDs (no matching feature in the provider) get
+`entered: 0, completed: 0`.
+
+## See Also
+
+- [`<AdoptionFunnel>`](/docs/adoption/dashboard/funnel) — the consumer component
+- [`useAdoptionStats`](/docs/adoption/hooks/use-adoption-stats) — underlying
+  current-state stats hook

--- a/packages/adoption/package.json
+++ b/packages/adoption/package.json
@@ -55,7 +55,8 @@
       }
     },
     "./styles/variables.css": "./dist/styles/variables.css",
-    "./styles/theme.css": "./dist/styles/theme.css"
+    "./styles/theme.css": "./dist/styles/theme.css",
+    "./styles/funnel.css": "./dist/styles/funnel.css"
   },
   "files": ["dist"],
   "publishConfig": {

--- a/packages/adoption/src/__tests__/_fixtures.ts
+++ b/packages/adoption/src/__tests__/_fixtures.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared fixtures for funnel / adoption-stats tests.
+ *
+ * - `sampleSteps` is the canonical 3-step funnel used in `<AdoptionFunnel>` tests.
+ * - `mockAdoptionContext` builds an `AdoptionContextValue` that matches the REAL
+ *   shape from `src/context/adoption-context.ts`. The hook reads the context via
+ *   `useAdoptionStats`, which projects `features` + `usageMap` into
+ *   `FeatureWithUsage[]`. We construct both shapes here so tests don't have to.
+ */
+import type { AdoptionContextValue } from '../context/adoption-context'
+import type {
+  AdoptionStatus,
+  Feature,
+  FeatureUsage,
+  FunnelStep,
+} from '../types/feature'
+
+export const sampleSteps: readonly FunnelStep[] = [
+  { id: 'view', label: 'Viewed', entered: 100, completed: 60 },
+  { id: 'click', label: 'Clicked', entered: 60, completed: 30 },
+  { id: 'convert', label: 'Converted', entered: 30, completed: 30 },
+]
+
+export interface MockFeatureOptions {
+  /** Number of times the user has touched the feature (drives `entered`). */
+  useCount: number
+  /** Adoption status (`'adopted'` drives `completed > 0`). */
+  status: AdoptionStatus
+  /** Optional human-readable label override. */
+  name?: string
+}
+
+export function mockAdoptionContext(
+  features: Record<string, MockFeatureOptions>
+): AdoptionContextValue {
+  const featureList: Feature[] = Object.entries(features).map(([id, opts]) => ({
+    id,
+    name: opts.name ?? id,
+    trigger: { event: id },
+  }))
+  const usageMap: Record<string, FeatureUsage> = Object.fromEntries(
+    Object.entries(features).map(([id, opts]) => [
+      id,
+      {
+        featureId: id,
+        firstUsed: opts.useCount > 0 ? '2026-01-01T00:00:00.000Z' : null,
+        lastUsed: opts.useCount > 0 ? '2026-01-02T00:00:00.000Z' : null,
+        useCount: opts.useCount,
+        status: opts.status,
+      },
+    ])
+  )
+  return {
+    features: featureList,
+    usageMap,
+    nudgeState: {
+      lastShown: null,
+      dismissed: [],
+      snoozed: {},
+      sessionCount: 0,
+    },
+    trackUsage: () => {},
+    getFeature: () => null,
+    showNudge: () => {},
+    dismissNudge: () => {},
+    snoozeNudge: () => {},
+    pendingNudges: [],
+  }
+}

--- a/packages/adoption/src/__tests__/_fixtures.ts
+++ b/packages/adoption/src/__tests__/_fixtures.ts
@@ -8,12 +8,7 @@
  *   `FeatureWithUsage[]`. We construct both shapes here so tests don't have to.
  */
 import type { AdoptionContextValue } from '../context/adoption-context'
-import type {
-  AdoptionStatus,
-  Feature,
-  FeatureUsage,
-  FunnelStep,
-} from '../types/feature'
+import type { AdoptionStatus, Feature, FeatureUsage, FunnelStep } from '../types/feature'
 
 export const sampleSteps: readonly FunnelStep[] = [
   { id: 'view', label: 'Viewed', entered: 100, completed: 60 },

--- a/packages/adoption/src/__tests__/package-json-deps.test.ts
+++ b/packages/adoption/src/__tests__/package-json-deps.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guards Phase 0's "native CSS, no chart peer" decision.
+ *
+ * If a future refactor accidentally pulls in `recharts` (or similar), this
+ * fails before the package can ship a fat bundle.
+ */
+describe('package.json — peerDependencies hygiene', () => {
+  const pkgPath = resolve(__dirname, '..', '..', 'package.json')
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+    peerDependencies?: Record<string, string>
+  }
+
+  const FORBIDDEN_CHART_DEPS = [
+    'recharts',
+    'd3',
+    'd3-shape',
+    'd3-scale',
+    'victory',
+    'chart.js',
+    'react-chartjs-2',
+    'nivo',
+    '@nivo/core',
+    'visx',
+    '@visx/visx',
+  ] as const
+
+  it.each(FORBIDDEN_CHART_DEPS)(
+    'has no `%s` in peerDependencies (Phase 0 decision: native CSS)',
+    (dep) => {
+      const peers = pkg.peerDependencies ?? {}
+      expect(peers).not.toHaveProperty(dep)
+    }
+  )
+
+  it('peerDependencies match the locked Phase 4 snapshot', () => {
+    // Snapshot of the legal peers as of Phase 4 — Phase 0 chart decision locked
+    // these. Adding a new peer requires an explicit code change + decision log.
+    const expected = new Set([
+      '@tour-kit/analytics',
+      'react',
+      'react-dom',
+      'tailwindcss',
+      '@mui/base',
+    ])
+    const actual = new Set(Object.keys(pkg.peerDependencies ?? {}))
+    expect(actual).toEqual(expected)
+  })
+})

--- a/packages/adoption/src/components/dashboard/__tests__/adoption-funnel.test.tsx
+++ b/packages/adoption/src/components/dashboard/__tests__/adoption-funnel.test.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+import { sampleSteps } from '../../../__tests__/_fixtures'
+import { AdoptionFunnel } from '../adoption-funnel'
+
+describe('<AdoptionFunnel>', () => {
+  describe('provider-less rendering (data-first)', () => {
+    it('mounts without any provider wrapper', () => {
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
+      const labels = Array.from(
+        container.querySelectorAll<HTMLElement>('.tk-funnel__label')
+      ).map((el) => el.textContent)
+      expect(labels).toEqual(['Viewed', 'Clicked', 'Converted'])
+    })
+
+    it('renders labels in order', () => {
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
+      const labelEls = Array.from(container.querySelectorAll('.tk-funnel__label'))
+      expect(labelEls.map((el) => el.textContent)).toEqual([
+        'Viewed',
+        'Clicked',
+        'Converted',
+      ])
+    })
+
+    it('renders a header when `title` is provided', () => {
+      render(<AdoptionFunnel steps={sampleSteps} title="Sign-up funnel" />)
+      expect(screen.getByText('Sign-up funnel')).toBeInTheDocument()
+    })
+
+    it('applies an extra className to the root', () => {
+      const { container } = render(
+        <AdoptionFunnel steps={sampleSteps} className="extra-class" />
+      )
+      expect(container.firstChild).toHaveClass('tk-funnel')
+      expect(container.firstChild).toHaveClass('extra-class')
+    })
+  })
+
+  describe('metrics math', () => {
+    it('shows retentionFromPrev between adjacent steps', () => {
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
+      const retentionEls = Array.from(
+        container.querySelectorAll<HTMLElement>('.tk-funnel__retention')
+      ).map((el) => el.textContent)
+      // 60/100 = 60.0%; 30/60 = 50.0%. First step has no retention shown.
+      expect(retentionEls).toEqual(['60.0%', '50.0%'])
+    })
+
+    it('does NOT show retention on the first step', () => {
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
+      const firstStep = container.querySelector('.tk-funnel__step')
+      expect(firstStep).not.toBeNull()
+      expect(firstStep?.querySelector('.tk-funnel__retention')).toBeNull()
+    })
+
+    it('bar widths are proportional to entered / max', () => {
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
+      const bars = container.querySelectorAll<HTMLElement>('.tk-funnel__bar')
+      expect(bars).toHaveLength(3)
+      // 100/100 = 100%, 60/100 = 60%, 30/100 = 30%
+      expect(bars[0]?.style.width).toBe('100%')
+      expect(bars[1]?.style.width).toBe('60%')
+      expect(bars[2]?.style.width).toBe('30%')
+    })
+  })
+
+  describe('empty state', () => {
+    it('renders default message when steps is empty', () => {
+      render(<AdoptionFunnel steps={[]} />)
+      expect(screen.getByText(/No funnel data yet/i)).toBeInTheDocument()
+    })
+
+    it('renders custom emptyState when provided', () => {
+      render(<AdoptionFunnel steps={[]} emptyState={<p>nothing here</p>} />)
+      expect(screen.getByText('nothing here')).toBeInTheDocument()
+    })
+  })
+
+  describe('interaction', () => {
+    it('invokes onStepClick with step + index', () => {
+      const onClick = vi.fn()
+      const { container } = render(
+        <AdoptionFunnel steps={sampleSteps} onStepClick={onClick} />
+      )
+      const stepEls = container.querySelectorAll<HTMLElement>('.tk-funnel__step')
+      expect(stepEls).toHaveLength(3)
+      fireEvent.click(stepEls[1]!)
+      expect(onClick).toHaveBeenCalledTimes(1)
+      expect(onClick).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'click' }),
+        1
+      )
+    })
+
+    it.each([
+      ['Enter', 'Enter'],
+      ['Space', ' '],
+    ])('activates onStepClick on %s key', (_label, key) => {
+      const onClick = vi.fn()
+      const { container } = render(
+        <AdoptionFunnel steps={sampleSteps} onStepClick={onClick} />
+      )
+      const firstStep = container.querySelector<HTMLElement>('.tk-funnel__step')
+      expect(firstStep).not.toBeNull()
+      fireEvent.keyDown(firstStep!, { key })
+      expect(onClick).toHaveBeenCalledTimes(1)
+      expect(onClick).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'view' }),
+        0
+      )
+    })
+
+    it('omits role=button when onStepClick is undefined', () => {
+      render(<AdoptionFunnel steps={sampleSteps} />)
+      expect(screen.queryAllByRole('button')).toHaveLength(0)
+    })
+
+    it('exposes role=button + tabIndex=0 when onStepClick is provided', () => {
+      render(<AdoptionFunnel steps={sampleSteps} onStepClick={() => {}} />)
+      const buttons = screen.getAllByRole('button')
+      expect(buttons).toHaveLength(3)
+      buttons.forEach((btn) => {
+        expect(btn).toHaveAttribute('tabindex', '0')
+      })
+    })
+  })
+
+  describe('screen-reader fallback', () => {
+    it('renders an SR table mirroring values', () => {
+      render(<AdoptionFunnel steps={sampleSteps} />)
+      const table = screen.getByRole('table', { hidden: true })
+      expect(table).toBeInTheDocument()
+      expect(table.querySelectorAll('tbody tr')).toHaveLength(3)
+      expect(table).toHaveTextContent('100')
+      expect(table).toHaveTextContent('60')
+      expect(table).toHaveTextContent('30')
+    })
+
+    it('SR table has visually-hidden styling via .sr-only class', () => {
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
+      const table = container.querySelector('table')
+      expect(table).not.toBeNull()
+      expect(table?.className).toMatch(/sr-only/)
+    })
+  })
+
+  describe('a11y', () => {
+    it('passes axe with zero violations', async () => {
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('default aria-label summarizes the funnel', () => {
+      render(<AdoptionFunnel steps={sampleSteps} />)
+      const chart = screen.getByRole('img')
+      expect(chart.getAttribute('aria-label')).toMatch(
+        /Adoption funnel: 100 → 60 → 30/
+      )
+    })
+
+    it('respects ariaLabel override', () => {
+      render(<AdoptionFunnel steps={sampleSteps} ariaLabel="Custom summary" />)
+      expect(screen.getByRole('img').getAttribute('aria-label')).toBe(
+        'Custom summary'
+      )
+    })
+
+    it('bars carry aria-hidden so SR consumers use the table instead', () => {
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
+      const bars = container.querySelectorAll('.tk-funnel__bar')
+      bars.forEach((bar) => {
+        expect(bar).toHaveAttribute('aria-hidden', 'true')
+      })
+    })
+  })
+})

--- a/packages/adoption/src/components/dashboard/__tests__/adoption-funnel.test.tsx
+++ b/packages/adoption/src/components/dashboard/__tests__/adoption-funnel.test.tsx
@@ -8,20 +8,16 @@ describe('<AdoptionFunnel>', () => {
   describe('provider-less rendering (data-first)', () => {
     it('mounts without any provider wrapper', () => {
       const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
-      const labels = Array.from(
-        container.querySelectorAll<HTMLElement>('.tk-funnel__label')
-      ).map((el) => el.textContent)
+      const labels = Array.from(container.querySelectorAll<HTMLElement>('.tk-funnel__label')).map(
+        (el) => el.textContent
+      )
       expect(labels).toEqual(['Viewed', 'Clicked', 'Converted'])
     })
 
     it('renders labels in order', () => {
       const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
       const labelEls = Array.from(container.querySelectorAll('.tk-funnel__label'))
-      expect(labelEls.map((el) => el.textContent)).toEqual([
-        'Viewed',
-        'Clicked',
-        'Converted',
-      ])
+      expect(labelEls.map((el) => el.textContent)).toEqual(['Viewed', 'Clicked', 'Converted'])
     })
 
     it('renders a header when `title` is provided', () => {
@@ -30,9 +26,7 @@ describe('<AdoptionFunnel>', () => {
     })
 
     it('applies an extra className to the root', () => {
-      const { container } = render(
-        <AdoptionFunnel steps={sampleSteps} className="extra-class" />
-      )
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} className="extra-class" />)
       expect(container.firstChild).toHaveClass('tk-funnel')
       expect(container.firstChild).toHaveClass('extra-class')
     })
@@ -81,17 +75,14 @@ describe('<AdoptionFunnel>', () => {
   describe('interaction', () => {
     it('invokes onStepClick with step + index', () => {
       const onClick = vi.fn()
-      const { container } = render(
-        <AdoptionFunnel steps={sampleSteps} onStepClick={onClick} />
-      )
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} onStepClick={onClick} />)
       const stepEls = container.querySelectorAll<HTMLElement>('.tk-funnel__step')
       expect(stepEls).toHaveLength(3)
-      fireEvent.click(stepEls[1]!)
+      const clickedStep = stepEls[1]
+      if (!clickedStep) throw new Error('expected step at index 1')
+      fireEvent.click(clickedStep)
       expect(onClick).toHaveBeenCalledTimes(1)
-      expect(onClick).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'click' }),
-        1
-      )
+      expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ id: 'click' }), 1)
     })
 
     it.each([
@@ -99,17 +90,12 @@ describe('<AdoptionFunnel>', () => {
       ['Space', ' '],
     ])('activates onStepClick on %s key', (_label, key) => {
       const onClick = vi.fn()
-      const { container } = render(
-        <AdoptionFunnel steps={sampleSteps} onStepClick={onClick} />
-      )
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} onStepClick={onClick} />)
       const firstStep = container.querySelector<HTMLElement>('.tk-funnel__step')
-      expect(firstStep).not.toBeNull()
-      fireEvent.keyDown(firstStep!, { key })
+      if (!firstStep) throw new Error('expected at least one step')
+      fireEvent.keyDown(firstStep, { key })
       expect(onClick).toHaveBeenCalledTimes(1)
-      expect(onClick).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'view' }),
-        0
-      )
+      expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ id: 'view' }), 0)
     })
 
     it('omits role=button when onStepClick is undefined', () => {
@@ -121,9 +107,9 @@ describe('<AdoptionFunnel>', () => {
       render(<AdoptionFunnel steps={sampleSteps} onStepClick={() => {}} />)
       const buttons = screen.getAllByRole('button')
       expect(buttons).toHaveLength(3)
-      buttons.forEach((btn) => {
+      for (const btn of buttons) {
         expect(btn).toHaveAttribute('tabindex', '0')
-      })
+      }
     })
   })
 
@@ -156,24 +142,20 @@ describe('<AdoptionFunnel>', () => {
     it('default aria-label summarizes the funnel', () => {
       render(<AdoptionFunnel steps={sampleSteps} />)
       const chart = screen.getByRole('img')
-      expect(chart.getAttribute('aria-label')).toMatch(
-        /Adoption funnel: 100 → 60 → 30/
-      )
+      expect(chart.getAttribute('aria-label')).toMatch(/Adoption funnel: 100 → 60 → 30/)
     })
 
     it('respects ariaLabel override', () => {
       render(<AdoptionFunnel steps={sampleSteps} ariaLabel="Custom summary" />)
-      expect(screen.getByRole('img').getAttribute('aria-label')).toBe(
-        'Custom summary'
-      )
+      expect(screen.getByRole('img').getAttribute('aria-label')).toBe('Custom summary')
     })
 
     it('bars carry aria-hidden so SR consumers use the table instead', () => {
       const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
       const bars = container.querySelectorAll('.tk-funnel__bar')
-      bars.forEach((bar) => {
+      for (const bar of bars) {
         expect(bar).toHaveAttribute('aria-hidden', 'true')
-      })
+      }
     })
   })
 })

--- a/packages/adoption/src/components/dashboard/__tests__/adoption-funnel.test.tsx
+++ b/packages/adoption/src/components/dashboard/__tests__/adoption-funnel.test.tsx
@@ -114,14 +114,28 @@ describe('<AdoptionFunnel>', () => {
   })
 
   describe('screen-reader fallback', () => {
-    it('renders an SR table mirroring values', () => {
+    it('renders the SR table in the accessibility tree (NOT inside role="img")', () => {
+      // No `hidden: true` opt-in — the table MUST be exposed to AT.
+      // role="img" suppresses its descendants from the AT tree, so the table
+      // is rendered as a sibling of the chart, not a child.
       render(<AdoptionFunnel steps={sampleSteps} />)
-      const table = screen.getByRole('table', { hidden: true })
+      const table = screen.getByRole('table')
       expect(table).toBeInTheDocument()
       expect(table.querySelectorAll('tbody tr')).toHaveLength(3)
       expect(table).toHaveTextContent('100')
       expect(table).toHaveTextContent('60')
       expect(table).toHaveTextContent('30')
+    })
+
+    it('SR table is a sibling of the role="img" chart, not a descendant', () => {
+      const { container } = render(<AdoptionFunnel steps={sampleSteps} />)
+      const chart = container.querySelector('[role="img"]')
+      const table = container.querySelector('table')
+      expect(chart).not.toBeNull()
+      expect(table).not.toBeNull()
+      // Containment check — if the table were inside the role="img" container,
+      // screen readers would treat it as decorative and skip it.
+      expect(chart?.contains(table)).toBe(false)
     })
 
     it('SR table has visually-hidden styling via .sr-only class', () => {

--- a/packages/adoption/src/components/dashboard/adoption-funnel.tsx
+++ b/packages/adoption/src/components/dashboard/adoption-funnel.tsx
@@ -2,10 +2,7 @@
 
 import { cn } from '@tour-kit/core'
 import * as React from 'react'
-import {
-  type FunnelStepMetrics,
-  calculateFunnelMetrics,
-} from '../../lib/calculate-funnel-metrics'
+import { type FunnelStepMetrics, calculateFunnelMetrics } from '../../lib/calculate-funnel-metrics'
 import type { AdoptionFunnelProps, FunnelStep } from '../../types/feature'
 
 /**
@@ -36,9 +33,7 @@ export function AdoptionFunnel({
   const metrics = React.useMemo(() => calculateFunnelMetrics(steps), [steps])
 
   if (steps.length === 0) {
-    return (
-      <>{emptyState ?? <p className="tk-funnel__empty">No funnel data yet.</p>}</>
-    )
+    return <>{emptyState ?? <p className="tk-funnel__empty">No funnel data yet.</p>}</>
   }
 
   const maxEntered = Math.max(...metrics.map((m) => m.entered), 1)
@@ -56,9 +51,7 @@ export function AdoptionFunnel({
             entered: m.entered,
             completed: m.completed,
           }
-          const handleClick = onStepClick
-            ? () => onStepClick(step, i)
-            : undefined
+          const handleClick = onStepClick ? () => onStepClick(step, i) : undefined
           const handleKeyDown = handleClick
             ? (e: React.KeyboardEvent<HTMLLIElement>) => {
                 if (e.key === 'Enter' || e.key === ' ') {
@@ -77,11 +70,7 @@ export function AdoptionFunnel({
               onKeyDown={handleKeyDown}
             >
               <div className="tk-funnel__label">{m.label}</div>
-              <div
-                className="tk-funnel__bar"
-                style={{ width: `${widthPct}%` }}
-                aria-hidden="true"
-              >
+              <div className="tk-funnel__bar" style={{ width: `${widthPct}%` }} aria-hidden="true">
                 <span className="tk-funnel__value">{m.entered}</span>
               </div>
               {i > 0 ? (
@@ -132,9 +121,6 @@ function buildAriaLabel(metrics: readonly FunnelStepMetrics[]): string {
   const enteredSeq = metrics.map((m) => m.entered).join(' → ')
   const first = metrics[0]?.entered ?? 0
   const last = metrics[metrics.length - 1]?.entered ?? 0
-  const endToEnd =
-    metrics.length > 1 && first > 0
-      ? ((last / first) * 100).toFixed(0)
-      : '100'
+  const endToEnd = metrics.length > 1 && first > 0 ? ((last / first) * 100).toFixed(0) : '100'
   return `Adoption funnel: ${enteredSeq}, ${endToEnd}% end-to-end retention`
 }

--- a/packages/adoption/src/components/dashboard/adoption-funnel.tsx
+++ b/packages/adoption/src/components/dashboard/adoption-funnel.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { cn } from '@tour-kit/core'
+import * as React from 'react'
+import {
+  type FunnelStepMetrics,
+  calculateFunnelMetrics,
+} from '../../lib/calculate-funnel-metrics'
+import type { AdoptionFunnelProps, FunnelStep } from '../../types/feature'
+
+/**
+ * Step-by-step adoption funnel with drop-off percentages.
+ *
+ * Data-first: `<AdoptionFunnel steps={data} />` renders without any provider.
+ * Pair with `useFunnelData({ featureIds })` inside `<AdoptionProvider>` for
+ * a one-line in-provider integration (current-state semantics; not historical).
+ *
+ * @example
+ * ```tsx
+ * <AdoptionFunnel
+ *   steps={[
+ *     { id: 'view', label: 'Viewed', entered: 100, completed: 60 },
+ *     { id: 'click', label: 'Clicked', entered: 60, completed: 30 },
+ *   ]}
+ * />
+ * ```
+ */
+export function AdoptionFunnel({
+  steps,
+  title,
+  onStepClick,
+  emptyState,
+  className,
+  ariaLabel,
+}: AdoptionFunnelProps): React.ReactElement {
+  const metrics = React.useMemo(() => calculateFunnelMetrics(steps), [steps])
+
+  if (steps.length === 0) {
+    return (
+      <>{emptyState ?? <p className="tk-funnel__empty">No funnel data yet.</p>}</>
+    )
+  }
+
+  const maxEntered = Math.max(...metrics.map((m) => m.entered), 1)
+  const summary = ariaLabel ?? buildAriaLabel(metrics)
+
+  return (
+    <div className={cn('tk-funnel', className)} role="img" aria-label={summary}>
+      {title ? <header className="tk-funnel__title">{title}</header> : null}
+      <ul className="tk-funnel__list">
+        {metrics.map((m, i) => {
+          const widthPct = (m.entered / maxEntered) * 100
+          const step: FunnelStep = {
+            id: m.id,
+            label: m.label,
+            entered: m.entered,
+            completed: m.completed,
+          }
+          const handleClick = onStepClick
+            ? () => onStepClick(step, i)
+            : undefined
+          const handleKeyDown = handleClick
+            ? (e: React.KeyboardEvent<HTMLLIElement>) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  handleClick()
+                }
+              }
+            : undefined
+          return (
+            <li
+              key={m.id}
+              className="tk-funnel__step"
+              role={handleClick ? 'button' : undefined}
+              tabIndex={handleClick ? 0 : undefined}
+              onClick={handleClick}
+              onKeyDown={handleKeyDown}
+            >
+              <div className="tk-funnel__label">{m.label}</div>
+              <div
+                className="tk-funnel__bar"
+                style={{ width: `${widthPct}%` }}
+                aria-hidden="true"
+              >
+                <span className="tk-funnel__value">{m.entered}</span>
+              </div>
+              {i > 0 ? (
+                <span className="tk-funnel__retention" aria-hidden="true">
+                  {(m.retentionFromPrev * 100).toFixed(1)}%
+                </span>
+              ) : null}
+            </li>
+          )
+        })}
+      </ul>
+      <FunnelTableForScreenReaders metrics={metrics} />
+    </div>
+  )
+}
+
+function FunnelTableForScreenReaders({
+  metrics,
+}: {
+  metrics: readonly FunnelStepMetrics[]
+}): React.ReactElement {
+  return (
+    <table className="sr-only">
+      <caption>Adoption funnel data</caption>
+      <thead>
+        <tr>
+          <th scope="col">Step</th>
+          <th scope="col">Entered</th>
+          <th scope="col">Completed</th>
+          <th scope="col">Retention from previous</th>
+        </tr>
+      </thead>
+      <tbody>
+        {metrics.map((m) => (
+          <tr key={m.id}>
+            <th scope="row">{m.label}</th>
+            <td>{m.entered}</td>
+            <td>{m.completed}</td>
+            <td>{(m.retentionFromPrev * 100).toFixed(1)}%</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function buildAriaLabel(metrics: readonly FunnelStepMetrics[]): string {
+  const enteredSeq = metrics.map((m) => m.entered).join(' → ')
+  const first = metrics[0]?.entered ?? 0
+  const last = metrics[metrics.length - 1]?.entered ?? 0
+  const endToEnd =
+    metrics.length > 1 && first > 0
+      ? ((last / first) * 100).toFixed(0)
+      : '100'
+  return `Adoption funnel: ${enteredSeq}, ${endToEnd}% end-to-end retention`
+}

--- a/packages/adoption/src/components/dashboard/adoption-funnel.tsx
+++ b/packages/adoption/src/components/dashboard/adoption-funnel.tsx
@@ -12,6 +12,14 @@ import type { AdoptionFunnelProps, FunnelStep } from '../../types/feature'
  * Pair with `useFunnelData({ featureIds })` inside `<AdoptionProvider>` for
  * a one-line in-provider integration (current-state semantics; not historical).
  *
+ * Accessibility:
+ * - The visual chart sits inside a `role="img"` container with an auto-built
+ *   `aria-label` summary. Per WAI-ARIA, `role="img"` with an accessible name
+ *   suppresses its descendants from the AT tree — so the SR-only `<table>`
+ *   mirror is rendered as a SIBLING of the chart (NOT a child), where screen
+ *   readers can actually reach it.
+ * - Clickable steps stay focusable; Enter + Space both fire `onStepClick`.
+ *
  * @example
  * ```tsx
  * <AdoptionFunnel
@@ -22,70 +30,76 @@ import type { AdoptionFunnelProps, FunnelStep } from '../../types/feature'
  * />
  * ```
  */
-export function AdoptionFunnel({
-  steps,
-  title,
-  onStepClick,
-  emptyState,
-  className,
-  ariaLabel,
-}: AdoptionFunnelProps): React.ReactElement {
-  const metrics = React.useMemo(() => calculateFunnelMetrics(steps), [steps])
+export const AdoptionFunnel = React.forwardRef<HTMLDivElement, AdoptionFunnelProps>(
+  ({ steps, title, onStepClick, emptyState, className, ariaLabel, ...rest }, ref) => {
+    const metrics = React.useMemo(() => calculateFunnelMetrics(steps), [steps])
 
-  if (steps.length === 0) {
-    return <>{emptyState ?? <p className="tk-funnel__empty">No funnel data yet.</p>}</>
-  }
+    if (steps.length === 0) {
+      return (
+        <div ref={ref} className={cn('tk-funnel', className)} {...rest}>
+          {emptyState ?? <p className="tk-funnel__empty">No funnel data yet.</p>}
+        </div>
+      )
+    }
 
-  const maxEntered = Math.max(...metrics.map((m) => m.entered), 1)
-  const summary = ariaLabel ?? buildAriaLabel(metrics)
+    const maxEntered = Math.max(...metrics.map((m) => m.entered), 1)
+    const summary = ariaLabel ?? buildAriaLabel(metrics)
 
-  return (
-    <div className={cn('tk-funnel', className)} role="img" aria-label={summary}>
-      {title ? <header className="tk-funnel__title">{title}</header> : null}
-      <ul className="tk-funnel__list">
-        {metrics.map((m, i) => {
-          const widthPct = (m.entered / maxEntered) * 100
-          const step: FunnelStep = {
-            id: m.id,
-            label: m.label,
-            entered: m.entered,
-            completed: m.completed,
-          }
-          const handleClick = onStepClick ? () => onStepClick(step, i) : undefined
-          const handleKeyDown = handleClick
-            ? (e: React.KeyboardEvent<HTMLLIElement>) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  handleClick()
-                }
+    return (
+      <div ref={ref} className={cn('tk-funnel', className)} {...rest}>
+        <div className="tk-funnel__chart" role="img" aria-label={summary}>
+          {title ? <header className="tk-funnel__title">{title}</header> : null}
+          <ul className="tk-funnel__list">
+            {metrics.map((m, i) => {
+              const widthPct = (m.entered / maxEntered) * 100
+              const step: FunnelStep = {
+                id: m.id,
+                label: m.label,
+                entered: m.entered,
+                completed: m.completed,
               }
-            : undefined
-          return (
-            <li
-              key={m.id}
-              className="tk-funnel__step"
-              role={handleClick ? 'button' : undefined}
-              tabIndex={handleClick ? 0 : undefined}
-              onClick={handleClick}
-              onKeyDown={handleKeyDown}
-            >
-              <div className="tk-funnel__label">{m.label}</div>
-              <div className="tk-funnel__bar" style={{ width: `${widthPct}%` }} aria-hidden="true">
-                <span className="tk-funnel__value">{m.entered}</span>
-              </div>
-              {i > 0 ? (
-                <span className="tk-funnel__retention" aria-hidden="true">
-                  {(m.retentionFromPrev * 100).toFixed(1)}%
-                </span>
-              ) : null}
-            </li>
-          )
-        })}
-      </ul>
-      <FunnelTableForScreenReaders metrics={metrics} />
-    </div>
-  )
-}
+              const handleClick = onStepClick ? () => onStepClick(step, i) : undefined
+              const handleKeyDown = handleClick
+                ? (e: React.KeyboardEvent<HTMLLIElement>) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      handleClick()
+                    }
+                  }
+                : undefined
+              return (
+                <li
+                  key={m.id}
+                  className="tk-funnel__step"
+                  role={handleClick ? 'button' : undefined}
+                  tabIndex={handleClick ? 0 : undefined}
+                  onClick={handleClick}
+                  onKeyDown={handleKeyDown}
+                >
+                  <div className="tk-funnel__label">{m.label}</div>
+                  <div
+                    className="tk-funnel__bar"
+                    style={{ width: `${widthPct}%` }}
+                    aria-hidden="true"
+                  >
+                    <span className="tk-funnel__value">{m.entered}</span>
+                  </div>
+                  {i > 0 ? (
+                    <span className="tk-funnel__retention" aria-hidden="true">
+                      {(m.retentionFromPrev * 100).toFixed(1)}%
+                    </span>
+                  ) : null}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+        <FunnelTableForScreenReaders metrics={metrics} />
+      </div>
+    )
+  }
+)
+AdoptionFunnel.displayName = 'AdoptionFunnel'
 
 function FunnelTableForScreenReaders({
   metrics,

--- a/packages/adoption/src/components/dashboard/index.ts
+++ b/packages/adoption/src/components/dashboard/index.ts
@@ -18,3 +18,5 @@ export type { AdoptionFiltersProps, AdoptionFiltersState } from './adoption-filt
 
 export { AdoptionDashboard } from './adoption-dashboard'
 export type { AdoptionDashboardProps } from './adoption-dashboard'
+
+export { AdoptionFunnel } from './adoption-funnel'

--- a/packages/adoption/src/hooks/__tests__/use-funnel-data.test.tsx
+++ b/packages/adoption/src/hooks/__tests__/use-funnel-data.test.tsx
@@ -1,17 +1,13 @@
 import { renderHook } from '@testing-library/react'
 import type * as React from 'react'
 import { describe, expect, it } from 'vitest'
-import { AdoptionContext } from '../../context/adoption-context'
 import { mockAdoptionContext } from '../../__tests__/_fixtures'
+import { AdoptionContext } from '../../context/adoption-context'
 import { useFunnelData } from '../use-funnel-data'
 
 function wrapperFactory(value: ReturnType<typeof mockAdoptionContext>) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <AdoptionContext.Provider value={value}>
-        {children}
-      </AdoptionContext.Provider>
-    )
+    return <AdoptionContext.Provider value={value}>{children}</AdoptionContext.Provider>
   }
 }
 
@@ -21,10 +17,9 @@ describe('useFunnelData', () => {
       onboarding: { useCount: 5, status: 'adopted' },
       checkout: { useCount: 2, status: 'exploring' },
     })
-    const { result } = renderHook(
-      () => useFunnelData({ featureIds: ['onboarding', 'checkout'] }),
-      { wrapper: wrapperFactory(ctxVal) }
-    )
+    const { result } = renderHook(() => useFunnelData({ featureIds: ['onboarding', 'checkout'] }), {
+      wrapper: wrapperFactory(ctxVal),
+    })
     expect(result.current.steps).toHaveLength(2)
     // Adopted feature: entered = useCount, completed = useCount (100% conversion).
     expect(result.current.steps[0]).toMatchObject({
@@ -47,10 +42,9 @@ describe('useFunnelData', () => {
     const ctxVal = mockAdoptionContext({
       tracked: { useCount: 3, status: 'adopted' },
     })
-    const { result } = renderHook(
-      () => useFunnelData({ featureIds: ['tracked', 'unknown'] }),
-      { wrapper: wrapperFactory(ctxVal) }
-    )
+    const { result } = renderHook(() => useFunnelData({ featureIds: ['tracked', 'unknown'] }), {
+      wrapper: wrapperFactory(ctxVal),
+    })
     expect(result.current.steps).toHaveLength(2)
     expect(result.current.steps[1]).toMatchObject({
       id: 'unknown',
@@ -79,10 +73,9 @@ describe('useFunnelData', () => {
     const ctxVal = mockAdoptionContext({
       feat: { useCount: 1, status: 'exploring', name: 'Friendly Name' },
     })
-    const { result } = renderHook(
-      () => useFunnelData({ featureIds: ['feat'] }),
-      { wrapper: wrapperFactory(ctxVal) }
-    )
+    const { result } = renderHook(() => useFunnelData({ featureIds: ['feat'] }), {
+      wrapper: wrapperFactory(ctxVal),
+    })
     expect(result.current.steps[0]?.label).toBe('Friendly Name')
   })
 })

--- a/packages/adoption/src/hooks/__tests__/use-funnel-data.test.tsx
+++ b/packages/adoption/src/hooks/__tests__/use-funnel-data.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react'
+import type * as React from 'react'
+import { describe, expect, it } from 'vitest'
+import { AdoptionContext } from '../../context/adoption-context'
+import { mockAdoptionContext } from '../../__tests__/_fixtures'
+import { useFunnelData } from '../use-funnel-data'
+
+function wrapperFactory(value: ReturnType<typeof mockAdoptionContext>) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <AdoptionContext.Provider value={value}>
+        {children}
+      </AdoptionContext.Provider>
+    )
+  }
+}
+
+describe('useFunnelData', () => {
+  it('maps two features into a FunnelStep[] of length 2 with current-state numbers', () => {
+    const ctxVal = mockAdoptionContext({
+      onboarding: { useCount: 5, status: 'adopted' },
+      checkout: { useCount: 2, status: 'exploring' },
+    })
+    const { result } = renderHook(
+      () => useFunnelData({ featureIds: ['onboarding', 'checkout'] }),
+      { wrapper: wrapperFactory(ctxVal) }
+    )
+    expect(result.current.steps).toHaveLength(2)
+    // Adopted feature: entered = useCount, completed = useCount (100% conversion).
+    expect(result.current.steps[0]).toMatchObject({
+      id: 'onboarding',
+      label: 'onboarding',
+      entered: 5,
+      completed: 5,
+    })
+    // Exploring feature: entered = useCount, completed = 0.
+    expect(result.current.steps[1]).toMatchObject({
+      id: 'checkout',
+      entered: 2,
+      completed: 0,
+    })
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('returns zero metrics for unknown feature ids', () => {
+    const ctxVal = mockAdoptionContext({
+      tracked: { useCount: 3, status: 'adopted' },
+    })
+    const { result } = renderHook(
+      () => useFunnelData({ featureIds: ['tracked', 'unknown'] }),
+      { wrapper: wrapperFactory(ctxVal) }
+    )
+    expect(result.current.steps).toHaveLength(2)
+    expect(result.current.steps[1]).toMatchObject({
+      id: 'unknown',
+      label: 'unknown',
+      entered: 0,
+      completed: 0,
+    })
+  })
+
+  it('applies label overrides via opts.labels', () => {
+    const ctxVal = mockAdoptionContext({
+      feat: { useCount: 1, status: 'exploring' },
+    })
+    const { result } = renderHook(
+      () =>
+        useFunnelData({
+          featureIds: ['feat'],
+          labels: { feat: 'Pretty Feature' },
+        }),
+      { wrapper: wrapperFactory(ctxVal) }
+    )
+    expect(result.current.steps[0]?.label).toBe('Pretty Feature')
+  })
+
+  it('falls back to the feature.name when no label override is provided', () => {
+    const ctxVal = mockAdoptionContext({
+      feat: { useCount: 1, status: 'exploring', name: 'Friendly Name' },
+    })
+    const { result } = renderHook(
+      () => useFunnelData({ featureIds: ['feat'] }),
+      { wrapper: wrapperFactory(ctxVal) }
+    )
+    expect(result.current.steps[0]?.label).toBe('Friendly Name')
+  })
+})

--- a/packages/adoption/src/hooks/__tests__/use-funnel-data.test.tsx
+++ b/packages/adoption/src/hooks/__tests__/use-funnel-data.test.tsx
@@ -20,22 +20,20 @@ describe('useFunnelData', () => {
     const { result } = renderHook(() => useFunnelData({ featureIds: ['onboarding', 'checkout'] }), {
       wrapper: wrapperFactory(ctxVal),
     })
-    expect(result.current.steps).toHaveLength(2)
+    expect(result.current).toHaveLength(2)
     // Adopted feature: entered = useCount, completed = useCount (100% conversion).
-    expect(result.current.steps[0]).toMatchObject({
+    expect(result.current[0]).toMatchObject({
       id: 'onboarding',
       label: 'onboarding',
       entered: 5,
       completed: 5,
     })
     // Exploring feature: entered = useCount, completed = 0.
-    expect(result.current.steps[1]).toMatchObject({
+    expect(result.current[1]).toMatchObject({
       id: 'checkout',
       entered: 2,
       completed: 0,
     })
-    expect(result.current.loading).toBe(false)
-    expect(result.current.error).toBeNull()
   })
 
   it('returns zero metrics for unknown feature ids', () => {
@@ -45,8 +43,8 @@ describe('useFunnelData', () => {
     const { result } = renderHook(() => useFunnelData({ featureIds: ['tracked', 'unknown'] }), {
       wrapper: wrapperFactory(ctxVal),
     })
-    expect(result.current.steps).toHaveLength(2)
-    expect(result.current.steps[1]).toMatchObject({
+    expect(result.current).toHaveLength(2)
+    expect(result.current[1]).toMatchObject({
       id: 'unknown',
       label: 'unknown',
       entered: 0,
@@ -66,7 +64,7 @@ describe('useFunnelData', () => {
         }),
       { wrapper: wrapperFactory(ctxVal) }
     )
-    expect(result.current.steps[0]?.label).toBe('Pretty Feature')
+    expect(result.current[0]?.label).toBe('Pretty Feature')
   })
 
   it('falls back to the feature.name when no label override is provided', () => {
@@ -76,6 +74,6 @@ describe('useFunnelData', () => {
     const { result } = renderHook(() => useFunnelData({ featureIds: ['feat'] }), {
       wrapper: wrapperFactory(ctxVal),
     })
-    expect(result.current.steps[0]?.label).toBe('Friendly Name')
+    expect(result.current[0]?.label).toBe('Friendly Name')
   })
 })

--- a/packages/adoption/src/hooks/index.ts
+++ b/packages/adoption/src/hooks/index.ts
@@ -1,2 +1,4 @@
 export { useFeature } from './use-feature'
 export { useNudge } from './use-nudge'
+export { useFunnelData } from './use-funnel-data'
+export type { UseFunnelDataInput, UseFunnelDataResult } from './use-funnel-data'

--- a/packages/adoption/src/hooks/index.ts
+++ b/packages/adoption/src/hooks/index.ts
@@ -1,4 +1,4 @@
 export { useFeature } from './use-feature'
 export { useNudge } from './use-nudge'
 export { useFunnelData } from './use-funnel-data'
-export type { UseFunnelDataInput, UseFunnelDataResult } from './use-funnel-data'
+export type { UseFunnelDataInput } from './use-funnel-data'

--- a/packages/adoption/src/hooks/use-funnel-data.ts
+++ b/packages/adoption/src/hooks/use-funnel-data.ts
@@ -1,6 +1,5 @@
 'use client'
 
-import * as React from 'react'
 import type { FunnelStep } from '../types/feature'
 import { useAdoptionStats } from './use-adoption-stats'
 
@@ -30,23 +29,25 @@ export interface UseFunnelDataResult {
  * For aggregated, date-ranged funnels, hand pre-computed data straight to
  * `<AdoptionFunnel steps={...}>` (the data-first path).
  *
+ * No memoization — `featureIds` and `labels` are usually fresh references each
+ * render, which would defeat `useMemo`. The mapping is O(featureIds) and the
+ * caller's render dominates anyway.
+ *
  * Throws via `useAdoptionStats` if used outside `<AdoptionProvider>`.
  */
 export function useFunnelData({ featureIds, labels }: UseFunnelDataInput): UseFunnelDataResult {
   const stats = useAdoptionStats()
-  return React.useMemo<UseFunnelDataResult>(() => {
-    const steps: FunnelStep[] = featureIds.map((id) => {
-      const feature = stats.features.find((f) => f.id === id)
-      const useCount = feature?.usage.useCount ?? 0
-      const isAdopted = feature?.usage.status === 'adopted'
-      const fallbackLabel = feature?.name ?? id
-      return {
-        id,
-        label: labels?.[id] ?? fallbackLabel,
-        entered: useCount,
-        completed: isAdopted ? useCount : 0,
-      }
-    })
-    return { steps, loading: false, error: null }
-  }, [stats.features, featureIds, labels])
+  const steps: FunnelStep[] = featureIds.map((id) => {
+    const feature = stats.features.find((f) => f.id === id)
+    const useCount = feature?.usage.useCount ?? 0
+    const isAdopted = feature?.usage.status === 'adopted'
+    const fallbackLabel = feature?.name ?? id
+    return {
+      id,
+      label: labels?.[id] ?? fallbackLabel,
+      entered: useCount,
+      completed: isAdopted ? useCount : 0,
+    }
+  })
+  return { steps, loading: false, error: null }
 }

--- a/packages/adoption/src/hooks/use-funnel-data.ts
+++ b/packages/adoption/src/hooks/use-funnel-data.ts
@@ -10,15 +10,6 @@ export interface UseFunnelDataInput {
   labels?: Partial<Record<string, string>>
 }
 
-export interface UseFunnelDataResult {
-  /** Funnel steps ready to hand to `<AdoptionFunnel steps>`. */
-  steps: FunnelStep[]
-  /** Reserved for future async sources. Always `false` for the in-memory provider. */
-  loading: boolean
-  /** Reserved for future async sources. Always `null` for the in-memory provider. */
-  error: Error | null
-}
-
 /**
  * Derive a CURRENT-STATE funnel from `useAdoptionStats`.
  *
@@ -35,9 +26,9 @@ export interface UseFunnelDataResult {
  *
  * Throws via `useAdoptionStats` if used outside `<AdoptionProvider>`.
  */
-export function useFunnelData({ featureIds, labels }: UseFunnelDataInput): UseFunnelDataResult {
+export function useFunnelData({ featureIds, labels }: UseFunnelDataInput): FunnelStep[] {
   const stats = useAdoptionStats()
-  const steps: FunnelStep[] = featureIds.map((id) => {
+  return featureIds.map((id) => {
     const feature = stats.features.find((f) => f.id === id)
     const useCount = feature?.usage.useCount ?? 0
     const isAdopted = feature?.usage.status === 'adopted'
@@ -49,5 +40,4 @@ export function useFunnelData({ featureIds, labels }: UseFunnelDataInput): UseFu
       completed: isAdopted ? useCount : 0,
     }
   })
-  return { steps, loading: false, error: null }
 }

--- a/packages/adoption/src/hooks/use-funnel-data.ts
+++ b/packages/adoption/src/hooks/use-funnel-data.ts
@@ -1,8 +1,8 @@
 'use client'
 
 import * as React from 'react'
-import { useAdoptionStats } from './use-adoption-stats'
 import type { FunnelStep } from '../types/feature'
+import { useAdoptionStats } from './use-adoption-stats'
 
 export interface UseFunnelDataInput {
   /** Feature IDs in funnel order. */
@@ -32,10 +32,7 @@ export interface UseFunnelDataResult {
  *
  * Throws via `useAdoptionStats` if used outside `<AdoptionProvider>`.
  */
-export function useFunnelData({
-  featureIds,
-  labels,
-}: UseFunnelDataInput): UseFunnelDataResult {
+export function useFunnelData({ featureIds, labels }: UseFunnelDataInput): UseFunnelDataResult {
   const stats = useAdoptionStats()
   return React.useMemo<UseFunnelDataResult>(() => {
     const steps: FunnelStep[] = featureIds.map((id) => {

--- a/packages/adoption/src/hooks/use-funnel-data.ts
+++ b/packages/adoption/src/hooks/use-funnel-data.ts
@@ -1,0 +1,55 @@
+'use client'
+
+import * as React from 'react'
+import { useAdoptionStats } from './use-adoption-stats'
+import type { FunnelStep } from '../types/feature'
+
+export interface UseFunnelDataInput {
+  /** Feature IDs in funnel order. */
+  featureIds: readonly string[]
+  /** Optional label overrides keyed by feature id. */
+  labels?: Partial<Record<string, string>>
+}
+
+export interface UseFunnelDataResult {
+  /** Funnel steps ready to hand to `<AdoptionFunnel steps>`. */
+  steps: FunnelStep[]
+  /** Reserved for future async sources. Always `false` for the in-memory provider. */
+  loading: boolean
+  /** Reserved for future async sources. Always `null` for the in-memory provider. */
+  error: Error | null
+}
+
+/**
+ * Derive a CURRENT-STATE funnel from `useAdoptionStats`.
+ *
+ * - `entered` is the current user's `useCount` for the feature.
+ * - `completed` is `useCount` when `status === 'adopted'`, else `0`.
+ *
+ * This is per-user, point-in-time data — NOT a historical cohort funnel.
+ * For aggregated, date-ranged funnels, hand pre-computed data straight to
+ * `<AdoptionFunnel steps={...}>` (the data-first path).
+ *
+ * Throws via `useAdoptionStats` if used outside `<AdoptionProvider>`.
+ */
+export function useFunnelData({
+  featureIds,
+  labels,
+}: UseFunnelDataInput): UseFunnelDataResult {
+  const stats = useAdoptionStats()
+  return React.useMemo<UseFunnelDataResult>(() => {
+    const steps: FunnelStep[] = featureIds.map((id) => {
+      const feature = stats.features.find((f) => f.id === id)
+      const useCount = feature?.usage.useCount ?? 0
+      const isAdopted = feature?.usage.status === 'adopted'
+      const fallbackLabel = feature?.name ?? id
+      return {
+        id,
+        label: labels?.[id] ?? fallbackLabel,
+        entered: useCount,
+        completed: isAdopted ? useCount : 0,
+      }
+    })
+    return { steps, loading: false, error: null }
+  }, [stats.features, featureIds, labels])
+}

--- a/packages/adoption/src/index.ts
+++ b/packages/adoption/src/index.ts
@@ -10,11 +10,7 @@ export { useAdoptionContext } from './context/adoption-context'
 export { useFeature, type UseFeatureReturn } from './hooks/use-feature'
 export { useAdoptionStats, type AdoptionStats } from './hooks/use-adoption-stats'
 export { useNudge, type UseNudgeReturn } from './hooks/use-nudge'
-export {
-  useFunnelData,
-  type UseFunnelDataInput,
-  type UseFunnelDataResult,
-} from './hooks/use-funnel-data'
+export { useFunnelData, type UseFunnelDataInput } from './hooks/use-funnel-data'
 
 // ============================================
 // COMPONENTS

--- a/packages/adoption/src/index.ts
+++ b/packages/adoption/src/index.ts
@@ -10,6 +10,11 @@ export { useAdoptionContext } from './context/adoption-context'
 export { useFeature, type UseFeatureReturn } from './hooks/use-feature'
 export { useAdoptionStats, type AdoptionStats } from './hooks/use-adoption-stats'
 export { useNudge, type UseNudgeReturn } from './hooks/use-nudge'
+export {
+  useFunnelData,
+  type UseFunnelDataInput,
+  type UseFunnelDataResult,
+} from './hooks/use-funnel-data'
 
 // ============================================
 // COMPONENTS
@@ -78,6 +83,8 @@ export type {
   FeatureUsage,
   AdoptionStatus,
   FeatureWithUsage,
+  FunnelStep,
+  AdoptionFunnelProps,
   StorageConfig,
   NudgeConfig,
   AdoptionProviderProps,

--- a/packages/adoption/src/lib/__tests__/calculate-funnel-metrics.test.ts
+++ b/packages/adoption/src/lib/__tests__/calculate-funnel-metrics.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { calculateFunnelMetrics } from '../calculate-funnel-metrics'
+
+describe('calculateFunnelMetrics', () => {
+  it('returns empty array on empty input', () => {
+    expect(calculateFunnelMetrics([])).toEqual([])
+  })
+
+  it('first step has retentionFromPrev=1 and dropoffFromPrev=0', () => {
+    const [m] = calculateFunnelMetrics([{ id: 'a', label: 'A', entered: 50 }])
+    expect(m?.retentionFromPrev).toBe(1)
+    expect(m?.dropoffFromPrev).toBe(0)
+  })
+
+  it('two-step retention/dropoff computed correctly', () => {
+    const m = calculateFunnelMetrics([
+      { id: 'a', label: 'A', entered: 100, completed: 60 },
+      { id: 'b', label: 'B', entered: 40, completed: 10 },
+    ])
+    expect(m[0]?.conversion).toBeCloseTo(0.6)
+    expect(m[1]?.retentionFromPrev).toBeCloseTo(0.4)
+    expect(m[1]?.dropoffFromPrev).toBe(60)
+    expect(m[1]?.conversion).toBeCloseTo(0.25)
+  })
+
+  it('does not produce NaN/Infinity when first step has entered=0', () => {
+    const m = calculateFunnelMetrics([
+      { id: 'a', label: 'A', entered: 0 },
+      { id: 'b', label: 'B', entered: 0 },
+    ])
+    expect(Number.isFinite(m[0]?.conversion ?? 0)).toBe(true)
+    expect(Number.isFinite(m[1]?.retentionFromPrev ?? 0)).toBe(true)
+    expect(m[0]?.conversion).toBe(0)
+    expect(m[1]?.retentionFromPrev).toBe(0)
+  })
+
+  it('handles missing completed (defaults to 0)', () => {
+    const [m] = calculateFunnelMetrics([
+      { id: 'a', label: 'A', entered: 10 },
+    ])
+    expect(m?.completed).toBe(0)
+    expect(m?.conversion).toBe(0)
+  })
+
+  it('clamps negative drop-off to 0 when a later step has more entered than the previous', () => {
+    // Should not happen in a real funnel, but the helper must not emit negatives.
+    const m = calculateFunnelMetrics([
+      { id: 'a', label: 'A', entered: 10 },
+      { id: 'b', label: 'B', entered: 20 },
+    ])
+    expect(m[1]?.dropoffFromPrev).toBe(0)
+  })
+
+  it('handles large numbers without precision drift in retention', () => {
+    const m = calculateFunnelMetrics([
+      { id: 'a', label: 'A', entered: 1_000_000, completed: 500_000 },
+      { id: 'b', label: 'B', entered: 250_000 },
+    ])
+    expect(m[0]?.conversion).toBeCloseTo(0.5)
+    expect(m[1]?.retentionFromPrev).toBeCloseTo(0.25)
+  })
+})

--- a/packages/adoption/src/lib/__tests__/calculate-funnel-metrics.test.ts
+++ b/packages/adoption/src/lib/__tests__/calculate-funnel-metrics.test.ts
@@ -35,9 +35,7 @@ describe('calculateFunnelMetrics', () => {
   })
 
   it('handles missing completed (defaults to 0)', () => {
-    const [m] = calculateFunnelMetrics([
-      { id: 'a', label: 'A', entered: 10 },
-    ])
+    const [m] = calculateFunnelMetrics([{ id: 'a', label: 'A', entered: 10 }])
     expect(m?.completed).toBe(0)
     expect(m?.conversion).toBe(0)
   })

--- a/packages/adoption/src/lib/calculate-funnel-metrics.ts
+++ b/packages/adoption/src/lib/calculate-funnel-metrics.ts
@@ -25,16 +25,13 @@ export interface FunnelStepMetrics {
  * Empty input returns `[]`. Guards against divide-by-zero in `conversion`
  * and `retentionFromPrev` so the funnel never emits `NaN`/`Infinity`.
  */
-export function calculateFunnelMetrics(
-  steps: readonly FunnelStep[]
-): FunnelStepMetrics[] {
+export function calculateFunnelMetrics(steps: readonly FunnelStep[]): FunnelStepMetrics[] {
   return steps.map((step, i) => {
     const entered = step.entered
     const completed = step.completed ?? 0
     const prevEntered = i === 0 ? entered : (steps[i - 1]?.entered ?? 0)
     const conversion = entered > 0 ? completed / entered : 0
-    const retentionFromPrev =
-      i === 0 ? 1 : prevEntered > 0 ? entered / prevEntered : 0
+    const retentionFromPrev = i === 0 ? 1 : prevEntered > 0 ? entered / prevEntered : 0
     const dropoffFromPrev = i === 0 ? 0 : Math.max(0, prevEntered - entered)
     return {
       id: step.id,

--- a/packages/adoption/src/lib/calculate-funnel-metrics.ts
+++ b/packages/adoption/src/lib/calculate-funnel-metrics.ts
@@ -1,0 +1,49 @@
+import type { FunnelStep } from '../types/feature'
+
+/**
+ * Computed per-step metrics derived from a `FunnelStep[]`.
+ *
+ * All percentages are 0..1 (callers format for display). Math is guarded
+ * against divide-by-zero so the output never contains `NaN` or `Infinity`.
+ */
+export interface FunnelStepMetrics {
+  id: string
+  label: string
+  entered: number
+  completed: number
+  /** `completed / entered`. 0 when `entered === 0`. */
+  conversion: number
+  /** `entered / prev.entered`. 1 for the first step. */
+  retentionFromPrev: number
+  /** `prev.entered - entered`. 0 for the first step; clamped to ≥ 0. */
+  dropoffFromPrev: number
+}
+
+/**
+ * Pure helper — no React, no side effects.
+ *
+ * Empty input returns `[]`. Guards against divide-by-zero in `conversion`
+ * and `retentionFromPrev` so the funnel never emits `NaN`/`Infinity`.
+ */
+export function calculateFunnelMetrics(
+  steps: readonly FunnelStep[]
+): FunnelStepMetrics[] {
+  return steps.map((step, i) => {
+    const entered = step.entered
+    const completed = step.completed ?? 0
+    const prevEntered = i === 0 ? entered : (steps[i - 1]?.entered ?? 0)
+    const conversion = entered > 0 ? completed / entered : 0
+    const retentionFromPrev =
+      i === 0 ? 1 : prevEntered > 0 ? entered / prevEntered : 0
+    const dropoffFromPrev = i === 0 ? 0 : Math.max(0, prevEntered - entered)
+    return {
+      id: step.id,
+      label: step.label,
+      entered,
+      completed,
+      conversion,
+      retentionFromPrev,
+      dropoffFromPrev,
+    }
+  })
+}

--- a/packages/adoption/src/styles/funnel.css
+++ b/packages/adoption/src/styles/funnel.css
@@ -38,17 +38,17 @@
     var(--tour-adoption-timing, cubic-bezier(0.4, 0, 0.2, 1));
 }
 
-.tk-funnel__step[role='button'] {
+.tk-funnel__step[role="button"] {
   cursor: pointer;
 }
 
-.tk-funnel__step[role='button']:hover,
-.tk-funnel__step[role='button']:focus-visible {
+.tk-funnel__step[role="button"]:hover,
+.tk-funnel__step[role="button"]:focus-visible {
   background-color: var(--tour-funnel-step-hover, rgba(0, 0, 0, 0.04));
   outline: none;
 }
 
-.tk-funnel__step[role='button']:focus-visible {
+.tk-funnel__step[role="button"]:focus-visible {
   box-shadow: 0 0 0 2px var(--tour-funnel-focus-ring, hsl(220, 90%, 56%));
 }
 

--- a/packages/adoption/src/styles/funnel.css
+++ b/packages/adoption/src/styles/funnel.css
@@ -6,7 +6,13 @@
  * Reduced motion honored at the bottom of the file.
  */
 
+/* Outer container — holds the visible chart + the visually-hidden SR table.
+   Visual layout is owned by .tk-funnel__chart (the .sr-only sibling is clipped). */
 .tk-funnel {
+  position: relative;
+}
+
+.tk-funnel__chart {
   display: flex;
   flex-direction: column;
   gap: var(--tour-funnel-gap, 0.5rem);

--- a/packages/adoption/src/styles/funnel.css
+++ b/packages/adoption/src/styles/funnel.css
@@ -1,0 +1,107 @@
+/**
+ * TourKit Adoption Funnel — base styles
+ *
+ * Native-CSS bars (Phase 0 chart decision: no recharts/d3/victory peer).
+ * Tailwind-free so consumers without Tailwind still get a usable widget.
+ * Reduced motion honored at the bottom of the file.
+ */
+
+.tk-funnel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tour-funnel-gap, 0.5rem);
+}
+
+.tk-funnel__title {
+  font-weight: 600;
+  font-size: 1rem;
+  margin: 0;
+}
+
+.tk-funnel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--tour-funnel-step-gap, 0.5rem);
+}
+
+.tk-funnel__step {
+  display: grid;
+  grid-template-columns: minmax(8rem, 1fr) 3fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  transition: background-color var(--tour-adoption-duration, 200ms)
+    var(--tour-adoption-timing, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.tk-funnel__step[role='button'] {
+  cursor: pointer;
+}
+
+.tk-funnel__step[role='button']:hover,
+.tk-funnel__step[role='button']:focus-visible {
+  background-color: var(--tour-funnel-step-hover, rgba(0, 0, 0, 0.04));
+  outline: none;
+}
+
+.tk-funnel__step[role='button']:focus-visible {
+  box-shadow: 0 0 0 2px var(--tour-funnel-focus-ring, hsl(220, 90%, 56%));
+}
+
+.tk-funnel__label {
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+.tk-funnel__bar {
+  position: relative;
+  height: 1.5rem;
+  min-width: 2px;
+  background-color: var(--tour-funnel-bar-bg, hsl(220, 90%, 56%));
+  border-radius: 0.25rem;
+  display: flex;
+  align-items: center;
+  padding: 0 0.5rem;
+  color: var(--tour-funnel-bar-fg, #fff);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.tk-funnel__value {
+  white-space: nowrap;
+}
+
+.tk-funnel__retention {
+  font-size: 0.75rem;
+  color: var(--tour-funnel-retention-fg, hsl(0, 0%, 40%));
+  font-variant-numeric: tabular-nums;
+}
+
+.tk-funnel__empty {
+  font-size: 0.875rem;
+  color: var(--tour-funnel-retention-fg, hsl(0, 0%, 40%));
+  margin: 0;
+}
+
+/* Visually hidden screen-reader-only utility. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tk-funnel__step {
+    transition: none;
+  }
+}

--- a/packages/adoption/src/types/feature.ts
+++ b/packages/adoption/src/types/feature.ts
@@ -1,3 +1,5 @@
+import type * as React from 'react'
+
 /**
  * How to detect when a feature is used
  */
@@ -99,4 +101,50 @@ export type AdoptionStatus =
  */
 export interface FeatureWithUsage extends Feature {
   usage: FeatureUsage
+}
+
+/**
+ * One step in an adoption funnel.
+ *
+ * The funnel is data-first: consumers compute these from their own analytics
+ * (e.g. cohort queries) and hand them to `<AdoptionFunnel steps={...}>` —
+ * no provider required. `useFunnelData()` is a convenience selector that
+ * derives a CURRENT-STATE funnel from `useAdoptionStats` for in-provider use.
+ */
+export interface FunnelStep {
+  /** Stable identifier for the step (used as React key + onClick payload). */
+  id: string
+  /** Visible label rendered next to the bar. */
+  label: string
+  /** Number of subjects that reached this step. */
+  entered: number
+  /**
+   * Number of subjects that completed the step.
+   * Defaults to 0 (no one progressed past this step) when omitted.
+   */
+  completed?: number
+}
+
+/**
+ * Props for `<AdoptionFunnel>`.
+ *
+ * Works WITHOUT `<AdoptionProvider>` — data-first by design. Consumers in a
+ * provider tree typically combine with `useFunnelData({ featureIds })`.
+ */
+export interface AdoptionFunnelProps {
+  /** Pre-computed funnel data, in display order. */
+  steps: readonly FunnelStep[]
+  /** Optional header rendered above the bars. */
+  title?: React.ReactNode
+  /** Click/keyboard activation handler. When omitted, steps are not focusable. */
+  onStepClick?: (step: FunnelStep, index: number) => void
+  /** Replaces the default "No funnel data yet." message when `steps` is empty. */
+  emptyState?: React.ReactNode
+  /** Extra className merged onto the root element. */
+  className?: string
+  /**
+   * Overrides the auto-generated chart summary on the `role="img"` element.
+   * Default: `Adoption funnel: 100 → 60 → 30, 30% end-to-end retention`.
+   */
+  ariaLabel?: string
 }

--- a/packages/adoption/src/types/feature.ts
+++ b/packages/adoption/src/types/feature.ts
@@ -130,8 +130,17 @@ export interface FunnelStep {
  *
  * Works WITHOUT `<AdoptionProvider>` — data-first by design. Consumers in a
  * provider tree typically combine with `useFunnelData({ featureIds })`.
+ *
+ * Extends standard `<div>` props so consumers can attach refs, `data-*`,
+ * `aria-describedby`, etc. `role`, `aria-label`, and `children` are owned by
+ * the component (an inner chart wrapper carries `role="img"` + the computed
+ * summary, and an `<sr-only>` table sibling provides the SR mirror).
  */
-export interface AdoptionFunnelProps {
+export interface AdoptionFunnelProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<'div'>,
+    'role' | 'aria-label' | 'children' | 'title'
+  > {
   /** Pre-computed funnel data, in display order. */
   steps: readonly FunnelStep[]
   /** Optional header rendered above the bars. */
@@ -140,8 +149,6 @@ export interface AdoptionFunnelProps {
   onStepClick?: (step: FunnelStep, index: number) => void
   /** Replaces the default "No funnel data yet." message when `steps` is empty. */
   emptyState?: React.ReactNode
-  /** Extra className merged onto the root element. */
-  className?: string
   /**
    * Overrides the auto-generated chart summary on the `role="img"` element.
    * Default: `Adoption funnel: 100 → 60 → 30, 30% end-to-end retention`.

--- a/packages/adoption/src/types/index.ts
+++ b/packages/adoption/src/types/index.ts
@@ -8,6 +8,8 @@ export type {
   FeatureUsage,
   AdoptionStatus,
   FeatureWithUsage,
+  FunnelStep,
+  AdoptionFunnelProps,
 } from './feature'
 
 export type {

--- a/packages/adoption/tsconfig.json
+++ b/packages/adoption/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/adoption/tsup.config.ts
+++ b/packages/adoption/tsup.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
       fs.mkdirSync('dist/styles', { recursive: true })
       fs.copyFileSync('src/styles/variables.css', 'dist/styles/variables.css')
       fs.copyFileSync('src/styles/theme.css', 'dist/styles/theme.css')
+      fs.copyFileSync('src/styles/funnel.css', 'dist/styles/funnel.css')
     } catch (e) {
       console.warn('Failed to copy CSS files:', e)
     }


### PR DESCRIPTION
## Phase 4 — AdoptionFunnel Widget

Closes the single most-requested Pendo/Userpilot parity gap in `@tour-kit/adoption`: a step-by-step funnel chart with retention/drop-off — built on the native-CSS approach the existing dashboard already uses (Phase 0 decision: no recharts/d3/victory peer).

## Changes

### New surfaces
- **`<AdoptionFunnel steps={...}>`** — data-first; renders without `<AdoptionProvider>` so it can drop into any tree (admin dashboards, server-rendered reports, etc.)
- **`useFunnelData({ featureIds, labels? })`** — provider-backed convenience selector over `useAdoptionStats`. Honestly documented as **current-state**, not historical.
- **`calculateFunnelMetrics()`** — pure helper, `NaN`/`Infinity`-safe under zero-entered inputs
- New stylesheet exported as `@tour-kit/adoption/styles/funnel.css`

### Accessibility
- `role="img"` + auto-generated `aria-label` summary (overrideable)
- Visual bars carry `aria-hidden="true"`; a visually-hidden `<table>` mirrors the numbers for screen readers
- Clickable steps activate on both **Enter** and **Space**
- Honors `prefers-reduced-motion: reduce`

### Tests added
- `calculate-funnel-metrics.test.ts` — 7 cases (empty / single / two-step / zero-entered / missing-completed / negative-clamp / large numbers)
- `adoption-funnel.test.tsx` — 13 cases including axe zero-violations
- `use-funnel-data.test.tsx` — 4 cases (mapping, unknown ids, label overrides, fallback to feature.name)
- `package-json-deps.test.ts` — guards against accidental chart peer deps (recharts/d3/victory/...)

## Test plan

- [x] `pnpm --filter @tour-kit/adoption test` → **217 passed (0 failed)**
- [x] `pnpm --filter @tour-kit/adoption typecheck` → clean
- [x] `pnpm --filter @tour-kit/adoption build` → ESM `dist/index.js` 24.75 KB (vs 23.8 KB on main; ~1 KB delta, well under the 2 KB budget)
- [x] `pnpm build --filter='!@tour-kit/docs'` → 17/17 monorepo tasks succeed
- [x] `peerDependencies` snapshot unchanged
- [x] Provider-less render verified (`<AdoptionFunnel>` mounts without `<AdoptionProvider>` wrapper)
- [x] axe-core reports zero violations on the default render
- [x] Docs: new `dashboard/funnel.mdx` + `hooks/use-funnel-data.mdx` (current-state caveat called out)

🤖 Generated with run-phase skill