### PR TITLE
feat(phase-6): @tour-kit/playwright + opt-in test bridge (#86)

### DIFF
--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -22,6 +22,7 @@
     "adoption-analytics",
     "announcements-scheduling",
     "checklists-tours",
-    "unified-slot"
+    "unified-slot",
+    "playwright"
   ]
 }

--- a/apps/docs/content/docs/guides/playwright.mdx
+++ b/apps/docs/content/docs/guides/playwright.mdx
@@ -1,0 +1,155 @@
+---
+title: Playwright
+description: >-
+  Drive Tour Kit from Playwright with the typed `test.extend({ tour })`
+  fixture and the opt-in `window.__tourKit__` bridge.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+`@tour-kit/playwright` adds a typed `test.extend({ tour })` fixture so your
+end-to-end specs can move a tour forward without writing `page.click`
+boilerplate. It is backed by `window.__tourKit__` — a dev-only bridge that
+`<TourProvider>` exposes only when you explicitly opt in.
+
+<Callout type="warn">
+  **Security**: `enableTestBridge` defaults to `false`. **Never** ship a
+  production bundle with the bridge enabled — wrap it in a `NODE_ENV` guard.
+</Callout>
+
+## Install
+
+```bash
+pnpm add -D @tour-kit/playwright @playwright/test
+```
+
+`@playwright/test` is a peer dependency. Tour Kit supports `^1.58.0` and up.
+
+## 1 — Activate the bridge
+
+The bridge is what Playwright actually drives. Toggle it via `enableTestBridge`
+on `<TourProvider>` — and guard it with `NODE_ENV` so production never gets
+the surface:
+
+```tsx
+import { TourProvider } from '@tour-kit/core'
+
+export function AppProviders({ children }) {
+  return (
+    <TourProvider
+      tours={[onboardingTour]}
+      enableTestBridge={process.env.NODE_ENV !== 'production'}
+    >
+      {children}
+    </TourProvider>
+  )
+}
+```
+
+When `enableTestBridge` is `true`, `<TourProvider>` publishes
+`window.__tourKit__` with the following shape:
+
+```ts
+import type { TestBridge, EligibilityReport } from '@tour-kit/core'
+
+declare global {
+  interface Window {
+    __tourKit__?: TestBridge
+  }
+}
+
+interface TestBridge {
+  start: (tourId: string) => void
+  next: () => void
+  previous: () => void
+  goToStep: (stepId: string) => void
+  complete: () => void
+  skip: () => void
+  getDiagnostic: (tourId: string) => EligibilityReport | null
+}
+```
+
+In development, the provider also logs a single `console.warn` per mount
+reminding you the bridge is on. Production builds are silent.
+
+## 2 — Write a test
+
+Import `test` and `expect` from `@tour-kit/playwright` instead of
+`@playwright/test`. The `tour` fixture is scoped per-test:
+
+```ts
+import { test, expect } from '@tour-kit/playwright'
+
+test('onboarding happy path', async ({ page, tour }) => {
+  await page.goto('/')
+  await tour.start('onboarding')
+  await tour.waitForStep('welcome')
+  await tour.next()
+  await tour.waitForStep('pricing')
+  await tour.complete()
+})
+```
+
+### `tour` helpers
+
+| Helper | Behavior |
+|---|---|
+| `tour.start(id)` | Calls `window.__tourKit__.start(id)`. |
+| `tour.waitForStep(stepId, opts?)` | Waits for `[data-tour-step="<id>"]` to be visible. Accepts `{ timeout }`. |
+| `tour.next()` / `tour.previous()` | Step navigation. |
+| `tour.goToStep(stepId)` | Jump directly. |
+| `tour.complete()` / `tour.skip()` | End the tour. |
+| `tour.getDiagnostic(tourId)` | Read the Phase 3 `EligibilityReport`. Returns `null` without `diagnose`. |
+
+Every helper short-circuits with a clear error pointing at
+`enableTestBridge` if the bridge is missing — saving you ten minutes of
+confused debugging.
+
+## 3 — Diagnostic integration
+
+Mount the provider with both `diagnose` and `enableTestBridge` to surface
+gate diagnostics in your specs:
+
+```tsx
+<TourProvider
+  tours={[onboardingTour]}
+  diagnose
+  enableTestBridge={process.env.NODE_ENV !== 'production'}
+>
+```
+
+```ts
+test('audience gate blocks free users', async ({ page, tour }) => {
+  await page.goto('/?role=free')
+  const report = await tour.getDiagnostic('pro-only-tour')
+  expect(report?.willFire).toBe(false)
+  expect(report?.firstFailingGate?.code).toBe('AUDIENCE_MISMATCH')
+})
+```
+
+See [Diagnostic engine](/docs/core/diagnostic) for the full `EligibilityReport`
+shape and gate codes.
+
+## Security note
+
+`window.__tourKit__` is a tour-control surface. A production build that
+exposes it lets anyone with browser dev tools start, complete, or skip
+your tours. The default is `false` for that reason — keep it that way:
+
+```tsx
+// ✅ Recommended
+enableTestBridge={process.env.NODE_ENV !== 'production'}
+
+// ❌ Never
+enableTestBridge
+```
+
+The provider's effect short-circuits at the top when `enableTestBridge` is
+`false`, so bundlers can dead-code-eliminate the bridge body in production.
+
+## Related
+
+- [Testing Library](/docs/guides/testing) — jsdom helpers for component-level
+  positioning assertions.
+- [Diagnostic engine](/docs/core/diagnostic) — what `tour.getDiagnostic`
+  returns.

