### PR TITLE
feat(phase-5): @tour-kit/testing-library — RTL helpers with zero consumer act() (#85)

### DIFF
--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -6,6 +6,7 @@
     "nextjs",
     "vite",
     "accessibility",
+    "testing",
     "animations",
     "reduced-motion",
     "branching",

--- a/apps/docs/content/docs/guides/testing.mdx
+++ b/apps/docs/content/docs/guides/testing.mdx
@@ -1,0 +1,158 @@
+---
+title: Testing with React Testing Library
+description: >-
+  Test Tour Kit components with React Testing Library and Vitest under jsdom
+  using @tour-kit/testing-library — zero consumer-side act() boilerplate.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
+
+`@tour-kit/testing-library` packages the Floating UI virtual-element pattern + the `act()` microtask flush behind a small set of helpers, so consumer tests can assert on tour state without re-deriving the pattern every time.
+
+<Callout type="info">
+  The default setup leaves `Element.prototype` untouched. Most teams need nothing more. The optional `positionShim` opt-in lazily loads `jsdom-testing-mocks` only for the rare assertion that depends on a non-zero `getBoundingClientRect`.
+</Callout>
+
+## Install
+
+```bash
+pnpm add -D @tour-kit/testing-library @testing-library/react @testing-library/user-event vitest jsdom
+```
+
+`vitest`, `@testing-library/react`, `@testing-library/user-event`, and `jsdom-testing-mocks` are peer dependencies. `jsdom-testing-mocks` is **optional** — install it only when you opt into `positionShim`.
+
+## Quick start
+
+```ts title="vitest.setup.ts"
+import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { setupTourKitTesting } from '@tour-kit/testing-library/setup'
+
+afterEach(() => {
+  cleanup()
+})
+
+// Default — touches nothing. Opt into positionShim only if needed.
+await setupTourKitTesting()
+```
+
+```tsx title="welcome-tour.test.tsx"
+import { render } from '@testing-library/react'
+import { TourProvider } from '@tour-kit/core'
+import { TourCard } from '@tour-kit/react'
+import {
+  expectStepVisible,
+  advanceTour,
+  completeTour,
+  HookProbe,
+} from '@tour-kit/testing-library'
+import { describe, it } from 'vitest'
+
+const tour = {
+  id: 'demo',
+  steps: [
+    { id: 'welcome', target: '#welcome', title: 'Welcome', content: 'Hi' },
+    { id: 'pricing', target: '#pricing', title: 'Pricing', content: 'Pay' },
+  ],
+}
+
+describe('welcome tour', () => {
+  it('walks through both steps', async () => {
+    render(
+      <>
+        <div id="welcome" />
+        <div id="pricing" />
+        <TourProvider tours={[tour]}>
+          <TourCard />
+          <HookProbe />
+        </TourProvider>
+      </>,
+    )
+
+    // expectStepVisible flushes Floating UI microtasks for you — no `act` needed.
+    await expectStepVisible('welcome')
+    await advanceTour()
+    await expectStepVisible('pricing')
+    await completeTour('demo')
+  })
+})
+```
+
+## Why no `await act(...)`?
+
+Under jsdom, `@floating-ui/react` computes `{ x: 0, y: 0 }` because there is no layout engine. The positioning state still needs a microtask flush before assertions can read it. Every helper in this package wraps that flush:
+
+```ts title="expect-step-visible.ts (excerpt)"
+await act(async () => {}) // Floating UI microtask flush
+return await waitFor(() => container.querySelector(`[data-tour-step="${stepId}"]`))
+```
+
+The headline contract is enforced inside the package's own test suite: every consumer-side `await act(...)` call would fail the build. See [`floating-ui.com/docs/virtual-elements`](https://floating-ui.com/docs/virtual-elements) for the upstream pattern.
+
+## The Floating UI virtual-element pattern
+
+When you DO need to assert against a positioned element directly (for example, a custom floating tooltip you wrote yourself), use `virtualTarget(rect?)`:
+
+```ts
+import { virtualTarget } from '@tour-kit/testing-library'
+
+// Provides a non-zero rect to Floating UI without patching Element.prototype.
+refs.setReference(virtualTarget({ top: 100, left: 200, width: 320, height: 60 }))
+```
+
+The default rect is 200×100 at the origin. Partial overrides merge with the defaults.
+
+## Optional position shim
+
+The default `setupTourKitTesting()` is a no-op — it does not touch `Element.prototype`. If your own assertions need a per-element `getBoundingClientRect` mock, opt in:
+
+```ts
+import { setupTourKitTesting } from '@tour-kit/testing-library/setup'
+
+await setupTourKitTesting({ positionShim: true })
+// Then per-element, in your beforeEach:
+import { mockElementBoundingClientRect } from 'jsdom-testing-mocks'
+
+mockElementBoundingClientRect(myElement, { top: 100, left: 200, width: 320, height: 60 })
+```
+
+The shim is a thin hint: the lazy import guarantees `jsdom-testing-mocks` is loaded; you still apply per-element rects yourself. Consumers who never opt in never pay for the dep.
+
+<Callout type="warn">
+  The package intentionally does **not** ship a global `Element.prototype` patch. Global patches mask drift between test and production positioning math — pick `virtualTarget()` or `mockElementBoundingClientRect()` so each test owns its layout assumptions.
+</Callout>
+
+## Failure context — `TourKitTestingError`
+
+Every helper throws `TourKitTestingError` (extending `Error`) with `stepId`, `tourId`, and a humanized message:
+
+```ts
+try {
+  await expectStepVisible('not-a-step', { timeout: 50 })
+} catch (e) {
+  if (e instanceof TourKitTestingError) {
+    console.log(e.message) // expectStepVisible: step "not-a-step" not visible within 50ms
+    console.log(e.stepId)  // "not-a-step"
+    console.log(e.cause)   // original RTL waitFor error
+  }
+}
+```
+
+## Helper reference
+
+| Helper | What it does |
+|--------|--------------|
+| `expectStepVisible(stepId, opts?)` | Resolves with the `[data-tour-step="<id>"]` element once it mounts. |
+| `advanceTour(opts?)` | Clicks **Next/Finish/Done**. Pass `steps: n` to click `n` times. |
+| `previousTour(opts?)` | Clicks **Previous/Back**. |
+| `skipTour(opts?)` | Clicks **Skip**. |
+| `completeTour(tourId, opts?)` | Clicks **Next** until the tour ends or the deadline elapses. |
+| `goToStep(stepId)` | Jumps to a non-adjacent step. Requires `<HookProbe />` in the provider tree. |
+| `virtualTarget(rect?, contextElement?)` | Returns a Floating UI virtual element with a merged DOMRect. |
+| `setupTourKitTesting(opts?)` | One-shot orchestrator; default touches nothing, `positionShim: true` lazy-loads `jsdom-testing-mocks`. |
+
+## Browser-positioning tests live elsewhere
+
+This package asserts on **presence** — "did the step mount?", "did Next advance?" — not **position**. For pixel-perfect placement assertions, use Playwright via [`@tour-kit/playwright`](./nextjs#end-to-end-with-playwright) (Phase 6). Phase 5 helpers stop at the jsdom boundary by design.

--- a/apps/docs/content/docs/guides/testing.mdx
+++ b/apps/docs/content/docs/guides/testing.mdx
@@ -39,8 +39,9 @@ await setupTourKitTesting()
 ```
 
 ```tsx title="welcome-tour.test.tsx"
+import * as React from 'react'
 import { render } from '@testing-library/react'
-import { TourProvider } from '@tour-kit/core'
+import { TourProvider, useTour } from '@tour-kit/core'
 import { TourCard } from '@tour-kit/react'
 import {
   expectStepVisible,
@@ -58,6 +59,19 @@ const tour = {
   ],
 }
 
+// <TourProvider> is inactive by default. Mount this tiny helper inside the
+// provider to start the tour on mount — or click your own "Start" button.
+function AutoStart({ id }: { id: string }) {
+  const { start } = useTour()
+  const started = React.useRef(false)
+  React.useEffect(() => {
+    if (started.current) return
+    started.current = true
+    start(id)
+  }, [])
+  return null
+}
+
 describe('welcome tour', () => {
   it('walks through both steps', async () => {
     render(
@@ -65,6 +79,7 @@ describe('welcome tour', () => {
         <div id="welcome" />
         <div id="pricing" />
         <TourProvider tours={[tour]}>
+          <AutoStart id="demo" />
           <TourCard />
           <HookProbe />
         </TourProvider>
@@ -79,6 +94,10 @@ describe('welcome tour', () => {
   })
 })
 ```
+
+<Callout type="warn">
+  `<TourProvider>` doesn't auto-start. Either render a helper component that calls `useTour().start(id)` on mount (as above), or wire your own "Start tour" button. `expectStepVisible` will time out otherwise — the card only mounts once the tour is active.
+</Callout>
 
 ## Why no `await act(...)`?
 

--- a/apps/docs/public/context/adoption.txt
+++ b/apps/docs/public/context/adoption.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/adoption Context File
-Version: 1.0.2 | Generated: 2026-05-06
+Version: 1.0.2 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/adoption.
 =========================================================================
 
@@ -42,6 +42,8 @@ Types:
     FeatureUsage
     AdoptionStatus
     FeatureWithUsage
+    FunnelStep
+    AdoptionFunnelProps
     StorageConfig
     NudgeConfig
     AdoptionProviderProps
@@ -59,12 +61,14 @@ Hooks:
     useFeature — Feature definition
     useAdoptionStats — All features with their usage data
     useNudge — Features that should be nudged
+    useFunnelData — Feature IDs in funnel order.
     useUILibrary
     useAdoptionAnalytics
 
 Components:
     AdoptionProvider
     AdoptionStats
+    UseFunnelDataInput
     AdoptionNudge
     FeatureButton
     IfNotAdopted
@@ -161,6 +165,13 @@ TYPES
       handleNudgeClick: (featureId: string) => void
     }
 
+    export interface UseFunnelDataInput {
+      /** Feature IDs in funnel order. */
+      featureIds: readonly string[]
+      /** Optional label overrides keyed by feature id. */
+      labels?: Partial<Record<string, string>>
+    }
+
     export interface NudgeRenderProps {
       feature: Feature
       onDismiss: () => void
@@ -240,6 +251,7 @@ HOOKS
     useFeature(featureId: string): UseFeatureReturn
     useAdoptionStats(): AdoptionStats
     useNudge(): UseNudgeReturn
+    useFunnelData({ featureIds, labels }: UseFunnelDataInput): FunnelStep[]
     useUILibrary(...)
     useAdoptionAnalytics(...)
 
@@ -247,6 +259,7 @@ COMPONENTS
 ----------
     <AdoptionProvider />
     <AdoptionStats />
+    <UseFunnelDataInput />
     <AdoptionNudge />
     <FeatureButton />
     <IfNotAdopted />

--- a/apps/docs/public/context/analytics.txt
+++ b/apps/docs/public/context/analytics.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/analytics Context File
-Version: 0.9.2 | Generated: 2026-05-06
+Version: 0.9.2 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/analytics.
 =========================================================================
 

--- a/apps/docs/public/context/announcements.txt
+++ b/apps/docs/public/context/announcements.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/announcements Context File
-Version: 1.2.0 | Generated: 2026-05-06
+Version: 1.2.0 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/announcements.
 =========================================================================
 

--- a/apps/docs/public/context/checklists.txt
+++ b/apps/docs/public/context/checklists.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/checklists Context File
-Version: 0.11.0 | Generated: 2026-05-06
+Version: 0.11.0 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/checklists.
 =========================================================================
 

--- a/apps/docs/public/context/core.txt
+++ b/apps/docs/public/context/core.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/core Context File
-Version: 0.11.0 | Generated: 2026-05-06
+Version: 0.11.0 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/core.
 =========================================================================
 
@@ -16,6 +16,7 @@ INSTALLATION
 Peer dependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
+    zod: ^3.25.0 || ^4.0.0
 
 EXPORTS
 -------
@@ -48,6 +49,7 @@ Types:
     TourKitConfig
     TourStep
     StepOptions
+    StepIdOf
     AudienceProp
     TourStepMedia
     Tour
@@ -94,6 +96,12 @@ Types:
     Messages
     TranslateFn
     AudienceCondition
+    DiagnosticContext
+    DiagnosticGate
+    EligibilityReport
+    GateCode
+    GateName
+    GateReason
     FrequencyRule
     FrequencyState
     LocalizedText
@@ -126,6 +134,7 @@ Hooks:
     useUILibrary — Hook to get the current UI library setting
     useLocale
     useT — Hook returning a translator function `t(key, vars?)` that:
+    useTourDiagnostic — Read the diagnostic report for a given tour id. Returns `null` when the
     useResolveLocalizedText — Returns a memoized resolver `(value) => string` that takes a `LocalizedText`
     useSegmentationContext
     useSegment
@@ -141,6 +150,7 @@ Components:
     UnifiedSlot
     UILibraryProvider
     LocaleProvider
+    BUILTIN_GATE_ORDER
     SegmentationProvider
 
 Utilities:
@@ -205,8 +215,10 @@ Utilities:
     validateTour
     waitForStepTarget
     interpolate
+    explainAudience
     matchesAudience
     validateConditions
+    explainTour
     canShowByFrequency
     canShowAfterDismissal
     getViewLimit
@@ -297,49 +309,65 @@ TYPES
       value?: unknown
     }
 
+    export interface EligibilityReport {
+      tourId: string
+      willFire: boolean
+      reasons: GateReason[]
+      firstFailingGate: Extract<GateReason, { ok: false }> | null
+      evaluatedAt: number
+    }
+
+    export interface DiagnosticContext {
+      userContext?: Record<string, unknown>
+      completedTours: readonly string[]
+      skippedTours: readonly string[]
+      schedule?: { from?: Date; to?: Date }
+      route?: {
+        current: string
+        matcher: string
+        mode: 'exact' | 'startsWith' | 'contains'
+      }
+      targetResolver?: (selector: string) => HTMLElement | null
+    }
+
+    export interface DiagnosticGate {
+      /** Stable identifier, e.g. 'license', 'scheduling', 'audience'. */
+      id: string
+      /** Run synchronously OR async. May throw — orchestrator captures the error. */
+      evaluate: (ctx: DiagnosticContext) => GateReason | Promise<GateReason>
+    }
+
     /**
-     * Frequency rules — promoted from `@tour-kit/announcements` in Phase 3a of the
-     * UserGuiding parity initiative. Re-exported from `@tour-kit/announcements`
-     * with `@deprecated` JSDoc for backward compat.
+     * Diagnostic engine types — Phase 3 (full surface).
+     *
+     * The `EligibilityReport` is what `explainTour` produces and
+     * `useTourDiagnostic` exposes. The `DiagnosticGate` interface is the
+     * extension contract — upper packages (`@tour-kit/license`,
+     * `@tour-kit/scheduling`, etc.) implement it WITHOUT this package importing
+     * any of them. Hard rule: `@tour-kit/core` sits at the bottom of the
+     * dependency graph; never `import { ... } from '@tour-kit/<anything>'` here.
      */
     
     /**
-     * How often a UI surface (announcement, hint, tour) can be shown.
-     *
-     *   - `'once'`     — show only when never viewed
-     *   - `'session'`  — show until dismissed in the current session
-     *   - `'always'`   — show every time conditions are met
-     *   - `{ type: 'times', count }
+     * Canonical failure codes. The `(string & {})` escape hatch keeps
+     * literal-union autocomplete for built-ins while allowing extension gates to
+     * surface their own codes (`'LICENSE_INVALID'`, `'OUT_OF_WINDOW'`, ...).
+     */
+    export type GateCode =
+      | 'STRUCTURE_INVALID'
+      | 'AUDIENCE_MISMATCH'
+      | 'ALREADY_COMPLETED'
+      | 'ALREADY_SKIPPED'
+      | 'OUT_OF_WINDOW'
+      | 'LICENSE_INVALID'
+      | 'LICENSE_EXPIRED'
+      | 'TARGET_NOT_FOUND'
+      | 'WHEN_RETURNED_FALSE'
+      | 'ROUTE_MISMATCH'
+      | 'AUTOSTART_DISABLED'
+      | (string & {})
 
-    /**
-     * Frequency rules — promoted from `@tour-kit/announcements` in Phase 3a of the
-     * UserGuiding parity initiative. Re-exported from `@tour-kit/announcements`
-     * with `@deprecated` JSDoc for backward compat.
-     */
-    
-    /**
-     * How often a UI surface (announcement, hint, tour) can be shown.
-     *
-     *   - `'once'`     — show only when never viewed
-     *   - `'session'`  — show until dismissed in the current session
-     *   - `'always'`   — show every time conditions are met
-     *   - `{ type: 'times', count }`     — show up to `count` times total
-     *   - `{ type: 'interval', days }`   — re-show after `days` days have passed
-     */
-    export type FrequencyRule =
-      | 'once'
-      | 'session'
-      | 'always'
-      | { type: 'times';
-
-    /**
-     * `LocalizedText` is the shared shape for any human-readable string that
-     * may either be a literal (interpolated via `interpolate`) or a dictionary
-     * key (resolved via `useT()`). The discriminated union narrows on
-     * `typeof === 'string'`, so existing string-based consumers stay assignable
-     * — adding the object branch is a pure widening.
-     */
-    export type LocalizedText = string | { key: string }
+    ... and 5 more types. See source for full definitions.
 
 HOOKS
 -----
@@ -365,6 +393,7 @@ HOOKS
     useUILibrary(): UILibrary
     useLocale(): LocaleContextValue
     useT(): TranslateFn
+    useTourDiagnostic(tourId: string): EligibilityReport | null
     useResolveLocalizedText(): (value: LocalizedText | undefined) => string
     useSegmentationContext(...)
     useSegment(...)
@@ -381,46 +410,57 @@ COMPONENTS
     <UnifiedSlot />
     <UILibraryProvider />
     <LocaleProvider />
+    <BUILTIN_GATE_ORDER />
     <SegmentationProvider />
 
 EXAMPLES
 --------
 
-Example 1: Usage
+Example 1: `<TourProvider diagnose>`
 
-    import { TourKitProvider } from '@tour-kit/core';
+    import { TourProvider, useTourDiagnostic } from '@tour-kit/core'
     
-    function App() {
+    export function App() {
       return (
-        <TourKitProvider>
+        <TourProvider tours={[myTour]} diagnose userContext={{ plan: 'pro' }}>
+          <DebugPanel />
           <YourApp />
-        </TourKitProvider>
-      );
+        </TourProvider>
+      )
+    }
+    
+    function DebugPanel() {
+      const report = useTourDiagnostic('my-tour')
+      if (!report) return null
+      return (
+        <pre>{JSON.stringify(report, null, 2)}</pre>
+      )
     }
 
-Example 2: With Global Config
+Example 2: `EligibilityReport` shape
 
-    <TourKitProvider
-      defaultConfig={{
-        keyboard: true,
-        spotlight: {
-          padding: 8,
-        },
-      }}
-      persistence={{
-        strategy: 'localStorage',
-        key: 'tour-kit-state',
-      }}
-    >
-      <App />
-    </TourKitProvider>
+    interface EligibilityReport {
+      tourId: string
+      willFire: boolean
+      reasons: GateReason[]
+      firstFailingGate: Extract<GateReason, { ok: false }> | null
+      evaluatedAt: number
+    }
 
-Example 3: Multiple Tours
+Example 3: Extension gates
 
-    <TourKitProvider>
-      <TourProvider tour={onboardingTour}>
-        <TourProvider tour={featureTour}>
-          <App />
-        </TourProvider>
-      </TourProvider>
-    </TourKitProvider>
+    import type { DiagnosticGate } from '@tour-kit/core'
+    
+    const licenseGate: DiagnosticGate = {
+      id: 'license',
+      evaluate: async (ctx) => {
+        const ok = await checkLicense(ctx.userContext)
+        return ok
+          ? { ok: true, gate: 'license' }
+          : { ok: false, gate: 'license', code: 'LICENSE_INVALID', message: 'License invalid', detail: {} }
+      },
+    }
+    
+    <TourProvider tours={tours} diagnose diagnosticGates={[licenseGate]}>
+      ...
+    </TourProvider>

--- a/apps/docs/public/context/hints.txt
+++ b/apps/docs/public/context/hints.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/hints Context File
-Version: 0.11.0 | Generated: 2026-05-06
+Version: 0.11.0 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/hints.
 =========================================================================
 

--- a/apps/docs/public/context/media.txt
+++ b/apps/docs/public/context/media.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/media Context File
-Version: 0.11.0 | Generated: 2026-05-06
+Version: 0.11.0 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/media.
 =========================================================================
 

--- a/apps/docs/public/context/react.txt
+++ b/apps/docs/public/context/react.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/react Context File
-Version: 0.11.0 | Generated: 2026-05-06
+Version: 0.11.0 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/react.
 =========================================================================
 
@@ -52,6 +52,12 @@ Types:
     TourInfo
     UseToursReturn
     UseThemeVariationReturn
+    DiagnosticContext
+    DiagnosticGate
+    EligibilityReport
+    GateCode
+    GateName
+    GateReason
     // Config types
   Side
     Alignment
@@ -119,6 +125,7 @@ Hooks:
     useMediaQuery
     usePrefersReducedMotion
     useBranch
+    useTourDiagnostic
 
 Components:
     Tour
@@ -151,6 +158,7 @@ Components:
     TourProvider
     TourKitContext
     TourKitProvider
+    BUILTIN_GATE_ORDER
 
 Utilities:
     resolveTheme
@@ -171,6 +179,8 @@ Utilities:
     createNextAppRouterAdapter
     createNextPagesRouterAdapter
     createReactRouterAdapter
+    explainAudience
+    explainTour
     createTour
     createStep
     waitForElement
@@ -358,6 +368,7 @@ HOOKS
     useMediaQuery(...)
     usePrefersReducedMotion(...)
     useBranch(...)
+    useTourDiagnostic(...)
 
 COMPONENTS
 ----------
@@ -391,6 +402,7 @@ COMPONENTS
     <TourProvider />
     <TourKitContext />
     <TourKitProvider />
+    <BUILTIN_GATE_ORDER />
 
 EXAMPLES
 --------

--- a/apps/docs/public/context/scheduling.txt
+++ b/apps/docs/public/context/scheduling.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/scheduling Context File
-Version: 0.9.0 | Generated: 2026-05-06
+Version: 0.9.0 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/scheduling.
 =========================================================================
 

--- a/apps/docs/public/context/surveys.txt
+++ b/apps/docs/public/context/surveys.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/surveys Context File
-Version: 1.2.0 | Generated: 2026-05-06
+Version: 1.2.0 | Generated: 2026-05-13
 Paste this into your LLM to get accurate answers about @tour-kit/surveys.
 =========================================================================
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -1,4 +1,4 @@
-# userTourKit v0.11.0 — Generated 2026-05-06T13:46:25Z
+# userTourKit v0.11.0 — Generated 2026-05-13T07:39:18Z
 
 # Feature Adoption Tracking
 
@@ -3021,6 +3021,172 @@ import { AdoptionStatusBadge } from '@tour-kit/adoption'
 
 ---
 
+# Adoption Funnel
+
+> Step-by-step adoption funnel with drop-off percentages — Pendo/Userpilot parity, native CSS, no chart peer dependency.
+
+`<AdoptionFunnel>` renders a vertical funnel chart with retention and
+drop-off between adjacent steps. It is **data-first**: hand it pre-computed
+`steps` and it works without any provider. Inside an
+`<AdoptionProvider>`, pair it with `useFunnelData({ featureIds })` for a
+one-line in-provider integration.
+
+## Provider-less Usage (Recommended)
+
+Compute funnel data from your analytics layer and pass it in directly:
+
+```tsx
+import { AdoptionFunnel } from '@tour-kit/adoption'
+import '@tour-kit/adoption/styles/funnel.css'
+
+const steps = [
+  { id: 'view', label: 'Viewed', entered: 1000, completed: 720 },
+  { id: 'click', label: 'Clicked CTA', entered: 720, completed: 380 },
+  { id: 'signup', label: 'Signed Up', entered: 380, completed: 240 },
+]
+
+<AdoptionFunnel
+  steps={steps}
+  title="Sign-up funnel"
+  onStepClick={(step, index) => console.log('drilldown:', step, index)}
+/>
+```
+
+This path needs no provider, so the funnel can live in any tree —
+admin dashboards, server-rendered reports, etc.
+
+## In-provider Usage with `useFunnelData`
+
+```tsx
+import {
+  AdoptionFunnel,
+  AdoptionProvider,
+  useFunnelData,
+} from '@tour-kit/adoption'
+
+function OnboardingFunnel() {
+  const steps = useFunnelData({
+    featureIds: ['view-pricing', 'start-trial', 'invite-team'],
+    labels: {
+      'view-pricing': 'Viewed Pricing',
+      'start-trial': 'Started Trial',
+      'invite-team': 'Invited Team',
+    },
+  })
+  return <AdoptionFunnel steps={steps} title="Activation funnel" />
+}
+
+<AdoptionProvider features={features}>
+  <OnboardingFunnel />
+</AdoptionProvider>
+```
+
+## `<AdoptionFunnel>` Props
+
+<TypeTable
+  type={{
+    steps: {
+      type: 'readonly FunnelStep[]',
+      required: true,
+      description: 'Pre-computed funnel data in display order.',
+    },
+    title: {
+      type: 'React.ReactNode',
+      description: 'Optional header rendered above the bars.',
+    },
+    onStepClick: {
+      type: '(step: FunnelStep, index: number) => void',
+      description:
+        'Click/keyboard activation handler. Steps become focusable (role="button", tabIndex=0) when provided; Enter and Space both fire the callback.',
+    },
+    emptyState: {
+      type: 'React.ReactNode',
+      description:
+        'Replaces the default "No funnel data yet." message when `steps` is empty.',
+    },
+    ariaLabel: {
+      type: 'string',
+      description:
+        'Overrides the auto-generated summary on the `role="img"` chart element.',
+    },
+    className: {
+      type: 'string',
+      description: 'Extra class merged onto the root.',
+    },
+  }}
+/>
+
+## `FunnelStep` Shape
+
+## `useFunnelData` Input/Output
+
+<TypeTable
+  type={{
+    featureIds: {
+      type: 'readonly string[]',
+      required: true,
+      description: 'Feature IDs in funnel order.',
+    },
+    labels: {
+      type: 'Partial<Record<string, string>>',
+      description:
+        'Override the visible label per feature ID. Falls back to `feature.name` then the raw id.',
+    },
+  }}
+/>
+
+Returns `FunnelStep[]` ready to pass to `<AdoptionFunnel steps={...}>`. The
+source data is in-memory and synchronous, so the hook returns the steps
+directly — no `loading`/`error` envelope.
+
+## Accessibility
+
+- The chart is exposed to assistive tech as a single `role="img"` element with
+  an auto-generated `aria-label` summarizing the funnel
+  (`Adoption funnel: 100 → 60 → 30, 30% end-to-end retention`). Override via
+  the `ariaLabel` prop.
+- Each bar carries `aria-hidden="true"` — screen readers receive the same
+  numbers through a visually-hidden `<table>` mirror placed alongside the
+  visual list.
+- Clickable steps are keyboard-activatable. **Enter** and **Space** both
+  fire `onStepClick`; tab order matches visual order.
+- Honors `prefers-reduced-motion: reduce` — the hover-transition is disabled
+  under the OS preference. See the
+  [reduced-motion guide](/docs/guides/reduced-motion).
+
+## Styling
+
+Import the base stylesheet once at your app root:
+
+```ts
+import '@tour-kit/adoption/styles/funnel.css'
+```
+
+CSS custom properties for theming:
+
+```css
+:root {
+  --tour-funnel-gap: 0.5rem;
+  --tour-funnel-step-gap: 0.5rem;
+  --tour-funnel-bar-bg: hsl(220 90% 56%);
+  --tour-funnel-bar-fg: #fff;
+  --tour-funnel-retention-fg: hsl(0 0% 40%);
+  --tour-funnel-step-hover: rgba(0, 0, 0, 0.04);
+  --tour-funnel-focus-ring: hsl(220 90% 56%);
+}
+```
+
+## Next Steps
+
+- [AdoptionDashboard](/docs/adoption/dashboard/adoption-dashboard) — full
+  dashboard component
+- [useAdoptionStats](/docs/adoption/hooks/use-adoption-stats) — underlying
+  per-feature stats hook
+- [Reduced-motion guide](/docs/guides/reduced-motion) — cross-package
+  motion contract
+
+---
+
 # Stat Cards
 
 > AdoptionStatCard and AdoptionStatsGrid: display aggregate adoption metrics with trend indicators and percentage changes
@@ -4433,6 +4599,83 @@ onChange={(e) => {
 - [useAdoptionStats Hook](/docs/adoption/hooks/use-adoption-stats) - Aggregate adoption metrics
 - [IfNotAdopted Component](/docs/adoption/components/conditional) - Conditional rendering based on adoption
 - [Analytics Integration](/docs/adoption/analytics) - Track adoption events automatically
+
+---
+
+# useFunnelData
+
+> Derive a current-state adoption funnel from useAdoptionStats — feed straight into AdoptionFunnel.
+
+`useFunnelData` is a convenience selector that projects the current user's
+adoption state — read via `useAdoptionStats` — into a `FunnelStep[]` ready
+to hand to `<AdoptionFunnel>`. Must be used inside `<AdoptionProvider>`.
+
+## Usage
+
+```tsx
+import {
+  AdoptionFunnel,
+  AdoptionProvider,
+  useFunnelData,
+} from '@tour-kit/adoption'
+
+function ActivationFunnel() {
+  const steps = useFunnelData({
+    featureIds: ['view-pricing', 'start-trial', 'invite-team'],
+    labels: {
+      'view-pricing': 'Viewed Pricing',
+      'start-trial': 'Started Trial',
+      'invite-team': 'Invited Team',
+    },
+  })
+  return <AdoptionFunnel steps={steps} title="Activation funnel" />
+}
+
+<AdoptionProvider features={features}>
+  <ActivationFunnel />
+</AdoptionProvider>
+```
+
+## Input
+
+<TypeTable
+  type={{
+    featureIds: {
+      type: 'readonly string[]',
+      required: true,
+      description: 'Feature IDs in funnel order.',
+    },
+    labels: {
+      type: 'Partial<Record<string, string>>',
+      description:
+        'Override the visible label per feature ID. Falls back to `feature.name`, then the raw id.',
+    },
+  }}
+/>
+
+## Output
+
+Returns `FunnelStep[]` directly — one step per `featureIds` entry, in input
+order. Pass straight to `<AdoptionFunnel steps={...}>`.
+
+## Mapping Semantics
+
+For each `featureIds[i]`, the hook reads the matching `FeatureWithUsage`
+from `useAdoptionStats()` and produces:
+
+- `entered` = `usage.useCount` — number of times the current user has touched
+  the feature.
+- `completed` = `usage.useCount` when `usage.status === 'adopted'`, else `0` —
+  100% per-user conversion once adopted; 0% before.
+
+Unknown feature IDs (no matching feature in the provider) get
+`entered: 0, completed: 0`.
+
+## See Also
+
+- [`<AdoptionFunnel>`](/docs/adoption/dashboard/funnel) — the consumer component
+- [`useAdoptionStats`](/docs/adoption/hooks/use-adoption-stats) — underlying
+  current-state stats hook
 
 ---
 
@@ -27384,6 +27627,140 @@ This package provides:
 
 ---
 
+# Diagnostic Engine
+
+> Replace the silent "tour didn't fire" failure mode with a structured `EligibilityReport` that names every gate's outcome.
+
+The diagnostic engine produces an `EligibilityReport` for every registered
+tour explaining whether it will fire — and, when it won't, exactly which gate
+rejected it. Opt in via `<TourProvider diagnose>` and read the result with
+`useTourDiagnostic(tourId)`.
+
+## Why diagnostics exist
+
+The most-asked support question on this repo is *"my tour did not fire and I
+have no idea why."* Before the diagnostic engine you had to grep through
+audience filters, route adapters, persistence stores, and license keys to
+guess. Now the provider runs all seven built-in gates plus any extension gates
+you registered, and the report names the first one that said no.
+
+## `<TourProvider diagnose>`
+
+```tsx
+import { TourProvider, useTourDiagnostic } from '@tour-kit/core'
+
+export function App() {
+  return (
+    <TourProvider tours={[myTour]} diagnose userContext={{ plan: 'pro' }}>
+      <DebugPanel />
+      <YourApp />
+    </TourProvider>
+  )
+}
+
+function DebugPanel() {
+  const report = useTourDiagnostic('my-tour')
+  if (!report) return null
+  return (
+    <pre>{JSON.stringify(report, null, 2)}</pre>
+  )
+}
+```
+
+The hook returns:
+
+- `null` when `diagnose` is off, the tour id is unknown, or the diagnostic
+  effect hasn't resolved yet
+- `EligibilityReport` once the orchestrator finishes
+
+## `EligibilityReport` shape
+
+```ts
+interface EligibilityReport {
+  tourId: string
+  willFire: boolean
+  reasons: GateReason[]
+  firstFailingGate: Extract<GateReason, { ok: false }> | null
+  evaluatedAt: number
+}
+```
+
+`reasons[]` is always populated for every built-in gate (in fixed order) plus
+your extension gates. `firstFailingGate` is a convenience — the first
+`ok: false` reason in evaluation order, or `null` when `willFire` is true.
+
+## Built-in gates
+
+Evaluated in this exact order — the contract is observable and tests pin it:
+
+| Order | Gate | Failure code | When it fires |
+|-------|------|--------------|---------------|
+| 1 | `structure` | `STRUCTURE_INVALID` | Tour has no steps, or `validateTour` threw |
+| 2 | `audience` | `AUDIENCE_MISMATCH` | Audience filter rejected the user. `detail.failingCondition` (array form) or `detail.segment` (object form) names the failing piece |
+| 3 | `persistence` | `ALREADY_COMPLETED` / `ALREADY_SKIPPED` | Tour id is in `completedTours` / `skippedTours` |
+| 4 | `route` | `ROUTE_MISMATCH` | Current route does not match the configured matcher under the chosen mode |
+| 5 | `target` | `TARGET_NOT_FOUND` | The first visible step's selector returned no element |
+| 6 | `when` | `WHEN_RETURNED_FALSE` | Tour-level `when()` returned `false` or threw |
+| 7 | `autostart` | `AUTOSTART_DISABLED` | `tour.autoStart === false` |
+
+## Extension gates
+
+License, scheduling, or any custom gate plugs in via `diagnosticGates`. The
+contract is `DiagnosticGate` — `@tour-kit/core` does not import the package
+implementing it.
+
+```tsx
+import type { DiagnosticGate } from '@tour-kit/core'
+
+const licenseGate: DiagnosticGate = {
+  id: 'license',
+  evaluate: async (ctx) => {
+    const ok = await checkLicense(ctx.userContext)
+    return ok
+      ? { ok: true, gate: 'license' }
+      : { ok: false, gate: 'license', code: 'LICENSE_INVALID', message: 'License invalid', detail: {} }
+  },
+}
+
+<TourProvider tours={tours} diagnose diagnosticGates={[licenseGate]}>
+  ...
+</TourProvider>
+```
+
+Rules:
+
+- Extensions run **after** every built-in gate, in registration order
+- Extensions may be async; built-ins are sync
+- A throwing extension is caught — the orchestrator inserts a synthetic
+  `{ ok: false, gate: id, code: '${ID}_THREW' }` reason and keeps going
+- `firstFailingGate` only points at an extension when no built-in failed first
+
+## `explainTour` (advanced)
+
+The orchestrator is also exported for non-React callers:
+
+```ts
+import { explainTour } from '@tour-kit/core'
+
+const report = await explainTour(myTour, {
+  completedTours: [],
+  skippedTours: [],
+  userContext: { plan: 'pro' },
+  targetResolver: (sel) => document.querySelector(sel),
+})
+```
+
+`explainTour` never throws. Internal errors land in the structure gate or, for
+extensions, as `_THREW` reasons.
+
+## Performance & bundle cost
+
+- Median **&lt;0.001ms** per call over 100 iterations (5-step tour, no extensions)
+- With `diagnose: false` the diagnostic module tree-shakes out of the consumer
+  bundle. The size-limit budget asserts this.
+
+---
+
 # useAdvanceOn
 
 > useAdvanceOn hook: automatically advance tour steps when users click buttons, submit forms, or interact with elements
@@ -29293,6 +29670,163 @@ function App() {
   <App />
 </TourProvider>
 ```
+
+---
+
+# Schemas
+
+> Runtime Zod validation for JSON-authorable tour definitions — load tours from CMS, JSON files, or MDX frontmatter without bloating your main bundle.
+
+The `@tour-kit/core/schemas` subpath ships Zod schemas plus `parseTourDefinition`
+and `safeParseTourDefinition` helpers for validating a JSON-safe subset of
+`Tour` at runtime. Use it when tours come from a CMS, a JSON file, or any
+boundary where you can't trust the shape at compile time.
+
+## Installation
+
+`zod` is an **optional peer dependency**. Install it only if you validate.
+
+```bash
+pnpm add @tour-kit/core zod
+```
+
+The package declares `zod` as `^3.25.0 || ^4.0.0` (the canonical dual-major peer
+range — Zod 4 ships at the root of `zod@^4.x` and at the `zod/v4` subpath
+inside `zod@^3.25.0`). Use the root `import { z } from 'zod'` in new code.
+
+## Quick start
+
+```ts
+import { parseTourDefinition } from '@tour-kit/core/schemas'
+
+// JSON from a CMS, file, or MDX frontmatter
+const payload = await fetch('/api/tours/onboarding').then((r) => r.json())
+
+// Throws ZodError on bad input
+const definition = parseTourDefinition(payload)
+
+// Attach runtime-only fields (refs, callbacks) before handing to TourProvider
+const tour = {
+  ...definition,
+  onComplete: () => analytics.track('tour.complete', { id: definition.id }),
+}
+```
+
+## API
+
+### `parseTourDefinition(input)`
+
+Throws `ZodError` on invalid input. Returns a `TourDefinition`.
+
+```ts
+import { parseTourDefinition } from '@tour-kit/core/schemas'
+
+const t = parseTourDefinition({
+  id: 'demo',
+  steps: [{ id: 's1', target: '#welcome', content: 'Welcome!' }],
+})
+```
+
+### `safeParseTourDefinition(input)`
+
+Non-throwing variant. Returns Zod's tagged union — useful when you want to
+surface a friendly error UI instead of catching exceptions:
+
+```ts
+const result = safeParseTourDefinition(payload)
+if (!result.success) {
+  console.error(result.error.issues)
+  return
+}
+const tour = result.data
+```
+
+### `createTourStepDefinitionSchema({ contentSchema })`
+
+Build a stricter **step** schema where `content` is validated by your own Zod
+schema. Returns a step-level schema — wrap it in `z.array(...).min(1)` and feed
+it to a custom tour schema if you want a full validation pipeline. Useful for
+CMS payloads with typed content blocks:
+
+```ts
+import { z } from 'zod'
+import { createTourStepDefinitionSchema } from '@tour-kit/core/schemas'
+
+const TextBlock = z.object({ kind: z.literal('text'), value: z.string() })
+const stepSchema = createTourStepDefinitionSchema({ contentSchema: TextBlock })
+
+stepSchema.parse({
+  id: 'welcome',
+  target: '#hero',
+  content: { kind: 'text', value: 'Hi there!' },
+})
+```
+
+## Schemas re-exported
+
+| Export | Description |
+|--------|-------------|
+| `tourDefinitionSchema` | Top-level tour shape — `{ id, steps, audience?, autoStart?, startAt? }` |
+| `tourStepDefinitionSchema` | Single step — `{ id, target, content, … }` |
+| `audienceSchema` | Discriminated union — `AudienceConditionDefinition[] \| { segment: string }` |
+| `audienceConditionSchema` | One audience condition — `{ key, operator, value? }` |
+| `flowSourceSchema` | Multi-tour container — `{ tours: TourDefinition[] }` |
+
+## Types
+
+The package also re-exports the matching TypeScript types from
+`@tour-kit/core/schemas`:
+
+- `TourDefinition`
+- `TourStepDefinition`
+- `AudienceDefinition`
+- `AudienceConditionDefinition`
+- `JsonValue`
+
+These are hand-authored interfaces, not `z.infer<…>` aliases — Zod 3's inferred
+types occasionally surface internal helper types in tooling, and the hand-authored
+shapes read better in IDE hovers. A compile-time parity test guarantees the
+hand-authored types and the schema's inferred keys stay in sync.
+
+## Example: CMS payload → TourProvider
+
+```tsx
+import { TourProvider } from '@tour-kit/core'
+import { parseTourDefinition } from '@tour-kit/core/schemas'
+
+async function loadTour(slug: string) {
+  const payload = await fetch(`/api/cms/tours/${slug}`).then((r) => r.json())
+  const definition = parseTourDefinition(payload)
+
+  // Attach runtime-only callbacks
+  return {
+    ...definition,
+    onComplete: () => analytics.track('tour.complete'),
+    onSkip: () => analytics.track('tour.skip'),
+  }
+}
+
+export function App({ tour }: { tour: Awaited<ReturnType<typeof loadTour>> }) {
+  return (
+    <TourProvider tour={tour}>
+      {/* … */}
+    </TourProvider>
+  )
+}
+```
+
+## Bundle-size guarantee
+
+Both the main entry and the schemas subpath have CI-enforced size budgets:
+
+| Entry | Budget | Today |
+|-------|--------|-------|
+| `@tour-kit/core` (main) | ≤ 24 KB brotlied | ~23 KB |
+| `@tour-kit/core/schemas` | ≤ 12 KB brotlied (excl. zod) | < 1 KB |
+
+The schemas bundle stays tiny because `zod` is `external` in `tsup` — the
+consumer pulls Zod from their own `node_modules`, not from us. The size-limit
+entry ignores `zod` to measure only the code we ship.
 
 ---
 
@@ -33784,6 +34318,82 @@ function MyComponent() {
   // tour.start, tour.next, tour.prev, etc.
 }
 ```
+
+## Typed Step IDs
+
+userTourKit ships generic `TourStep<TId>` and `Tour<TStep>` so that const-authored tours catch misspelled step ids at compile time. The default is `TId extends string = string`, so dynamic tours (server-fetched, JIT-built) keep working without any changes.
+
+### Const-tuple narrowing (recommended)
+
+Author your steps as a `const` tuple with `satisfies` and feed them to `StepIdOf` to derive the literal union:
+
+```tsx
+import { useTour } from '@tour-kit/react';
+import type { StepIdOf, TourStep } from '@tour-kit/react';
+
+const steps = [
+  { id: 'welcome', target: '#hero', content: 'Welcome' },
+  { id: 'pricing', target: '#pricing', content: 'Pricing' },
+] as const satisfies ReadonlyArray<TourStep>;
+
+type StepId = StepIdOf<typeof steps>;
+// StepId = 'welcome' | 'pricing'
+
+function MyComponent() {
+  const tour = useTour<(typeof steps)[number]>();
+
+  // ✅ Compiles
+  tour.goToStep('welcome');
+
+  // ❌ Type error: Argument of type '"biling"' is not assignable...
+  tour.goToStep('biling');
+}
+```
+
+The same narrowing applies to `startTour(tourId, stepId?)`:
+
+```tsx
+tour.startTour('onboarding', 'welcome'); // ✅
+tour.startTour('onboarding', 0);         // ✅ numeric index escape hatch
+tour.startTour('onboarding', 'biling');  // ❌ unknown step id
+```
+
+### Dynamic tours (server-fetched JSON)
+
+When step ids aren't known at compile time, omit the generic — the default `TourStep` widens id back to `string`:
+
+```tsx
+import type { Tour, TourStep } from '@tour-kit/react';
+
+// Server returns arbitrary tour JSON
+const dynamicSteps: TourStep[] = await fetch('/api/tour').then((r) => r.json());
+
+const dynamic: Tour = { id: 'dynamic', steps: dynamicSteps };
+// dynamic.steps[0].id is `string` — no narrowing applied
+```
+
+If you want the widening to be explicit in your type signatures, pass `TourStep<string>` directly:
+
+```tsx
+const widened: Tour<TourStep<string>> = dynamic;
+```
+
+### Narrowed callbacks
+
+`Tour.onStepChange` receives a step typed as `TStep`, not the base `TourStep`. Pass a literal-union step type to narrow `step.id` inside the callback:
+
+```tsx
+const tour: Tour<TourStep<'a' | 'b'>> = {
+  id: 'demo',
+  steps: [/* ... */],
+  onStepChange: (step) => {
+    // step.id is 'a' | 'b'
+    if (step.id === 'a') {/* ... */}
+  },
+};
+```
+
+See [issue #34](https://github.com/domidex01/tour-kit/issues/34) for the design discussion and the test fixtures under `packages/core/src/__tests__/types/` for the canonical patterns.
 
 ## Generic Step Data
 
@@ -39687,6 +40297,153 @@ describe('eu-pro segment', () => {
 ```
 
 For provider-scoped tests, render under `<SegmentationProvider>` with the cohort you want to exercise — segments are pure functions of `userContext` and `currentUserId`, so the harness needs no async setup.
+
+---
+
+# Testing with React Testing Library
+
+> Test Tour Kit components with React Testing Library and Vitest under jsdom using @tour-kit/testing-library — zero consumer-side act() boilerplate.
+
+`@tour-kit/testing-library` packages the Floating UI virtual-element pattern + the `act()` microtask flush behind a small set of helpers, so consumer tests can assert on tour state without re-deriving the pattern every time.
+
+## Install
+
+```bash
+pnpm add -D @tour-kit/testing-library @testing-library/react @testing-library/user-event vitest jsdom
+```
+
+`vitest`, `@testing-library/react`, `@testing-library/user-event`, and `jsdom-testing-mocks` are peer dependencies. `jsdom-testing-mocks` is **optional** — install it only when you opt into `positionShim`.
+
+## Quick start
+
+```ts title="vitest.setup.ts"
+import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { setupTourKitTesting } from '@tour-kit/testing-library/setup'
+
+afterEach(() => {
+  cleanup()
+})
+
+// Default — touches nothing. Opt into positionShim only if needed.
+await setupTourKitTesting()
+```
+
+```tsx title="welcome-tour.test.tsx"
+import { render } from '@testing-library/react'
+import { TourProvider } from '@tour-kit/core'
+import { TourCard } from '@tour-kit/react'
+import {
+  expectStepVisible,
+  advanceTour,
+  completeTour,
+  HookProbe,
+} from '@tour-kit/testing-library'
+import { describe, it } from 'vitest'
+
+const tour = {
+  id: 'demo',
+  steps: [
+    { id: 'welcome', target: '#welcome', title: 'Welcome', content: 'Hi' },
+    { id: 'pricing', target: '#pricing', title: 'Pricing', content: 'Pay' },
+  ],
+}
+
+describe('welcome tour', () => {
+  it('walks through both steps', async () => {
+    render(
+      <>
+        <div id="welcome" />
+        <div id="pricing" />
+        <TourProvider tours={[tour]}>
+          <TourCard />
+          <HookProbe />
+        </TourProvider>
+      </>,
+    )
+
+    // expectStepVisible flushes Floating UI microtasks for you — no `act` needed.
+    await expectStepVisible('welcome')
+    await advanceTour()
+    await expectStepVisible('pricing')
+    await completeTour('demo')
+  })
+})
+```
+
+## Why no `await act(...)`?
+
+Under jsdom, `@floating-ui/react` computes `{ x: 0, y: 0 }` because there is no layout engine. The positioning state still needs a microtask flush before assertions can read it. Every helper in this package wraps that flush:
+
+```ts title="expect-step-visible.ts (excerpt)"
+await act(async () => {}) // Floating UI microtask flush
+return await waitFor(() => container.querySelector(`[data-tour-step="${stepId}"]`))
+```
+
+The headline contract is enforced inside the package's own test suite: every consumer-side `await act(...)` call would fail the build. See [`floating-ui.com/docs/virtual-elements`](https://floating-ui.com/docs/virtual-elements) for the upstream pattern.
+
+## The Floating UI virtual-element pattern
+
+When you DO need to assert against a positioned element directly (for example, a custom floating tooltip you wrote yourself), use `virtualTarget(rect?)`:
+
+```ts
+import { virtualTarget } from '@tour-kit/testing-library'
+
+// Provides a non-zero rect to Floating UI without patching Element.prototype.
+refs.setReference(virtualTarget({ top: 100, left: 200, width: 320, height: 60 }))
+```
+
+The default rect is 200×100 at the origin. Partial overrides merge with the defaults.
+
+## Optional position shim
+
+The default `setupTourKitTesting()` is a no-op — it does not touch `Element.prototype`. If your own assertions need a per-element `getBoundingClientRect` mock, opt in:
+
+```ts
+import { setupTourKitTesting } from '@tour-kit/testing-library/setup'
+
+await setupTourKitTesting({ positionShim: true })
+// Then per-element, in your beforeEach:
+import { mockElementBoundingClientRect } from 'jsdom-testing-mocks'
+
+mockElementBoundingClientRect(myElement, { top: 100, left: 200, width: 320, height: 60 })
+```
+
+The shim is a thin hint: the lazy import guarantees `jsdom-testing-mocks` is loaded; you still apply per-element rects yourself. Consumers who never opt in never pay for the dep.
+
+## Failure context — `TourKitTestingError`
+
+Every helper throws `TourKitTestingError` (extending `Error`) with `stepId`, `tourId`, and a humanized message:
+
+```ts
+try {
+  await expectStepVisible('not-a-step', { timeout: 50 })
+} catch (e) {
+  if (e instanceof TourKitTestingError) {
+    console.log(e.message) // expectStepVisible: step "not-a-step" not visible within 50ms
+    console.log(e.stepId)  // "not-a-step"
+    console.log(e.cause)   // original RTL waitFor error
+  }
+}
+```
+
+## Helper reference
+
+| Helper | What it does |
+|--------|--------------|
+| `expectStepVisible(stepId, opts?)` | Resolves with the `[data-tour-step="<id>"]` element once it mounts. |
+| `advanceTour(opts?)` | Clicks **Next/Finish/Done**. Pass `steps: n` to click `n` times. |
+| `previousTour(opts?)` | Clicks **Previous/Back**. |
+| `skipTour(opts?)` | Clicks **Skip**. |
+| `completeTour(tourId, opts?)` | Clicks **Next** until the tour ends or the deadline elapses. |
+| `goToStep(stepId)` | Jumps to a non-adjacent step. Requires `<HookProbe />` in the provider tree. |
+| `virtualTarget(rect?, contextElement?)` | Returns a Floating UI virtual element with a merged DOMRect. |
+| `setupTourKitTesting(opts?)` | One-shot orchestrator; default touches nothing, `positionShim: true` lazy-loads `jsdom-testing-mocks`. |
+
+## Browser-positioning tests live elsewhere
+
+This package asserts on **presence** — "did the step mount?", "did Next advance?" — not **position**. For pixel-perfect placement assertions, use Playwright via [`@tour-kit/playwright`](./nextjs#end-to-end-with-playwright) (Phase 6). Phase 5 helpers stop at the jsdom boundary by design.
 
 ---
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,4 +1,4 @@
-# userTourKit v0.11.0 — Generated 2026-05-06T13:46:25Z
+# userTourKit v0.11.0 — Generated 2026-05-13T07:39:18Z
 
 # userTourKit
 
@@ -14,6 +14,7 @@
 ## Core
 
 - [@tour-kit/core](https://usertourkit.com/docs/core): Framework-agnostic hooks and utilities for building product tours — state management, positioning, and accessibility
+- [Diagnostic Engine](https://usertourkit.com/docs/core/diagnostic): Replace the silent "tour didn't fire" failure mode with a structured `EligibilityReport` that names every gate's outcome.
 - [useAdvanceOn](https://usertourkit.com/docs/core/hooks/use-advance-on): useAdvanceOn hook: automatically advance tour steps when users click buttons, submit forms, or interact with elements
 - [useBranch](https://usertourkit.com/docs/core/hooks/use-branch): useBranch hook: trigger conditional branching paths from step content based on user choices or application state
 - [useDirection](https://usertourkit.com/docs/core/hooks/use-direction): Hook returning the resolved text direction (ltr or rtl) and an isRTL boolean for RTL-aware components
@@ -30,6 +31,7 @@
 - [useTourKitContext](https://usertourkit.com/docs/core/hooks/use-tour-kit-context): Hook returning the global TourKit context value — config, resolved direction, and global callbacks set on TourKitProvider
 - [TourKitProvider](https://usertourkit.com/docs/core/providers/tour-kit-provider): TourKitProvider: wrap your app to enable global tour management, shared configuration, and multi-tour coordination
 - [TourProvider](https://usertourkit.com/docs/core/providers/tour-provider): TourProvider: context provider that manages state, steps, and lifecycle for an individual product tour instance
+- [Schemas](https://usertourkit.com/docs/core/schemas): Runtime Zod validation for JSON-authorable tour definitions — load tours from CMS, JSON files, or MDX frontmatter without bloating your main bundle.
 - [Types](https://usertourkit.com/docs/core/types): TypeScript type definitions for userTourKit — tour, step, and configuration interfaces that power fully type-safe onboarding flows.
 - [Config Types](https://usertourkit.com/docs/core/types/config-types): TypeScript interfaces for TourConfig, SpotlightConfig, KeyboardConfig, and other userTourKit configuration options
 - [Step Types](https://usertourkit.com/docs/core/types/step-types): TypeScript interfaces for StepConfig, StepTarget, StepPlacement, and step-level configuration in userTourKit tours
@@ -95,11 +97,13 @@
 - [Dashboard Components](https://usertourkit.com/docs/adoption/dashboard): Pre-built admin dashboard components for visualizing feature adoption metrics, trends, and per-feature engagement rates
 - [AdoptionDashboard](https://usertourkit.com/docs/adoption/dashboard/adoption-dashboard): AdoptionDashboard component: complete admin view combining stats grid, category chart, and feature table in one layout
 - [Charts](https://usertourkit.com/docs/adoption/dashboard/charts): AdoptionCategoryChart and AdoptionStatusBadge: visualize adoption distribution by category and individual feature status
+- [Adoption Funnel](https://usertourkit.com/docs/adoption/dashboard/funnel): Step-by-step adoption funnel with drop-off percentages — Pendo/Userpilot parity, native CSS, no chart peer dependency.
 - [Stat Cards](https://usertourkit.com/docs/adoption/dashboard/stats): AdoptionStatCard and AdoptionStatsGrid: display aggregate adoption metrics with trend indicators and percentage changes
 - [AdoptionTable](https://usertourkit.com/docs/adoption/dashboard/table): AdoptionTable component: sortable, filterable table of tracked features showing adoption status, usage count, and trends
 - [useAdoptionContext](https://usertourkit.com/docs/adoption/hooks/use-adoption-context): Low-level hook returning the raw AdoptionProvider context — features, usage map, nudge state, and full action surface
 - [useAdoptionStats](https://usertourkit.com/docs/adoption/hooks/use-adoption-stats): useAdoptionStats hook: retrieve aggregated adoption metrics across all tracked features for dashboards and reporting
 - [useFeature](https://usertourkit.com/docs/adoption/hooks/use-feature): useFeature hook: track individual feature usage, query adoption state, and record interactions for adoption metrics
+- [useFunnelData](https://usertourkit.com/docs/adoption/hooks/use-funnel-data): Derive a current-state adoption funnel from useAdoptionStats — feed straight into AdoptionFunnel.
 - [useNudge](https://usertourkit.com/docs/adoption/hooks/use-nudge): useNudge hook: manage nudge visibility, dismissal, snooze, and user interaction state for feature discovery prompts
 - [AdoptionProvider](https://usertourkit.com/docs/adoption/providers/adoption-provider): AdoptionProvider: configure feature definitions, usage thresholds, nudge rules, and storage for the adoption tracking system
 - [TypeScript Types](https://usertourkit.com/docs/adoption/types): TypeScript types for FeatureConfig, AdoptionState, NudgeRule, UsageThreshold, and the @tour-kit/adoption API surface
@@ -239,6 +243,7 @@
 - [Reduced Motion](https://usertourkit.com/docs/guides/reduced-motion): How Tour Kit honors prefers-reduced-motion across announcements, surveys, hints, checklists, and the core tour runtime
 - [Router Integration](https://usertourkit.com/docs/guides/router-integration): Build multi-page tours with Next.js, React Router, or custom routers using route-aware step targeting and persistence
 - [Audience Segmentation](https://usertourkit.com/docs/guides/segmentation): Target tours, hints, surveys, and announcements at named user segments using SegmentationProvider, useSegment, and CSV-driven user lists.
+- [Testing with React Testing Library](https://usertourkit.com/docs/guides/testing): Test Tour Kit components with React Testing Library and Vitest under jsdom using @tour-kit/testing-library — zero consumer-side act() boilerplate.
 - [Theme Variations](https://usertourkit.com/docs/guides/theme-variations): Resolve tour themes by system colour scheme, explicit mode, route, or arbitrary trait predicates with `<ThemeProvider>` and `useThemeVariation`.
 - [Troubleshooting](https://usertourkit.com/docs/guides/troubleshooting): Diagnose and fix common userTourKit issues: missing targets, positioning glitches, hydration errors, and focus trap problems
 - [Unified Slot (Radix UI + Base UI)](https://usertourkit.com/docs/guides/unified-slot): Single composition primitive that supports both Radix UI's asChild element cloning and Base UI's render-prop style — covers UnifiedSlot, UILibrary, UILibraryProvider, and the RenderProp shape

--- a/packages/react/src/components/card/tour-card.tsx
+++ b/packages/react/src/components/card/tour-card.tsx
@@ -141,6 +141,7 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
           role="dialog"
           aria-modal="true"
           aria-labelledby={`tour-step-title-${currentStep.id}`}
+          data-tour-step={currentStep.id}
           {...props}
         >
           <TourCardHeader

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -13,14 +13,7 @@
   "bugs": {
     "url": "https://github.com/domidex01/tour-kit/issues"
   },
-  "keywords": [
-    "tour-kit",
-    "react-testing-library",
-    "vitest",
-    "jsdom",
-    "floating-ui",
-    "testing"
-  ],
+  "keywords": ["tour-kit", "react-testing-library", "vitest", "jsdom", "floating-ui", "testing"],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -1,0 +1,97 @@
+{
+  "name": "@tour-kit/testing-library",
+  "version": "0.1.0",
+  "description": "React Testing Library helpers for Tour Kit — virtual-element Floating UI pattern + act() flush wrapped once, so consumer tests don't repeat the boilerplate.",
+  "author": "Tour Kit Team",
+  "license": "MIT",
+  "homepage": "https://github.com/domidex01/tour-kit#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/domidex01/tour-kit.git",
+    "directory": "packages/testing-library"
+  },
+  "bugs": {
+    "url": "https://github.com/domidex01/tour-kit/issues"
+  },
+  "keywords": [
+    "tour-kit",
+    "react-testing-library",
+    "vitest",
+    "jsdom",
+    "floating-ui",
+    "testing"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./setup": {
+      "import": {
+        "types": "./dist/setup.d.ts",
+        "default": "./dist/setup.js"
+      },
+      "require": {
+        "types": "./dist/setup.d.cts",
+        "default": "./dist/setup.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@tour-kit/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.0.0",
+    "vitest": "^4.0.0",
+    "jsdom-testing-mocks": "^1.13.0"
+  },
+  "peerDependenciesMeta": {
+    "jsdom-testing-mocks": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@tour-kit/react": "workspace:*",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/user-event": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "^4.5.2",
+    "jsdom": "catalog:",
+    "jsdom-testing-mocks": "catalog:",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:"
+  }
+}

--- a/packages/testing-library/src/__tests__/_fixtures.tsx
+++ b/packages/testing-library/src/__tests__/_fixtures.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { type Tour, TourProvider, useTour } from '@tour-kit/core'
+import { TourCard } from '@tour-kit/react'
+import * as React from 'react'
+import { HookProbe } from '../helpers/hook-probe'
+
+export const twoStepTour: Tour = {
+  id: 'demo',
+  steps: [
+    { id: 'welcome', target: '[data-test=welcome-target]', title: 'Welcome', content: 'Hi' },
+    { id: 'pricing', target: '[data-test=pricing-target]', title: 'Pricing', content: 'Pay' },
+  ],
+}
+
+export const threeStepTour: Tour = {
+  id: 'demo3',
+  steps: [
+    { id: 'welcome', target: '[data-test=welcome-target]', title: 'Welcome', content: 'Hi' },
+    { id: 'pricing', target: '[data-test=pricing-target]', title: 'Pricing', content: 'Pay' },
+    { id: 'finale', target: '[data-test=finale-target]', title: 'Finale', content: 'Done' },
+  ],
+}
+
+function AutoStart({ tourId }: { tourId: string }) {
+  const { start } = useTour()
+  const startedRef = React.useRef(false)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-once start
+  React.useEffect(() => {
+    if (startedRef.current) return
+    startedRef.current = true
+    start(tourId)
+  }, [])
+  return null
+}
+
+export function TwoStepFixture() {
+  return (
+    <>
+      <div data-test="welcome-target">welcome target</div>
+      <div data-test="pricing-target">pricing target</div>
+      <TourProvider tours={[twoStepTour]}>
+        <AutoStart tourId="demo" />
+        <TourCard />
+        <HookProbe />
+      </TourProvider>
+    </>
+  )
+}
+
+export function ThreeStepFixture() {
+  return (
+    <>
+      <div data-test="welcome-target">welcome target</div>
+      <div data-test="pricing-target">pricing target</div>
+      <div data-test="finale-target">finale target</div>
+      <TourProvider tours={[threeStepTour]}>
+        <AutoStart tourId="demo3" />
+        <TourCard />
+        <HookProbe />
+      </TourProvider>
+    </>
+  )
+}

--- a/packages/testing-library/src/__tests__/entry-points.test.ts
+++ b/packages/testing-library/src/__tests__/entry-points.test.ts
@@ -22,7 +22,10 @@ describe('entry points', () => {
   it.skipIf(!distExists)('CJS require of ./setup resolves setupTourKitTesting', () => {
     const out = execFileSync(
       'node',
-      ['-e', `process.stdout.write(typeof require(${JSON.stringify(SETUP_CJS)}).setupTourKitTesting)`],
+      [
+        '-e',
+        `process.stdout.write(typeof require(${JSON.stringify(SETUP_CJS)}).setupTourKitTesting)`,
+      ],
       { encoding: 'utf8' }
     )
     expect(out).toBe('function')

--- a/packages/testing-library/src/__tests__/entry-points.test.ts
+++ b/packages/testing-library/src/__tests__/entry-points.test.ts
@@ -1,0 +1,68 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PKG_ROOT = join(__dirname, '..', '..')
+const MAIN_CJS = join(PKG_ROOT, 'dist', 'index.cjs')
+const SETUP_CJS = join(PKG_ROOT, 'dist', 'setup.cjs')
+
+const distExists = existsSync(MAIN_CJS) && existsSync(SETUP_CJS)
+
+describe('entry points', () => {
+  it.skipIf(!distExists)('CJS require of main entry resolves expectStepVisible', () => {
+    const out = execFileSync(
+      'node',
+      ['-e', `process.stdout.write(typeof require(${JSON.stringify(MAIN_CJS)}).expectStepVisible)`],
+      { encoding: 'utf8' }
+    )
+    expect(out).toBe('function')
+  })
+
+  it.skipIf(!distExists)('CJS require of ./setup resolves setupTourKitTesting', () => {
+    const out = execFileSync(
+      'node',
+      ['-e', `process.stdout.write(typeof require(${JSON.stringify(SETUP_CJS)}).setupTourKitTesting)`],
+      { encoding: 'utf8' }
+    )
+    expect(out).toBe('function')
+  })
+
+  // Phrase is split to avoid the grep matching this file's own description.
+  it(`test files contain ZERO consumer-side ${'await' + ' ' + 'act'}(...) calls`, () => {
+    // Headline contract — helpers wrap the flush internally; consumers must
+    // never need to repeat the flush themselves.
+    let out: string
+    try {
+      out = execFileSync(
+        'grep',
+        [
+          '-rEc',
+          '--include=*.ts',
+          '--include=*.tsx',
+          '--exclude=entry-points.test.ts',
+          'await\\s+act\\b',
+          'src/__tests__',
+        ],
+        {
+          cwd: PKG_ROOT,
+          encoding: 'utf8',
+        }
+      )
+    } catch (e) {
+      // grep exits 1 when no matches found across any file. The `-c` per-file
+      // counts are still printed on stdout, so capture from the error.
+      const err = e as { stdout?: string; status?: number }
+      if (err.status === 1 && typeof err.stdout === 'string') {
+        out = err.stdout
+      } else {
+        throw e
+      }
+    }
+    const total = out
+      .split('\n')
+      .filter(Boolean)
+      .reduce((sum, line) => sum + Number(line.split(':').at(-1) ?? 0), 0)
+    expect(total).toBe(0)
+  })
+})

--- a/packages/testing-library/src/__tests__/error.test.ts
+++ b/packages/testing-library/src/__tests__/error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { TourKitTestingError } from '../error'
+
+describe('TourKitTestingError', () => {
+  it('is instanceof Error', () => {
+    expect(new TourKitTestingError('x')).toBeInstanceOf(Error)
+  })
+
+  it('is instanceof TourKitTestingError', () => {
+    expect(new TourKitTestingError('x')).toBeInstanceOf(TourKitTestingError)
+  })
+
+  it('preserves stepId and tourId', () => {
+    const e = new TourKitTestingError('x', { stepId: 's', tourId: 't' })
+    expect(e.stepId).toBe('s')
+    expect(e.tourId).toBe('t')
+  })
+
+  it('preserves cause', () => {
+    const inner = new Error('inner')
+    const e = new TourKitTestingError('outer', { cause: inner })
+    expect(e.cause).toBe(inner)
+  })
+
+  it('name === "TourKitTestingError"', () => {
+    expect(new TourKitTestingError('x').name).toBe('TourKitTestingError')
+  })
+})

--- a/packages/testing-library/src/__tests__/floating-ui-integration.test.tsx
+++ b/packages/testing-library/src/__tests__/floating-ui-integration.test.tsx
@@ -104,9 +104,9 @@ describe('@tour-kit/testing-library — integration against real <TourCard>', ()
     // <TourCard> portals to document.body, so passing the render container
     // intentionally scopes the query OUT of where the card lives. The helper
     // must throw rather than fall through to body.
-    await expect(
-      expectStepVisible('welcome', { container, timeout: 100 })
-    ).rejects.toBeInstanceOf(TourKitTestingError)
+    await expect(expectStepVisible('welcome', { container, timeout: 100 })).rejects.toBeInstanceOf(
+      TourKitTestingError
+    )
   })
 
   it('container=document.body finds the portalled card', async () => {

--- a/packages/testing-library/src/__tests__/floating-ui-integration.test.tsx
+++ b/packages/testing-library/src/__tests__/floating-ui-integration.test.tsx
@@ -1,0 +1,128 @@
+/// <reference types="vitest-axe/extend-expect" />
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+import { TourKitTestingError } from '../error'
+import { advanceTour } from '../helpers/advance-tour'
+import { completeTour } from '../helpers/complete-tour'
+import { expectStepVisible } from '../helpers/expect-step-visible'
+import { goToStep } from '../helpers/go-to-step'
+import { previousTour } from '../helpers/previous-tour'
+import { skipTour } from '../helpers/skip-tour'
+import { setupTourKitTesting } from '../setup'
+import { ThreeStepFixture, TwoStepFixture } from './_fixtures'
+
+// Spy on the dynamic `import('jsdom-testing-mocks')` inside setupTourKitTesting.
+// The factory body fires once per resolved import per vitest module cache slot.
+let jdmLoadCount = 0
+vi.mock('jsdom-testing-mocks', async (importOriginal: () => Promise<unknown>) => {
+  jdmLoadCount++
+  return importOriginal()
+})
+
+beforeEach(async () => {
+  jdmLoadCount = 0
+  // Default path — no shim. The whole point of Phase 5.
+  await setupTourKitTesting()
+})
+
+describe('@tour-kit/testing-library — integration against real <TourCard>', () => {
+  it('expectStepVisible resolves on the welcome step (no consumer act() flush)', async () => {
+    render(<TwoStepFixture />)
+    const el = await expectStepVisible('welcome')
+    expect(el).toBeInTheDocument()
+    expect(el.getAttribute('data-tour-step')).toBe('welcome')
+  })
+
+  it('advanceTour moves to the next step', async () => {
+    render(<TwoStepFixture />)
+    await expectStepVisible('welcome')
+    await advanceTour()
+    await expectStepVisible('pricing')
+  })
+
+  it('previousTour goes back one step', async () => {
+    render(<TwoStepFixture />)
+    await expectStepVisible('welcome')
+    await advanceTour()
+    await expectStepVisible('pricing')
+    await previousTour()
+    await expectStepVisible('welcome')
+  })
+
+  it('completeTour finishes a 2-step tour', async () => {
+    render(<TwoStepFixture />)
+    await completeTour('demo')
+    // After completion no step card is mounted.
+    expect(document.querySelector('[data-tour-step]')).toBeNull()
+  })
+
+  it('skipTour invokes the Skip action and ends the tour', async () => {
+    render(<TwoStepFixture />)
+    await expectStepVisible('welcome')
+    await skipTour()
+    expect(document.querySelector('[data-tour-step]')).toBeNull()
+  })
+
+  it('goToStep jumps to a non-adjacent step', async () => {
+    render(<ThreeStepFixture />)
+    await expectStepVisible('welcome')
+    await goToStep('finale')
+    await expectStepVisible('finale')
+  })
+
+  it('expectStepVisible throws TourKitTestingError on timeout', async () => {
+    render(<TwoStepFixture />)
+    await expect(expectStepVisible('not-a-step', { timeout: 50 })).rejects.toThrow(
+      /not visible within 50ms/
+    )
+  })
+
+  it('thrown TourKitTestingError carries stepId', async () => {
+    render(<TwoStepFixture />)
+    try {
+      await expectStepVisible('missing', { timeout: 50 })
+      throw new Error('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(TourKitTestingError)
+      expect((e as TourKitTestingError).stepId).toBe('missing')
+    }
+  })
+
+  it('default setup does NOT lazy-import jsdom-testing-mocks', () => {
+    // beforeEach already called setupTourKitTesting() with no args.
+    expect(jdmLoadCount).toBe(0)
+  })
+
+  it('positionShim:true triggers at least one lazy import', async () => {
+    await setupTourKitTesting({ positionShim: true })
+    expect(jdmLoadCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('container option scopes queries', async () => {
+    const { container } = render(<TwoStepFixture />)
+    // <TourCard> portals to document.body, so passing the render container
+    // intentionally scopes the query OUT of where the card lives. The helper
+    // must throw rather than fall through to body.
+    await expect(
+      expectStepVisible('welcome', { container, timeout: 100 })
+    ).rejects.toBeInstanceOf(TourKitTestingError)
+  })
+
+  it('container=document.body finds the portalled card', async () => {
+    render(<TwoStepFixture />)
+    const el = await expectStepVisible('welcome', { container: document.body })
+    expect(document.body.contains(el)).toBe(true)
+  })
+
+  it('axe zero violations on the rendered welcome step card', async () => {
+    render(<TwoStepFixture />)
+    const card = await expectStepVisible('welcome')
+    // Scope axe to the card itself — the surrounding fixture isn't wrapped in
+    // landmarks and that's not something a test-library can fix for consumers.
+    const results = await axe(card, {
+      rules: { region: { enabled: false } },
+    })
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/packages/testing-library/src/__tests__/prototype-untouched.test.ts
+++ b/packages/testing-library/src/__tests__/prototype-untouched.test.ts
@@ -1,0 +1,18 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { setupTourKitTesting } from '../setup'
+
+let baseline: PropertyDescriptor | undefined
+
+beforeAll(() => {
+  baseline = Object.getOwnPropertyDescriptor(Element.prototype, 'getBoundingClientRect')
+})
+
+describe('default setup — prototype untouched', () => {
+  it('Element.prototype.getBoundingClientRect descriptor matches the JSDOM baseline after setupTourKitTesting()', async () => {
+    await setupTourKitTesting()
+    const after = Object.getOwnPropertyDescriptor(Element.prototype, 'getBoundingClientRect')
+    expect(after?.value).toBe(baseline?.value)
+    expect(after?.get).toBe(baseline?.get)
+    expect(after?.set).toBe(baseline?.set)
+  })
+})

--- a/packages/testing-library/src/__tests__/setup-position-shim.test.ts
+++ b/packages/testing-library/src/__tests__/setup-position-shim.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setupTourKitTesting } from '../setup'
+
+let jdmLoadCount = 0
+vi.mock('jsdom-testing-mocks', async (importOriginal: () => Promise<unknown>) => {
+  jdmLoadCount++
+  return importOriginal()
+})
+
+beforeEach(() => {
+  jdmLoadCount = 0
+})
+
+describe('setupTourKitTesting positionShim', () => {
+  it('returns a resolving promise with no args', async () => {
+    await expect(setupTourKitTesting()).resolves.toBeUndefined()
+  })
+
+  it('with positionShim:false, jsdom-testing-mocks is NOT loaded', async () => {
+    await setupTourKitTesting({ positionShim: false })
+    expect(jdmLoadCount).toBe(0)
+  })
+
+  it('with positionShim:true, jsdom-testing-mocks is loaded exactly once', async () => {
+    await setupTourKitTesting({ positionShim: true })
+    // vi.mock factory runs at most once for a module — the dynamic import
+    // returns the cached module on the second call, so `jdmLoadCount` may
+    // remain at 1 across the suite. Assert "at least once".
+    expect(jdmLoadCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('calling setupTourKitTesting({ positionShim: true }) twice is idempotent', async () => {
+    // vitest caches the module once the factory fires, so the second call
+    // hits the cache and resolves without re-invoking the factory. We assert
+    // on the contract — neither call throws — not on a per-call counter.
+    await expect(setupTourKitTesting({ positionShim: true })).resolves.toBeUndefined()
+    await expect(setupTourKitTesting({ positionShim: true })).resolves.toBeUndefined()
+  })
+})

--- a/packages/testing-library/src/__tests__/setup-position-shim.test.ts
+++ b/packages/testing-library/src/__tests__/setup-position-shim.test.ts
@@ -21,11 +21,11 @@ describe('setupTourKitTesting positionShim', () => {
     expect(jdmLoadCount).toBe(0)
   })
 
-  it('with positionShim:true, jsdom-testing-mocks is loaded exactly once', async () => {
+  it('with positionShim:true, jsdom-testing-mocks is loaded at least once', async () => {
     await setupTourKitTesting({ positionShim: true })
     // vi.mock factory runs at most once for a module — the dynamic import
-    // returns the cached module on the second call, so `jdmLoadCount` may
-    // remain at 1 across the suite. Assert "at least once".
+    // returns the cached module on subsequent calls, so we can't assert
+    // "exactly once" without ordering guarantees we don't control.
     expect(jdmLoadCount).toBeGreaterThanOrEqual(1)
   })
 

--- a/packages/testing-library/src/__tests__/virtual-target.test.ts
+++ b/packages/testing-library/src/__tests__/virtual-target.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { virtualTarget } from '../helpers/virtual-target'
+
+describe('virtualTarget', () => {
+  it('default rect has non-zero width and height', () => {
+    const rect = virtualTarget().getBoundingClientRect()
+    expect(rect.width).toBeGreaterThan(0)
+    expect(rect.height).toBeGreaterThan(0)
+  })
+
+  it('merges a partial rect, overriding defaults', () => {
+    const rect = virtualTarget({ width: 500, top: 50 }).getBoundingClientRect()
+    expect(rect.width).toBe(500)
+    expect(rect.top).toBe(50)
+    // Unspecified fields fall back to the default rect.
+    expect(rect.height).toBe(100)
+  })
+
+  it('returns a DOMRect-shaped object', () => {
+    const rect = virtualTarget({ width: 42 }).getBoundingClientRect()
+    for (const key of ['x', 'y', 'top', 'left', 'right', 'bottom', 'width', 'height'] as const) {
+      expect(rect[key]).toBeTypeOf('number')
+    }
+    expect(typeof rect.toJSON).toBe('function')
+  })
+
+  it('attaches contextElement when provided', () => {
+    const el = document.createElement('div')
+    const target = virtualTarget({}, el)
+    expect(target.contextElement).toBe(el)
+  })
+})

--- a/packages/testing-library/src/error.ts
+++ b/packages/testing-library/src/error.ts
@@ -1,0 +1,19 @@
+export interface TourKitTestingErrorOptions {
+  cause?: unknown
+  stepId?: string
+  tourId?: string
+}
+
+export class TourKitTestingError extends Error {
+  readonly stepId?: string
+  readonly tourId?: string
+
+  constructor(message: string, opts: TourKitTestingErrorOptions = {}) {
+    super(message, { cause: opts.cause })
+    this.name = 'TourKitTestingError'
+    this.stepId = opts.stepId
+    this.tourId = opts.tourId
+    // Restore prototype chain across compiled targets (ES5 down-level safety).
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}

--- a/packages/testing-library/src/helpers/_click-by-name.ts
+++ b/packages/testing-library/src/helpers/_click-by-name.ts
@@ -1,0 +1,28 @@
+import { act, screen } from '@testing-library/react'
+import type userEvent from '@testing-library/user-event'
+import { TourKitTestingError } from '../error'
+
+type UserEvent = ReturnType<typeof userEvent.setup>
+
+/**
+ * Locate a button matching the given accessible-name pattern, click it, and
+ * flush Floating UI microtasks. Throws `TourKitTestingError` (preserving the
+ * RTL cause) when no matching button exists.
+ *
+ * Internal helper — keeps advance-tour / previous-tour / skip-tour from
+ * re-deriving the same try/click/flush ritual.
+ */
+export async function clickButtonByName(
+  user: UserEvent,
+  pattern: RegExp,
+  errorMessage: string
+): Promise<void> {
+  let btn: HTMLElement
+  try {
+    btn = screen.getByRole('button', { name: pattern })
+  } catch (cause) {
+    throw new TourKitTestingError(errorMessage, { cause })
+  }
+  await user.click(btn)
+  await act(async () => {})
+}

--- a/packages/testing-library/src/helpers/advance-tour.ts
+++ b/packages/testing-library/src/helpers/advance-tour.ts
@@ -1,0 +1,30 @@
+import { act, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TourKitTestingError } from '../error'
+
+type UserEvent = ReturnType<typeof userEvent.setup>
+
+export interface AdvanceTourOptions {
+  /** Number of times to click Next. Defaults to 1. */
+  steps?: number
+  /** Reuse an existing userEvent instance (recommended for multi-helper tests). */
+  user?: UserEvent
+}
+
+export async function advanceTour(opts: AdvanceTourOptions = {}): Promise<void> {
+  const user = opts.user ?? userEvent.setup()
+  const steps = opts.steps ?? 1
+  for (let i = 0; i < steps; i++) {
+    let btn: HTMLElement
+    try {
+      btn = screen.getByRole('button', { name: /next|finish|done/i })
+    } catch (e) {
+      throw new TourKitTestingError(
+        `advanceTour: no Next/Finish/Done button found (step ${i + 1} of ${steps})`,
+        { cause: e }
+      )
+    }
+    await user.click(btn)
+    await act(async () => {})
+  }
+}

--- a/packages/testing-library/src/helpers/advance-tour.ts
+++ b/packages/testing-library/src/helpers/advance-tour.ts
@@ -1,6 +1,5 @@
-import { act, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { TourKitTestingError } from '../error'
+import { clickButtonByName } from './_click-by-name'
 
 type UserEvent = ReturnType<typeof userEvent.setup>
 
@@ -15,16 +14,10 @@ export async function advanceTour(opts: AdvanceTourOptions = {}): Promise<void> 
   const user = opts.user ?? userEvent.setup()
   const steps = opts.steps ?? 1
   for (let i = 0; i < steps; i++) {
-    let btn: HTMLElement
-    try {
-      btn = screen.getByRole('button', { name: /next|finish|done/i })
-    } catch (e) {
-      throw new TourKitTestingError(
-        `advanceTour: no Next/Finish/Done button found (step ${i + 1} of ${steps})`,
-        { cause: e }
-      )
-    }
-    await user.click(btn)
-    await act(async () => {})
+    await clickButtonByName(
+      user,
+      /next|finish|done/i,
+      `advanceTour: no Next/Finish/Done button found (step ${i + 1} of ${steps})`
+    )
   }
 }

--- a/packages/testing-library/src/helpers/complete-tour.ts
+++ b/packages/testing-library/src/helpers/complete-tour.ts
@@ -1,0 +1,37 @@
+import { act, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TourKitTestingError } from '../error'
+
+type UserEvent = ReturnType<typeof userEvent.setup>
+
+export interface CompleteTourOptions {
+  /** Overall deadline. Defaults to 5000ms. */
+  timeout?: number
+  /** Hard cap on click iterations. Defaults to 50. */
+  maxSteps?: number
+  user?: UserEvent
+}
+
+export async function completeTour(tourId: string, opts: CompleteTourOptions = {}): Promise<void> {
+  const { timeout = 5000, maxSteps = 50 } = opts
+  const user = opts.user ?? userEvent.setup()
+  const start = Date.now()
+
+  for (let i = 0; i < maxSteps; i++) {
+    if (Date.now() - start > timeout) {
+      throw new TourKitTestingError(
+        `completeTour: tour "${tourId}" not complete within ${timeout}ms`,
+        { tourId }
+      )
+    }
+    // Flush before query so the previous click's state lands first.
+    await act(async () => {})
+    const btn = screen.queryByRole('button', { name: /next|finish|done/i })
+    if (!btn) return
+    await user.click(btn)
+  }
+  throw new TourKitTestingError(
+    `completeTour: tour "${tourId}" exceeded ${maxSteps} click iterations`,
+    { tourId }
+  )
+}

--- a/packages/testing-library/src/helpers/expect-step-visible.ts
+++ b/packages/testing-library/src/helpers/expect-step-visible.ts
@@ -31,7 +31,8 @@ export async function expectStepVisible(
   try {
     const el = await waitFor(
       () => {
-        const root: ParentNode = opts.container ?? (typeof document !== 'undefined' ? document.body : (null as never))
+        const root: ParentNode =
+          opts.container ?? (typeof document !== 'undefined' ? document.body : (null as never))
         const found = root.querySelector<HTMLElement>(`[data-tour-step="${stepId}"]`)
         if (!found) throw new Error(`step "${stepId}" not in DOM`)
         return found

--- a/packages/testing-library/src/helpers/expect-step-visible.ts
+++ b/packages/testing-library/src/helpers/expect-step-visible.ts
@@ -1,0 +1,48 @@
+import { act, waitFor } from '@testing-library/react'
+import { TourKitTestingError } from '../error'
+
+export interface ExpectStepVisibleOptions {
+  /** Override the polling deadline. Defaults to 1000ms. */
+  timeout?: number
+  /**
+   * Scope queries to a subtree. Defaults to `document.body` because `<TourCard>`
+   * portals to body and consumers won't find it under their render container.
+   */
+  container?: ParentNode
+}
+
+/**
+ * Resolve once a `[data-tour-step="<stepId>"]` element is in the DOM.
+ *
+ * Wraps the Floating UI virtual-element + `act()` microtask flush so consumer
+ * tests never need to write `await act(async () => {})` themselves.
+ *
+ * Throws `TourKitTestingError` with the stepId, helper name, and timeout when
+ * the element does not appear inside the deadline.
+ */
+export async function expectStepVisible(
+  stepId: string,
+  opts: ExpectStepVisibleOptions = {}
+): Promise<HTMLElement> {
+  const { timeout = 1000 } = opts
+  // Flush Floating UI positioning microtasks before the first query attempt.
+  await act(async () => {})
+
+  try {
+    const el = await waitFor(
+      () => {
+        const root: ParentNode = opts.container ?? (typeof document !== 'undefined' ? document.body : (null as never))
+        const found = root.querySelector<HTMLElement>(`[data-tour-step="${stepId}"]`)
+        if (!found) throw new Error(`step "${stepId}" not in DOM`)
+        return found
+      },
+      { timeout }
+    )
+    return el
+  } catch (e) {
+    throw new TourKitTestingError(
+      `expectStepVisible: step "${stepId}" not visible within ${timeout}ms`,
+      { cause: e, stepId }
+    )
+  }
+}

--- a/packages/testing-library/src/helpers/expect-step-visible.ts
+++ b/packages/testing-library/src/helpers/expect-step-visible.ts
@@ -31,8 +31,7 @@ export async function expectStepVisible(
   try {
     const el = await waitFor(
       () => {
-        const root: ParentNode =
-          opts.container ?? (typeof document !== 'undefined' ? document.body : (null as never))
+        const root: ParentNode = opts.container ?? document.body
         const found = root.querySelector<HTMLElement>(`[data-tour-step="${stepId}"]`)
         if (!found) throw new Error(`step "${stepId}" not in DOM`)
         return found

--- a/packages/testing-library/src/helpers/go-to-step.ts
+++ b/packages/testing-library/src/helpers/go-to-step.ts
@@ -1,0 +1,30 @@
+import { act } from '@testing-library/react'
+import { TourKitTestingError } from '../error'
+import { getActiveTourHandle } from './hook-probe'
+
+/**
+ * Jump the active tour to a specific step.
+ *
+ * Requires a `<HookProbe />` to be rendered inside the same `<TourProvider>` —
+ * the probe captures `useTour()` so this helper can call `goToStep` without
+ * reaching into globals. Phase 5 stays in-process; Phase 6 owns `window.__tourKit__`.
+ */
+export async function goToStep(stepId: string): Promise<void> {
+  const handle = getActiveTourHandle()
+  if (!handle) {
+    throw new TourKitTestingError(
+      'goToStep: no active <HookProbe /> mounted. Render <HookProbe /> inside <TourProvider> to use this helper.',
+      { stepId }
+    )
+  }
+  try {
+    await act(async () => {
+      await handle.goToStep(stepId)
+    })
+  } catch (e) {
+    throw new TourKitTestingError(`goToStep: failed to navigate to step "${stepId}"`, {
+      cause: e,
+      stepId,
+    })
+  }
+}

--- a/packages/testing-library/src/helpers/hook-probe.tsx
+++ b/packages/testing-library/src/helpers/hook-probe.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useTour } from '@tour-kit/core'
+import * as React from 'react'
+
+type UseTourResult = ReturnType<typeof useTour>
+
+/**
+ * Module-level handle that captures the most recently-mounted `<HookProbe />`'s
+ * `useTour()` return value. Helpers like `goToStep` consult this to drive the
+ * tour imperatively from outside the React tree.
+ *
+ * Reset between tests — `cleanup()` unmounts the probe and `currentRef` flips
+ * back to null via the unmount effect.
+ */
+const hookRef: { current: UseTourResult | null } = { current: null }
+
+export function getActiveTourHandle(): UseTourResult | null {
+  return hookRef.current
+}
+
+/**
+ * Hidden bridge component — render it inside `<TourProvider>` to make
+ * `goToStep` (and any future imperative helper) work.
+ */
+export function HookProbe(): null {
+  const value = useTour()
+  // Keep the latest value live; React re-renders the probe whenever the
+  // provider state changes.
+  hookRef.current = value
+  React.useEffect(() => {
+    return () => {
+      // Only clear if we still own the slot — guards against StrictMode
+      // double-mount sequences where a fresh instance has already taken over.
+      if (hookRef.current === value) hookRef.current = null
+    }
+  }, [value])
+  return null
+}

--- a/packages/testing-library/src/helpers/previous-tour.ts
+++ b/packages/testing-library/src/helpers/previous-tour.ts
@@ -1,0 +1,28 @@
+import { act, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TourKitTestingError } from '../error'
+
+type UserEvent = ReturnType<typeof userEvent.setup>
+
+export interface PreviousTourOptions {
+  steps?: number
+  user?: UserEvent
+}
+
+export async function previousTour(opts: PreviousTourOptions = {}): Promise<void> {
+  const user = opts.user ?? userEvent.setup()
+  const steps = opts.steps ?? 1
+  for (let i = 0; i < steps; i++) {
+    let btn: HTMLElement
+    try {
+      btn = screen.getByRole('button', { name: /previous|back|prev/i })
+    } catch (e) {
+      throw new TourKitTestingError(
+        `previousTour: no Previous/Back button found (step ${i + 1} of ${steps})`,
+        { cause: e }
+      )
+    }
+    await user.click(btn)
+    await act(async () => {})
+  }
+}

--- a/packages/testing-library/src/helpers/previous-tour.ts
+++ b/packages/testing-library/src/helpers/previous-tour.ts
@@ -1,6 +1,5 @@
-import { act, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { TourKitTestingError } from '../error'
+import { clickButtonByName } from './_click-by-name'
 
 type UserEvent = ReturnType<typeof userEvent.setup>
 
@@ -13,16 +12,10 @@ export async function previousTour(opts: PreviousTourOptions = {}): Promise<void
   const user = opts.user ?? userEvent.setup()
   const steps = opts.steps ?? 1
   for (let i = 0; i < steps; i++) {
-    let btn: HTMLElement
-    try {
-      btn = screen.getByRole('button', { name: /previous|back|prev/i })
-    } catch (e) {
-      throw new TourKitTestingError(
-        `previousTour: no Previous/Back button found (step ${i + 1} of ${steps})`,
-        { cause: e }
-      )
-    }
-    await user.click(btn)
-    await act(async () => {})
+    await clickButtonByName(
+      user,
+      /previous|back|prev/i,
+      `previousTour: no Previous/Back button found (step ${i + 1} of ${steps})`
+    )
   }
 }

--- a/packages/testing-library/src/helpers/skip-tour.ts
+++ b/packages/testing-library/src/helpers/skip-tour.ts
@@ -1,6 +1,5 @@
-import { act, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { TourKitTestingError } from '../error'
+import { clickButtonByName } from './_click-by-name'
 
 type UserEvent = ReturnType<typeof userEvent.setup>
 
@@ -10,12 +9,5 @@ export interface SkipTourOptions {
 
 export async function skipTour(opts: SkipTourOptions = {}): Promise<void> {
   const user = opts.user ?? userEvent.setup()
-  let btn: HTMLElement
-  try {
-    btn = screen.getByRole('button', { name: /skip/i })
-  } catch (e) {
-    throw new TourKitTestingError('skipTour: no Skip button found', { cause: e })
-  }
-  await user.click(btn)
-  await act(async () => {})
+  await clickButtonByName(user, /skip/i, 'skipTour: no Skip button found')
 }

--- a/packages/testing-library/src/helpers/skip-tour.ts
+++ b/packages/testing-library/src/helpers/skip-tour.ts
@@ -1,0 +1,21 @@
+import { act, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TourKitTestingError } from '../error'
+
+type UserEvent = ReturnType<typeof userEvent.setup>
+
+export interface SkipTourOptions {
+  user?: UserEvent
+}
+
+export async function skipTour(opts: SkipTourOptions = {}): Promise<void> {
+  const user = opts.user ?? userEvent.setup()
+  let btn: HTMLElement
+  try {
+    btn = screen.getByRole('button', { name: /skip/i })
+  } catch (e) {
+    throw new TourKitTestingError('skipTour: no Skip button found', { cause: e })
+  }
+  await user.click(btn)
+  await act(async () => {})
+}

--- a/packages/testing-library/src/helpers/virtual-target.ts
+++ b/packages/testing-library/src/helpers/virtual-target.ts
@@ -21,7 +21,10 @@ export interface VirtualTarget {
   contextElement?: Element
 }
 
-export function virtualTarget(rect: Partial<DOMRect> = {}, contextElement?: Element): VirtualTarget {
+export function virtualTarget(
+  rect: Partial<DOMRect> = {},
+  contextElement?: Element
+): VirtualTarget {
   const merged: DOMRect = { ...DEFAULT_RECT, ...rect }
   return {
     getBoundingClientRect: () => merged,

--- a/packages/testing-library/src/helpers/virtual-target.ts
+++ b/packages/testing-library/src/helpers/virtual-target.ts
@@ -1,0 +1,30 @@
+// Floating UI virtual-element pattern. Confirmed against /floating-ui/floating-ui
+// docs (memory #180, 2026-05-12): refs.setReference({ getBoundingClientRect })
+// is the supported way to position a floating element without a DOM target.
+
+const DEFAULT_RECT: DOMRect = {
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 100,
+  top: 0,
+  left: 0,
+  right: 200,
+  bottom: 100,
+  toJSON() {
+    return this
+  },
+}
+
+export interface VirtualTarget {
+  getBoundingClientRect: () => DOMRect
+  contextElement?: Element
+}
+
+export function virtualTarget(rect: Partial<DOMRect> = {}, contextElement?: Element): VirtualTarget {
+  const merged: DOMRect = { ...DEFAULT_RECT, ...rect }
+  return {
+    getBoundingClientRect: () => merged,
+    ...(contextElement ? { contextElement } : {}),
+  }
+}

--- a/packages/testing-library/src/index.ts
+++ b/packages/testing-library/src/index.ts
@@ -1,0 +1,25 @@
+// Error
+export { TourKitTestingError, type TourKitTestingErrorOptions } from './error'
+
+// Setup (re-exported here so consumers can import from the main barrel; the
+// dedicated `./setup` subpath exists for setup files that don't want to pull
+// the helpers' RTL dependency graph).
+export { setupTourKitTesting, type SetupOptions } from './setup'
+
+// Helpers
+export { virtualTarget, type VirtualTarget } from './helpers/virtual-target'
+export {
+  expectStepVisible,
+  type ExpectStepVisibleOptions,
+} from './helpers/expect-step-visible'
+export { advanceTour, type AdvanceTourOptions } from './helpers/advance-tour'
+export { previousTour, type PreviousTourOptions } from './helpers/previous-tour'
+export { skipTour, type SkipTourOptions } from './helpers/skip-tour'
+export { completeTour, type CompleteTourOptions } from './helpers/complete-tour'
+export { goToStep } from './helpers/go-to-step'
+
+// Probe — required for `goToStep` to function; render inside <TourProvider>.
+export { HookProbe, getActiveTourHandle } from './helpers/hook-probe'
+
+// Re-exports for ergonomic consumer imports.
+export { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react'

--- a/packages/testing-library/src/setup.ts
+++ b/packages/testing-library/src/setup.ts
@@ -1,0 +1,30 @@
+export interface SetupOptions {
+  /**
+   * Opt in to the `jsdom-testing-mocks` lazy shim. When `true`, the package is
+   * dynamically imported on demand — consumers who don't opt in never load it.
+   *
+   * The optional `defaultRect` is a hint surface; mutating a global default
+   * isn't shipped in Phase 5 (the underlying library is per-element). Call
+   * `mockElementBoundingClientRect(element, rect)` from `jsdom-testing-mocks`
+   * directly in your `beforeEach` for the elements you care about.
+   */
+  positionShim?: boolean | { defaultRect?: Partial<DOMRect> }
+}
+
+/**
+ * One-shot setup orchestrator for Tour Kit RTL tests.
+ *
+ * Default (no args): touches NOTHING. `Element.prototype.getBoundingClientRect`
+ * stays the JSDOM stock descriptor. Phase 5's whole contract is that you only
+ * pay for what you opt into.
+ *
+ * With `positionShim: true`: lazy-imports `jsdom-testing-mocks` so its public
+ * API (e.g. `mockElementBoundingClientRect`) is available in the same tick.
+ * The shim is intentionally a thin hint — consumers still apply per-element
+ * rects themselves; the lazy import just guarantees the dep is loaded.
+ */
+export async function setupTourKitTesting(opts: SetupOptions = {}): Promise<void> {
+  if (!opts.positionShim) return
+  // Lazy — the require/import chain is what gates the optional peer dep.
+  await import('jsdom-testing-mocks')
+}

--- a/packages/testing-library/src/setup.ts
+++ b/packages/testing-library/src/setup.ts
@@ -3,12 +3,11 @@ export interface SetupOptions {
    * Opt in to the `jsdom-testing-mocks` lazy shim. When `true`, the package is
    * dynamically imported on demand — consumers who don't opt in never load it.
    *
-   * The optional `defaultRect` is a hint surface; mutating a global default
-   * isn't shipped in Phase 5 (the underlying library is per-element). Call
+   * Per-element rect mocking stays the consumer's responsibility: call
    * `mockElementBoundingClientRect(element, rect)` from `jsdom-testing-mocks`
    * directly in your `beforeEach` for the elements you care about.
    */
-  positionShim?: boolean | { defaultRect?: Partial<DOMRect> }
+  positionShim?: boolean
 }
 
 /**

--- a/packages/testing-library/tsconfig.json
+++ b/packages/testing-library/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tooling/tsconfig/react-library.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vitest/globals", "@testing-library/jest-dom", "node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/testing-library/tsup.config.ts
+++ b/packages/testing-library/tsup.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    setup: 'src/setup.ts',
+  },
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  treeshake: true,
+  splitting: false,
+  minify: false,
+  sourcemap: true,
+  target: 'es2020',
+  outDir: 'dist',
+  external: [
+    'react',
+    'react-dom',
+    '@tour-kit/core',
+    '@tour-kit/react',
+    '@testing-library/react',
+    '@testing-library/user-event',
+    'vitest',
+    'jsdom-testing-mocks',
+  ],
+})

--- a/packages/testing-library/vitest.config.ts
+++ b/packages/testing-library/vitest.config.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      // Run against live source so tests pick up the latest TourCard without
+      // a rebuild step in between. Aligns with how the @tour-kit/react
+      // package tests its own source tree.
+      '@tour-kit/core': resolve(__dirname, '../core/src'),
+      '@tour-kit/react': resolve(__dirname, '../react/src'),
+      '@tour-kit/media': resolve(__dirname, '../media/src'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/__tests__/**/*.test.{ts,tsx}'],
+  },
+})

--- a/packages/testing-library/vitest.setup.ts
+++ b/packages/testing-library/vitest.setup.ts
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom/vitest'
+import 'vitest-axe/extend-expect'
+import { cleanup } from '@testing-library/react'
+import { afterEach, vi } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  document.body.innerHTML = ''
+})
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
+window.scrollTo = vi.fn() as unknown as typeof window.scrollTo
+Element.prototype.scrollIntoView = vi.fn()
+
+Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+  get(this: HTMLElement) {
+    if ((this as HTMLElement).style?.display === 'none' || !this.isConnected) {
+      return null
+    }
+    return document.body
+  },
+  configurable: true,
+})
+
+// IMPORTANT: This setup intentionally does NOT touch
+// Element.prototype.getBoundingClientRect. Phase 5's contract is that the
+// default test setup leaves that descriptor alone — opt in via
+// setupTourKitTesting({ positionShim: true }) when you need it.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ catalogs:
     jsdom:
       specifier: ^27.3.0
       version: 27.4.0
+    jsdom-testing-mocks:
+      specifier: ^1.13.0
+      version: 1.16.0
     tsup:
       specifier: ^8.5.1
       version: 8.5.1
@@ -1310,6 +1313,58 @@ importers:
       jsdom:
         specifier: 'catalog:'
         version: 27.4.0
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
+
+  packages/testing-library:
+    dependencies:
+      '@tour-kit/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@tour-kit/react':
+        specifier: workspace:*
+        version: link:../react
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.2
+        version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      jsdom:
+        specifier: 'catalog:'
+        version: 27.4.0
+      jsdom-testing-mocks:
+        specifier: 'catalog:'
+        version: 1.16.0
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -4110,6 +4165,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bezier-easing@2.1.0:
+    resolution: {integrity: sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -4328,6 +4386,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-mediaquery@0.1.2:
+    resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -5508,6 +5569,10 @@ packages:
     peerDependenciesMeta:
       '@babel/preset-env':
         optional: true
+
+  jsdom-testing-mocks@1.16.0:
+    resolution: {integrity: sha512-wLrulXiLpjmcUYOYGEvz4XARkrmdVpyxzdBl9IAMbQ+ib2/UhUTRCn49McdNfXLff2ysGBUms49ZKX0LR1Q0gg==}
+    engines: {node: '>=14'}
 
   jsdom@27.4.0:
     resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
@@ -10421,6 +10486,8 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bezier-easing@2.1.0: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -10624,6 +10691,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-mediaquery@0.1.2: {}
 
   css-tree@3.2.1:
     dependencies:
@@ -12121,6 +12190,11 @@ snapshots:
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
+
+  jsdom-testing-mocks@1.16.0:
+    dependencies:
+      bezier-easing: 2.1.0
+      css-mediaquery: 0.1.2
 
   jsdom@27.4.0:
     dependencies:

--- a/tasks/sprint-1-ts-first-dx/plan/phase-5-status.json
+++ b/tasks/sprint-1-ts-first-dx/plan/phase-5-status.json
@@ -1,0 +1,10 @@
+{
+  "phase": 5,
+  "status": "green",
+  "iterations": 1,
+  "tests_total": 30,
+  "tests_passed": 30,
+  "bundle_index_gz_bytes": 1573,
+  "bundle_setup_gz_bytes": 181,
+  "timestamp": "2026-05-13T07:42:33.950202+00:00"
+}

--- a/tasks/sprint-1-ts-first-dx/plan/phase-5-status.json
+++ b/tasks/sprint-1-ts-first-dx/plan/phase-5-status.json
@@ -1,10 +1,11 @@
 {
   "phase": 5,
-  "status": "green",
+  "status": "pr_open",
   "iterations": 1,
+  "pr_url": "https://github.com/domidex01/tour-kit/pull/43",
   "tests_total": 30,
   "tests_passed": 30,
   "bundle_index_gz_bytes": 1573,
   "bundle_setup_gz_bytes": 181,
-  "timestamp": "2026-05-13T07:42:33.950202+00:00"
+  "timestamp": "2026-05-13T07:44:09.691168+00:00"
 }


### PR DESCRIPTION
## Phase 5 — `@tour-kit/testing-library`

Sprint 1 / Phase 5 of TS-First DX. Ships a new headless RTL package so consumer tests can write `await expectStepVisible('welcome')` and `await advanceTour()` against real `<TourCard>` without re-deriving the Floating UI virtual-element + `act()` flush pattern in every suite.

### Key contracts

- **Zero consumer `await act(...)`.** Every helper wraps the flush internally. Enforced as a build gate via grep in `entry-points.test.ts`.
- **Default `setupTourKitTesting()` touches nothing.** `Element.prototype.getBoundingClientRect` stays the JSDOM stock descriptor (verified by `prototype-untouched.test.ts`).
- **Opt-in `positionShim: true`** lazy-imports `jsdom-testing-mocks`. Consumers who don't opt in never load the dep.
- **`TourKitTestingError`** carries `stepId`, `tourId`, `cause`, and a humanised message — debuggers don't grep the stack.

### Public surface

```ts
import {
  expectStepVisible, advanceTour, previousTour, skipTour,
  completeTour, goToStep, virtualTarget, HookProbe,
  setupTourKitTesting, TourKitTestingError,
} from '@tour-kit/testing-library'
import { setupTourKitTesting } from '@tour-kit/testing-library/setup'
```

### Bundle sizes (gzipped)

| Entry | Size | Budget |
|-------|------|--------|
| `dist/index.js` | 1573 B | 4096 B |
| `dist/setup.js` | 181 B  | 4096 B |

### Verification

- `pnpm --filter @tour-kit/testing-library typecheck` → exit 0
- `pnpm --filter @tour-kit/testing-library build` → ESM + CJS + DTS for both entries
- `pnpm --filter @tour-kit/testing-library test` → **30 tests, 6 files, all green**
- `pnpm --filter @tour-kit/react typecheck && test` → **460 tests still green** (TourCard `data-tour-step` attribute is purely additive)
- `grep -rEc 'await\s+act\b' packages/testing-library/src/__tests__` over consumer test files → **0**

### Changes

| File | Why |
|------|-----|
| `packages/react/src/components/card/tour-card.tsx` | Emit `data-tour-step={id}` on the rendered dialog so `expectStepVisible` can locate the active step |
| `packages/testing-library/**` | New package — helpers, error, setup, fixtures, 6 test files |
| `apps/docs/content/docs/guides/testing.mdx` (+ `meta.json`) | New testing guide; cross-links to Phase 6 Playwright for browser-position tests |
| `apps/docs/public/{context,llms*}` | Regenerated by `fumadocs-mdx` — picks up Phase 3 diagnostic page that wasn't yet indexed |
| `tasks/sprint-1-ts-first-dx/plan/phase-5-status.json` | Run-phase status (status: green, 30/30 passing, 1 iteration to GREEN) |

### Test plan

- [x] Type check + build green for the new package
- [x] All 30 tests pass; 12+ integration cases against real `<TourCard>`
- [x] axe zero violations on the rendered welcome card
- [x] Default setup leaves `Element.prototype.getBoundingClientRect` descriptor untouched (verified)
- [x] `positionShim: true` lazy-imports `jsdom-testing-mocks` (verified via `vi.mock` factory counter)
- [x] CJS + ESM resolution for `.` and `./setup` entry points (spawned `node -e require(...)` smoke)
- [x] No consumer-side `await act(...)` in any integration test file
- [x] `@tour-kit/react` test suite remains green (460 tests) after `data-tour-step` addition

### Note on docs build

`pnpm --filter docs build` currently fails on `/blog/page` with `TypeError: Cannot read properties of null (reading 'useMemo')` — pre-existing on `main` (independent of this PR). MDX compilation for `testing.mdx` itself succeeds (`pnpm exec fumadocs-mdx` clean).

🤖 Generated with run-phase skill