--- a/apps/docs/content/docs/guides/testing.mdx
+++ b/apps/docs/content/docs/guides/testing.mdx
@@ -174,4 +174,4 @@ try {
 
 ## Browser-positioning tests live elsewhere
 
-This package asserts on **presence** — "did the step mount?", "did Next advance?" — not **position**. For pixel-perfect placement assertions, use Playwright via [`@tour-kit/playwright`](./nextjs#end-to-end-with-playwright) (Phase 6). Phase 5 helpers stop at the jsdom boundary by design.
+This package asserts on **presence** — "did the step mount?", "did Next advance?" — not **position**. For pixel-perfect placement assertions, use [`@tour-kit/playwright`](./playwright) — it ships a `test.extend({ tour })` fixture backed by the opt-in `window.__tourKit__` bridge. Phase 5 helpers stop at the jsdom boundary by design.

--- a/packages/core/src/context/__tests__/test-bridge.test.tsx
+++ b/packages/core/src/context/__tests__/test-bridge.test.tsx
@@ -6,6 +6,7 @@ import { TourProvider } from '../tour-provider'
 beforeEach(() => {
   // Belt-and-suspenders: previous tests' provider cleanup should already have
   // removed the global, but a missed unmount would leak across this suite.
+  // biome-ignore lint/performance/noDelete: must fully remove the property — `= undefined` leaves it as an own property and would mask leaks
   delete (window as { __tourKit__?: unknown }).__tourKit__
   // Mount the targets referenced by the fixture so any diagnose path resolves.
   document.body.innerHTML = '<div id="a"></div><div id="b"></div>'
@@ -69,6 +70,7 @@ describe('TestBridge — surface & lifecycle', () => {
     unmount()
     expect(window.__tourKit__).toBe(sentinel)
     // Reset for the next test.
+    // biome-ignore lint/performance/noDelete: full removal — keeps test isolation symmetrical with provider cleanup
     delete (window as { __tourKit__?: unknown }).__tourKit__
   })
 

--- a/packages/core/src/context/__tests__/test-bridge.test.tsx
+++ b/packages/core/src/context/__tests__/test-bridge.test.tsx
@@ -1,0 +1,145 @@
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { twoStepTour } from '../../__tests__/_fixtures'
+import { TourProvider } from '../tour-provider'
+
+beforeEach(() => {
+  // Belt-and-suspenders: previous tests' provider cleanup should already have
+  // removed the global, but a missed unmount would leak across this suite.
+  delete (window as { __tourKit__?: unknown }).__tourKit__
+  // Mount the targets referenced by the fixture so any diagnose path resolves.
+  document.body.innerHTML = '<div id="a"></div><div id="b"></div>'
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('TestBridge — surface & lifecycle', () => {
+  it('window.__tourKit__ is undefined when enableTestBridge is unset', () => {
+    render(
+      <TourProvider tours={[twoStepTour]}>
+        <div />
+      </TourProvider>
+    )
+    expect(window.__tourKit__).toBeUndefined()
+  })
+
+  it('exposes all 7 methods when enableTestBridge is true', () => {
+    render(
+      <TourProvider tours={[twoStepTour]} enableTestBridge>
+        <div />
+      </TourProvider>
+    )
+    const bridge = window.__tourKit__
+    expect(bridge).toBeDefined()
+    expect(typeof bridge?.start).toBe('function')
+    expect(typeof bridge?.next).toBe('function')
+    expect(typeof bridge?.previous).toBe('function')
+    expect(typeof bridge?.goToStep).toBe('function')
+    expect(typeof bridge?.complete).toBe('function')
+    expect(typeof bridge?.skip).toBe('function')
+    expect(typeof bridge?.getDiagnostic).toBe('function')
+  })
+
+  it('cleans up window.__tourKit__ on unmount', () => {
+    const { unmount } = render(
+      <TourProvider tours={[twoStepTour]} enableTestBridge>
+        <div />
+      </TourProvider>
+    )
+    expect(window.__tourKit__).toBeDefined()
+    unmount()
+    expect(window.__tourKit__).toBeUndefined()
+  })
+
+  it('cleanup does NOT delete a foreign value reassigned after mount', () => {
+    const { unmount } = render(
+      <TourProvider tours={[twoStepTour]} enableTestBridge>
+        <div />
+      </TourProvider>
+    )
+    // Simulate a foreign library (or a second provider) overwriting the global
+    // after our mount. The cleanup must only remove its OWN bridge — proving
+    // it identity-checks before deleting.
+    const sentinel = { foreign: true } as unknown as Window['__tourKit__']
+    ;(window as Window).__tourKit__ = sentinel
+    unmount()
+    expect(window.__tourKit__).toBe(sentinel)
+    // Reset for the next test.
+    delete (window as { __tourKit__?: unknown }).__tourKit__
+  })
+
+  it('logs dev warning once per mount', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const { rerender } = render(
+      <TourProvider tours={[twoStepTour]} enableTestBridge>
+        <div />
+      </TourProvider>
+    )
+    rerender(
+      <TourProvider tours={[twoStepTour]} enableTestBridge>
+        <div />
+      </TourProvider>
+    )
+    const bridgeCalls = warn.mock.calls.filter((args) =>
+      String(args[0] ?? '').includes('Test bridge')
+    )
+    expect(bridgeCalls).toHaveLength(1)
+    expect(String(bridgeCalls[0]?.[0])).toMatch(/Tour Kit/i)
+  })
+
+  it('does NOT warn in production', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    render(
+      <TourProvider tours={[twoStepTour]} enableTestBridge>
+        <div />
+      </TourProvider>
+    )
+    const bridgeCalls = warn.mock.calls.filter((args) =>
+      String(args[0] ?? '').includes('Test bridge')
+    )
+    expect(bridgeCalls).toHaveLength(0)
+  })
+
+  it('getDiagnostic returns a populated EligibilityReport when diagnose is on', async () => {
+    render(
+      <TourProvider tours={[twoStepTour]} enableTestBridge diagnose>
+        <div />
+      </TourProvider>
+    )
+    // Phase 3 populates `diagnostics` asynchronously after explainTour resolves.
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const report = window.__tourKit__?.getDiagnostic('demo')
+    expect(report).not.toBeNull()
+    expect(report?.tourId).toBe('demo')
+    expect(Array.isArray(report?.reasons)).toBe(true)
+  })
+
+  it('getDiagnostic returns null without diagnose', () => {
+    render(
+      <TourProvider tours={[twoStepTour]} enableTestBridge>
+        <div />
+      </TourProvider>
+    )
+    expect(window.__tourKit__?.getDiagnostic('demo')).toBeNull()
+  })
+
+  it('getDiagnostic returns null for an unknown tour id even with diagnose on', async () => {
+    render(
+      <TourProvider tours={[twoStepTour]} enableTestBridge diagnose>
+        <div />
+      </TourProvider>
+    )
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(window.__tourKit__?.getDiagnostic('does-not-exist')).toBeNull()
+  })
+})

--- a/packages/core/src/context/__tests__/test-bridge.test.tsx
+++ b/packages/core/src/context/__tests__/test-bridge.test.tsx
@@ -74,19 +74,23 @@ describe('TestBridge — surface & lifecycle', () => {
     delete (window as { __tourKit__?: unknown }).__tourKit__
   })
 
-  it('logs dev warning once per mount', () => {
+  it('logs dev warning once even across an enableTestBridge toggle cycle', () => {
+    // The warn-once guard is only meaningful when the effect actually re-runs.
+    // Toggling `enableTestBridge` forces cleanup → re-mount of the effect; the
+    // `testBridgeWarnedRef` must suppress the second warn. A bare rerender with
+    // identical props wouldn't exercise the guard at all (effect deps stable).
     vi.stubEnv('NODE_ENV', 'development')
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const { rerender } = render(
-      <TourProvider tours={[twoStepTour]} enableTestBridge>
-        <div />
-      </TourProvider>
-    )
-    rerender(
-      <TourProvider tours={[twoStepTour]} enableTestBridge>
-        <div />
-      </TourProvider>
-    )
+    function Harness({ enabled }: { enabled: boolean }) {
+      return (
+        <TourProvider tours={[twoStepTour]} enableTestBridge={enabled}>
+          <div />
+        </TourProvider>
+      )
+    }
+    const { rerender } = render(<Harness enabled={true} />)
+    rerender(<Harness enabled={false} />) // cleanup; bridge gone
+    rerender(<Harness enabled={true} />) // effect runs again; guard must skip warn
     const bridgeCalls = warn.mock.calls.filter((args) =>
       String(args[0] ?? '').includes('Test bridge')
     )
@@ -94,7 +98,7 @@ describe('TestBridge — surface & lifecycle', () => {
     expect(String(bridgeCalls[0]?.[0])).toMatch(/Tour Kit/i)
   })
 
-  it('does NOT warn in production', () => {
+  it('does NOT warn in production but still publishes the bridge when opted in', () => {
     vi.stubEnv('NODE_ENV', 'production')
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     render(
@@ -106,6 +110,10 @@ describe('TestBridge — surface & lifecycle', () => {
       String(args[0] ?? '').includes('Test bridge')
     )
     expect(bridgeCalls).toHaveLength(0)
+    // Explicit opt-in MUST work in any NODE_ENV — guards a regression where the
+    // prod check short-circuits the whole effect instead of just the warning.
+    expect(window.__tourKit__).toBeDefined()
+    expect(typeof window.__tourKit__?.next).toBe('function')
   })
 
   it('getDiagnostic returns a populated EligibilityReport when diagnose is on', async () => {

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -1563,16 +1563,10 @@ export function TourProvider({
   //   re-creating (and re-publishing) the bridge on every controller-method
   //   identity change, which would invalidate any cached helper closures in
   //   long-running Playwright contexts.
-  const bridgeMethodsRef = React.useRef<{
-    start: typeof start
-    next: typeof next
-    previous: typeof prev
-    goToStep: typeof goToStep
-    complete: typeof complete
-    skip: typeof skip
-    diagnostics: typeof diagnostics
-  }>({ start, next, previous: prev, goToStep, complete, skip, diagnostics })
-  bridgeMethodsRef.current = {
+  // Build the latest-methods snapshot once per render, then publish to the ref.
+  // The ref initial value uses the same object so the first effect run sees a
+  // populated `current` even before this render's assignment commits.
+  const bridgeMethods = {
     start,
     next,
     previous: prev,
@@ -1581,6 +1575,8 @@ export function TourProvider({
     skip,
     diagnostics,
   }
+  const bridgeMethodsRef = React.useRef(bridgeMethods)
+  bridgeMethodsRef.current = bridgeMethods
 
   const testBridgeWarnedRef = React.useRef(false)
 

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -16,8 +16,8 @@ import type {
   TourStep,
 } from '../types'
 import type { DiagnosticContext, DiagnosticGate, EligibilityReport } from '../types/diagnostic'
-import type { TestBridge } from '../types/test-bridge'
 import type { MultiPagePersistenceConfig, RouterAdapter } from '../types/router'
+import type { TestBridge } from '../types/test-bridge'
 import {
   isBranchToTour,
   isBranchWait,
@@ -1584,15 +1584,11 @@ export function TourProvider({
 
   const testBridgeWarnedRef = React.useRef(false)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the bridge is intentionally established once per enableTestBridge toggle; method dispatch goes through bridgeMethodsRef
   React.useEffect(() => {
     if (!enableTestBridge) return
     if (typeof window === 'undefined') return
 
-    if (
-      typeof process === 'undefined' ||
-      process.env?.NODE_ENV !== 'production'
-    ) {
+    if (typeof process === 'undefined' || process.env?.NODE_ENV !== 'production') {
       if (!testBridgeWarnedRef.current) {
         testBridgeWarnedRef.current = true
         console.warn('[Tour Kit] Test bridge enabled. Disable for production.')
@@ -1626,6 +1622,7 @@ export function TourProvider({
       // Identity check defends against another library reassigning the global
       // between our mount and unmount — see the cleanup-safety unit test.
       if (window.__tourKit__ === bridge) {
+        // biome-ignore lint/performance/noDelete: full removal mirrors the absent-by-default invariant — `= undefined` would leave an own property and break consumer `'__tourKit__' in window` checks
         delete window.__tourKit__
       }
     }

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -16,6 +16,7 @@ import type {
   TourStep,
 } from '../types'
 import type { DiagnosticContext, DiagnosticGate, EligibilityReport } from '../types/diagnostic'
+import type { TestBridge } from '../types/test-bridge'
 import type { MultiPagePersistenceConfig, RouterAdapter } from '../types/router'
 import {
   isBranchToTour,
@@ -370,6 +371,16 @@ export interface TourProviderProps {
    * Only read when `diagnose` is `true`.
    */
   userContext?: Record<string, unknown>
+  /**
+   * Dev-only test bridge — when `true`, sets `window.__tourKit__` to a
+   * `TestBridge` exposing the imperative controls (mirrors the existing
+   * ref) so Playwright/E2E drivers can advance a tour from outside React.
+   *
+   * Defaults to `false`. Production builds MUST never expose this — wrap
+   * in a `process.env.NODE_ENV !== 'production'` guard at the call site.
+   * Tree-shakes when the prop is a literal `false`.
+   */
+  enableTestBridge?: boolean
 }
 
 interface CrossTabActiveMessage {
@@ -391,6 +402,7 @@ export function TourProvider({
   diagnose = false,
   diagnosticGates,
   userContext,
+  enableTestBridge = false,
 }: TourProviderProps) {
   // Validate synchronously at render time so misconfigured hidden steps throw
   // at the caller's render() instead of leaking into runtime. Cheap: just a
@@ -1538,6 +1550,86 @@ export function TourProvider({
       handleBranchTarget,
     ]
   )
+
+  // ─── Test bridge wiring (Phase 6, issue #86) ─────────────────────────────
+  // `enableTestBridge` opts in to `window.__tourKit__` — used by Playwright
+  // helpers to drive a tour from out-of-process. Default is `false` so
+  // production never leaks the surface. The effect short-circuits at the top
+  // when disabled, making the bridge body dead-code under a literal `false`.
+  //
+  // Why a methods ref:
+  // - The bridge identity is stable per mount, but each call must dispatch
+  //   through the LATEST `start`/`next`/etc. closures. A ref avoids
+  //   re-creating (and re-publishing) the bridge on every controller-method
+  //   identity change, which would invalidate any cached helper closures in
+  //   long-running Playwright contexts.
+  const bridgeMethodsRef = React.useRef<{
+    start: typeof start
+    next: typeof next
+    previous: typeof prev
+    goToStep: typeof goToStep
+    complete: typeof complete
+    skip: typeof skip
+    diagnostics: typeof diagnostics
+  }>({ start, next, previous: prev, goToStep, complete, skip, diagnostics })
+  bridgeMethodsRef.current = {
+    start,
+    next,
+    previous: prev,
+    goToStep,
+    complete,
+    skip,
+    diagnostics,
+  }
+
+  const testBridgeWarnedRef = React.useRef(false)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the bridge is intentionally established once per enableTestBridge toggle; method dispatch goes through bridgeMethodsRef
+  React.useEffect(() => {
+    if (!enableTestBridge) return
+    if (typeof window === 'undefined') return
+
+    if (
+      typeof process === 'undefined' ||
+      process.env?.NODE_ENV !== 'production'
+    ) {
+      if (!testBridgeWarnedRef.current) {
+        testBridgeWarnedRef.current = true
+        console.warn('[Tour Kit] Test bridge enabled. Disable for production.')
+      }
+    }
+
+    const bridge: TestBridge = {
+      start: (tourId) => {
+        void bridgeMethodsRef.current.start(tourId)
+      },
+      next: () => {
+        void bridgeMethodsRef.current.next()
+      },
+      previous: () => {
+        void bridgeMethodsRef.current.previous()
+      },
+      goToStep: (stepId) => {
+        void bridgeMethodsRef.current.goToStep(stepId)
+      },
+      complete: () => {
+        bridgeMethodsRef.current.complete()
+      },
+      skip: () => {
+        bridgeMethodsRef.current.skip()
+      },
+      getDiagnostic: (tourId) => bridgeMethodsRef.current.diagnostics[tourId] ?? null,
+    }
+    window.__tourKit__ = bridge
+
+    return () => {
+      // Identity check defends against another library reassigning the global
+      // between our mount and unmount — see the cleanup-safety unit test.
+      if (window.__tourKit__ === bridge) {
+        delete window.__tourKit__
+      }
+    }
+  }, [enableTestBridge])
 
   const contextValue = React.useMemo<TourContextValue>(
     () => ({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -208,6 +208,12 @@ export type {
   GateReason,
 } from './types/diagnostic'
 
+// Test bridge — Phase 6 (issue #86). Importing `./types/window-augment` for
+// its side-effect registers the ambient `Window.__tourKit__?` declaration so
+// consumers writing Playwright tests get strict typing without re-declaring it.
+import './types/window-augment'
+export type { TestBridge } from './types/test-bridge'
+
 // Frequency rules — Phase 3a (lifted from @tour-kit/announcements)
 export {
   canShowByFrequency,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,9 @@
+// Side-effect import: registers the ambient `Window.__tourKit__?` declaration
+// in `./types/window-augment.ts` so consumers writing Playwright tests get
+// strict typing without re-declaring it. The file is type-only; tsup rolls
+// the `declare global` into the published .d.ts.
+import './types/window-augment'
+
 // Types - use explicit type exports for tree shaking
 export type {
   // Branch types
@@ -208,10 +214,8 @@ export type {
   GateReason,
 } from './types/diagnostic'
 
-// Test bridge — Phase 6 (issue #86). Importing `./types/window-augment` for
-// its side-effect registers the ambient `Window.__tourKit__?` declaration so
-// consumers writing Playwright tests get strict typing without re-declaring it.
-import './types/window-augment'
+// Test bridge — Phase 6 (issue #86). The ambient `Window.__tourKit__?`
+// declaration is registered via the side-effect import at the top of this file.
 export type { TestBridge } from './types/test-bridge'
 
 // Frequency rules — Phase 3a (lifted from @tour-kit/announcements)

--- a/packages/core/src/types/test-bridge.ts
+++ b/packages/core/src/types/test-bridge.ts
@@ -1,0 +1,33 @@
+import type { EligibilityReport } from './diagnostic'
+
+/**
+ * Dev-mode test bridge — published on `window.__tourKit__` ONLY when a
+ * `<TourProvider enableTestBridge>` is mounted. Mirrors the existing
+ * imperative ref so Playwright (and other out-of-process drivers) can move
+ * a tour forward without re-deriving controller boilerplate.
+ *
+ * The bridge is intentionally read-mostly: every control verb already exists
+ * on the provider. Production builds tree-shake it away because
+ * `enableTestBridge` defaults to `false` and the effect short-circuits at
+ * the top.
+ */
+export interface TestBridge {
+  /** Programmatically start a tour by id. */
+  start: (tourId: string) => void
+  /** Advance to the next step in the active tour. */
+  next: () => void
+  /** Go back one step in the active tour. */
+  previous: () => void
+  /** Jump to a specific step by id in the active tour. */
+  goToStep: (stepId: string) => void
+  /** Mark the active tour completed. */
+  complete: () => void
+  /** Skip the active tour. */
+  skip: () => void
+  /**
+   * Read the diagnostic for a registered tour. Returns `null` when
+   * `diagnose` is `false` (the default) or when no tour with the given id
+   * is registered.
+   */
+  getDiagnostic: (tourId: string) => EligibilityReport | null
+}

--- a/packages/core/src/types/window-augment.ts
+++ b/packages/core/src/types/window-augment.ts
@@ -15,5 +15,3 @@ declare global {
     __tourKit__?: TestBridge
   }
 }
-
-export {}

--- a/packages/core/src/types/window-augment.ts
+++ b/packages/core/src/types/window-augment.ts
@@ -1,0 +1,19 @@
+import type { TestBridge } from './test-bridge'
+
+/**
+ * Ambient augmentation publishing the dev-mode test bridge on `window`.
+ *
+ * The `?` is non-negotiable: production builds (and any provider that omits
+ * `enableTestBridge`) MUST leave the global as `undefined`. Consumers should
+ * always optional-chain through `window.__tourKit__?.` so a missing bridge
+ * never crashes their tooling.
+ *
+ * @internal Wired by `<TourProvider enableTestBridge>` — never set directly.
+ */
+declare global {
+  interface Window {
+    __tourKit__?: TestBridge
+  }
+}
+
+export {}

--- a/packages/playwright/__tests__/entry-types.test.ts
+++ b/packages/playwright/__tests__/entry-types.test.ts
@@ -1,0 +1,25 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const DTS = join(__dirname, '..', 'dist', 'index.d.ts')
+
+describe('@tour-kit/playwright — strict typings', () => {
+  it('built dist/index.d.ts exists (run `pnpm --filter @tour-kit/playwright build` first)', () => {
+    expect(existsSync(DTS)).toBe(true)
+  })
+
+  it('public surface contains zero `any` types', () => {
+    if (!existsSync(DTS)) {
+      // The previous test already failed loudly — short-circuit so this
+      // assertion reports the meaningful "0 any" expectation.
+      return
+    }
+    const dts = readFileSync(DTS, 'utf8')
+    // Word-boundary regex so we don't count `many`, `company`, etc.
+    const matches = dts.match(/\bany\b/g) ?? []
+    expect(matches.length).toBe(0)
+  })
+})

--- a/packages/playwright/__tests__/entry-types.test.ts
+++ b/packages/playwright/__tests__/entry-types.test.ts
@@ -4,20 +4,26 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const DTS = join(__dirname, '..', 'dist', 'index.d.ts')
+const DIST = join(__dirname, '..', 'dist')
+
+/**
+ * Both d.ts surfaces ship to consumers via the package `exports` field — ESM
+ * via `.types: ./dist/index.d.ts`, CJS via `require.types: ./dist/index.d.cts`.
+ * tsup normally emits identical content, but a future conditional re-export
+ * could diverge; assert the strict-typing promise holds on BOTH.
+ */
+const DTS_FILES = ['index.d.ts', 'index.d.cts'].map((f) => join(DIST, f))
 
 describe('@tour-kit/playwright — strict typings', () => {
-  it('built dist/index.d.ts exists (run `pnpm --filter @tour-kit/playwright build` first)', () => {
-    expect(existsSync(DTS)).toBe(true)
-  })
-
-  it('public surface contains zero `any` types', () => {
-    if (!existsSync(DTS)) {
-      // The previous test already failed loudly — short-circuit so this
-      // assertion reports the meaningful "0 any" expectation.
-      return
+  it.each(DTS_FILES)('%s contains zero `any` types', (file) => {
+    if (!existsSync(file)) {
+      // Fail loudly rather than silently passing — a missing dist means the
+      // gate didn't actually run, which is worse than a real `any` slipping in.
+      expect.fail(
+        `Missing ${file}. Run \`pnpm --filter @tour-kit/playwright build\` before this test.`
+      )
     }
-    const dts = readFileSync(DTS, 'utf8')
+    const dts = readFileSync(file, 'utf8')
     // Word-boundary regex so we don't count `many`, `company`, etc.
     const matches = dts.match(/\bany\b/g) ?? []
     expect(matches.length).toBe(0)

--- a/packages/playwright/__tests__/smoke.spec.ts
+++ b/packages/playwright/__tests__/smoke.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '../src'
+
+test.describe('@tour-kit/playwright smoke', () => {
+  test('start → waitForStep → next → waitForStep on real Chromium', async ({ page, tour }) => {
+    await page.goto('/two-step.html')
+    await tour.start('demo')
+    await tour.waitForStep('welcome')
+    await tour.next()
+    await tour.waitForStep('pricing')
+  })
+
+  test('window.__tourKit__ is undefined when enableTestBridge prop is omitted', async ({
+    page,
+  }) => {
+    await page.goto('/no-bridge.html')
+    // Wait one tick so React mount completes — without this we'd be racing
+    // the initial render and could read `undefined` for the wrong reason.
+    await page.waitForLoadState('networkidle')
+    const exists = await page.evaluate(() => typeof window.__tourKit__ !== 'undefined')
+    expect(exists).toBe(false)
+  })
+
+  test('tour.next() rejects with a useful error when the bridge is missing', async ({
+    page,
+    tour,
+  }) => {
+    await page.goto('/no-bridge.html')
+    await page.waitForLoadState('networkidle')
+    await expect(tour.next()).rejects.toThrow(/enableTestBridge/i)
+  })
+
+  test('tour.getDiagnostic returns a populated EligibilityReport with diagnose+bridge', async ({
+    page,
+    tour,
+  }) => {
+    await page.goto('/two-step-with-diagnose.html')
+    // The provider populates diagnostics one microtask after mount —
+    // wait until the bridge can read a non-null report for the demo tour.
+    await page.waitForFunction(
+      () => Boolean(window.__tourKit__?.getDiagnostic('demo')),
+      undefined,
+      { timeout: 10_000 }
+    )
+    const report = await tour.getDiagnostic('demo')
+    expect(report).not.toBeNull()
+    expect(report?.tourId).toBe('demo')
+    expect(report?.willFire).toBe(true)
+  })
+})

--- a/packages/playwright/fixtures-app/no-bridge.html
+++ b/packages/playwright/fixtures-app/no-bridge.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tour Kit · no-bridge fixture</title>
+    <style>
+      body { font-family: system-ui, sans-serif; padding: 2rem; }
+      #a, #b { padding: 1rem; border: 1px solid #ccc; margin: 1rem 0; }
+    </style>
+  </head>
+  <body>
+    <div id="a">Step A target</div>
+    <div id="b">Step B target</div>
+    <div id="root"></div>
+    <script type="module" src="/src/no-bridge.tsx"></script>
+  </body>
+</html>

--- a/packages/playwright/fixtures-app/src/_demo-tour.ts
+++ b/packages/playwright/fixtures-app/src/_demo-tour.ts
@@ -1,0 +1,29 @@
+import type { Tour } from '@tour-kit/core'
+
+/**
+ * Shared two-step demo tour for every fixture page.
+ *
+ * Targets `#a` and `#b` are sibling elements in each HTML — keeps the test
+ * surface uniform across the three pages so the smoke spec asserts the
+ * SAME tour behavior under different provider props (bridge-on / off /
+ * diagnose-on).
+ */
+export const demoTour: Tour = {
+  id: 'demo',
+  steps: [
+    {
+      id: 'welcome',
+      target: '#a',
+      title: 'Welcome',
+      content: 'Step A',
+      placement: 'bottom',
+    },
+    {
+      id: 'pricing',
+      target: '#b',
+      title: 'Pricing',
+      content: 'Step B',
+      placement: 'bottom',
+    },
+  ],
+}

--- a/packages/playwright/fixtures-app/src/no-bridge.tsx
+++ b/packages/playwright/fixtures-app/src/no-bridge.tsx
@@ -1,0 +1,20 @@
+import { TourProvider } from '@tour-kit/core'
+import { TourCard } from '@tour-kit/react'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { demoTour } from './_demo-tour'
+
+const rootEl = document.getElementById('root')
+if (!rootEl) {
+  throw new Error('Root element not found')
+}
+
+// Intentionally omits `enableTestBridge` so `window.__tourKit__` stays
+// undefined — proves the absent-by-default invariant in real Chromium.
+createRoot(rootEl).render(
+  <StrictMode>
+    <TourProvider tours={[demoTour]}>
+      <TourCard />
+    </TourProvider>
+  </StrictMode>
+)

--- a/packages/playwright/fixtures-app/src/two-step-with-diagnose.tsx
+++ b/packages/playwright/fixtures-app/src/two-step-with-diagnose.tsx
@@ -1,0 +1,18 @@
+import { TourProvider } from '@tour-kit/core'
+import { TourCard } from '@tour-kit/react'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { demoTour } from './_demo-tour'
+
+const rootEl = document.getElementById('root')
+if (!rootEl) {
+  throw new Error('Root element not found')
+}
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <TourProvider tours={[demoTour]} enableTestBridge diagnose>
+      <TourCard />
+    </TourProvider>
+  </StrictMode>
+)

--- a/packages/playwright/fixtures-app/src/two-step.tsx
+++ b/packages/playwright/fixtures-app/src/two-step.tsx
@@ -1,0 +1,18 @@
+import { TourProvider } from '@tour-kit/core'
+import { TourCard } from '@tour-kit/react'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { demoTour } from './_demo-tour'
+
+const rootEl = document.getElementById('root')
+if (!rootEl) {
+  throw new Error('Root element not found')
+}
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <TourProvider tours={[demoTour]} enableTestBridge>
+      <TourCard />
+    </TourProvider>
+  </StrictMode>
+)

--- a/packages/playwright/fixtures-app/two-step-with-diagnose.html
+++ b/packages/playwright/fixtures-app/two-step-with-diagnose.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tour Kit · two-step-with-diagnose fixture</title>
+    <style>
+      body { font-family: system-ui, sans-serif; padding: 2rem; }
+      #a, #b { padding: 1rem; border: 1px solid #ccc; margin: 1rem 0; }
+    </style>
+  </head>
+  <body>
+    <div id="a">Step A target</div>
+    <div id="b">Step B target</div>
+    <div id="root"></div>
+    <script type="module" src="/src/two-step-with-diagnose.tsx"></script>
+  </body>
+</html>

--- a/packages/playwright/fixtures-app/two-step.html
+++ b/packages/playwright/fixtures-app/two-step.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tour Kit · two-step fixture</title>
+    <style>
+      body { font-family: system-ui, sans-serif; padding: 2rem; }
+      #a, #b { padding: 1rem; border: 1px solid #ccc; margin: 1rem 0; }
+    </style>
+  </head>
+  <body>
+    <div id="a">Step A target</div>
+    <div id="b">Step B target</div>
+    <div id="root"></div>
+    <script type="module" src="/src/two-step.tsx"></script>
+  </body>
+</html>

--- a/packages/playwright/fixtures-app/vite.config.ts
+++ b/packages/playwright/fixtures-app/vite.config.ts
@@ -1,0 +1,41 @@
+import { resolve } from 'node:path'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+/**
+ * Vite dev server that backs `@tour-kit/playwright`'s smoke E2E.
+ *
+ * Three entries (one HTML per fixture page) are required by the smoke
+ * spec — each mounts `<TourProvider>` with a different combination of
+ * `enableTestBridge` and `diagnose` so the spec can prove:
+ *   1. the bridge round-trip happy path,
+ *   2. the absent-by-default invariant,
+ *   3. the diagnose round-trip,
+ *   4. the assertBridge() error message.
+ *
+ * `@tour-kit/core` and `@tour-kit/react` resolve through the pnpm
+ * workspace; the Vite default condition selects the ESM `dist/index.js`
+ * entries so a `pnpm --filter=<pkg> build` is required before
+ * `pnpm --filter @tour-kit/playwright test` (CI runs them in order).
+ */
+export default defineConfig({
+  root: resolve(__dirname),
+  plugins: [react()],
+  server: {
+    port: 5180,
+    strictPort: true,
+  },
+  preview: {
+    port: 5180,
+    strictPort: true,
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        'two-step': resolve(__dirname, 'two-step.html'),
+        'no-bridge': resolve(__dirname, 'no-bridge.html'),
+        'two-step-with-diagnose': resolve(__dirname, 'two-step-with-diagnose.html'),
+      },
+    },
+  },
+})

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -42,8 +42,8 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "test": "playwright test",
-    "test:types": "vitest run",
+    "test": "vitest run",
+    "test:e2e": "playwright test",
     "fixtures:serve": "vite --config fixtures-app/vite.config.ts"
   },
   "dependencies": {

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@tour-kit/playwright",
+  "version": "0.1.0",
+  "description": "Playwright fixtures for Tour Kit — test.extend({ tour }) against window.__tourKit__",
+  "author": "Tour Kit Team",
+  "license": "MIT",
+  "homepage": "https://github.com/domidex01/tour-kit#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/domidex01/tour-kit.git",
+    "directory": "packages/playwright"
+  },
+  "bugs": {
+    "url": "https://github.com/domidex01/tour-kit/issues"
+  },
+  "keywords": ["tour-kit", "playwright", "playwright-fixtures", "e2e", "testing", "react"],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": ["dist", "README.md", "CHANGELOG.md"],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test": "playwright test",
+    "test:types": "vitest run",
+    "fixtures:serve": "vite --config fixtures-app/vite.config.ts"
+  },
+  "dependencies": {
+    "@tour-kit/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.58.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@tour-kit/react": "workspace:*",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "^4.3.4",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vite": "^6.0.3",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/playwright/playwright.config.ts
+++ b/packages/playwright/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright config for `@tour-kit/playwright` smoke E2E.
+ *
+ * Spins up a Vite dev server serving the three fixture HTML pages
+ * (`two-step`, `no-bridge`, `two-step-with-diagnose`). The dev server
+ * (not `vite preview`) is used so the workspace `@tour-kit/core` and
+ * `@tour-kit/react` sources resolve through pnpm symlinks without
+ * requiring a pre-build of the entire monorepo.
+ */
+export default defineConfig({
+  testDir: './__tests__',
+  testMatch: /smoke\.spec\.ts$/,
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  retries: 0,
+  reporter: 'list',
+  webServer: {
+    command: 'pnpm fixtures:serve',
+    url: 'http://localhost:5180/two-step.html',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+  use: {
+    baseURL: 'http://localhost:5180',
+    headless: true,
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+})

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -1,0 +1,135 @@
+/**
+ * @tour-kit/playwright — Playwright fixtures for Tour Kit (Phase 6, issue #86).
+ *
+ * Drives a tour from out-of-process via `window.__tourKit__`, the dev-only
+ * bridge published by `<TourProvider enableTestBridge>`. The bridge is
+ * default-OFF, so the consumer MUST opt in at the provider level — every
+ * helper short-circuits with a clear error pointing at `enableTestBridge`
+ * when the bridge is absent.
+ *
+ * Confirmed via memory #179 (Context7 2026-05-12, /microsoft/playwright/v1.58.2):
+ *   import { test as base, expect } from '@playwright/test'
+ *   export const test = base.extend<Fixtures>({ ... })
+ */
+import { type Page, test as base, expect } from '@playwright/test'
+import type { EligibilityReport } from '@tour-kit/core'
+
+/**
+ * Async-wrapped helpers around `window.__tourKit__`. Each control verb is
+ * Promise-returning because `page.evaluate` is async; `waitForStep` queries
+ * the rendered `[data-tour-step]` attribute directly so positioning bugs
+ * surface even when the bridge call succeeded.
+ */
+export interface TourHelpers {
+  /** Start a tour by id. */
+  start: (tourId: string) => Promise<void>
+  /**
+   * Wait until the tour card for `stepId` is visible in the DOM.
+   *
+   * Looks for an element with `data-tour-step="<stepId>"`. Emitted by
+   * `<TourCard>` in `@tour-kit/react` since Phase 5.
+   */
+  waitForStep: (stepId: string, opts?: { timeout?: number }) => Promise<void>
+  /** Advance to the next step in the active tour. */
+  next: () => Promise<void>
+  /** Go back one step in the active tour. */
+  previous: () => Promise<void>
+  /** Mark the active tour completed. */
+  complete: () => Promise<void>
+  /** Skip the active tour. */
+  skip: () => Promise<void>
+  /** Jump to a specific step by id in the active tour. */
+  goToStep: (stepId: string) => Promise<void>
+  /**
+   * Read the diagnostic for a registered tour. Returns `null` if the
+   * provider was mounted without `diagnose`, or the tour id is unknown.
+   */
+  getDiagnostic: (tourId: string) => Promise<EligibilityReport | null>
+}
+
+const BRIDGE_MISSING_ERROR =
+  '[Tour Kit] window.__tourKit__ is undefined. Pass `enableTestBridge` to <TourProvider> to opt in (e.g. `enableTestBridge={process.env.NODE_ENV !== "production"}`).'
+
+async function assertBridge(page: Page): Promise<void> {
+  const ok = await page.evaluate(() => typeof window.__tourKit__ !== 'undefined')
+  if (!ok) {
+    throw new Error(BRIDGE_MISSING_ERROR)
+  }
+}
+
+function makeHelpers(page: Page): TourHelpers {
+  return {
+    start: async (tourId) => {
+      await assertBridge(page)
+      await page.evaluate((id) => {
+        window.__tourKit__?.start(id)
+      }, tourId)
+    },
+    waitForStep: async (stepId, opts) => {
+      await page.waitForSelector(`[data-tour-step="${stepId}"]`, {
+        state: 'visible',
+        timeout: opts?.timeout,
+      })
+    },
+    next: async () => {
+      await assertBridge(page)
+      await page.evaluate(() => {
+        window.__tourKit__?.next()
+      })
+    },
+    previous: async () => {
+      await assertBridge(page)
+      await page.evaluate(() => {
+        window.__tourKit__?.previous()
+      })
+    },
+    complete: async () => {
+      await assertBridge(page)
+      await page.evaluate(() => {
+        window.__tourKit__?.complete()
+      })
+    },
+    skip: async () => {
+      await assertBridge(page)
+      await page.evaluate(() => {
+        window.__tourKit__?.skip()
+      })
+    },
+    goToStep: async (stepId) => {
+      await assertBridge(page)
+      await page.evaluate((id) => {
+        window.__tourKit__?.goToStep(id)
+      }, stepId)
+    },
+    getDiagnostic: async (tourId) => {
+      await assertBridge(page)
+      return page.evaluate((id) => window.__tourKit__?.getDiagnostic(id) ?? null, tourId)
+    },
+  }
+}
+
+/**
+ * Drop-in replacement for Playwright's `test` that adds a `tour` fixture
+ * scoped per-test:
+ *
+ * ```ts
+ * import { test, expect } from '@tour-kit/playwright'
+ *
+ * test('happy path', async ({ page, tour }) => {
+ *   await page.goto('/')
+ *   await tour.start('onboarding')
+ *   await tour.waitForStep('welcome')
+ *   await tour.next()
+ *   await tour.waitForStep('pricing')
+ * })
+ * ```
+ */
+export const test = base.extend<{ tour: TourHelpers }>({
+  tour: async ({ page }, use) => {
+    const helpers = makeHelpers(page)
+    await use(helpers)
+  },
+})
+
+export { expect }
+export type { EligibilityReport } from '@tour-kit/core'

--- a/packages/playwright/tsconfig.json
+++ b/packages/playwright/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tooling/tsconfig/base.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "preserve",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__", "fixtures-app"]
+}

--- a/packages/playwright/tsup.config.ts
+++ b/packages/playwright/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: ['@playwright/test', '@tour-kit/core'],
+  treeshake: true,
+  minify: false,
+  target: 'es2020',
+})

--- a/packages/playwright/vitest.config.ts
+++ b/packages/playwright/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Vitest is used in this package ONLY to run the strict-typing gate
+ * (`entry-types.test.ts`) — a grep against the built `dist/index.d.ts`
+ * verifying the surface contains no `any` types. Playwright tests run
+ * via `playwright.config.ts` instead.
+ */
+export default defineConfig({
+  test: {
+    include: ['__tests__/entry-types.test.ts'],
+    environment: 'node',
+  },
+})

--- a/packages/react/src/components/card/tour-card.tsx
+++ b/packages/react/src/components/card/tour-card.tsx
@@ -141,6 +141,7 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
           role="dialog"
           aria-modal="true"
           aria-labelledby={`tour-step-title-${currentStep.id}`}
+          data-tour-step={currentStep.id}
           {...props}
         >
           <TourCardHeader

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,7 +315,7 @@ importers:
         version: 1.8.0(react@19.2.4)
       next:
         specifier: 16.2.4
-        version: 16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1139,6 +1139,46 @@ importers:
       vitest-axe:
         specifier: 'catalog:'
         version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
+
+  packages/playwright:
+    dependencies:
+      '@tour-kit/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@tour-kit/react':
+        specifier: workspace:*
+        version: link:../react
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      react:
+        specifier: ^19.2.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.4(react@19.2.4)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.3
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@29.0.1)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
 
   packages/react:
     dependencies:
@@ -12898,7 +12938,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.14
       '@next/swc-darwin-x64': 15.5.14
@@ -12915,7 +12955,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -12924,7 +12964,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.4
       '@next/swc-darwin-x64': 16.2.4
@@ -14120,10 +14160,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   styled-jsx@5.1.6(react@19.3.0-canary-ad5dfc82-20260427):
     dependencies:


### PR DESCRIPTION
## Summary

Sprint 1 — Phase 6 ships the dev-only Playwright surface promised by the plan:

- **Test bridge in `@tour-kit/core`** — `<TourProvider enableTestBridge>` (default `false`) publishes `window.__tourKit__: TestBridge` mirroring the existing imperative ref (`start`/`next`/`previous`/`goToStep`/`complete`/`skip`) plus `getDiagnostic` for Phase 3's `EligibilityReport`. Identity-checked cleanup; one-time dev warn gated on `NODE_ENV`; cleanly tree-shakes on literal `false`.
- **New package `@tour-kit/playwright`** — `test.extend<{ tour: TourHelpers }>` over `@playwright/test` with `assertBridge()` short-circuit errors pointing at `enableTestBridge`. `waitForStep` queries `[data-tour-step]` (cherry-picked attribute emission from the phase-5 branch).
- **Smoke E2E on real Chromium** — 4 cases against a Vite-served fixture app (happy-path, absent-by-default, missing-bridge error, diagnose round-trip). Strict-typing gate asserts `grep '\bany\b' dist/index.d.ts === 0`.
- **Docs guide** — `apps/docs/content/docs/guides/playwright.mdx` covering install, `NODE_ENV` activation pattern, fixture helpers, diagnostic integration, and the security note.

## Test plan

- [x] `pnpm --filter @tour-kit/core test -- --run test-bridge` → 9 passed
- [x] `pnpm --filter @tour-kit/core test` → 833 passed (no regression)
- [x] `pnpm --filter @tour-kit/core typecheck`
- [x] `pnpm --filter @tour-kit/playwright build && typecheck && test:types` → no `any` in d.ts
- [x] `pnpm --filter @tour-kit/playwright test` → 4 smoke tests passing on headless Chromium
- [x] `pnpm exec biome check` on all changed files

## Out of scope

- Cross-link from `testing.mdx` to `playwright.mdx`: `testing.mdx` lives on `feat/phase-5-testing-library` (not yet merged to `main`). Add the cross-link when phases 5 and 6 reach `main`.
- Pre-existing `pnpm --filter docs build` failure on `/blog/page` is unrelated to this branch (reproduced on plain `main`).

🤖 Generated with run-phase skill