### PR TITLE
feat(phase-7b): @tour-kit/codemods — shepherd.js + driver.js transforms (#84)

### DIFF
--- a/.changeset/phase-7b-shepherd-driver-codemods.md
+++ b/.changeset/phase-7b-shepherd-driver-codemods.md
@@ -1,0 +1,30 @@
+---
+'@tour-kit/codemods': minor
+---
+
+feat(codemods): shepherd.js + driver.js transforms
+
+Adds `--from shepherd` and `--from driver` to `tour-kit-migrate`. The
+Joyride transform from Phase 7a is unchanged.
+
+- **Shepherd.js** reconstitutes the class-chain imperative API
+  (`new Shepherd.Tour({...})` + chained `.addStep({...})` + `.start()`)
+  into a single `{ id, steps: [...] }` Tour Kit tour literal. Step
+  shapes (`attachTo.element` / `attachTo.on` / `text` / `id`) map to
+  Tour Kit's `target` / `placement` / `content` / `id`. Control-flow
+  calls (`start`, `cancel`, `show`, `hide`, `complete`, `next`, `back`)
+  become empty statements with TODO comments pointing at the
+  `useTour()` equivalent.
+- **Driver.js** reshapes the `driver({...})` function-style config into
+  the same Tour Kit tour literal. Step shapes map `element` → `target`
+  and `popover.{title, description, side}` → `{title, content, placement}`.
+  `.drive()` becomes an empty statement with a TODO pointing at
+  `useTour().start()`.
+
+Both transforms emit `// TODO: ... https://tourkit.dev/migration/{source}#{anchor}`
+comments for any unsupported pattern; the corresponding `shepherd.mdx` and
+`driver.mdx` pages document the manual-port path for every anchor.
+
+Coverage on the committed fixture corpora: Joyride 100%, Shepherd 100%,
+Driver 100%. The `EXPERIMENTAL_TRANSFORMS` set in `src/cli.ts` is empty —
+both new transforms ship stable.

--- a/apps/docs/content/docs/migration/driver.mdx
+++ b/apps/docs/content/docs/migration/driver.mdx
@@ -1,0 +1,292 @@
+---
+title: Migrate from driver.js
+description: >-
+  Use `npx tour-kit-migrate --from driver` to rewrite a driver.js codebase to
+  Tour Kit in seconds. Covers the function-call pattern
+  (`driver({...}).drive()`).
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+## Quick start
+
+```bash
+npx tour-kit-migrate --from driver ./src
+```
+
+The migrate command runs a `jscodeshift` transform over your `.ts`/`.tsx`/`.js`/`.jsx`
+files and reshapes `driver({...})` config objects into Tour Kit tours. The
+`.drive()` chain becomes a TODO pointing at `useTour().start()`. Patterns
+that have no Tour Kit equivalent are kept in place and annotated with `// TODO:`
+comments that link back to this page.
+
+<Callout type="info">
+Run with `--dry-run` to see the diff without writing. Run with `--print` to
+write transformed source to stdout.
+</Callout>
+
+### Flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--from <source>` | required | One of `joyride`, `shepherd`, `driver` |
+| `--parser <parser>` | `tsx` | `tsx` / `ts` / `babel` |
+| `--dry-run` | off | Print diffs, don't write |
+| `--print` | off | Write transformed source to stdout |
+| `--extensions <list>` | `ts,tsx,js,jsx` | Comma-separated extension list |
+| `--verbose` | off | Log every file action |
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Parse error during transform |
+| 2 | Bad CLI args |
+| 3 | No files matched |
+
+## What gets migrated
+
+| Pattern | driver.js | Tour Kit |
+| --- | --- | --- |
+| Import | `import { driver } from 'driver.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| Config call | `driver({ steps: [...] })` | `{ id: 'migrated-tour', steps: [...] }` literal + TODO to register at `<TourProvider>` |
+| `Step.element` (selector) | `'#hero'` | `target: '#hero'` |
+| `Step.popover.title` | `'Welcome'` | `title: 'Welcome'` |
+| `Step.popover.description` | `'Hi there'` | `content: 'Hi there'` |
+| `Step.popover.side` | `'top'` / `'bottom'` / ... | `placement: 'top'` / `'bottom'` / ... |
+| `.drive()` chain | `d.drive()` | empty statement + TODO to call `useTour().start()` |
+
+## Anchors emitted by the codemod
+
+Each heading below corresponds to a `// TODO:` link emitted by the transform.
+Grep your migrated codebase for the anchor or follow it here for hand-port
+guidance.
+
+### driver-call
+
+`driver({...})` is replaced with a Tour Kit tour shape:
+
+```tsx
+const d = {
+  id: 'migrated-tour',
+  steps: [/* migrated steps */],
+}
+```
+
+Register the migrated tour at a `<TourProvider>` ancestor and call
+`useTour().start()` from a descendant when you want the tour to begin.
+
+### driver-config-dynamic
+
+The `driver(...)` argument was dynamic (not an inline object). Populate the
+migrated `steps` array manually.
+
+### steps-dynamic
+
+The config's `steps` field was dynamic (not an inline array). Populate the
+migrated `steps` array manually.
+
+### step-dynamic
+
+A step inside the `steps` array was dynamic (not an inline object). Port the
+step shape manually.
+
+### element-function
+
+```ts
+{ element: () => document.body, popover: {...} }
+```
+
+Tour Kit's `target` accepts a CSS selector string or a DOM ref — not a
+function. Rewrite as a selector or pass a ref via the headless slot API.
+
+### element-dom
+
+```ts
+const el = document.getElementById('hero')!
+driver({ steps: [{ element: el, popover: {...} }] })
+```
+
+A captured DOM Element is preserved as `target: el`. Tour Kit accepts a ref
+directly — verify the value resolves at runtime, or rewrite as a CSS
+selector.
+
+### target
+
+The codemod could not resolve `Step.element` to a selector. Set `Step.target`
+by hand to a CSS selector string or DOM ref.
+
+### placement
+
+driver.js's `popover.side` accepts `top` / `bottom` / `left` / `right` and
+`over`. `over` is mapped to `top`; review manually.
+
+### align
+
+`popover.align` (e.g. `start`, `end`) is folded into Tour Kit's compound
+placement values (`top-start`, `top-end`, etc.) — port manually.
+
+### popover-dynamic
+
+`Step.popover` was not an inline object. Port `title` / `content` / `placement`
+manually.
+
+### popover-class
+
+`popover.popoverClass` injected a CSS class. Use theme tokens via your
+`<ThemeProvider>` and `<TourCard />` slots.
+
+### show-progress
+
+`showProgress: true` (tour-level) or `popover.showProgress` (step-level)
+rendered a `step n/N` indicator. Render `<TourProgress />` inside your
+`<TourCard />` slot.
+
+### allow-close
+
+`allowClose: false` removed the close button. Include or omit `<TourClose />`
+inside your `<TourCard />` composition.
+
+### btn-text
+
+`doneBtnText`, `nextBtnText`, `prevBtnText`, `closeBtnText` (and the same
+fields nested in `popover`) overrode button labels. Pass label props to your
+`<TourNavigation />` and `<TourClose />` slot components.
+
+### show-buttons
+
+`showButtons: ['next', 'previous']` (or fewer) selected which buttons to
+render. Compose your `<TourCard />` with only the slots you need — omitted
+slots simply don't render.
+
+### disable-active-interaction
+
+`disableActiveInteraction: true` made the spotlighted element non-interactive.
+Configure the spotlight interactive flag on your `<TourOverlay />` slot.
+
+### smooth-scroll
+
+`smoothScroll: true` enabled smooth scrolling. Tour Kit always scrolls when
+the target is off-screen; gate manually if you need a custom scroll
+behaviour.
+
+### animate
+
+`animate: true` toggled animation. Tour Kit respects
+`prefers-reduced-motion` automatically — drop the flag.
+
+### stage-padding
+
+`stagePadding` controlled padding around the spotlight ring. Pass `padding`
+to your `<TourOverlay />` slot.
+
+### stage-radius
+
+`stageRadius` controlled the spotlight corner radius. Theme tokens via your
+`<ThemeProvider>`.
+
+### overlay-color
+
+`overlayColor` set the backdrop colour. Theme tokens via your
+`<ThemeProvider>`.
+
+### overlay-opacity
+
+`overlayOpacity` set the backdrop opacity. Theme tokens via your
+`<ThemeProvider>`.
+
+### on-highlight-started
+
+`Step.onHighlightStarted` and `onHighlighted` fired when the spotlight moved.
+Port to `onShow` on the migrated step.
+
+### on-highlighted
+
+Alias of `on-highlight-started` — see above.
+
+### on-deselected
+
+`Step.onDeselected` fired when leaving a step. Port to `onHide` on the
+migrated step.
+
+### on-popover-render
+
+`popover.onPopoverRender` was a render callback for the popover DOM. Render
+custom JSX in `<TourCard />` children instead.
+
+### on-next-click
+
+`popover.onNextClick` / `onPrevClick` / `onCloseClick` were per-step button
+callbacks. Handle in your `<TourNavigation />` / `<TourClose />` slot.
+
+### on-prev-click
+
+See `on-next-click`.
+
+### on-close-click
+
+See `on-next-click`.
+
+### on-click
+
+Generic on-click anchor for popover button handlers — see `on-next-click`.
+
+### on-destroy-started
+
+`onDestroyStarted` fired before tour teardown. Use `onSkip` / `onComplete` on
+your `<TourProvider>`.
+
+### on-destroyed
+
+`onDestroyed` fired after tour teardown. Use `onSkip` / `onComplete` on your
+`<TourProvider>`.
+
+### drive
+
+```ts
+d.drive()
+```
+
+The migrated tour object has no `.drive()` method. Call `useTour().start()`
+from inside a descendant of the `<TourProvider>` that registers the tour.
+
+### control-flow
+
+`.destroy()`, `.moveNext()`, `.movePrevious()`, `.moveTo(index)` are replaced
+with empty statements + TODO comments. Their Tour Kit equivalents are:
+
+| driver.js | Tour Kit |
+| --- | --- |
+| `d.destroy()` | `useTour().stop()` |
+| `d.moveNext()` | `useTour().next()` |
+| `d.movePrevious()` | `useTour().prev()` |
+| `d.moveTo(i)` | `useTour().goTo(i)` |
+
+### highlight
+
+`d.highlight()` showed a single popover without a tour. Tour Kit has no
+single-step highlight — render `<HintHotspot>` from `@tour-kit/hints` for the
+same UX.
+
+### unknown-config-field
+
+A tour-level config field not in this matrix. Check the version of driver.js
+you ran against.
+
+### unknown-popover-field
+
+A `popover.*` field not in this matrix.
+
+### unknown-step-field
+
+A `Step.*` field not in this matrix.
+
+## CLI smoke test
+
+```bash
+npx tour-kit-migrate --from driver --dry-run ./src
+```
+
+If the dry-run prints clean diffs and exits 0, run again without `--dry-run`
+to write the changes.

--- a/apps/docs/content/docs/migration/meta.json
+++ b/apps/docs/content/docs/migration/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Migration",
-  "pages": ["joyride"]
+  "pages": ["joyride", "shepherd", "driver"]
 }

--- a/apps/docs/content/docs/migration/shepherd.mdx
+++ b/apps/docs/content/docs/migration/shepherd.mdx
@@ -1,0 +1,221 @@
+---
+title: Migrate from shepherd.js
+description: >-
+  Use `npx tour-kit-migrate --from shepherd` to rewrite a shepherd.js codebase
+  to Tour Kit in seconds. Covers the class-chain pattern (`new Shepherd.Tour`
+  + `.addStep(...)` + `.start()`).
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+## Quick start
+
+```bash
+npx tour-kit-migrate --from shepherd ./src
+```
+
+The migrate command runs a `jscodeshift` transform over your `.ts`/`.tsx`/`.js`/`.jsx`
+files and reconstitutes the `new Shepherd.Tour({...})` + `.addStep({...})` +
+`.start()` imperative chain into a single Tour Kit-shaped tour object literal.
+Patterns that have no Tour Kit equivalent are kept in place and annotated with
+`// TODO:` comments that link back to this page.
+
+<Callout type="info">
+Run with `--dry-run` to see the diff without writing. Run with `--print` to
+write transformed source to stdout.
+</Callout>
+
+### Flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--from <source>` | required | One of `joyride`, `shepherd`, `driver` |
+| `--parser <parser>` | `tsx` | `tsx` / `ts` / `babel` |
+| `--dry-run` | off | Print diffs, don't write |
+| `--print` | off | Write transformed source to stdout |
+| `--extensions <list>` | `ts,tsx,js,jsx` | Comma-separated extension list |
+| `--verbose` | off | Log every file action |
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Parse error during transform |
+| 2 | Bad CLI args |
+| 3 | No files matched |
+
+## What gets migrated
+
+| Pattern | shepherd.js | Tour Kit |
+| --- | --- | --- |
+| Default import | `import Shepherd from 'shepherd.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| Named import | `import { Tour } from 'shepherd.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| Tour constructor | `new Shepherd.Tour({...})` | `{ id: 'migrated-tour', steps: [...] }` literal + TODO to register at `<TourProvider>` |
+| `.addStep({...})` chain | `tour.addStep({id, attachTo, text})` | merged into `steps: [{id, target, placement, content}]` array |
+| `Step.attachTo.element` | `'#cta'` | `target: '#cta'` |
+| `Step.attachTo.on` | `'top'` / `'bottom'` / ... | `placement: 'top'` / `'bottom'` / ... |
+| `Step.text` | `'Welcome'` | `content: 'Welcome'` |
+
+## Anchors emitted by the codemod
+
+Each heading below corresponds to a `// TODO:` link emitted by the transform.
+Grep your migrated codebase for the anchor or follow it here for hand-port
+guidance.
+
+### tour-constructor
+
+`new Shepherd.Tour({...})` is replaced with a Tour Kit tour shape:
+
+```tsx
+const tour = {
+  id: 'migrated-tour',
+  steps: [/* migrated steps */],
+}
+```
+
+Register the migrated tour at a `<TourProvider>` ancestor and call
+`useTour().start()` from a descendant when you want the tour to begin.
+
+### add-step-dynamic
+
+`.addStep(someVariable)` is dynamic — the codemod cannot inline the step
+shape. Port the variable contents into the `steps` array manually.
+
+### attach-to-dynamic
+
+`attachTo` was not an inline object literal (e.g. spread from another
+variable). Set `target` / `placement` manually.
+
+### attach-to-element-function
+
+```ts
+attachTo: { element: () => document.body, on: 'top' }
+```
+
+Tour Kit's `target` accepts a CSS selector string or a DOM ref — not a
+function. Rewrite as a selector or pass a ref via the headless slot API.
+
+### target
+
+The codemod could not resolve `attachTo.element` to a selector. Set
+`Step.target` by hand to a CSS selector string or DOM ref.
+
+### target-dynamic
+
+A dynamic identifier or member expression was preserved as-is — verify it
+resolves to a string selector at runtime.
+
+### placement
+
+shepherd.js's `attachTo.on` accepts the same primary axis values as Tour Kit
+(`top` / `bottom` / `left` / `right` plus start/end variants). `auto` is
+mapped to `top`; review manually.
+
+### start
+
+```ts
+tour.start()
+```
+
+The migrated tour object has no `.start()` method. Call `useTour().start()`
+from inside a descendant of the `<TourProvider>` that registers the tour.
+
+### control-flow
+
+`tour.show()`, `tour.hide()`, `tour.cancel()`, `tour.complete()`, `tour.next()`,
+and `tour.back()` are replaced with empty statements + TODO comments. Their
+Tour Kit equivalents are:
+
+| Shepherd | Tour Kit |
+| --- | --- |
+| `tour.show(id)` | `useTour().goTo(index)` |
+| `tour.hide()` | `useTour().stop()` |
+| `tour.cancel()` | `useTour().skip()` |
+| `tour.complete()` | `useTour().complete()` |
+| `tour.next()` | `useTour().next()` |
+| `tour.back()` | `useTour().prev()` |
+
+### classes
+
+`Step.classes` injected CSS class names onto the popover. Tour Kit uses theme
+tokens — port styling via your `<ThemeProvider>` and `<TourCard />` slots.
+
+### modal-overlay-class
+
+`Step.modalOverlayOpeningClass` styled the modal overlay opening. Configure
+the spotlight ring via your `<TourOverlay />` slot.
+
+### modal-overlay-padding
+
+`Step.modalOverlayOpeningPadding` set padding on the modal overlay opening.
+Pass `padding` to your `<TourOverlay />` slot.
+
+### can-click-target
+
+`Step.canClickTarget` toggled whether the spotlighted element accepts clicks.
+Tour Kit's spotlight is non-interactive by default — configure the overlay
+spotlight interactive flag manually.
+
+### scroll-to
+
+`Step.scrollTo` / `Step.scrollToHandler` set a custom scroll behaviour. Tour
+Kit auto-scrolls when the target is off-screen; gate manually if you need a
+custom container.
+
+### highlight-class
+
+`Step.highlightClass` injected a CSS class on the highlighted element. Use
+theme tokens on the spotlight slot.
+
+### when
+
+`Step.when` was a map of lifecycle hooks (`show`, `hide`, `complete`, etc.).
+Port each handler to the matching `onShow` / `onHide` property on the
+migrated step, or pass through `<TourProvider>` callbacks for tour-wide
+events.
+
+### advance-on
+
+`Step.advanceOn` advanced the tour on a DOM event from another element.
+Wire `useTour().next()` from your own event handler.
+
+### before-show-promise
+
+`Step.beforeShowPromise` returned a Promise that resolved before the step
+showed. Await it before calling `useTour().goTo()`, or move the deferred
+logic into a custom `onShow` handler.
+
+### show-on
+
+`Step.showOn` was a predicate that conditionally skipped the step. Branch on
+`useTour().currentStepIndex` from a descendant or call `useTour().goTo()` to
+skip.
+
+### buttons
+
+```ts
+buttons: [
+  { text: 'Skip', action: () => tour.cancel() },
+  { text: 'Next', action: () => tour.next() },
+]
+```
+
+shepherd.js's button array is open-ended. Tour Kit ships fixed `<TourCard />`
+slots (Next / Prev / Skip / Close). Wire any custom button actions through
+the `<TourCard />` children — see the
+[card composition guide](/docs/react/components).
+
+### unknown-step-field
+
+A `Step.*` field not in this matrix. Check the version of shepherd.js you ran
+against and decide if it has a Tour Kit equivalent the codemod missed.
+
+## CLI smoke test
+
+```bash
+npx tour-kit-migrate --from shepherd --dry-run ./src
+```
+
+If the dry-run prints clean diffs and exits 0, run again without `--dry-run`
+to write the changes.

--- a/apps/docs/public/context/core.txt
+++ b/apps/docs/public/context/core.txt
@@ -102,6 +102,7 @@ Types:
     GateCode
     GateName
     GateReason
+    TestBridge
     FrequencyRule
     FrequencyState
     LocalizedText
@@ -367,7 +368,7 @@ TYPES
       | 'AUTOSTART_DISABLED'
       | (string & {})
 
-    ... and 5 more types. See source for full definitions.
+    ... and 6 more types. See source for full definitions.
 
 HOOKS
 -----

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -1,4 +1,4 @@
-# userTourKit v0.11.0 — Generated 2026-05-13T07:39:18Z
+# userTourKit v0.11.0 — Generated 2026-05-13T15:24:38Z
 
 # Feature Adoption Tracking
 
@@ -39580,6 +39580,154 @@ Stale sessions are filtered on read — `useFlowSession` checks `Date.now() - la
 
 ---
 
+# Playwright
+
+> Drive Tour Kit from Playwright with the typed `test.extend({ tour })` fixture and the opt-in `window.__tourKit__` bridge.
+
+`@tour-kit/playwright` adds a typed `test.extend({ tour })` fixture so your
+end-to-end specs can move a tour forward without writing `page.click`
+boilerplate. It is backed by `window.__tourKit__` — a dev-only bridge that
+`<TourProvider>` exposes only when you explicitly opt in.
+
+## Install
+
+```bash
+pnpm add -D @tour-kit/playwright @playwright/test
+```
+
+`@playwright/test` is a peer dependency. Tour Kit supports `^1.58.0` and up.
+
+## 1 — Activate the bridge
+
+The bridge is what Playwright actually drives. Toggle it via `enableTestBridge`
+on `<TourProvider>` — and guard it with `NODE_ENV` so production never gets
+the surface:
+
+```tsx
+import { TourProvider } from '@tour-kit/core'
+
+export function AppProviders({ children }) {
+  return (
+    <TourProvider
+      tours={[onboardingTour]}
+      enableTestBridge={process.env.NODE_ENV !== 'production'}
+    >
+      {children}
+    </TourProvider>
+  )
+}
+```
+
+When `enableTestBridge` is `true`, `<TourProvider>` publishes
+`window.__tourKit__` with the following shape:
+
+```ts
+import type { TestBridge, EligibilityReport } from '@tour-kit/core'
+
+declare global {
+  interface Window {
+    __tourKit__?: TestBridge
+  }
+}
+
+interface TestBridge {
+  start: (tourId: string) => void
+  next: () => void
+  previous: () => void
+  goToStep: (stepId: string) => void
+  complete: () => void
+  skip: () => void
+  getDiagnostic: (tourId: string) => EligibilityReport | null
+}
+```
+
+In development, the provider also logs a single `console.warn` per mount
+reminding you the bridge is on. Production builds are silent.
+
+## 2 — Write a test
+
+Import `test` and `expect` from `@tour-kit/playwright` instead of
+`@playwright/test`. The `tour` fixture is scoped per-test:
+
+```ts
+import { test, expect } from '@tour-kit/playwright'
+
+test('onboarding happy path', async ({ page, tour }) => {
+  await page.goto('/')
+  await tour.start('onboarding')
+  await tour.waitForStep('welcome')
+  await tour.next()
+  await tour.waitForStep('pricing')
+  await tour.complete()
+})
+```
+
+### `tour` helpers
+
+| Helper | Behavior |
+|---|---|
+| `tour.start(id)` | Calls `window.__tourKit__.start(id)`. |
+| `tour.waitForStep(stepId, opts?)` | Waits for `[data-tour-step="<id>"]` to be visible. Accepts `{ timeout }`. |
+| `tour.next()` / `tour.previous()` | Step navigation. |
+| `tour.goToStep(stepId)` | Jump directly. |
+| `tour.complete()` / `tour.skip()` | End the tour. |
+| `tour.getDiagnostic(tourId)` | Read the Phase 3 `EligibilityReport`. Returns `null` without `diagnose`. |
+
+Every helper short-circuits with a clear error pointing at
+`enableTestBridge` if the bridge is missing — saving you ten minutes of
+confused debugging.
+
+## 3 — Diagnostic integration
+
+Mount the provider with both `diagnose` and `enableTestBridge` to surface
+gate diagnostics in your specs:
+
+```tsx
+<TourProvider
+  tours={[onboardingTour]}
+  diagnose
+  enableTestBridge={process.env.NODE_ENV !== 'production'}
+>
+```
+
+```ts
+test('audience gate blocks free users', async ({ page, tour }) => {
+  await page.goto('/?role=free')
+  const report = await tour.getDiagnostic('pro-only-tour')
+  expect(report?.willFire).toBe(false)
+  expect(report?.firstFailingGate?.code).toBe('AUDIENCE_MISMATCH')
+})
+```
+
+See [Diagnostic engine](/docs/core/diagnostic) for the full `EligibilityReport`
+shape and gate codes.
+
+## Security note
+
+`window.__tourKit__` is a tour-control surface. A production build that
+exposes it lets anyone with browser dev tools start, complete, or skip
+your tours. The default is `false` for that reason — keep it that way:
+
+```tsx
+// ✅ Recommended
+enableTestBridge={process.env.NODE_ENV !== 'production'}
+
+// ❌ Never
+enableTestBridge
+```
+
+The provider's effect short-circuits at the top when `enableTestBridge` is
+`false`, so bundlers can dead-code-eliminate the bridge body in production.
+
+## Related
+
+- [Testing Library](/docs/guides/testing) — jsdom helpers for component-level
+  positioning assertions.
+- [Diagnostic engine](/docs/core/diagnostic) — what `tour.getDiagnostic`
+  returns.
+
+---
+
 # Reduced Motion
 
 > How Tour Kit honors prefers-reduced-motion across announcements, surveys, hints, checklists, and the core tour runtime
@@ -40331,8 +40479,9 @@ await setupTourKitTesting()
 ```
 
 ```tsx title="welcome-tour.test.tsx"
+import * as React from 'react'
 import { render } from '@testing-library/react'
-import { TourProvider } from '@tour-kit/core'
+import { TourProvider, useTour } from '@tour-kit/core'
 import { TourCard } from '@tour-kit/react'
 import {
   expectStepVisible,
@@ -40350,6 +40499,19 @@ const tour = {
   ],
 }
 
+// <TourProvider> is inactive by default. Mount this tiny helper inside the
+// provider to start the tour on mount — or click your own "Start" button.
+function AutoStart({ id }: { id: string }) {
+  const { start } = useTour()
+  const started = React.useRef(false)
+  React.useEffect(() => {
+    if (started.current) return
+    started.current = true
+    start(id)
+  }, [])
+  return null
+}
+
 describe('welcome tour', () => {
   it('walks through both steps', async () => {
     render(
@@ -40357,6 +40519,7 @@ describe('welcome tour', () => {
         <div id="welcome" />
         <div id="pricing" />
         <TourProvider tours={[tour]}>
+          <AutoStart id="demo" />
           <TourCard />
           <HookProbe />
         </TourProvider>
@@ -40443,7 +40606,7 @@ try {
 
 ## Browser-positioning tests live elsewhere
 
-This package asserts on **presence** — "did the step mount?", "did Next advance?" — not **position**. For pixel-perfect placement assertions, use Playwright via [`@tour-kit/playwright`](./nextjs#end-to-end-with-playwright) (Phase 6). Phase 5 helpers stop at the jsdom boundary by design.
+This package asserts on **presence** — "did the step mount?", "did Next advance?" — not **position**. For pixel-perfect placement assertions, use [`@tour-kit/playwright`](./playwright) — it ships a `test.extend({ tour })` fixture backed by the opt-in `window.__tourKit__` bridge. Phase 5 helpers stop at the jsdom boundary by design.
 
 ---
 
@@ -51238,6 +51401,789 @@ Always validate with `isSupportedMediaUrl()` first for reliable results.
 - [Embed URL Utilities](/docs/media/utilities/embed-urls) - Build embed URLs
 - [TourMedia](/docs/media/components/tour-media) - Auto-detecting media component
 - [MediaHeadless](/docs/media/headless/media-headless) - Headless API with URL parsing
+
+---
+
+# Migrate from driver.js
+
+> Use `npx tour-kit-migrate --from driver` to rewrite a driver.js codebase to Tour Kit in seconds. Covers the function-call pattern (`driver({...}).drive()`).
+
+## Quick start
+
+```bash
+npx tour-kit-migrate --from driver ./src
+```
+
+The migrate command runs a `jscodeshift` transform over your `.ts`/`.tsx`/`.js`/`.jsx`
+files and reshapes `driver({...})` config objects into Tour Kit tours. The
+`.drive()` chain becomes a TODO pointing at `useTour().start()`. Patterns
+that have no Tour Kit equivalent are kept in place and annotated with `// TODO:`
+comments that link back to this page.
+
+### Flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--from <source>` | required | One of `joyride`, `shepherd`, `driver` |
+| `--parser <parser>` | `tsx` | `tsx` / `ts` / `babel` |
+| `--dry-run` | off | Print diffs, don't write |
+| `--print` | off | Write transformed source to stdout |
+| `--extensions <list>` | `ts,tsx,js,jsx` | Comma-separated extension list |
+| `--verbose` | off | Log every file action |
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Parse error during transform |
+| 2 | Bad CLI args |
+| 3 | No files matched |
+
+## What gets migrated
+
+| Pattern | driver.js | Tour Kit |
+| --- | --- | --- |
+| Import | `import { driver } from 'driver.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| Config call | `driver({ steps: [...] })` | `{ id: 'migrated-tour', steps: [...] }` literal + TODO to register at `<TourProvider>` |
+| `Step.element` (selector) | `'#hero'` | `target: '#hero'` |
+| `Step.popover.title` | `'Welcome'` | `title: 'Welcome'` |
+| `Step.popover.description` | `'Hi there'` | `content: 'Hi there'` |
+| `Step.popover.side` | `'top'` / `'bottom'` / ... | `placement: 'top'` / `'bottom'` / ... |
+| `.drive()` chain | `d.drive()` | empty statement + TODO to call `useTour().start()` |
+
+## Anchors emitted by the codemod
+
+Each heading below corresponds to a `// TODO:` link emitted by the transform.
+Grep your migrated codebase for the anchor or follow it here for hand-port
+guidance.
+
+### driver-call
+
+`driver({...})` is replaced with a Tour Kit tour shape:
+
+```tsx
+const d = {
+  id: 'migrated-tour',
+  steps: [/* migrated steps */],
+}
+```
+
+Register the migrated tour at a `<TourProvider>` ancestor and call
+`useTour().start()` from a descendant when you want the tour to begin.
+
+### driver-config-dynamic
+
+The `driver(...)` argument was dynamic (not an inline object). Populate the
+migrated `steps` array manually.
+
+### steps-dynamic
+
+The config's `steps` field was dynamic (not an inline array). Populate the
+migrated `steps` array manually.
+
+### step-dynamic
+
+A step inside the `steps` array was dynamic (not an inline object). Port the
+step shape manually.
+
+### element-function
+
+```ts
+{ element: () => document.body, popover: {...} }
+```
+
+Tour Kit's `target` accepts a CSS selector string or a DOM ref — not a
+function. Rewrite as a selector or pass a ref via the headless slot API.
+
+### element-dom
+
+```ts
+const el = document.getElementById('hero')!
+driver({ steps: [{ element: el, popover: {...} }] })
+```
+
+A captured DOM Element is preserved as `target: el`. Tour Kit accepts a ref
+directly — verify the value resolves at runtime, or rewrite as a CSS
+selector.
+
+### target
+
+The codemod could not resolve `Step.element` to a selector. Set `Step.target`
+by hand to a CSS selector string or DOM ref.
+
+### placement
+
+driver.js's `popover.side` accepts `top` / `bottom` / `left` / `right` and
+`over`. `over` is mapped to `top`; review manually.
+
+### align
+
+`popover.align` (e.g. `start`, `end`) is folded into Tour Kit's compound
+placement values (`top-start`, `top-end`, etc.) — port manually.
+
+### popover-dynamic
+
+`Step.popover` was not an inline object. Port `title` / `content` / `placement`
+manually.
+
+### popover-class
+
+`popover.popoverClass` injected a CSS class. Use theme tokens via your
+`<ThemeProvider>` and `<TourCard />` slots.
+
+### show-progress
+
+`showProgress: true` (tour-level) or `popover.showProgress` (step-level)
+rendered a `step n/N` indicator. Render `<TourProgress />` inside your
+`<TourCard />` slot.
+
+### allow-close
+
+`allowClose: false` removed the close button. Include or omit `<TourClose />`
+inside your `<TourCard />` composition.
+
+### btn-text
+
+`doneBtnText`, `nextBtnText`, `prevBtnText`, `closeBtnText` (and the same
+fields nested in `popover`) overrode button labels. Pass label props to your
+`<TourNavigation />` and `<TourClose />` slot components.
+
+### show-buttons
+
+`showButtons: ['next', 'previous']` (or fewer) selected which buttons to
+render. Compose your `<TourCard />` with only the slots you need — omitted
+slots simply don't render.
+
+### disable-active-interaction
+
+`disableActiveInteraction: true` made the spotlighted element non-interactive.
+Configure the spotlight interactive flag on your `<TourOverlay />` slot.
+
+### smooth-scroll
+
+`smoothScroll: true` enabled smooth scrolling. Tour Kit always scrolls when
+the target is off-screen; gate manually if you need a custom scroll
+behaviour.
+
+### animate
+
+`animate: true` toggled animation. Tour Kit respects
+`prefers-reduced-motion` automatically — drop the flag.
+
+### stage-padding
+
+`stagePadding` controlled padding around the spotlight ring. Pass `padding`
+to your `<TourOverlay />` slot.
+
+### stage-radius
+
+`stageRadius` controlled the spotlight corner radius. Theme tokens via your
+`<ThemeProvider>`.
+
+### overlay-color
+
+`overlayColor` set the backdrop colour. Theme tokens via your
+`<ThemeProvider>`.
+
+### overlay-opacity
+
+`overlayOpacity` set the backdrop opacity. Theme tokens via your
+`<ThemeProvider>`.
+
+### on-highlight-started
+
+`Step.onHighlightStarted` and `onHighlighted` fired when the spotlight moved.
+Port to `onShow` on the migrated step.
+
+### on-highlighted
+
+Alias of `on-highlight-started` — see above.
+
+### on-deselected
+
+`Step.onDeselected` fired when leaving a step. Port to `onHide` on the
+migrated step.
+
+### on-popover-render
+
+`popover.onPopoverRender` was a render callback for the popover DOM. Render
+custom JSX in `<TourCard />` children instead.
+
+### on-next-click
+
+`popover.onNextClick` / `onPrevClick` / `onCloseClick` were per-step button
+callbacks. Handle in your `<TourNavigation />` / `<TourClose />` slot.
+
+### on-prev-click
+
+See `on-next-click`.
+
+### on-close-click
+
+See `on-next-click`.
+
+### on-click
+
+Generic on-click anchor for popover button handlers — see `on-next-click`.
+
+### on-destroy-started
+
+`onDestroyStarted` fired before tour teardown. Use `onSkip` / `onComplete` on
+your `<TourProvider>`.
+
+### on-destroyed
+
+`onDestroyed` fired after tour teardown. Use `onSkip` / `onComplete` on your
+`<TourProvider>`.
+
+### drive
+
+```ts
+d.drive()
+```
+
+The migrated tour object has no `.drive()` method. Call `useTour().start()`
+from inside a descendant of the `<TourProvider>` that registers the tour.
+
+### control-flow
+
+`.destroy()`, `.moveNext()`, `.movePrevious()`, `.moveTo(index)` are replaced
+with empty statements + TODO comments. Their Tour Kit equivalents are:
+
+| driver.js | Tour Kit |
+| --- | --- |
+| `d.destroy()` | `useTour().stop()` |
+| `d.moveNext()` | `useTour().next()` |
+| `d.movePrevious()` | `useTour().prev()` |
+| `d.moveTo(i)` | `useTour().goTo(i)` |
+
+### highlight
+
+`d.highlight()` showed a single popover without a tour. Tour Kit has no
+single-step highlight — render `<HintHotspot>` from `@tour-kit/hints` for the
+same UX.
+
+### unknown-config-field
+
+A tour-level config field not in this matrix. Check the version of driver.js
+you ran against.
+
+### unknown-popover-field
+
+A `popover.*` field not in this matrix.
+
+### unknown-step-field
+
+A `Step.*` field not in this matrix.
+
+## CLI smoke test
+
+```bash
+npx tour-kit-migrate --from driver --dry-run ./src
+```
+
+If the dry-run prints clean diffs and exits 0, run again without `--dry-run`
+to write the changes.
+
+---
+
+# Migrate from react-joyride
+
+> Use `npx tour-kit-migrate --from joyride` to rewrite a react-joyride codebase to Tour Kit in seconds. Covers both the legacy `<Joyride>` JSX form and the modern `useJoyride()` hook form.
+
+## Quick start
+
+```bash
+npx tour-kit-migrate --from joyride ./src
+```
+
+The migrate command runs a `jscodeshift` transform over your `.ts`/`.tsx`/`.js`/`.jsx`
+files and rewrites every `react-joyride` import + every `<Joyride>` JSX + every
+`useJoyride()` hook call. Patterns that have no Tour Kit equivalent are kept
+in place and annotated with `// TODO:` comments that link back to this page.
+
+### Flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--from <source>` | required | One of `joyride`, `shepherd`, `driver` |
+| `--parser <parser>` | `tsx` | `tsx` / `ts` / `babel` |
+| `--dry-run` | off | Print diffs, don't write |
+| `--print` | off | Write transformed source to stdout |
+| `--extensions <list>` | `ts,tsx,js,jsx` | Comma-separated extension list |
+| `--verbose` | off | Log every file action |
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Parse error during transform |
+| 2 | Bad CLI args |
+| 3 | No files matched |
+
+## What gets migrated
+
+| Pattern | Joyride | Tour Kit |
+| --- | --- | --- |
+| Import | `import Joyride from 'react-joyride'` | `import { TourProvider } from '@tour-kit/react'` |
+| Hook import | `import { useJoyride } from 'react-joyride'` | `import { useTour } from '@tour-kit/react'` |
+| JSX root | `<Joyride steps={steps} ... />` | `<TourProvider tours={[{ id: 'migrated-tour', steps }]} />` |
+| Hook call | `const { Tour, controls } = useJoyride({ steps })` | `const controls = useTour()` (steps move to `<TourProvider>`) |
+
+## Anchors emitted by the codemod
+
+Each pattern below lists a heading the codemod links to from a `// TODO:` comment.
+You can either grep your codebase for these anchors or follow them here to learn how
+to finish the migration by hand.
+
+### run-prop
+
+Tour Kit is imperative: there's no `run={true}` JSX prop. Call `useTour().start()`
+from a descendant of `<TourProvider>` (typically a small effect-only component) when
+you want the tour to begin.
+
+```tsx
+function StartTour() {
+  const { start } = useTour()
+  useEffect(() => { start() }, [start])
+  return null
+}
+```
+
+### continuous
+
+Joyride's `continuous` prop was opt-in chaining. Tour Kit chains by default — drop
+the `continuous` flag entirely.
+
+### show-progress
+
+`<Joyride showProgress>` displayed a `step n/N` indicator. In Tour Kit, render
+`<TourProgress />` inside your `<TourCard />` slot.
+
+### show-skip-button
+
+`<Joyride showSkipButton>` rendered a skip button. In Tour Kit, render `<TourClose />`
+inside `<TourCard />`.
+
+### step-index
+
+Joyride accepted a controlled `stepIndex` prop. Tour Kit owns step index internally.
+Use `useTour().goTo(index)` to navigate imperatively.
+
+### callback
+
+Joyride's single `callback({ action, status, type, index })` becomes three separate
+handlers in Tour Kit:
+
+- `onTourEnd(args)` — tour finished
+- `onTourSkip(args)` — user skipped
+- `onStepAdvance(args)` — step changed
+
+Walk through your original callback body and split each branch into the appropriate
+handler.
+
+### use-joyride-hook
+
+`useJoyride({ steps, ... })` collapses into:
+
+- `useTour()` — controls (start/next/prev/skip/stop)
+- `<TourProvider tours={[{ id, steps }]}>` — declarative tour registration in an ancestor
+
+The codemod cannot synthesize the ancestor provider — move the tour registration to
+the right place in your tree by hand.
+
+### controls-api
+
+Joyride's `controls.start()`, `.next()`, `.previous()`, `.skip()` map to Tour Kit's
+`useTour()` return value. `previous` becomes `prev`. Spot-check each call site.
+
+### tour-component
+
+The `<Tour />` component returned by `useJoyride()` rendered the tour inline. Tour Kit
+does not have an inline `<Tour />` — render `<TourProvider>` + `<TourCard />` in an
+ancestor and remove the inline element.
+
+### callbackprops
+
+The `CallBackProps` type has no Tour Kit equivalent — handlers receive narrow argument
+shapes (`{ index, status }` etc.) instead of one wide union. Remove the import.
+
+### eventdata
+
+The `EventData` type from `useJoyride().onEvent` has no Tour Kit equivalent. Each
+handler (`onTourEnd`, `onStepAdvance`) gets a narrowly-typed argument.
+
+### actions
+
+`ACTIONS.NEXT` / `ACTIONS.PREV` etc. enums have no Tour Kit equivalent — Tour Kit
+splits the callback by handler so the action discriminator is moot.
+
+### status
+
+`STATUS.FINISHED` / `STATUS.SKIPPED` enums have no Tour Kit equivalent — use the
+dedicated `onTourEnd` / `onTourSkip` handlers instead.
+
+## Step shape
+
+### target-function
+
+```tsx
+{ target: () => document.body }  // ✗ not supported
+```
+
+Tour Kit's `target` accepts a CSS selector string or a DOM ref. If your Joyride
+target was a function returning an element, rewrite as a selector OR pass a ref via
+the headless slot API.
+
+### target-dynamic
+
+```tsx
+{ target: someVariable }  // ⚠ verify
+```
+
+A dynamic identifier or expression is preserved as-is — confirm the value resolves
+to a string selector at runtime.
+
+### placement
+
+Joyride placements (`top` / `bottom` / etc.) map 1:1. `auto` and `center` are not
+Tour Kit values — the codemod maps both to `top`; review manually.
+
+### beacon
+
+Joyride pulses a beacon on each step until the user clicks. Tour Kit shows the tour
+immediately and has no default beacon. `Step.disableBeacon` and `Step.skipBeacon`
+are no-ops in Tour Kit — drop them.
+
+### styles
+
+Joyride's `Step.styles` accepted a deep object of inline styles. Tour Kit uses
+theme tokens via `<ThemeProvider />`. Port styling at the theme layer.
+
+### tooltip-component
+
+`Step.tooltipComponent` swapped the entire tooltip shell. Tour Kit uses headless
+slots — see the `<TourCard />` slot documentation for the equivalent.
+
+### beacon-component
+
+`Step.beaconComponent` swapped the beacon. Tour Kit has no default beacon — there
+is nothing to swap.
+
+### spotlight-target
+
+Joyride's `Step.spotlightTarget` let you spotlight a different element from the
+tooltip anchor. Tour Kit's spotlight is anchored to `target`; if you need a split,
+use a custom overlay component.
+
+### spotlight-clicks
+
+`Step.spotlightClicks` let users click through the spotlight onto the target.
+Tour Kit's spotlight is non-interactive by default; configure via the headless
+`<TourOverlay />` slot.
+
+### spotlight-padding
+
+`Step.spotlightPadding` controlled the spotlight ring. Tour Kit accepts a `padding`
+number on the headless overlay slot. If you used an object (per-side padding), pick
+the largest value and review.
+
+### scroll-target
+
+`Step.scrollTarget` chose a different scroll container. Tour Kit auto-detects the
+nearest scroll parent; if you need a custom container, set it manually before the
+tour starts.
+
+### is-fixed
+
+`Step.isFixed` opted into fixed positioning. Tour Kit always uses Floating UI for
+positioning — drop this field.
+
+### portal-element
+
+`Step.portalElement` overrode the portal root. Tour Kit's `<TourPortal />` slot
+accepts a `container` prop — port the value there.
+
+### disable-overlay
+
+Joyride's `disableOverlay` removed the dimmed background. In Tour Kit, omit
+`<TourOverlay />` from your `<TourCard />` composition.
+
+### disable-scrolling
+
+Joyride's `disableScrolling` prevented programmatic scroll to the target. Tour Kit
+scrolls when the target is off-screen; gate this in your own logic if you need to.
+
+### hide-close-button
+
+Joyride's `hideCloseButton` removed the X button. In Tour Kit, omit `<TourClose />`
+from your card composition.
+
+### hide-footer
+
+Joyride's `hideFooter` removed the footer. In Tour Kit, omit `<TourCardFooter />`
+from your card composition.
+
+### hide-back-button
+
+Joyride's `hideBackButton` removed the back button. In Tour Kit, omit the prev
+button from your `<TourNavigation />` composition.
+
+### locale
+
+Joyride's `locale` overrode button labels. In Tour Kit, pass label props to each
+slot component (`<TourNavigation prevLabel="..." nextLabel="..." />`).
+
+### debug
+
+Joyride's `debug` mode dumped state to the console. Tour Kit's `<TourProvider diagnose>`
+prop is the equivalent — see the [Diagnostics guide](/docs/guides) for usage.
+
+### disablecloseonesc
+
+`disableCloseOnEsc` disabled the Escape-key close handler. In Tour Kit, override
+the keyboard handler via the headless slots or the `<TourCard />` `onKeyDown` prop.
+
+## Step shape — unrecognized
+
+### unknown-step-field
+
+The codemod surfaces unknown `Step.*` fields with this anchor. Check the docs for
+the version of `react-joyride` you ran and decide if the field has a Tour Kit
+equivalent that the codemod didn't recognize.
+
+### unknown-jsx-prop
+
+Same idea for `<Joyride someProp={...} />` props the codemod didn't recognize.
+
+### jsx-spread
+
+A JSX spread (`<Joyride {...props} />`) hides what's actually being passed. The
+codemod can't see through it — verify your props against the Tour Kit API manually.
+
+## CLI smoke test
+
+```bash
+npx tour-kit-migrate --from joyride --dry-run ./src
+```
+
+If the dry-run prints clean diffs and exits 0, run again without `--dry-run` to
+write the changes.
+
+---
+
+# Migrate from shepherd.js
+
+> Use `npx tour-kit-migrate --from shepherd` to rewrite a shepherd.js codebase to Tour Kit in seconds. Covers the class-chain pattern (`new Shepherd.Tour` + `.addStep(...)` + `.start()`).
+
+## Quick start
+
+```bash
+npx tour-kit-migrate --from shepherd ./src
+```
+
+The migrate command runs a `jscodeshift` transform over your `.ts`/`.tsx`/`.js`/`.jsx`
+files and reconstitutes the `new Shepherd.Tour({...})` + `.addStep({...})` +
+`.start()` imperative chain into a single Tour Kit-shaped tour object literal.
+Patterns that have no Tour Kit equivalent are kept in place and annotated with
+`// TODO:` comments that link back to this page.
+
+### Flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--from <source>` | required | One of `joyride`, `shepherd`, `driver` |
+| `--parser <parser>` | `tsx` | `tsx` / `ts` / `babel` |
+| `--dry-run` | off | Print diffs, don't write |
+| `--print` | off | Write transformed source to stdout |
+| `--extensions <list>` | `ts,tsx,js,jsx` | Comma-separated extension list |
+| `--verbose` | off | Log every file action |
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Parse error during transform |
+| 2 | Bad CLI args |
+| 3 | No files matched |
+
+## What gets migrated
+
+| Pattern | shepherd.js | Tour Kit |
+| --- | --- | --- |
+| Default import | `import Shepherd from 'shepherd.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| Named import | `import { Tour } from 'shepherd.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| Tour constructor | `new Shepherd.Tour({...})` | `{ id: 'migrated-tour', steps: [...] }` literal + TODO to register at `<TourProvider>` |
+| `.addStep({...})` chain | `tour.addStep({id, attachTo, text})` | merged into `steps: [{id, target, placement, content}]` array |
+| `Step.attachTo.element` | `'#cta'` | `target: '#cta'` |
+| `Step.attachTo.on` | `'top'` / `'bottom'` / ... | `placement: 'top'` / `'bottom'` / ... |
+| `Step.text` | `'Welcome'` | `content: 'Welcome'` |
+
+## Anchors emitted by the codemod
+
+Each heading below corresponds to a `// TODO:` link emitted by the transform.
+Grep your migrated codebase for the anchor or follow it here for hand-port
+guidance.
+
+### tour-constructor
+
+`new Shepherd.Tour({...})` is replaced with a Tour Kit tour shape:
+
+```tsx
+const tour = {
+  id: 'migrated-tour',
+  steps: [/* migrated steps */],
+}
+```
+
+Register the migrated tour at a `<TourProvider>` ancestor and call
+`useTour().start()` from a descendant when you want the tour to begin.
+
+### add-step-dynamic
+
+`.addStep(someVariable)` is dynamic — the codemod cannot inline the step
+shape. Port the variable contents into the `steps` array manually.
+
+### attach-to-dynamic
+
+`attachTo` was not an inline object literal (e.g. spread from another
+variable). Set `target` / `placement` manually.
+
+### attach-to-element-function
+
+```ts
+attachTo: { element: () => document.body, on: 'top' }
+```
+
+Tour Kit's `target` accepts a CSS selector string or a DOM ref — not a
+function. Rewrite as a selector or pass a ref via the headless slot API.
+
+### target
+
+The codemod could not resolve `attachTo.element` to a selector. Set
+`Step.target` by hand to a CSS selector string or DOM ref.
+
+### target-dynamic
+
+A dynamic identifier or member expression was preserved as-is — verify it
+resolves to a string selector at runtime.
+
+### placement
+
+shepherd.js's `attachTo.on` accepts the same primary axis values as Tour Kit
+(`top` / `bottom` / `left` / `right` plus start/end variants). `auto` is
+mapped to `top`; review manually.
+
+### start
+
+```ts
+tour.start()
+```
+
+The migrated tour object has no `.start()` method. Call `useTour().start()`
+from inside a descendant of the `<TourProvider>` that registers the tour.
+
+### control-flow
+
+`tour.show()`, `tour.hide()`, `tour.cancel()`, `tour.complete()`, `tour.next()`,
+and `tour.back()` are replaced with empty statements + TODO comments. Their
+Tour Kit equivalents are:
+
+| Shepherd | Tour Kit |
+| --- | --- |
+| `tour.show(id)` | `useTour().goTo(index)` |
+| `tour.hide()` | `useTour().stop()` |
+| `tour.cancel()` | `useTour().skip()` |
+| `tour.complete()` | `useTour().complete()` |
+| `tour.next()` | `useTour().next()` |
+| `tour.back()` | `useTour().prev()` |
+
+### classes
+
+`Step.classes` injected CSS class names onto the popover. Tour Kit uses theme
+tokens — port styling via your `<ThemeProvider>` and `<TourCard />` slots.
+
+### modal-overlay-class
+
+`Step.modalOverlayOpeningClass` styled the modal overlay opening. Configure
+the spotlight ring via your `<TourOverlay />` slot.
+
+### modal-overlay-padding
+
+`Step.modalOverlayOpeningPadding` set padding on the modal overlay opening.
+Pass `padding` to your `<TourOverlay />` slot.
+
+### can-click-target
+
+`Step.canClickTarget` toggled whether the spotlighted element accepts clicks.
+Tour Kit's spotlight is non-interactive by default — configure the overlay
+spotlight interactive flag manually.
+
+### scroll-to
+
+`Step.scrollTo` / `Step.scrollToHandler` set a custom scroll behaviour. Tour
+Kit auto-scrolls when the target is off-screen; gate manually if you need a
+custom container.
+
+### highlight-class
+
+`Step.highlightClass` injected a CSS class on the highlighted element. Use
+theme tokens on the spotlight slot.
+
+### when
+
+`Step.when` was a map of lifecycle hooks (`show`, `hide`, `complete`, etc.).
+Port each handler to the matching `onShow` / `onHide` property on the
+migrated step, or pass through `<TourProvider>` callbacks for tour-wide
+events.
+
+### advance-on
+
+`Step.advanceOn` advanced the tour on a DOM event from another element.
+Wire `useTour().next()` from your own event handler.
+
+### before-show-promise
+
+`Step.beforeShowPromise` returned a Promise that resolved before the step
+showed. Await it before calling `useTour().goTo()`, or move the deferred
+logic into a custom `onShow` handler.
+
+### show-on
+
+`Step.showOn` was a predicate that conditionally skipped the step. Branch on
+`useTour().currentStepIndex` from a descendant or call `useTour().goTo()` to
+skip.
+
+### buttons
+
+```ts
+buttons: [
+  { text: 'Skip', action: () => tour.cancel() },
+  { text: 'Next', action: () => tour.next() },
+]
+```
+
+shepherd.js's button array is open-ended. Tour Kit ships fixed `<TourCard />`
+slots (Next / Prev / Skip / Close). Wire any custom button actions through
+the `<TourCard />` children — see the
+[card composition guide](/docs/react/components).
+
+### unknown-step-field
+
+A `Step.*` field not in this matrix. Check the version of shepherd.js you ran
+against and decide if it has a Tour Kit equivalent the codemod missed.
+
+## CLI smoke test
+
+```bash
+npx tour-kit-migrate --from shepherd --dry-run ./src
+```
+
+If the dry-run prints clean diffs and exits 0, run again without `--dry-run`
+to write the changes.
 
 ---
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,4 +1,4 @@
-# userTourKit v0.11.0 — Generated 2026-05-13T07:39:18Z
+# userTourKit v0.11.0 — Generated 2026-05-13T15:24:38Z
 
 # userTourKit
 
@@ -240,6 +240,7 @@
 - [Multi-tab Tours](https://usertourkit.com/docs/guides/multi-tab): Pause an active tour in tab B when the user starts the same flow in tab A — cross-tab coordination via BroadcastChannel.
 - [Next.js Integration](https://usertourkit.com/docs/guides/nextjs): Set up userTourKit with Next.js App Router or Pages Router — server component layouts, route-aware tours, and SSR support
 - [Persistence](https://usertourkit.com/docs/guides/persistence): Save tour progress, checklist completion, and hint dismissals across browser sessions with pluggable storage adapters
+- [Playwright](https://usertourkit.com/docs/guides/playwright): Drive Tour Kit from Playwright with the typed `test.extend({ tour })` fixture and the opt-in `window.__tourKit__` bridge.
 - [Reduced Motion](https://usertourkit.com/docs/guides/reduced-motion): How Tour Kit honors prefers-reduced-motion across announcements, surveys, hints, checklists, and the core tour runtime
 - [Router Integration](https://usertourkit.com/docs/guides/router-integration): Build multi-page tours with Next.js, React Router, or custom routers using route-aware step targeting and persistence
 - [Audience Segmentation](https://usertourkit.com/docs/guides/segmentation): Target tours, hints, surveys, and announcements at named user segments using SegmentationProvider, useSegment, and CSV-driven user lists.
@@ -285,6 +286,12 @@
 ## Licensing
 
 - [Licensing](https://usertourkit.com/docs/licensing): Set up userTourKit Pro licensing with Polar.sh — installation, configuration, and CI/CD
+
+## Migration
+
+- [Migrate from driver.js](https://usertourkit.com/docs/migration/driver): Use `npx tour-kit-migrate --from driver` to rewrite a driver.js codebase to Tour Kit in seconds. Covers the function-call pattern (`driver({...}).drive()`).
+- [Migrate from react-joyride](https://usertourkit.com/docs/migration/joyride): Use `npx tour-kit-migrate --from joyride` to rewrite a react-joyride codebase to Tour Kit in seconds. Covers both the legacy `<Joyride>` JSX form and the modern `useJoyride()` hook form.
+- [Migrate from shepherd.js](https://usertourkit.com/docs/migration/shepherd): Use `npx tour-kit-migrate --from shepherd` to rewrite a shepherd.js codebase to Tour Kit in seconds. Covers the class-chain pattern (`new Shepherd.Tour` + `.addStep(...)` + `.start()`).
 
 ## Surveys
 

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -1,7 +1,8 @@
 # @tour-kit/codemods
 
 Codemods for migrating to Tour Kit from competing tour libraries. Ships as a
-single `tour-kit-migrate` CLI plus reusable `jscodeshift` transforms.
+single `tour-kit-migrate` CLI plus reusable `jscodeshift` transforms for
+**react-joyride**, **shepherd.js**, and **driver.js**.
 
 ## Install
 
@@ -14,11 +15,17 @@ pnpm add -D @tour-kit/codemods
 ## Usage
 
 ```bash
-# Dry-run a Joyride codebase
+# Joyride
 npx tour-kit-migrate --from joyride --dry-run ./src
-
-# Apply
 npx tour-kit-migrate --from joyride ./src
+
+# Shepherd.js
+npx tour-kit-migrate --from shepherd --dry-run ./src
+npx tour-kit-migrate --from shepherd ./src
+
+# Driver.js
+npx tour-kit-migrate --from driver --dry-run ./src
+npx tour-kit-migrate --from driver ./src
 
 # Pipe transformed source to stdout
 npx tour-kit-migrate --from joyride --print ./src/MyTour.tsx
@@ -28,7 +35,7 @@ npx tour-kit-migrate --from joyride --print ./src/MyTour.tsx
 
 | Flag                  | Default          | Meaning                                        |
 | --------------------- | ---------------- | ---------------------------------------------- |
-| `--from <source>`     | required         | `joyride` (Shepherd / Driver coming in Phase 7b) |
+| `--from <source>`     | required         | `joyride` \| `shepherd` \| `driver`            |
 | `--parser <parser>`   | `tsx`            | `tsx` \| `ts` \| `babel`                       |
 | `--dry-run`           | off              | Print diffs, don't write                       |
 | `--print`             | off              | Write transformed source to stdout             |
@@ -44,7 +51,29 @@ npx tour-kit-migrate --from joyride --print ./src/MyTour.tsx
 | 2    | Bad CLI args                     |
 | 3    | No files matched                 |
 
-## What gets migrated (Joyride)
+## Coverage status
+
+Fixture-corpus coverage from the parametrized `fixture-runner.test.ts`. Numbers
+reflect the percentage of committed fixtures where the transform output
+matches the expected output AND passes `tsc --noEmit` against the stub types.
+
+| Source           | Coverage | Status |
+| ---------------- | -------- | ------ |
+| `joyride`        | 100%     | stable |
+| `shepherd`       | 100%     | stable |
+| `driver`         | 100%     | stable |
+
+When a transform's coverage drops below 80%, it is added to the
+`EXPERIMENTAL_TRANSFORMS` set in `src/cli.ts` and the CLI prints a one-line
+warning to stderr the first time `--from <source>` is invoked:
+
+```
+[Tour Kit] <source> transform is experimental. Coverage: <pct>%. Review TODOs carefully.
+```
+
+## What gets migrated
+
+### Joyride (`--from joyride`)
 
 | Pattern                                           | Migrated                                                  |
 | ------------------------------------------------- | --------------------------------------------------------- |
@@ -56,9 +85,41 @@ npx tour-kit-migrate --from joyride --print ./src/MyTour.tsx
 
 Every Joyride-only pattern (callback, run, stepIndex, showProgress,
 showSkipButton, continuous, Step.styles, Step.tooltipComponent, …) is preserved
-with a `// TODO:` comment linking to a heading in the [migration guide](https://tourkit.dev/docs/migration/joyride).
+with a `// TODO:` comment linking to a heading in the
+[migration guide](https://tourkit.dev/docs/migration/joyride).
 
-## What doesn't migrate yet
+### Shepherd.js (`--from shepherd`)
+
+| Pattern                                  | Migrated                                                        |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| `import Shepherd from 'shepherd.js'`     | `import { TourProvider } from '@tour-kit/react'`                |
+| `import { Tour } from 'shepherd.js'`     | `import { TourProvider } from '@tour-kit/react'`                |
+| `new Shepherd.Tour({...})`               | `{ id: 'migrated-tour', steps: [...] }` literal + TODO          |
+| `.addStep({...})` chain                  | merged into the `steps: [...]` array                            |
+| `Step.attachTo.element` (selector)       | `target` field                                                  |
+| `Step.attachTo.on` (placement)           | `placement` field                                               |
+| `tour.start()` / `.cancel()` / etc.      | empty statements + TODO pointing at `useTour()`                 |
+
+Every Shepherd-only pattern (buttons, classes, beforeShowPromise, advanceOn,
+scrollTo, …) is preserved with a `// TODO:` comment linking to the
+[migration guide](https://tourkit.dev/docs/migration/shepherd).
+
+### Driver.js (`--from driver`)
+
+| Pattern                                  | Migrated                                                        |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| `import { driver } from 'driver.js'`     | `import { TourProvider } from '@tour-kit/react'`                |
+| `driver({ steps: [...] })`               | `{ id: 'migrated-tour', steps: [...] }` literal + TODO          |
+| `Step.element` (selector)                | `target` field                                                  |
+| `Step.element` (DOM Element)             | `target: el` + TODO                                             |
+| `popover.title` / `description` / `side` | `title` / `content` / `placement`                               |
+| `d.drive()` / `.destroy()` / `.moveNext` | empty statements + TODO pointing at `useTour()`                 |
+
+Every driver-only pattern (showProgress, allowClose, button-label overrides,
+onHighlightStarted, popoverClass, …) is preserved with a `// TODO:` comment
+linking to the [migration guide](https://tourkit.dev/docs/migration/driver).
+
+## What doesn't migrate
 
 The codemod is conservative — it does NOT synthesize helper components,
 refactor callback dispatchers, or move tour registration to the right ancestor.
@@ -66,13 +127,12 @@ A transform that mangles user code is worse than no transform. Patterns the
 codemod can't handle are surfaced as `// TODO:` comments so the user can hand
 port — never silently dropped.
 
-See the [Joyride migration guide](https://tourkit.dev/docs/migration/joyride) for
-the full list of supported patterns and the manual-port path for everything else.
+See the per-source migration guides for the supported patterns and the
+manual-port path for everything else:
 
-## Roadmap
-
-- Phase 7b — Shepherd.js and Driver.js transforms
-- Future — Step-level rewriting (mapping `Step.styles` to theme tokens, etc.)
+- [Joyride migration guide](https://tourkit.dev/docs/migration/joyride)
+- [Shepherd.js migration guide](https://tourkit.dev/docs/migration/shepherd)
+- [Driver.js migration guide](https://tourkit.dev/docs/migration/driver)
 
 ## License
 

--- a/packages/codemods/__tests__/fixtures/driver/driver-basic.expected.tsx
+++ b/packages/codemods/__tests__/fixtures/driver/driver-basic.expected.tsx
@@ -1,0 +1,30 @@
+// Source pattern: driver.js v1+ — function-style imperative API. The
+// shape that ships in driver.js docs verbatim.
+
+import { useEffect } from 'react'
+import { TourProvider } from '@tour-kit/react'
+
+export function ProductTour() {
+  useEffect(() => {
+    const d = // TODO: driver.js config — register via <TourProvider tours={[migratedTour]}> in an ancestor; call useTour().start() to begin — see https://tourkit.dev/migration/driver#driver-call
+    {
+      id: 'migrated-tour',
+
+      steps: [{
+        target: '#hero',
+        title: 'Welcome',
+        content: 'Quick tour ahead.',
+        placement: 'bottom',
+      }, {
+        target: '#cta',
+        title: 'Get started',
+        content: 'Click to begin.',
+        placement: 'top',
+      }],
+    }
+
+    // TODO: driver.js .drive() → call useTour().start() from a descendant of <TourProvider> — see https://tourkit.dev/migration/driver#drive
+
+  }, [])
+  return null
+}

--- a/packages/codemods/__tests__/fixtures/driver/driver-basic.input.tsx
+++ b/packages/codemods/__tests__/fixtures/driver/driver-basic.input.tsx
@@ -1,0 +1,24 @@
+// Source pattern: driver.js v1+ — function-style imperative API. The
+// shape that ships in driver.js docs verbatim.
+
+import { useEffect } from 'react'
+import { driver } from 'driver.js'
+
+export function ProductTour() {
+  useEffect(() => {
+    const d = driver({
+      steps: [
+        {
+          element: '#hero',
+          popover: { title: 'Welcome', description: 'Quick tour ahead.', side: 'bottom' },
+        },
+        {
+          element: '#cta',
+          popover: { title: 'Get started', description: 'Click to begin.', side: 'top' },
+        },
+      ],
+    })
+    d.drive()
+  }, [])
+  return null
+}

--- a/packages/codemods/__tests__/fixtures/driver/driver-element-dom.expected.tsx
+++ b/packages/codemods/__tests__/fixtures/driver/driver-element-dom.expected.tsx
@@ -1,0 +1,28 @@
+// Source pattern: driver.js with a step that uses a captured DOM Element
+// instance (not a selector). The codemod can't statically resolve this — it
+// emits a TODO and leaves the binding in place for hand-port.
+
+import { TourProvider } from '@tour-kit/react'
+
+export function highlightOnboardingNode(el: HTMLElement) {
+  const d = // TODO: driver.js config — register via <TourProvider tours={[migratedTour]}> in an ancestor; call useTour().start() to begin — see https://tourkit.dev/migration/driver#driver-call
+  // TODO: driver.js Step.element is a DOM Element instance — Tour Kit expects a selector string or DOM ref — see https://tourkit.dev/migration/driver#element-dom
+  {
+    id: 'migrated-tour',
+
+    steps: [{
+      target: el,
+      title: 'Hi',
+      content: 'Just here.',
+      placement: 'top',
+    }, {
+      target: '#static-anchor',
+      title: 'Static',
+      content: 'Selector-anchored.',
+      placement: 'bottom',
+    }],
+  }
+
+  // TODO: driver.js .drive() → call useTour().start() from a descendant of <TourProvider> — see https://tourkit.dev/migration/driver#drive
+
+}

--- a/packages/codemods/__tests__/fixtures/driver/driver-element-dom.input.tsx
+++ b/packages/codemods/__tests__/fixtures/driver/driver-element-dom.input.tsx
@@ -1,0 +1,21 @@
+// Source pattern: driver.js with a step that uses a captured DOM Element
+// instance (not a selector). The codemod can't statically resolve this — it
+// emits a TODO and leaves the binding in place for hand-port.
+
+import { driver } from 'driver.js'
+
+export function highlightOnboardingNode(el: HTMLElement) {
+  const d = driver({
+    steps: [
+      {
+        element: el,
+        popover: { title: 'Hi', description: 'Just here.', side: 'top' },
+      },
+      {
+        element: '#static-anchor',
+        popover: { title: 'Static', description: 'Selector-anchored.', side: 'bottom' },
+      },
+    ],
+  })
+  d.drive()
+}

--- a/packages/codemods/__tests__/fixtures/driver/driver-options.expected.tsx
+++ b/packages/codemods/__tests__/fixtures/driver/driver-options.expected.tsx
@@ -1,0 +1,37 @@
+// Source pattern: driver.js with tour-level options (showProgress,
+// allowClose, button-label overrides). Each tour-level field maps to a slot
+// composition in Tour Kit; the codemod emits TODOs for every one.
+
+import { TourProvider } from '@tour-kit/react'
+
+export function startAdminTour() {
+  const d = // TODO: driver.js config — register via <TourProvider tours={[migratedTour]}> in an ancestor; call useTour().start() to begin — see https://tourkit.dev/migration/driver#driver-call
+  // TODO: driver.js showProgress → render <TourProgress /> inside <TourCard /> — see https://tourkit.dev/migration/driver#show-progress
+  // TODO: driver.js allowClose → omit / include <TourClose /> inside <TourCard /> — see https://tourkit.dev/migration/driver#allow-close
+  // TODO: driver.js nextBtnText → pass labels to your <TourNavigation /> slot — see https://tourkit.dev/migration/driver#btn-text
+  // TODO: driver.js prevBtnText → pass labels to your <TourNavigation /> slot — see https://tourkit.dev/migration/driver#btn-text
+  // TODO: driver.js doneBtnText → pass labels to your <TourNavigation /> slot — see https://tourkit.dev/migration/driver#btn-text
+  {
+    id: 'migrated-tour',
+
+    steps: [{
+      target: '#dashboard',
+      title: 'Dashboard',
+      content: 'Your KPIs.',
+      placement: 'right',
+    }, {
+      target: '#settings',
+      title: 'Settings',
+      content: 'Configure here.',
+      placement: 'left',
+    }, {
+      target: '#logout',
+      title: 'Sign out',
+      content: 'Use this to log out.',
+      placement: 'top',
+    }],
+  }
+
+  // TODO: driver.js .drive() → call useTour().start() from a descendant of <TourProvider> — see https://tourkit.dev/migration/driver#drive
+
+}

--- a/packages/codemods/__tests__/fixtures/driver/driver-options.input.tsx
+++ b/packages/codemods/__tests__/fixtures/driver/driver-options.input.tsx
@@ -1,0 +1,30 @@
+// Source pattern: driver.js with tour-level options (showProgress,
+// allowClose, button-label overrides). Each tour-level field maps to a slot
+// composition in Tour Kit; the codemod emits TODOs for every one.
+
+import { driver } from 'driver.js'
+
+export function startAdminTour() {
+  const d = driver({
+    showProgress: true,
+    allowClose: false,
+    nextBtnText: 'Continue',
+    prevBtnText: 'Back',
+    doneBtnText: 'Done',
+    steps: [
+      {
+        element: '#dashboard',
+        popover: { title: 'Dashboard', description: 'Your KPIs.', side: 'right' },
+      },
+      {
+        element: '#settings',
+        popover: { title: 'Settings', description: 'Configure here.', side: 'left' },
+      },
+      {
+        element: '#logout',
+        popover: { title: 'Sign out', description: 'Use this to log out.', side: 'top' },
+      },
+    ],
+  })
+  d.drive()
+}

--- a/packages/codemods/__tests__/fixtures/shepherd/shepherd-basic.expected.tsx
+++ b/packages/codemods/__tests__/fixtures/shepherd/shepherd-basic.expected.tsx
@@ -1,0 +1,31 @@
+// Source pattern: shepherd.js default import + chained addStep + start.
+// Representative of OSS shepherd.js examples — a simple onboarding tour
+// built imperatively in a React component effect.
+
+import { useEffect } from 'react'
+import { TourProvider } from '@tour-kit/react';
+
+export function OnboardingTour() {
+  useEffect(() => {
+    const tour = // TODO: Shepherd Tour constructed — register via <TourProvider tours={[migratedTour]}> in an ancestor and call useTour().start() to begin — see https://tourkit.dev/migration/shepherd#tour-constructor
+    {
+      id: 'migrated-tour',
+
+      steps: [{
+        id: 'welcome',
+        target: '#app-header',
+        placement: 'bottom',
+        content: 'Welcome to the app.',
+      }, {
+        id: 'cta',
+        target: '#cta',
+        placement: 'top',
+        content: 'Click here to get started.',
+      }],
+    }
+
+    // TODO: Shepherd tour.start() → call useTour().start() from a descendant of <TourProvider> — see https://tourkit.dev/migration/shepherd#start
+
+  }, [])
+  return null
+}

--- a/packages/codemods/__tests__/fixtures/shepherd/shepherd-basic.input.tsx
+++ b/packages/codemods/__tests__/fixtures/shepherd/shepherd-basic.input.tsx
@@ -1,0 +1,24 @@
+// Source pattern: shepherd.js default import + chained addStep + start.
+// Representative of OSS shepherd.js examples — a simple onboarding tour
+// built imperatively in a React component effect.
+
+import { useEffect } from 'react'
+import Shepherd from 'shepherd.js'
+
+export function OnboardingTour() {
+  useEffect(() => {
+    const tour = new Shepherd.Tour({ useModalOverlay: true })
+    tour.addStep({
+      id: 'welcome',
+      attachTo: { element: '#app-header', on: 'bottom' },
+      text: 'Welcome to the app.',
+    })
+    tour.addStep({
+      id: 'cta',
+      attachTo: { element: '#cta', on: 'top' },
+      text: 'Click here to get started.',
+    })
+    tour.start()
+  }, [])
+  return null
+}

--- a/packages/codemods/__tests__/fixtures/shepherd/shepherd-buttons.expected.tsx
+++ b/packages/codemods/__tests__/fixtures/shepherd/shepherd-buttons.expected.tsx
@@ -1,0 +1,32 @@
+// Source pattern: shepherd.js with custom buttons + lifecycle hooks +
+// unsupported step fields (classes, scrollTo, canClickTarget). Mirrors a
+// dense production tour that exercises every TODO anchor.
+
+import { TourProvider } from '@tour-kit/react';
+
+export function startCheckoutTour() {
+  const tour = // TODO: Shepherd Tour constructed — register via <TourProvider tours={[migratedTour]}> in an ancestor and call useTour().start() to begin — see https://tourkit.dev/migration/shepherd#tour-constructor
+  // TODO: Step.classes — Tour Kit uses theme tokens; port via <ThemeProvider> — see https://tourkit.dev/migration/shepherd#classes
+  // TODO: Step.scrollTo — Tour Kit auto-scrolls; gate manually if you need a custom container — see https://tourkit.dev/migration/shepherd#scroll-to
+  // TODO: Step.canClickTarget → configure the overlay spotlight interactive flag manually — see https://tourkit.dev/migration/shepherd#can-click-target
+  // TODO: Shepherd Step.buttons — Tour Kit fixed Next/Prev/Skip slots; wire custom button actions via <TourCard /> children — see https://tourkit.dev/migration/shepherd#buttons
+  // TODO: Step.advanceOn — wire useTour().next() from your own event handler — see https://tourkit.dev/migration/shepherd#advance-on
+  {
+    id: 'migrated-tour',
+
+    steps: [{
+      id: 'cart',
+      target: '#cart',
+      placement: 'top',
+      content: 'Review your cart.',
+    }, {
+      id: 'checkout',
+      target: '#checkout-btn',
+      placement: 'bottom',
+      content: 'Click here to check out.',
+    }],
+  }
+
+  // TODO: Shepherd tour.start() → call useTour().start() from a descendant of <TourProvider> — see https://tourkit.dev/migration/shepherd#start
+
+}

--- a/packages/codemods/__tests__/fixtures/shepherd/shepherd-buttons.input.tsx
+++ b/packages/codemods/__tests__/fixtures/shepherd/shepherd-buttons.input.tsx
@@ -1,0 +1,28 @@
+// Source pattern: shepherd.js with custom buttons + lifecycle hooks +
+// unsupported step fields (classes, scrollTo, canClickTarget). Mirrors a
+// dense production tour that exercises every TODO anchor.
+
+import Shepherd from 'shepherd.js'
+
+export function startCheckoutTour() {
+  const tour = new Shepherd.Tour({ useModalOverlay: true })
+  tour.addStep({
+    id: 'cart',
+    attachTo: { element: '#cart', on: 'top' },
+    text: 'Review your cart.',
+    classes: 'shepherd-cart',
+    scrollTo: true,
+    canClickTarget: false,
+    buttons: [
+      { text: 'Skip', action: () => tour.cancel() },
+      { text: 'Next', action: () => tour.next() },
+    ],
+  })
+  tour.addStep({
+    id: 'checkout',
+    attachTo: { element: '#checkout-btn', on: 'bottom' },
+    text: 'Click here to check out.',
+    advanceOn: { selector: '#checkout-btn', event: 'click' },
+  })
+  tour.start()
+}

--- a/packages/codemods/__tests__/fixtures/shepherd/shepherd-named-tour.expected.tsx
+++ b/packages/codemods/__tests__/fixtures/shepherd/shepherd-named-tour.expected.tsx
@@ -1,0 +1,31 @@
+// Source pattern: shepherd.js named { Tour } import (common in TypeScript
+// codebases that prefer ergonomic named imports over the default re-export).
+
+import { TourProvider } from '@tour-kit/react'
+
+export function startProductTour() {
+  const tour = // TODO: Shepherd Tour constructed — register via <TourProvider tours={[migratedTour]}> in an ancestor and call useTour().start() to begin — see https://tourkit.dev/migration/shepherd#tour-constructor
+  {
+    id: 'migrated-tour',
+
+    steps: [{
+      id: 'sidebar',
+      target: '[data-tour="sidebar"]',
+      placement: 'right',
+      content: 'Navigation lives here.',
+    }, {
+      id: 'search',
+      target: '[data-tour="search"]',
+      placement: 'bottom',
+      content: 'Use search to jump anywhere.',
+    }, {
+      id: 'profile',
+      target: '[data-tour="profile"]',
+      placement: 'left',
+      content: 'Open your profile here.',
+    }],
+  }
+
+  // TODO: Shepherd tour.start() → call useTour().start() from a descendant of <TourProvider> — see https://tourkit.dev/migration/shepherd#start
+
+}

--- a/packages/codemods/__tests__/fixtures/shepherd/shepherd-named-tour.input.tsx
+++ b/packages/codemods/__tests__/fixtures/shepherd/shepherd-named-tour.input.tsx
@@ -1,0 +1,24 @@
+// Source pattern: shepherd.js named { Tour } import (common in TypeScript
+// codebases that prefer ergonomic named imports over the default re-export).
+
+import { Tour } from 'shepherd.js'
+
+export function startProductTour() {
+  const tour = new Tour({ useModalOverlay: false })
+  tour.addStep({
+    id: 'sidebar',
+    attachTo: { element: '[data-tour="sidebar"]', on: 'right' },
+    text: 'Navigation lives here.',
+  })
+  tour.addStep({
+    id: 'search',
+    attachTo: { element: '[data-tour="search"]', on: 'bottom' },
+    text: 'Use search to jump anywhere.',
+  })
+  tour.addStep({
+    id: 'profile',
+    attachTo: { element: '[data-tour="profile"]', on: 'left' },
+    text: 'Open your profile here.',
+  })
+  tour.start()
+}

--- a/packages/codemods/docs/from-driver.md
+++ b/packages/codemods/docs/from-driver.md
@@ -1,0 +1,64 @@
+# driver.js → Tour Kit coverage matrix
+
+The Driver transform reshapes `driver({...})` function-style configs into
+Tour Kit tour literals. It runs over `.ts` / `.tsx` files matched by
+`tour-kit-migrate --from driver`.
+
+## Supported patterns (✓)
+
+| Pattern | driver.js | Tour Kit |
+| --- | --- | --- |
+| Import | `import { driver } from 'driver.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| Config call | `driver({ steps: [...] })` | `{ id: 'migrated-tour', steps: [...] }` |
+| `Step.element` (selector) | `'#hero'` | `target: '#hero'` |
+| `Step.element` (DOM Element) | captured `el` | `target: el` + TODO |
+| `popover.title` | `'Welcome'` | `title: 'Welcome'` |
+| `popover.description` | `'Hi there'` | `content: 'Hi there'` |
+| `popover.side` | `top` / `bottom` / `left` / `right` | identical |
+
+## Unsupported patterns (✗, emit `// TODO:`)
+
+Every unsupported pattern emits a TODO comment that links to the matching
+heading in `apps/docs/content/docs/migration/driver.mdx`. Headings exist
+for:
+
+| Anchor | Why unsupported |
+| --- | --- |
+| `driver-call` | `driver({...})` has no runtime mapping — register the migrated literal at `<TourProvider>` |
+| `driver-config-dynamic` | `driver(...)` argument was dynamic |
+| `steps-dynamic` | `config.steps` was dynamic (not an inline array) |
+| `step-dynamic` | A step inside `steps` was dynamic (not an inline object) |
+| `element-function` | `Step.element` returned an element from a function |
+| `element-dom` | `Step.element` is a captured DOM Element instance (preserved + TODO) |
+| `target` | Could not resolve `Step.element` to a selector |
+| `placement` | `popover.side: 'over'` mapped to `'top'` |
+| `align` | `popover.align` folded into compound Tour Kit placements |
+| `popover-dynamic` | `Step.popover` was not an inline object |
+| `popover-class` | `popover.popoverClass` — theme tokens via `<ThemeProvider>` |
+| `show-progress` | `showProgress` (tour or popover) → `<TourProgress />` slot |
+| `allow-close` | `allowClose` — include / omit `<TourClose />` slot |
+| `btn-text` | `doneBtnText` / `nextBtnText` / `prevBtnText` / `closeBtnText` → slot labels |
+| `show-buttons` | `showButtons[]` → compose `<TourCard />` with only the slots you need |
+| `disable-active-interaction` | Configure the spotlight interactive flag on `<TourOverlay />` |
+| `smooth-scroll` | `smoothScroll` — Tour Kit always scrolls |
+| `animate` | `animate` — Tour Kit respects `prefers-reduced-motion` automatically |
+| `stage-padding` | `stagePadding` → pass `padding` to `<TourOverlay />` |
+| `stage-radius` | `stageRadius` → theme tokens |
+| `overlay-color` | `overlayColor` → theme tokens |
+| `overlay-opacity` | `overlayOpacity` → theme tokens |
+| `on-highlight-started` | `onHighlightStarted` / `onHighlighted` → `onShow` on the step |
+| `on-highlighted` | Alias of `on-highlight-started` |
+| `on-deselected` | `onDeselected` → `onHide` on the step |
+| `on-popover-render` | `onPopoverRender` → custom JSX in `<TourCard />` children |
+| `on-next-click` | `onNextClick` / `onPrevClick` / `onCloseClick` → slot handlers |
+| `on-prev-click` | See `on-next-click` |
+| `on-close-click` | See `on-next-click` |
+| `on-click` | Generic on-click anchor for popover button handlers |
+| `on-destroy-started` | `onDestroyStarted` → `<TourProvider onSkip / onComplete>` |
+| `on-destroyed` | `onDestroyed` → `<TourProvider onSkip / onComplete>` |
+| `drive` | `.drive()` removed — call `useTour().start()` from a descendant |
+| `control-flow` | `.destroy()` / `.moveNext()` / `.movePrevious()` / `.moveTo()` removed |
+| `highlight` | `.highlight()` — render `<HintHotspot>` from `@tour-kit/hints` |
+| `unknown-config-field` | A tour-level config field not in this matrix |
+| `unknown-popover-field` | A `popover.*` field not in this matrix |
+| `unknown-step-field` | A `Step.*` field not in this matrix |

--- a/packages/codemods/docs/from-shepherd.md
+++ b/packages/codemods/docs/from-shepherd.md
@@ -1,0 +1,50 @@
+# shepherd.js → Tour Kit coverage matrix
+
+The Shepherd transform reconstitutes the class-chain imperative API
+(`new Shepherd.Tour({...})` + `.addStep({...})` + `.start()`) into a single
+Tour Kit-shaped object literal. It runs over `.ts` / `.tsx` files matched by
+`tour-kit-migrate --from shepherd`.
+
+## Supported patterns (✓)
+
+| Pattern | shepherd.js | Tour Kit |
+| --- | --- | --- |
+| Default import | `import Shepherd from 'shepherd.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| Named import | `import { Tour } from 'shepherd.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| Tour constructor | `new Shepherd.Tour({...})` / `new Tour({...})` | `{ id: 'migrated-tour', steps: [...] }` |
+| addStep chain | `tour.addStep({...})` (any depth) | merged into the `steps: [...]` array |
+| `attachTo.element` (selector) | `'#cta'` | `target: '#cta'` |
+| `attachTo.on` | `top` / `bottom` / `left` / `right` (+ start/end) | identical |
+| `Step.text` | `'Welcome'` | `content: 'Welcome'` |
+| `Step.title` | `'Hi'` | `title: 'Hi'` |
+| `Step.id` | `'step-1'` | `id: 'step-1'` |
+
+## Unsupported patterns (✗, emit `// TODO:`)
+
+Every unsupported pattern emits a TODO comment that links to the matching
+heading in `apps/docs/content/docs/migration/shepherd.mdx`. Headings exist
+for:
+
+| Anchor | Why unsupported |
+| --- | --- |
+| `tour-constructor` | `new Shepherd.Tour({...})` has no runtime mapping — register the migrated literal at `<TourProvider>` |
+| `add-step-dynamic` | `.addStep(someVariable)` — can't inline a dynamic step shape |
+| `attach-to-dynamic` | `attachTo` was not an inline object literal |
+| `attach-to-element-function` | `attachTo.element` returned an element from a function |
+| `target` | Could not resolve `attachTo.element` to a selector |
+| `target-dynamic` | Dynamic identifier preserved — verify it resolves |
+| `placement` | `attachTo.on: 'auto'` mapped to `'top'` |
+| `start` | `tour.start()` removed — call `useTour().start()` from a descendant |
+| `control-flow` | `.show()` / `.hide()` / `.cancel()` / `.complete()` / `.next()` / `.back()` removed |
+| `buttons` | `Step.buttons` array — Tour Kit has fixed Next/Prev/Skip slots |
+| `classes` | `Step.classes` — Tour Kit uses theme tokens |
+| `modal-overlay-class` | `Step.modalOverlayOpeningClass` → `<TourOverlay />` slot |
+| `modal-overlay-padding` | `Step.modalOverlayOpeningPadding` → `<TourOverlay />` slot |
+| `can-click-target` | Configure the overlay spotlight interactive flag |
+| `scroll-to` | `Step.scrollTo` / `scrollToHandler` — Tour Kit auto-scrolls |
+| `highlight-class` | `Step.highlightClass` — theme tokens via `<ThemeProvider>` |
+| `when` | `Step.when` lifecycle hooks → `onShow` / `onHide` |
+| `advance-on` | `Step.advanceOn` — wire `useTour().next()` manually |
+| `before-show-promise` | `Step.beforeShowPromise` — await before `goTo()` or use `onShow` |
+| `show-on` | `Step.showOn` predicate — branch on `useTour().currentStepIndex` |
+| `unknown-step-field` | A `Step.*` field not in this matrix |

--- a/packages/codemods/scripts/dump-fixtures.mjs
+++ b/packages/codemods/scripts/dump-fixtures.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// One-off helper: run a transform across every .input.tsx in a fixtures dir
+// and print the actual output to stdout. Used to seed .expected.tsx files,
+// then deleted from the working tree.
+
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import jscodeshift from 'jscodeshift'
+
+const [, , transformName, dirArg, mode = 'print'] = process.argv
+if (!transformName || !dirArg) {
+  console.error('usage: node scripts/dump-fixtures.mjs <transform> <fixtures-dir> [print|write]')
+  process.exit(2)
+}
+
+const transformPath = resolve(`./src/transforms/${transformName}.ts`)
+const { default: transform } = await import(transformPath)
+const j = jscodeshift.withParser('tsx')
+
+for (const file of readdirSync(dirArg).sort()) {
+  if (!file.endsWith('.input.tsx')) continue
+  const inputPath = join(dirArg, file)
+  const source = readFileSync(inputPath, 'utf8')
+  const api = { jscodeshift: j, j, stats: () => undefined, report: () => undefined }
+  const out = transform({ source, path: inputPath }, api, {})
+  if (mode === 'write') {
+    const expectedPath = inputPath.replace(/\.input\.tsx$/, '.expected.tsx')
+    writeFileSync(expectedPath, out, 'utf8')
+    console.error(`wrote ${expectedPath}`)
+  } else {
+    process.stdout.write(`===== ${file} =====\n${out}\n`)
+  }
+}

--- a/packages/codemods/src/__tests__/cli.test.ts
+++ b/packages/codemods/src/__tests__/cli.test.ts
@@ -2,8 +2,8 @@ import { createHash } from 'node:crypto'
 import { copyFileSync, mkdtempSync, readFileSync, readdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
-import { runMigrate } from '../cli'
+import { describe, expect, it, vi } from 'vitest'
+import { EXPERIMENTAL_TRANSFORMS, runMigrate } from '../cli'
 
 const FIXTURES = join(__dirname, '..', '..', '__tests__', 'fixtures', 'joyride')
 
@@ -62,5 +62,68 @@ describe('CLI --dry-run safety (SHA comparison)', () => {
     const after = snapshotDir(dir)
     expect(code).toBe(0)
     expect(after).toEqual(before)
+  })
+})
+
+describe('CLI — TRANSFORMS map recognizes shepherd + driver', () => {
+  // Exit 3 (no paths) proves the --from source is wired into the TRANSFORMS
+  // map. Exit 2 (bad-args) would mean the source isn't registered.
+  it('accepts --from shepherd (exits 3 on no paths)', async () => {
+    const code = await runMigrate(['--from', 'shepherd'])
+    expect(code).toBe(3)
+  })
+  it('accepts --from driver (exits 3 on no paths)', async () => {
+    const code = await runMigrate(['--from', 'driver'])
+    expect(code).toBe(3)
+  })
+})
+
+describe('CLI — experimental warnings', () => {
+  function captureStderr() {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    return {
+      get text(): string {
+        return spy.mock.calls.map((c) => c.map(String).join(' ')).join('\n')
+      },
+      restore: () => spy.mockRestore(),
+    }
+  }
+
+  const SHEPHERD_FIXTURES = join(__dirname, '..', '..', '__tests__', 'fixtures', 'shepherd')
+  const DRIVER_FIXTURES = join(__dirname, '..', '..', '__tests__', 'fixtures', 'driver')
+  const fixturesByName: Record<string, string> = {
+    joyride: FIXTURES,
+    shepherd: SHEPHERD_FIXTURES,
+    driver: DRIVER_FIXTURES,
+  }
+
+  it('prints an experimental warning + percentage when --from is flagged experimental', async () => {
+    if (EXPERIMENTAL_TRANSFORMS.size === 0) {
+      // No transform is flagged — the suite shipped both at ≥80% so there's
+      // nothing to warn about. The remaining tests in this describe still
+      // assert the negative path.
+      return
+    }
+    const flagged = [...EXPERIMENTAL_TRANSFORMS][0]
+    if (!flagged) return
+    const path = fixturesByName[flagged] ?? FIXTURES
+    const stderr = captureStderr()
+    await runMigrate(['--from', flagged, '--dry-run', path])
+    expect(stderr.text).toMatch(/experimental/i)
+    expect(stderr.text).toMatch(/\d+%/)
+    stderr.restore()
+  })
+
+  it('does NOT print the experimental warning for non-flagged sources', async () => {
+    const stable = (['joyride', 'shepherd', 'driver'] as const).filter(
+      (s) => !EXPERIMENTAL_TRANSFORMS.has(s)
+    )
+    if (stable.length === 0) return
+    const sample = stable[0]
+    const path = fixturesByName[sample] ?? FIXTURES
+    const stderr = captureStderr()
+    await runMigrate(['--from', sample, '--dry-run', path])
+    expect(stderr.text).not.toMatch(/experimental/i)
+    stderr.restore()
   })
 })

--- a/packages/codemods/src/__tests__/docs-anchors.test.ts
+++ b/packages/codemods/src/__tests__/docs-anchors.test.ts
@@ -1,23 +1,41 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import transform from '../transforms/from-joyride'
+import fromDriver from '../transforms/from-driver'
+import fromJoyride from '../transforms/from-joyride'
+import fromShepherd from '../transforms/from-shepherd'
 import { runTransform } from './_helpers'
 
-const FIXTURES = join(__dirname, '..', '..', '__tests__', 'fixtures', 'joyride')
-const MDX = join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  '..',
-  'apps',
-  'docs',
-  'content',
-  'docs',
-  'migration',
-  'joyride.mdx'
-)
+const PKG_ROOT = join(__dirname, '..', '..')
+const REPO_ROOT = join(PKG_ROOT, '..', '..')
+
+interface SourceAnchors {
+  name: 'joyride' | 'shepherd' | 'driver'
+  transform: typeof fromJoyride
+  fixturesDir: string
+  mdxPath: string
+}
+
+const SOURCES: readonly SourceAnchors[] = [
+  {
+    name: 'joyride',
+    transform: fromJoyride,
+    fixturesDir: join(PKG_ROOT, '__tests__', 'fixtures', 'joyride'),
+    mdxPath: join(REPO_ROOT, 'apps', 'docs', 'content', 'docs', 'migration', 'joyride.mdx'),
+  },
+  {
+    name: 'shepherd',
+    transform: fromShepherd as unknown as typeof fromJoyride,
+    fixturesDir: join(PKG_ROOT, '__tests__', 'fixtures', 'shepherd'),
+    mdxPath: join(REPO_ROOT, 'apps', 'docs', 'content', 'docs', 'migration', 'shepherd.mdx'),
+  },
+  {
+    name: 'driver',
+    transform: fromDriver as unknown as typeof fromJoyride,
+    fixturesDir: join(PKG_ROOT, '__tests__', 'fixtures', 'driver'),
+    mdxPath: join(REPO_ROOT, 'apps', 'docs', 'content', 'docs', 'migration', 'driver.mdx'),
+  },
+]
 
 function slugify(heading: string): string {
   return heading
@@ -27,28 +45,45 @@ function slugify(heading: string): string {
     .replace(/\s+/g, '-')
 }
 
-describe('TODO anchors emitted by from-joyride resolve to headings in joyride.mdx', () => {
-  it('every emitted anchor matches a slugified heading in the MDX docs page', () => {
-    expect(
-      existsSync(MDX),
-      `expected migration docs page at ${MDX} — write apps/docs/content/docs/migration/joyride.mdx`
-    ).toBe(true)
-    const mdx = readFileSync(MDX, 'utf8')
-    const headings = new Set<string>(
-      [...mdx.matchAll(/^#{1,6}\s+(.+)$/gm)].map(([, h]) => slugify(h))
-    )
-
-    const emittedAnchors = new Set<string>()
-    for (const file of readdirSync(FIXTURES).filter((f) => f.endsWith('.input.tsx'))) {
-      const out = runTransform(transform, readFileSync(join(FIXTURES, file), 'utf8'), file)
-      for (const m of out.matchAll(
-        /\/\/ TODO:.*?https:\/\/tourkit\.dev\/migration\/joyride#([a-z0-9-]+)/g
-      )) {
-        emittedAnchors.add(m[1])
-      }
+for (const src of SOURCES) {
+  describe(`TODO anchors emitted by from-${src.name} resolve to headings in ${src.name}.mdx`, () => {
+    if (!existsSync(src.fixturesDir)) {
+      it.skip(`corpus not present at ${src.fixturesDir}`, () => {})
+      return
+    }
+    if (!existsSync(src.mdxPath)) {
+      it.skip(`migration MDX not present at ${src.mdxPath}`, () => {})
+      return
     }
 
-    const orphans = [...emittedAnchors].filter((a) => !headings.has(a))
-    expect(orphans, `orphan anchors with no MDX heading: ${orphans.join(', ')}`).toEqual([])
+    it('every emitted anchor matches a slugified heading in the MDX docs page', () => {
+      const mdx = readFileSync(src.mdxPath, 'utf8')
+      const headings = new Set<string>(
+        [...mdx.matchAll(/^#{1,6}\s+(.+)$/gm)].map(([, h]) => slugify(h))
+      )
+
+      const anchorPattern = new RegExp(
+        `\\/\\/ TODO:.*?https:\\/\\/tourkit\\.dev\\/migration\\/${src.name}#([a-z0-9-]+)`,
+        'g'
+      )
+
+      const emittedAnchors = new Set<string>()
+      for (const file of readdirSync(src.fixturesDir).filter((f) => f.endsWith('.input.tsx'))) {
+        const out = runTransform(
+          src.transform,
+          readFileSync(join(src.fixturesDir, file), 'utf8'),
+          file
+        )
+        for (const m of out.matchAll(anchorPattern)) {
+          emittedAnchors.add(m[1])
+        }
+      }
+
+      const orphans = [...emittedAnchors].filter((a) => !headings.has(a))
+      expect(
+        orphans,
+        `orphan anchors with no MDX heading: ${orphans.join(', ')}`
+      ).toEqual([])
+    })
   })
-})
+}

--- a/packages/codemods/src/__tests__/docs-anchors.test.ts
+++ b/packages/codemods/src/__tests__/docs-anchors.test.ts
@@ -80,10 +80,7 @@ for (const src of SOURCES) {
       }
 
       const orphans = [...emittedAnchors].filter((a) => !headings.has(a))
-      expect(
-        orphans,
-        `orphan anchors with no MDX heading: ${orphans.join(', ')}`
-      ).toEqual([])
+      expect(orphans, `orphan anchors with no MDX heading: ${orphans.join(', ')}`).toEqual([])
     })
   })
 }

--- a/packages/codemods/src/__tests__/fixture-runner.test.ts
+++ b/packages/codemods/src/__tests__/fixture-runner.test.ts
@@ -94,7 +94,6 @@ for (const { src, results, skip } of computed) {
     for (const r of results) {
       it(`${r.name} matches expected output (normalized whitespace)`, () => {
         if (!r.diffOk) {
-          // biome-ignore lint/suspicious/noConsole: developer-only debugging
           console.error(`--- ${r.name} actual ---\n${r.actual}`)
         }
         expect(r.diffOk, `normalized diff mismatch for ${r.name}`).toBe(true)

--- a/packages/codemods/src/__tests__/fixture-runner.test.ts
+++ b/packages/codemods/src/__tests__/fixture-runner.test.ts
@@ -1,13 +1,32 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import transform from '../transforms/from-joyride'
+import { EXPERIMENTAL_TRANSFORMS } from '../cli'
+import fromDriver from '../transforms/from-driver'
+import fromJoyride from '../transforms/from-joyride'
+import fromShepherd from '../transforms/from-shepherd'
 import { normalize, reparses, runTransform, tscNoEmit } from './_helpers'
 
-const FIXTURES = join(__dirname, '..', '..', '__tests__', 'fixtures', 'joyride')
-const inputs = readdirSync(FIXTURES)
-  .filter((f) => f.endsWith('.input.tsx'))
-  .sort()
+interface Source {
+  name: 'joyride' | 'shepherd' | 'driver'
+  transform: typeof fromJoyride
+  // Joyride covers two distinct surface APIs; the gate asserts the pass-set
+  // spans both. Other sources have a single surface.
+  requirePairings?: ReadonlyArray<{ label: string; prefix: string }>
+}
+
+const SOURCES: readonly Source[] = [
+  {
+    name: 'joyride',
+    transform: fromJoyride,
+    requirePairings: [
+      { label: 'JSX form', prefix: 'joyride-jsx' },
+      { label: 'useJoyride hook form', prefix: 'useJoyride' },
+    ],
+  },
+  { name: 'shepherd', transform: fromShepherd as unknown as typeof fromJoyride },
+  { name: 'driver', transform: fromDriver as unknown as typeof fromJoyride },
+]
 
 interface FixtureResult {
   name: string
@@ -16,88 +35,118 @@ interface FixtureResult {
   tscOk: boolean
   tscOutput: string
   actual: string
-  expected: string
 }
 
-const results: FixtureResult[] = inputs.map((file) => {
-  const name = file.replace('.input.tsx', '')
-  const expectedPath = join(FIXTURES, `${name}.expected.tsx`)
-  if (!existsSync(expectedPath)) {
+interface Computed {
+  src: Source
+  results: FixtureResult[]
+  skip: boolean
+}
+
+const computed: Computed[] = SOURCES.map((src) => {
+  const dir = join(__dirname, '..', '..', '__tests__', 'fixtures', src.name)
+  if (!existsSync(dir)) {
+    return { src, results: [], skip: true }
+  }
+  const inputs = readdirSync(dir)
+    .filter((f) => f.endsWith('.input.tsx'))
+    .sort()
+  const results: FixtureResult[] = inputs.map((file) => {
+    const name = file.replace('.input.tsx', '')
+    const expectedPath = join(dir, `${name}.expected.tsx`)
+    if (!existsSync(expectedPath)) {
+      return {
+        name,
+        diffOk: false,
+        reparses: false,
+        tscOk: false,
+        tscOutput: `expected file missing: ${expectedPath}`,
+        actual: '',
+      }
+    }
+    const inputSrc = readFileSync(join(dir, file), 'utf8')
+    const expected = readFileSync(expectedPath, 'utf8')
+    const actual = runTransform(src.transform, inputSrc, file)
+    const diffOk = normalize(actual) === normalize(expected)
+    const reparsed = reparses(actual)
+    const tsc = tscNoEmit(actual)
     return {
       name,
-      diffOk: false,
-      reparses: false,
-      tscOk: false,
-      tscOutput: `expected file missing: ${expectedPath}`,
-      actual: '',
-      expected: '',
+      diffOk,
+      reparses: reparsed,
+      tscOk: tsc.ok,
+      tscOutput: tsc.output,
+      actual,
     }
-  }
-
-  const source = readFileSync(join(FIXTURES, file), 'utf8')
-  const expected = readFileSync(expectedPath, 'utf8')
-  const actual = runTransform(transform, source, file)
-  const diffOk = normalize(actual) === normalize(expected)
-  const reparsed = reparses(actual)
-  const tsc = tscNoEmit(actual)
-  return {
-    name,
-    diffOk,
-    reparses: reparsed,
-    tscOk: tsc.ok,
-    tscOutput: tsc.output,
-    actual,
-    expected,
-  }
+  })
+  return { src, results, skip: false }
 })
 
-describe('Joyride transform — per-fixture diff against expected output', () => {
-  for (const r of results) {
-    it(`${r.name} matches expected output (normalized whitespace)`, () => {
-      if (!r.diffOk) {
-        // Surface the actual output to help iteration when the diff fails.
-        // Vitest assertion below is the source of truth; the console hint
-        // is just for the developer.
-        // eslint-disable-next-line no-console
-        console.error(`--- ${r.name} actual ---\n${r.actual}`)
-      }
-      expect(r.diffOk, `normalized diff mismatch for ${r.name}`).toBe(true)
+for (const { src, results, skip } of computed) {
+  if (skip) {
+    describe(`${src.name} fixtures`, () => {
+      it.skip(`corpus not present at packages/codemods/__tests__/fixtures/${src.name} — Phase 0.6 may have been skipped`, () => {})
     })
+    continue
   }
-})
 
-describe('Joyride transform — every output is parseable TSX', () => {
-  for (const r of results) {
-    it(`${r.name} reparses through jscodeshift`, () => {
-      expect(r.reparses, `output is not parseable TSX for ${r.name}`).toBe(true)
-    })
-  }
-})
-
-describe('Joyride transform — every passing output is tsc --noEmit clean', () => {
-  for (const r of results) {
-    if (!r.diffOk) continue
-    it(`${r.name} output passes tsc --noEmit`, () => {
-      expect(r.tscOk, r.tscOutput).toBe(true)
-    })
-  }
-})
-
-describe('Joyride transform — coverage gate', () => {
-  it('hits ≥80% of committed fixtures with diff AND tsc clean', () => {
-    const passed = results.filter((r) => r.diffOk && r.tscOk).length
-    const total = results.length
-    const ratio = total > 0 ? passed / total : 0
-    const failing = results.filter((r) => !(r.diffOk && r.tscOk)).map((r) => r.name)
-    expect(
-      ratio,
-      `passed ${passed}/${total}; failing: ${failing.join(', ')}`
-    ).toBeGreaterThanOrEqual(0.8)
+  describe(`${src.name} transform — per-fixture diff against expected output`, () => {
+    for (const r of results) {
+      it(`${r.name} matches expected output (normalized whitespace)`, () => {
+        if (!r.diffOk) {
+          // biome-ignore lint/suspicious/noConsole: developer-only debugging
+          console.error(`--- ${r.name} actual ---\n${r.actual}`)
+        }
+        expect(r.diffOk, `normalized diff mismatch for ${r.name}`).toBe(true)
+      })
+    }
   })
 
-  it('includes at least one JSX-form AND one useJoyride-hook-form fixture in the pass-set', () => {
-    const passed = results.filter((r) => r.diffOk && r.tscOk).map((r) => r.name)
-    expect(passed.some((n) => n.startsWith('joyride-jsx'))).toBe(true)
-    expect(passed.some((n) => n.startsWith('useJoyride'))).toBe(true)
+  describe(`${src.name} transform — every output is parseable TSX`, () => {
+    for (const r of results) {
+      it(`${r.name} reparses through jscodeshift`, () => {
+        expect(r.reparses, `output is not parseable TSX for ${r.name}`).toBe(true)
+      })
+    }
   })
-})
+
+  describe(`${src.name} transform — every passing output is tsc --noEmit clean`, () => {
+    for (const r of results) {
+      if (!r.diffOk) continue
+      it(`${r.name} output passes tsc --noEmit`, () => {
+        expect(r.tscOk, r.tscOutput).toBe(true)
+      })
+    }
+  })
+
+  describe(`${src.name} transform — coverage gate`, () => {
+    it('hits ≥80% of committed fixtures with diff AND tsc clean (OR is flagged experimental)', () => {
+      const passed = results.filter((r) => r.diffOk && r.tscOk).length
+      const total = results.length
+      const ratio = total > 0 ? passed / total : 0
+      const failing = results.filter((r) => !(r.diffOk && r.tscOk)).map((r) => r.name)
+      const isExperimental = (EXPERIMENTAL_TRANSFORMS as ReadonlySet<string>).has(src.name)
+      expect(
+        ratio >= 0.8 || isExperimental,
+        `${src.name} coverage ${(ratio * 100).toFixed(0)}% < 80% AND not flagged experimental — failing: ${failing.join(
+          ', '
+        )}`
+      ).toBe(true)
+    })
+
+    const pairings = src.requirePairings
+    if (pairings && pairings.length > 0) {
+      it(`includes at least one of each required surface in the pass-set: ${pairings
+        .map((p) => p.label)
+        .join(', ')}`, () => {
+        const passed = results.filter((r) => r.diffOk && r.tscOk).map((r) => r.name)
+        for (const pairing of pairings) {
+          expect(
+            passed.some((n) => n.startsWith(pairing.prefix)),
+            `no ${pairing.label} fixture in the pass-set (looked for prefix '${pairing.prefix}')`
+          ).toBe(true)
+        }
+      })
+    }
+  })
+}

--- a/packages/codemods/src/__tests__/from-driver.test.ts
+++ b/packages/codemods/src/__tests__/from-driver.test.ts
@@ -77,4 +77,21 @@ d.drive()
     expect(out).toMatch(/\/\/ TODO:.*driver\.js\s+\.drive\(\)/i)
     expect(out).not.toMatch(/d\.drive\(\)/)
   })
+
+  // Regression: pre-fix, when no driver(...) call was bound to a variable
+  // (`driverVarNames.size === 0`), the size guard fell open and ALL matching
+  // method names got rewritten regardless of receiver.
+  it('does NOT rewrite control-method calls on unrelated bindings when no driver binding was captured', () => {
+    const out = runTransform(
+      transform,
+      `
+import { driver } from 'driver.js'
+driver({ steps: [] })
+foo.destroy()
+bar.drive()
+`
+    )
+    expect(out).toContain('foo.destroy()')
+    expect(out).toContain('bar.drive()')
+  })
 })

--- a/packages/codemods/src/__tests__/from-driver.test.ts
+++ b/packages/codemods/src/__tests__/from-driver.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import transform from '../transforms/from-driver'
+import { runTransform } from './_helpers'
+
+describe('from-driver — basic shapes', () => {
+  it('rewrites import "driver.js" to "@tour-kit/react"', () => {
+    const out = runTransform(
+      transform,
+      `import { driver } from 'driver.js'\ndriver({ steps: [] }).drive()\n`
+    )
+    expect(out).toContain(`from '@tour-kit/react'`)
+    expect(out).not.toContain(`'driver.js'`)
+  })
+
+  it('maps popover.title/description/side to title/content/placement', () => {
+    const out = runTransform(
+      transform,
+      `
+import { driver } from 'driver.js'
+const d = driver({ steps: [{ element: '#hero', popover: { title: 'Hi', description: 'There', side: 'top' } }] })
+d.drive()
+`
+    )
+    expect(out).toMatch(/title:\s*['"]Hi['"]/)
+    expect(out).toMatch(/content:\s*['"]There['"]/)
+    expect(out).toMatch(/placement:\s*['"]top['"]/)
+  })
+
+  it('maps Step.element selector to target', () => {
+    const out = runTransform(
+      transform,
+      `
+import { driver } from 'driver.js'
+driver({ steps: [{ element: '#hero', popover: { description: 'X' } }] }).drive()
+`
+    )
+    expect(out).toMatch(/target:\s*['"]#hero['"]/)
+  })
+
+  it('emits TODO when element is a DOM Element instance (not a selector)', () => {
+    const out = runTransform(
+      transform,
+      `
+import { driver } from 'driver.js'
+const el = document.getElementById('hero')!
+driver({ steps: [{ element: el, popover: { description: 'X' } }] }).drive()
+`
+    )
+    expect(out).toMatch(/\/\/ TODO:.*element.*Element/i)
+    expect(out).toMatch(/https:\/\/tourkit\.dev\/migration\/driver#/)
+  })
+
+  it('emits a TODO for tour-level showProgress and forwards step-level content', () => {
+    const out = runTransform(
+      transform,
+      `
+import { driver } from 'driver.js'
+driver({
+  showProgress: true,
+  steps: [{ element: '#a', popover: { description: 'X' } }],
+}).drive()
+`
+    )
+    expect(out).toMatch(/\/\/ TODO:.*showProgress/i)
+    expect(out).toMatch(/content:\s*['"]X['"]/)
+  })
+
+  it('replaces .drive() with an EmptyStatement + leading TODO so tsc stays clean', () => {
+    const out = runTransform(
+      transform,
+      `
+import { driver } from 'driver.js'
+const d = driver({ steps: [] })
+d.drive()
+`
+    )
+    expect(out).toMatch(/\/\/ TODO:.*driver\.js\s+\.drive\(\)/i)
+    expect(out).not.toMatch(/d\.drive\(\)/)
+  })
+})

--- a/packages/codemods/src/__tests__/from-shepherd.test.ts
+++ b/packages/codemods/src/__tests__/from-shepherd.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import transform from '../transforms/from-shepherd'
+import { runTransform } from './_helpers'
+
+describe('from-shepherd — basic shapes', () => {
+  it('rewrites import "shepherd.js" to "@tour-kit/react"', () => {
+    const out = runTransform(
+      transform,
+      `import Shepherd from 'shepherd.js'\nconst tour = new Shepherd.Tour({})\ntour.start()\n`
+    )
+    expect(out).toContain(`from '@tour-kit/react'`)
+    expect(out).not.toContain(`'shepherd.js'`)
+  })
+
+  it('reconstitutes addStep chain into a steps array', () => {
+    const src = `
+import Shepherd from 'shepherd.js'
+const tour = new Shepherd.Tour({})
+tour.addStep({ id: 'a', attachTo: { element: '#hero', on: 'top' }, text: 'A' })
+tour.addStep({ id: 'b', attachTo: { element: '#cta', on: 'bottom' }, text: 'B' })
+tour.start()
+`
+    const out = runTransform(transform, src)
+    expect(out).toMatch(/steps\s*:\s*\[/)
+    expect(out).toMatch(/id:\s*['"]a['"]/)
+    expect(out).toMatch(/id:\s*['"]b['"]/)
+  })
+
+  it('maps attachTo.element string + on to target + placement', () => {
+    const out = runTransform(
+      transform,
+      `
+import Shepherd from 'shepherd.js'
+const t = new Shepherd.Tour({})
+t.addStep({ attachTo: { element: '#hero', on: 'top' }, text: 'X' })
+t.start()
+`
+    )
+    expect(out).toMatch(/target:\s*['"]#hero['"]/)
+    expect(out).toMatch(/placement:\s*['"]top['"]/)
+  })
+
+  it('emits TODO for attachTo.element as function', () => {
+    const out = runTransform(
+      transform,
+      `
+import Shepherd from 'shepherd.js'
+const t = new Shepherd.Tour({})
+t.addStep({ attachTo: { element: () => document.body, on: 'top' }, text: 'X' })
+t.start()
+`
+    )
+    expect(out).toMatch(/\/\/ TODO:.*attachTo.*element.*function/i)
+    expect(out).toMatch(/https:\/\/tourkit\.dev\/migration\/shepherd#/)
+  })
+
+  it('emits TODO for buttons array (no Tour Kit equivalent of free-form buttons)', () => {
+    const out = runTransform(
+      transform,
+      `
+import Shepherd from 'shepherd.js'
+const t = new Shepherd.Tour({})
+t.addStep({
+  attachTo: { element: '#hero', on: 'top' },
+  text: 'X',
+  buttons: [{ text: 'Next', action: () => t.next() }],
+})
+t.start()
+`
+    )
+    expect(out).toMatch(/\/\/ TODO:.*buttons/i)
+    expect(out).toMatch(/https:\/\/tourkit\.dev\/migration\/shepherd#buttons/)
+  })
+
+  it('supports the named { Tour } import as well as the default Shepherd import', () => {
+    const out = runTransform(
+      transform,
+      `
+import { Tour } from 'shepherd.js'
+const t = new Tour({})
+t.addStep({ attachTo: { element: '#x', on: 'right' }, text: 'X' })
+t.start()
+`
+    )
+    expect(out).toContain(`from '@tour-kit/react'`)
+    expect(out).toMatch(/target:\s*['"]#x['"]/)
+    expect(out).toMatch(/placement:\s*['"]right['"]/)
+  })
+})

--- a/packages/codemods/src/__tests__/from-shepherd.test.ts
+++ b/packages/codemods/src/__tests__/from-shepherd.test.ts
@@ -86,4 +86,26 @@ t.start()
     expect(out).toMatch(/target:\s*['"]#x['"]/)
     expect(out).toMatch(/placement:\s*['"]right['"]/)
   })
+
+  // Regression: pre-fix, the control-call rewriter matched on method name
+  // alone and would clobber `.start()`/`.next()`/`.back()` on any identifier
+  // in a file that happened to import 'shepherd.js'.
+  it('does NOT rewrite control-method calls on unrelated bindings', () => {
+    const out = runTransform(
+      transform,
+      `
+import Shepherd from 'shepherd.js'
+const tour = new Shepherd.Tour({})
+tour.addStep({ attachTo: { element: '#a', on: 'top' }, text: 'A' })
+tour.start()
+const carousel = makeCarousel()
+carousel.next()
+carousel.back()
+animation.start()
+`
+    )
+    expect(out).toContain('carousel.next()')
+    expect(out).toContain('carousel.back()')
+    expect(out).toContain('animation.start()')
+  })
 })

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -41,7 +41,9 @@ const TRANSFORMS: Partial<Record<CliOptions['from'], JscodeshiftTransform>> = {
 // stable; populated post-fixture-run if a corpus drops below the gate.
 // Tests read this set live (not a hardcoded list) so the experimental status
 // is part of the code review, not buried in a changelog.
-export const EXPERIMENTAL_TRANSFORMS: ReadonlySet<CliOptions['from']> = new Set<CliOptions['from']>([])
+export const EXPERIMENTAL_TRANSFORMS: ReadonlySet<CliOptions['from']> = new Set<CliOptions['from']>(
+  []
+)
 
 // Per-source coverage percentages reported alongside the experimental
 // warning. Numbers come from the actual fixture-runner output — kept here so

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -5,7 +5,9 @@ import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { extname, join, resolve } from 'node:path'
 import jscodeshift from 'jscodeshift'
+import fromDriver from './transforms/from-driver'
 import fromJoyride from './transforms/from-joyride'
+import fromShepherd from './transforms/from-shepherd'
 
 export interface CliOptions {
   from: 'joyride' | 'shepherd' | 'driver'
@@ -30,6 +32,24 @@ type JscodeshiftTransform = (
 
 const TRANSFORMS: Partial<Record<CliOptions['from'], JscodeshiftTransform>> = {
   joyride: fromJoyride as unknown as JscodeshiftTransform,
+  shepherd: fromShepherd as unknown as JscodeshiftTransform,
+  driver: fromDriver as unknown as JscodeshiftTransform,
+}
+
+// Sources whose corpus coverage is below the ≥80% ship gate. Members trigger a
+// one-line warning on stderr when used. Empty when every transform shipped
+// stable; populated post-fixture-run if a corpus drops below the gate.
+// Tests read this set live (not a hardcoded list) so the experimental status
+// is part of the code review, not buried in a changelog.
+export const EXPERIMENTAL_TRANSFORMS: ReadonlySet<CliOptions['from']> = new Set<CliOptions['from']>([])
+
+// Per-source coverage percentages reported alongside the experimental
+// warning. Numbers come from the actual fixture-runner output — kept here so
+// the CLI message names the gap explicitly. Update with each corpus change.
+export const TRANSFORM_COVERAGE: Readonly<Record<CliOptions['from'], number>> = {
+  joyride: 100,
+  shepherd: 100,
+  driver: 100,
 }
 
 const DEFAULT_EXTENSIONS = ['ts', 'tsx', 'js', 'jsx'] as const
@@ -59,6 +79,13 @@ export async function runMigrate(argv: readonly string[]): Promise<number> {
   if (!transform) {
     console.error(`usage error: --from='${opts.from}' is not yet implemented`)
     return EXIT_BAD_ARGS
+  }
+
+  if (EXPERIMENTAL_TRANSFORMS.has(opts.from)) {
+    const pct = TRANSFORM_COVERAGE[opts.from]
+    console.error(
+      `[Tour Kit] ${opts.from} transform is experimental. Coverage: ${pct}%. Review TODOs carefully.`
+    )
   }
 
   const files = await collectFiles(opts.paths, opts.extensions)

--- a/packages/codemods/src/lib/todo-emitter.ts
+++ b/packages/codemods/src/lib/todo-emitter.ts
@@ -16,3 +16,23 @@ export function todoToComment(t: Todo): string {
   const src = t.source ?? 'joyride'
   return `// TODO: ${t.message} — see https://tourkit.dev/migration/${src}#${t.anchor}`
 }
+
+export interface LineComment {
+  type: 'CommentLine'
+  value: string
+  leading: true
+  trailing: false
+}
+
+export function makeLineComment(rawComment: string): LineComment {
+  const stripped = rawComment.startsWith('//') ? rawComment.slice(2).trimStart() : rawComment
+  return { type: 'CommentLine', value: ` ${stripped}`, leading: true, trailing: false }
+}
+
+export function attachLeadingComments(node: unknown, todos: Todo[]): void {
+  if (todos.length === 0) return
+  const target = node as { comments?: unknown[] }
+  const existing = (target.comments as unknown[] | undefined) ?? []
+  const additions = todos.map((t) => makeLineComment(todoToComment(t)))
+  target.comments = [...existing, ...additions]
+}

--- a/packages/codemods/src/lib/todo-emitter.ts
+++ b/packages/codemods/src/lib/todo-emitter.ts
@@ -1,12 +1,18 @@
+export type TodoSource = 'joyride' | 'shepherd' | 'driver'
+
 export interface Todo {
   message: string
   anchor: string
+  source?: TodoSource
 }
 
-export function emitTodo(message: string, anchor: string): Todo {
-  return { message, anchor }
+// Source defaults to 'joyride' so the Phase 7a transform keeps emitting the
+// same URLs it always did — Shepherd/Driver pass an explicit source.
+export function emitTodo(message: string, anchor: string, source: TodoSource = 'joyride'): Todo {
+  return { message, anchor, source }
 }
 
 export function todoToComment(t: Todo): string {
-  return `// TODO: ${t.message} — see https://tourkit.dev/migration/joyride#${t.anchor}`
+  const src = t.source ?? 'joyride'
+  return `// TODO: ${t.message} — see https://tourkit.dev/migration/${src}#${t.anchor}`
 }

--- a/packages/codemods/src/transforms/from-driver.ts
+++ b/packages/codemods/src/transforms/from-driver.ts
@@ -592,11 +592,7 @@ function mapDriverPopoverSide(
   const literal = readStringLiteral(value)
   if (!literal) {
     todoSink.push(
-      emitTodo(
-        'driver.js popover.side is dynamic — set placement manually',
-        'placement',
-        SOURCE
-      )
+      emitTodo('driver.js popover.side is dynamic — set placement manually', 'placement', SOURCE)
     )
     return null
   }

--- a/packages/codemods/src/transforms/from-driver.ts
+++ b/packages/codemods/src/transforms/from-driver.ts
@@ -1,0 +1,545 @@
+// jscodeshift transform — driver.js → @tour-kit/react.
+//
+// Driver.js v1+ is the simplest of the three competitor APIs:
+//   const d = driver({ steps: [{ element, popover: { title, description, side } }, ...] })
+//   d.drive()
+//
+// Output reshape:
+//   - `driver({...})` ObjectExpression argument is rewritten into a Tour Kit
+//     tour shape `{ id: 'migrated-tour', steps: [{ target, title, content, placement }, ...] }`.
+//   - The `driver(...)` CallExpression itself is replaced by the rewritten
+//     ObjectExpression so the binding holds the migrated tour literal.
+//   - `d.drive()` and other instance methods become EmptyStatement + leading
+//     TODO so tsc doesn't choke calling methods that no longer exist.
+//   - Import `'driver.js'` → `'@tour-kit/react'` as `{ TourProvider }`.
+
+import type {
+  API,
+  ASTNode,
+  ASTPath,
+  Collection,
+  FileInfo,
+  JSCodeshift,
+  ObjectExpression,
+  ObjectProperty,
+  Property,
+} from 'jscodeshift'
+import { type Todo, emitTodo, todoToComment } from '../lib/todo-emitter'
+
+export const parser = 'tsx'
+
+const TARGET_MODULE = '@tour-kit/react'
+const SOURCE = 'driver' as const
+
+type PropLike = ObjectProperty | Property
+
+interface DriverImports {
+  driverLocal: string | null
+}
+
+export default function transform(file: FileInfo, api: API): string {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  const driverImports = root.find(j.ImportDeclaration, {
+    source: { value: 'driver.js' },
+  })
+  if (driverImports.size() === 0) return file.source
+
+  const imports = collectDriverImports(driverImports)
+
+  const driverVarNames = new Set<string>()
+  let mutated = false
+  if (imports.driverLocal) {
+    if (rewriteDriverCalls(j, root, imports.driverLocal, driverVarNames)) mutated = true
+  }
+  if (rewriteDriverInstanceCalls(j, root, driverVarNames)) mutated = true
+
+  rewriteDriverImport(j, driverImports)
+
+  return mutated || driverImports.size() > 0
+    ? root.toSource({ quote: 'single', trailingComma: true })
+    : file.source
+}
+
+function collectDriverImports(decls: Collection): DriverImports {
+  const out: DriverImports = { driverLocal: null }
+  for (const path of decls.paths()) {
+    const specifiers = path.node.specifiers ?? []
+    for (const spec of specifiers) {
+      if (spec.type === 'ImportSpecifier' && spec.imported.name === 'driver') {
+        out.driverLocal = spec.local?.name ?? 'driver'
+      }
+    }
+  }
+  return out
+}
+
+function rewriteDriverImport(j: JSCodeshift, decls: Collection): void {
+  const paths = decls.paths()
+  for (let idx = 0; idx < paths.length; idx += 1) {
+    const path = paths[idx]
+    if (idx > 0) {
+      j(path).remove()
+      continue
+    }
+    path.node.source = j.literal(TARGET_MODULE)
+    path.node.specifiers = [j.importSpecifier(j.identifier('TourProvider'))]
+    ;(path.node as { importKind?: string }).importKind = 'value'
+  }
+}
+
+function rewriteDriverCalls(
+  j: JSCodeshift,
+  root: Collection,
+  driverLocal: string,
+  driverVarNames: Set<string>
+): boolean {
+  let mutated = false
+  root
+    .find(j.CallExpression, {
+      callee: { type: 'Identifier', name: driverLocal },
+    })
+    .forEach((path) => {
+      // Capture the local variable binding so we can rewrite `.drive()`-style
+      // chains later.
+      const parent = path.parent.node as { type: string; id?: { type?: string; name?: string } }
+      if (parent.type === 'VariableDeclarator' && parent.id?.type === 'Identifier' && parent.id.name) {
+        driverVarNames.add(parent.id.name)
+      }
+
+      const node = path.node as { arguments: unknown[] }
+      const arg0 = node.arguments[0] as ASTNode | undefined
+      const todoSink: Todo[] = []
+      const stepsArray = extractDriverSteps(j, arg0, todoSink)
+
+      const replacement = j.objectExpression([
+        j.property('init', j.identifier('id'), j.literal('migrated-tour')),
+        j.property('init', j.identifier('steps'), stepsArray),
+      ])
+
+      const constructorTodos: Todo[] = [
+        emitTodo(
+          'driver.js config — register via <TourProvider tours={[migratedTour]}> in an ancestor; call useTour().start() to begin',
+          'driver-call',
+          SOURCE
+        ),
+        ...todoSink,
+      ]
+      attachLeadingComments(replacement, constructorTodos)
+      ;(path as ASTPath<unknown>).replace(replacement as unknown as never)
+      mutated = true
+    })
+  return mutated
+}
+
+// driver.js instance methods that mutate tour state at runtime. After the
+// rewrite, the binding holds a plain object, so calling these is a TypeError.
+// Replace each statement with an EmptyStatement + leading TODO.
+const DRIVER_CONTROL_METHODS: ReadonlyMap<string, { anchor: string; msg: string }> = new Map([
+  ['drive', { anchor: 'drive', msg: 'driver.js .drive() → call useTour().start() from a descendant of <TourProvider>' }],
+  ['destroy', { anchor: 'control-flow', msg: 'driver.js .destroy() → useTour().stop() inside a descendant of <TourProvider>' }],
+  ['moveNext', { anchor: 'control-flow', msg: 'driver.js .moveNext() → useTour().next() inside a descendant of <TourProvider>' }],
+  ['movePrevious', { anchor: 'control-flow', msg: 'driver.js .movePrevious() → useTour().prev() inside a descendant of <TourProvider>' }],
+  ['moveTo', { anchor: 'control-flow', msg: 'driver.js .moveTo(index) → useTour().goTo(index) inside a descendant of <TourProvider>' }],
+  ['highlight', { anchor: 'highlight', msg: 'driver.js .highlight() — Tour Kit has no single-step highlight; render <HintHotspot> from @tour-kit/hints' }],
+])
+
+function rewriteDriverInstanceCalls(
+  j: JSCodeshift,
+  root: Collection,
+  driverVarNames: Set<string>
+): boolean {
+  let mutated = false
+  root
+    .find(j.ExpressionStatement, {
+      expression: {
+        type: 'CallExpression',
+        callee: { type: 'MemberExpression' },
+      },
+    })
+    .forEach((path) => {
+      const stmt = path.node as {
+        expression: { callee?: { property?: { name?: string }; object?: { type?: string; name?: string } } }
+      }
+      const callee = stmt.expression.callee
+      if (!callee) return
+      const methodName = callee.property?.name
+      if (!methodName) return
+      const entry = DRIVER_CONTROL_METHODS.get(methodName)
+      if (!entry) return
+      // Only rewrite when the receiver is a known driver(...) binding. This
+      // avoids accidentally clobbering unrelated `.destroy()` / `.drive()`
+      // method calls in the file.
+      if (callee.object?.type !== 'Identifier') return
+      if (driverVarNames.size > 0 && !driverVarNames.has(callee.object.name ?? '')) return
+
+      const empty = j.emptyStatement()
+      attachLeadingComments(empty, [emitTodo(entry.msg, entry.anchor, SOURCE)])
+      ;(path as ASTPath<unknown>).replace(empty as unknown as never)
+      mutated = true
+    })
+  return mutated
+}
+
+// ----- Step shape mapping -----
+
+function extractDriverSteps(
+  j: JSCodeshift,
+  configArg: ASTNode | undefined,
+  todoSink: Todo[]
+): ReturnType<JSCodeshift['arrayExpression']> {
+  if (!configArg || (configArg as { type: string }).type !== 'ObjectExpression') {
+    todoSink.push(
+      emitTodo(
+        'driver.js config argument is dynamic — populate the migrated steps array manually',
+        'driver-config-dynamic',
+        SOURCE
+      )
+    )
+    return j.arrayExpression([])
+  }
+  const config = configArg as ObjectExpression
+
+  let stepsValue: ASTNode | null = null
+  for (const prop of config.properties) {
+    if (!isPropLike(prop)) continue
+    const name = getKeyName(prop)
+    if (!name) continue
+    if (name === 'steps') {
+      stepsValue = prop.value as ASTNode
+      continue
+    }
+    const fieldEntry = DRIVER_TOUR_LEVEL_FIELDS[name]
+    if (fieldEntry) {
+      todoSink.push(emitTodo(fieldEntry.msg, fieldEntry.anchor, SOURCE))
+      continue
+    }
+    todoSink.push(
+      emitTodo(
+        `driver.js config field '${name}' unrecognized — verify after migration`,
+        'unknown-config-field',
+        SOURCE
+      )
+    )
+  }
+
+  if (!stepsValue) {
+    return j.arrayExpression([])
+  }
+  if ((stepsValue as { type: string }).type !== 'ArrayExpression') {
+    todoSink.push(
+      emitTodo(
+        'driver.js config.steps is dynamic — populate the migrated steps array manually',
+        'steps-dynamic',
+        SOURCE
+      )
+    )
+    return j.arrayExpression([])
+  }
+  const arr = stepsValue as { elements: Array<ASTNode | null> }
+  const mapped = arr.elements.map((el) => {
+    if (!el) return null
+    if ((el as { type: string }).type !== 'ObjectExpression') {
+      todoSink.push(
+        emitTodo(
+          'driver.js step is not an inline object — port the shape manually',
+          'step-dynamic',
+          SOURCE
+        )
+      )
+      return el
+    }
+    return mapDriverStep(j, el as ObjectExpression, todoSink)
+  })
+  return j.arrayExpression(mapped as never[])
+}
+
+const DRIVER_TOUR_LEVEL_FIELDS: Record<string, { anchor: string; msg: string }> = {
+  showProgress: { anchor: 'show-progress', msg: 'driver.js showProgress → render <TourProgress /> inside <TourCard />' },
+  allowClose: { anchor: 'allow-close', msg: 'driver.js allowClose → omit / include <TourClose /> inside <TourCard />' },
+  doneBtnText: { anchor: 'btn-text', msg: 'driver.js doneBtnText → pass labels to your <TourNavigation /> slot' },
+  nextBtnText: { anchor: 'btn-text', msg: 'driver.js nextBtnText → pass labels to your <TourNavigation /> slot' },
+  prevBtnText: { anchor: 'btn-text', msg: 'driver.js prevBtnText → pass labels to your <TourNavigation /> slot' },
+  closeBtnText: { anchor: 'btn-text', msg: 'driver.js closeBtnText → pass labels to your <TourClose /> slot' },
+  showButtons: { anchor: 'show-buttons', msg: 'driver.js showButtons[] → compose <TourCard /> with only the slots you need' },
+  disableActiveInteraction: { anchor: 'disable-active-interaction', msg: 'driver.js disableActiveInteraction → configure the overlay spotlight interactive flag' },
+  smoothScroll: { anchor: 'smooth-scroll', msg: 'driver.js smoothScroll → Tour Kit always scrolls; gate manually if you need otherwise' },
+  animate: { anchor: 'animate', msg: 'driver.js animate → respects prefers-reduced-motion automatically; remove the flag' },
+  stagePadding: { anchor: 'stage-padding', msg: 'driver.js stagePadding → pass `padding` to your <TourOverlay /> slot' },
+  stageRadius: { anchor: 'stage-radius', msg: 'driver.js stageRadius → theme tokens via <ThemeProvider>' },
+  overlayColor: { anchor: 'overlay-color', msg: 'driver.js overlayColor → theme tokens via <ThemeProvider>' },
+  overlayOpacity: { anchor: 'overlay-opacity', msg: 'driver.js overlayOpacity → theme tokens via <ThemeProvider>' },
+  onHighlightStarted: { anchor: 'on-highlight-started', msg: 'driver.js onHighlightStarted → onShow on the per-step handler' },
+  onHighlighted: { anchor: 'on-highlighted', msg: 'driver.js onHighlighted → onShow on the per-step handler' },
+  onDeselected: { anchor: 'on-deselected', msg: 'driver.js onDeselected → onHide on the per-step handler' },
+  onPopoverRender: { anchor: 'on-popover-render', msg: 'driver.js onPopoverRender → render custom JSX in <TourCard /> children' },
+  onNextClick: { anchor: 'on-next-click', msg: 'driver.js onNextClick → handle in your <TourNavigation /> slot' },
+  onPrevClick: { anchor: 'on-prev-click', msg: 'driver.js onPrevClick → handle in your <TourNavigation /> slot' },
+  onCloseClick: { anchor: 'on-close-click', msg: 'driver.js onCloseClick → handle in your <TourClose /> slot' },
+  onDestroyStarted: { anchor: 'on-destroy-started', msg: 'driver.js onDestroyStarted → onSkip / onComplete on <TourProvider>' },
+  onDestroyed: { anchor: 'on-destroyed', msg: 'driver.js onDestroyed → onSkip / onComplete on <TourProvider>' },
+}
+
+const DRIVER_PLACEMENT_MAP: Record<string, string> = {
+  top: 'top',
+  bottom: 'bottom',
+  left: 'left',
+  right: 'right',
+  over: 'top',
+}
+
+const DRIVER_UNSUPPORTED_FIELDS: Record<string, { anchor: string; msg: string }> = {
+  disableActiveInteraction: { anchor: 'disable-active-interaction', msg: 'Step.disableActiveInteraction → configure the overlay spotlight interactive flag' },
+  popoverClass: { anchor: 'popover-class', msg: 'Step.popoverClass — theme tokens via <ThemeProvider>' },
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: per-field dispatch — splitting hides the contract
+function mapDriverStep(
+  j: JSCodeshift,
+  step: ObjectExpression,
+  todoSink: Todo[]
+): ObjectExpression {
+  const out: Array<ObjectProperty | Property> = []
+  let hasTarget = false
+
+  for (const prop of step.properties) {
+    if (!isPropLike(prop)) continue
+    const name = getKeyName(prop)
+    if (!name) continue
+
+    if (name === 'element') {
+      const v = prop.value as ASTNode | null
+      if (!v) continue
+      const t = (v as { type: string }).type
+      if (t === 'Literal' || t === 'StringLiteral' || t === 'TemplateLiteral') {
+        out.push(j.property('init', j.identifier('target'), v as never))
+        hasTarget = true
+        continue
+      }
+      if (t === 'ArrowFunctionExpression' || t === 'FunctionExpression') {
+        todoSink.push(
+          emitTodo(
+            'driver.js Step.element is a function — Tour Kit expects a selector string or DOM ref',
+            'element-function',
+            SOURCE
+          )
+        )
+        continue
+      }
+      // Identifier / MemberExpression / etc. — most commonly a captured DOM
+      // Element instance. We can't tell statically; flag for review.
+      todoSink.push(
+        emitTodo(
+          'driver.js Step.element is a DOM Element instance — Tour Kit expects a selector string or DOM ref',
+          'element-dom',
+          SOURCE
+        )
+      )
+      out.push(j.property('init', j.identifier('target'), v as never))
+      hasTarget = true
+      continue
+    }
+    if (name === 'popover') {
+      const popoverProps = mapDriverPopover(j, prop.value as ASTNode, todoSink)
+      for (const pp of popoverProps) out.push(pp)
+      continue
+    }
+    if (name === 'onHighlightStarted' || name === 'onHighlighted') {
+      todoSink.push(
+        emitTodo(
+          `driver.js Step.${name} → onShow on the migrated step`,
+          'on-highlight-started',
+          SOURCE
+        )
+      )
+      continue
+    }
+    if (name === 'onDeselected') {
+      todoSink.push(
+        emitTodo('driver.js Step.onDeselected → onHide on the migrated step', 'on-deselected', SOURCE)
+      )
+      continue
+    }
+    if (name in DRIVER_UNSUPPORTED_FIELDS) {
+      const entry = DRIVER_UNSUPPORTED_FIELDS[name]
+      todoSink.push(emitTodo(entry.msg, entry.anchor, SOURCE))
+      continue
+    }
+    todoSink.push(
+      emitTodo(`Step.${name} unrecognized — verify after migration`, 'unknown-step-field', SOURCE)
+    )
+  }
+
+  if (!hasTarget) {
+    todoSink.push(
+      emitTodo(
+        'driver.js step had no resolvable Step.element — set target to a CSS selector or DOM ref',
+        'target',
+        SOURCE
+      )
+    )
+  }
+  return j.objectExpression(out)
+}
+
+function mapDriverPopover(
+  j: JSCodeshift,
+  value: ASTNode,
+  todoSink: Todo[]
+): Array<ObjectProperty | Property> {
+  if ((value as { type: string }).type !== 'ObjectExpression') {
+    todoSink.push(
+      emitTodo(
+        'driver.js Step.popover is dynamic — port title/content/placement manually',
+        'popover-dynamic',
+        SOURCE
+      )
+    )
+    return []
+  }
+  const out: Array<ObjectProperty | Property> = []
+  const obj = value as ObjectExpression
+  for (const prop of obj.properties) {
+    if (!isPropLike(prop)) continue
+    const name = getKeyName(prop)
+    if (!name) continue
+
+    if (name === 'title') {
+      out.push(j.property('init', j.identifier('title'), prop.value as never))
+      continue
+    }
+    if (name === 'description') {
+      out.push(j.property('init', j.identifier('content'), prop.value as never))
+      continue
+    }
+    if (name === 'side') {
+      const literal = readStringLiteral(prop.value as ASTNode)
+      if (literal && DRIVER_PLACEMENT_MAP[literal]) {
+        out.push(
+          j.property('init', j.identifier('placement'), j.literal(DRIVER_PLACEMENT_MAP[literal]) as never)
+        )
+      } else if (literal) {
+        todoSink.push(
+          emitTodo(
+            `driver.js popover.side '${literal}' unrecognized — defaulting to 'top'`,
+            'placement',
+            SOURCE
+          )
+        )
+        out.push(j.property('init', j.identifier('placement'), j.literal('top') as never))
+      }
+      continue
+    }
+    if (name === 'align') {
+      todoSink.push(
+        emitTodo(
+          'driver.js popover.align → fold into Tour Kit placement (e.g. top-start, top-end)',
+          'align',
+          SOURCE
+        )
+      )
+      continue
+    }
+    if (name === 'showButtons' || name === 'doneBtnText' || name === 'nextBtnText' || name === 'prevBtnText') {
+      todoSink.push(
+        emitTodo(
+          `driver.js popover.${name} → pass labels to your <TourNavigation /> slot or omit the slot`,
+          'btn-text',
+          SOURCE
+        )
+      )
+      continue
+    }
+    if (name === 'showProgress' || name === 'progressText') {
+      todoSink.push(
+        emitTodo(
+          `driver.js popover.${name} → render <TourProgress /> inside <TourCard />`,
+          'show-progress',
+          SOURCE
+        )
+      )
+      continue
+    }
+    if (name === 'popoverClass') {
+      todoSink.push(
+        emitTodo(
+          'driver.js popover.popoverClass → theme tokens via <ThemeProvider>',
+          'popover-class',
+          SOURCE
+        )
+      )
+      continue
+    }
+    if (name === 'onPopoverRender') {
+      todoSink.push(
+        emitTodo(
+          'driver.js popover.onPopoverRender → render custom JSX in <TourCard /> children',
+          'on-popover-render',
+          SOURCE
+        )
+      )
+      continue
+    }
+    if (name === 'onNextClick' || name === 'onPrevClick' || name === 'onCloseClick') {
+      todoSink.push(
+        emitTodo(
+          `driver.js popover.${name} → handle in your <TourNavigation /> / <TourClose /> slot`,
+          'on-click',
+          SOURCE
+        )
+      )
+      continue
+    }
+    todoSink.push(
+      emitTodo(
+        `driver.js popover.${name} unrecognized — verify after migration`,
+        'unknown-popover-field',
+        SOURCE
+      )
+    )
+  }
+  return out
+}
+
+// ----- helpers -----
+
+function isPropLike(node: ASTNode): node is PropLike {
+  return node.type === 'ObjectProperty' || node.type === 'Property'
+}
+
+function getKeyName(prop: PropLike): string | null {
+  const key = prop.key
+  if (!key) return null
+  if (key.type === 'Identifier') return key.name
+  return readStringLiteral(key)
+}
+
+function readStringLiteral(node: ASTNode | null | undefined): string | null {
+  if (!node) return null
+  if (node.type === 'Literal' && typeof (node as { value: unknown }).value === 'string') {
+    return (node as { value: string }).value
+  }
+  if (node.type === 'StringLiteral') return (node as { value: string }).value
+  return null
+}
+
+interface LineComment {
+  type: 'CommentLine'
+  value: string
+  leading: true
+  trailing: false
+}
+
+function makeLineComment(rawComment: string): LineComment {
+  const stripped = rawComment.startsWith('//') ? rawComment.slice(2).trimStart() : rawComment
+  return { type: 'CommentLine', value: ` ${stripped}`, leading: true, trailing: false }
+}
+
+function attachLeadingComments(node: unknown, todos: Todo[]): void {
+  if (todos.length === 0) return
+  const target = node as { comments?: unknown[] }
+  const existing = (target.comments as unknown[] | undefined) ?? []
+  const additions = todos.map((t) => makeLineComment(todoToComment(t)))
+  target.comments = [...existing, ...additions]
+}

--- a/packages/codemods/src/transforms/from-driver.ts
+++ b/packages/codemods/src/transforms/from-driver.ts
@@ -96,40 +96,45 @@ function rewriteDriverCalls(
   driverVarNames: Set<string>
 ): boolean {
   let mutated = false
-  root
+  const driverCallPaths = root
     .find(j.CallExpression, {
       callee: { type: 'Identifier', name: driverLocal },
     })
-    .forEach((path) => {
-      // Capture the local variable binding so we can rewrite `.drive()`-style
-      // chains later.
-      const parent = path.parent.node as { type: string; id?: { type?: string; name?: string } }
-      if (parent.type === 'VariableDeclarator' && parent.id?.type === 'Identifier' && parent.id.name) {
-        driverVarNames.add(parent.id.name)
-      }
+    .paths()
+  for (const path of driverCallPaths) {
+    // Capture the local variable binding so we can rewrite `.drive()`-style
+    // chains later.
+    const parent = path.parent.node as { type: string; id?: { type?: string; name?: string } }
+    if (
+      parent.type === 'VariableDeclarator' &&
+      parent.id?.type === 'Identifier' &&
+      parent.id.name
+    ) {
+      driverVarNames.add(parent.id.name)
+    }
 
-      const node = path.node as { arguments: unknown[] }
-      const arg0 = node.arguments[0] as ASTNode | undefined
-      const todoSink: Todo[] = []
-      const stepsArray = extractDriverSteps(j, arg0, todoSink)
+    const node = path.node as { arguments: unknown[] }
+    const arg0 = node.arguments[0] as ASTNode | undefined
+    const todoSink: Todo[] = []
+    const stepsArray = extractDriverSteps(j, arg0, todoSink)
 
-      const replacement = j.objectExpression([
-        j.property('init', j.identifier('id'), j.literal('migrated-tour')),
-        j.property('init', j.identifier('steps'), stepsArray),
-      ])
+    const replacement = j.objectExpression([
+      j.property('init', j.identifier('id'), j.literal('migrated-tour')),
+      j.property('init', j.identifier('steps'), stepsArray),
+    ])
 
-      const constructorTodos: Todo[] = [
-        emitTodo(
-          'driver.js config — register via <TourProvider tours={[migratedTour]}> in an ancestor; call useTour().start() to begin',
-          'driver-call',
-          SOURCE
-        ),
-        ...todoSink,
-      ]
-      attachLeadingComments(replacement, constructorTodos)
-      ;(path as ASTPath<unknown>).replace(replacement as unknown as never)
-      mutated = true
-    })
+    const constructorTodos: Todo[] = [
+      emitTodo(
+        'driver.js config — register via <TourProvider tours={[migratedTour]}> in an ancestor; call useTour().start() to begin',
+        'driver-call',
+        SOURCE
+      ),
+      ...todoSink,
+    ]
+    attachLeadingComments(replacement, constructorTodos)
+    ;(path as ASTPath<unknown>).replace(replacement as unknown as never)
+    mutated = true
+  }
   return mutated
 }
 
@@ -137,12 +142,48 @@ function rewriteDriverCalls(
 // rewrite, the binding holds a plain object, so calling these is a TypeError.
 // Replace each statement with an EmptyStatement + leading TODO.
 const DRIVER_CONTROL_METHODS: ReadonlyMap<string, { anchor: string; msg: string }> = new Map([
-  ['drive', { anchor: 'drive', msg: 'driver.js .drive() → call useTour().start() from a descendant of <TourProvider>' }],
-  ['destroy', { anchor: 'control-flow', msg: 'driver.js .destroy() → useTour().stop() inside a descendant of <TourProvider>' }],
-  ['moveNext', { anchor: 'control-flow', msg: 'driver.js .moveNext() → useTour().next() inside a descendant of <TourProvider>' }],
-  ['movePrevious', { anchor: 'control-flow', msg: 'driver.js .movePrevious() → useTour().prev() inside a descendant of <TourProvider>' }],
-  ['moveTo', { anchor: 'control-flow', msg: 'driver.js .moveTo(index) → useTour().goTo(index) inside a descendant of <TourProvider>' }],
-  ['highlight', { anchor: 'highlight', msg: 'driver.js .highlight() — Tour Kit has no single-step highlight; render <HintHotspot> from @tour-kit/hints' }],
+  [
+    'drive',
+    {
+      anchor: 'drive',
+      msg: 'driver.js .drive() → call useTour().start() from a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'destroy',
+    {
+      anchor: 'control-flow',
+      msg: 'driver.js .destroy() → useTour().stop() inside a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'moveNext',
+    {
+      anchor: 'control-flow',
+      msg: 'driver.js .moveNext() → useTour().next() inside a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'movePrevious',
+    {
+      anchor: 'control-flow',
+      msg: 'driver.js .movePrevious() → useTour().prev() inside a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'moveTo',
+    {
+      anchor: 'control-flow',
+      msg: 'driver.js .moveTo(index) → useTour().goTo(index) inside a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'highlight',
+    {
+      anchor: 'highlight',
+      msg: 'driver.js .highlight() — Tour Kit has no single-step highlight; render <HintHotspot> from @tour-kit/hints',
+    },
+  ],
 ])
 
 function rewriteDriverInstanceCalls(
@@ -151,34 +192,37 @@ function rewriteDriverInstanceCalls(
   driverVarNames: Set<string>
 ): boolean {
   let mutated = false
-  root
+  const stmtPaths = root
     .find(j.ExpressionStatement, {
       expression: {
         type: 'CallExpression',
         callee: { type: 'MemberExpression' },
       },
     })
-    .forEach((path) => {
-      const stmt = path.node as {
-        expression: { callee?: { property?: { name?: string }; object?: { type?: string; name?: string } } }
+    .paths()
+  for (const path of stmtPaths) {
+    const stmt = path.node as {
+      expression: {
+        callee?: { property?: { name?: string }; object?: { type?: string; name?: string } }
       }
-      const callee = stmt.expression.callee
-      if (!callee) return
-      const methodName = callee.property?.name
-      if (!methodName) return
-      const entry = DRIVER_CONTROL_METHODS.get(methodName)
-      if (!entry) return
-      // Only rewrite when the receiver is a known driver(...) binding. This
-      // avoids accidentally clobbering unrelated `.destroy()` / `.drive()`
-      // method calls in the file.
-      if (callee.object?.type !== 'Identifier') return
-      if (driverVarNames.size > 0 && !driverVarNames.has(callee.object.name ?? '')) return
+    }
+    const callee = stmt.expression.callee
+    if (!callee) continue
+    const methodName = callee.property?.name
+    if (!methodName) continue
+    const entry = DRIVER_CONTROL_METHODS.get(methodName)
+    if (!entry) continue
+    // Only rewrite when the receiver is a known driver(...) binding. This
+    // avoids accidentally clobbering unrelated `.destroy()` / `.drive()`
+    // method calls in the file.
+    if (callee.object?.type !== 'Identifier') continue
+    if (driverVarNames.size > 0 && !driverVarNames.has(callee.object.name ?? '')) continue
 
-      const empty = j.emptyStatement()
-      attachLeadingComments(empty, [emitTodo(entry.msg, entry.anchor, SOURCE)])
-      ;(path as ASTPath<unknown>).replace(empty as unknown as never)
-      mutated = true
-    })
+    const empty = j.emptyStatement()
+    attachLeadingComments(empty, [emitTodo(entry.msg, entry.anchor, SOURCE)])
+    ;(path as ASTPath<unknown>).replace(empty as unknown as never)
+    mutated = true
+  }
   return mutated
 }
 
@@ -256,29 +300,98 @@ function extractDriverSteps(
 }
 
 const DRIVER_TOUR_LEVEL_FIELDS: Record<string, { anchor: string; msg: string }> = {
-  showProgress: { anchor: 'show-progress', msg: 'driver.js showProgress → render <TourProgress /> inside <TourCard />' },
-  allowClose: { anchor: 'allow-close', msg: 'driver.js allowClose → omit / include <TourClose /> inside <TourCard />' },
-  doneBtnText: { anchor: 'btn-text', msg: 'driver.js doneBtnText → pass labels to your <TourNavigation /> slot' },
-  nextBtnText: { anchor: 'btn-text', msg: 'driver.js nextBtnText → pass labels to your <TourNavigation /> slot' },
-  prevBtnText: { anchor: 'btn-text', msg: 'driver.js prevBtnText → pass labels to your <TourNavigation /> slot' },
-  closeBtnText: { anchor: 'btn-text', msg: 'driver.js closeBtnText → pass labels to your <TourClose /> slot' },
-  showButtons: { anchor: 'show-buttons', msg: 'driver.js showButtons[] → compose <TourCard /> with only the slots you need' },
-  disableActiveInteraction: { anchor: 'disable-active-interaction', msg: 'driver.js disableActiveInteraction → configure the overlay spotlight interactive flag' },
-  smoothScroll: { anchor: 'smooth-scroll', msg: 'driver.js smoothScroll → Tour Kit always scrolls; gate manually if you need otherwise' },
-  animate: { anchor: 'animate', msg: 'driver.js animate → respects prefers-reduced-motion automatically; remove the flag' },
-  stagePadding: { anchor: 'stage-padding', msg: 'driver.js stagePadding → pass `padding` to your <TourOverlay /> slot' },
-  stageRadius: { anchor: 'stage-radius', msg: 'driver.js stageRadius → theme tokens via <ThemeProvider>' },
-  overlayColor: { anchor: 'overlay-color', msg: 'driver.js overlayColor → theme tokens via <ThemeProvider>' },
-  overlayOpacity: { anchor: 'overlay-opacity', msg: 'driver.js overlayOpacity → theme tokens via <ThemeProvider>' },
-  onHighlightStarted: { anchor: 'on-highlight-started', msg: 'driver.js onHighlightStarted → onShow on the per-step handler' },
-  onHighlighted: { anchor: 'on-highlighted', msg: 'driver.js onHighlighted → onShow on the per-step handler' },
-  onDeselected: { anchor: 'on-deselected', msg: 'driver.js onDeselected → onHide on the per-step handler' },
-  onPopoverRender: { anchor: 'on-popover-render', msg: 'driver.js onPopoverRender → render custom JSX in <TourCard /> children' },
-  onNextClick: { anchor: 'on-next-click', msg: 'driver.js onNextClick → handle in your <TourNavigation /> slot' },
-  onPrevClick: { anchor: 'on-prev-click', msg: 'driver.js onPrevClick → handle in your <TourNavigation /> slot' },
-  onCloseClick: { anchor: 'on-close-click', msg: 'driver.js onCloseClick → handle in your <TourClose /> slot' },
-  onDestroyStarted: { anchor: 'on-destroy-started', msg: 'driver.js onDestroyStarted → onSkip / onComplete on <TourProvider>' },
-  onDestroyed: { anchor: 'on-destroyed', msg: 'driver.js onDestroyed → onSkip / onComplete on <TourProvider>' },
+  showProgress: {
+    anchor: 'show-progress',
+    msg: 'driver.js showProgress → render <TourProgress /> inside <TourCard />',
+  },
+  allowClose: {
+    anchor: 'allow-close',
+    msg: 'driver.js allowClose → omit / include <TourClose /> inside <TourCard />',
+  },
+  doneBtnText: {
+    anchor: 'btn-text',
+    msg: 'driver.js doneBtnText → pass labels to your <TourNavigation /> slot',
+  },
+  nextBtnText: {
+    anchor: 'btn-text',
+    msg: 'driver.js nextBtnText → pass labels to your <TourNavigation /> slot',
+  },
+  prevBtnText: {
+    anchor: 'btn-text',
+    msg: 'driver.js prevBtnText → pass labels to your <TourNavigation /> slot',
+  },
+  closeBtnText: {
+    anchor: 'btn-text',
+    msg: 'driver.js closeBtnText → pass labels to your <TourClose /> slot',
+  },
+  showButtons: {
+    anchor: 'show-buttons',
+    msg: 'driver.js showButtons[] → compose <TourCard /> with only the slots you need',
+  },
+  disableActiveInteraction: {
+    anchor: 'disable-active-interaction',
+    msg: 'driver.js disableActiveInteraction → configure the overlay spotlight interactive flag',
+  },
+  smoothScroll: {
+    anchor: 'smooth-scroll',
+    msg: 'driver.js smoothScroll → Tour Kit always scrolls; gate manually if you need otherwise',
+  },
+  animate: {
+    anchor: 'animate',
+    msg: 'driver.js animate → respects prefers-reduced-motion automatically; remove the flag',
+  },
+  stagePadding: {
+    anchor: 'stage-padding',
+    msg: 'driver.js stagePadding → pass `padding` to your <TourOverlay /> slot',
+  },
+  stageRadius: {
+    anchor: 'stage-radius',
+    msg: 'driver.js stageRadius → theme tokens via <ThemeProvider>',
+  },
+  overlayColor: {
+    anchor: 'overlay-color',
+    msg: 'driver.js overlayColor → theme tokens via <ThemeProvider>',
+  },
+  overlayOpacity: {
+    anchor: 'overlay-opacity',
+    msg: 'driver.js overlayOpacity → theme tokens via <ThemeProvider>',
+  },
+  onHighlightStarted: {
+    anchor: 'on-highlight-started',
+    msg: 'driver.js onHighlightStarted → onShow on the per-step handler',
+  },
+  onHighlighted: {
+    anchor: 'on-highlighted',
+    msg: 'driver.js onHighlighted → onShow on the per-step handler',
+  },
+  onDeselected: {
+    anchor: 'on-deselected',
+    msg: 'driver.js onDeselected → onHide on the per-step handler',
+  },
+  onPopoverRender: {
+    anchor: 'on-popover-render',
+    msg: 'driver.js onPopoverRender → render custom JSX in <TourCard /> children',
+  },
+  onNextClick: {
+    anchor: 'on-next-click',
+    msg: 'driver.js onNextClick → handle in your <TourNavigation /> slot',
+  },
+  onPrevClick: {
+    anchor: 'on-prev-click',
+    msg: 'driver.js onPrevClick → handle in your <TourNavigation /> slot',
+  },
+  onCloseClick: {
+    anchor: 'on-close-click',
+    msg: 'driver.js onCloseClick → handle in your <TourClose /> slot',
+  },
+  onDestroyStarted: {
+    anchor: 'on-destroy-started',
+    msg: 'driver.js onDestroyStarted → onSkip / onComplete on <TourProvider>',
+  },
+  onDestroyed: {
+    anchor: 'on-destroyed',
+    msg: 'driver.js onDestroyed → onSkip / onComplete on <TourProvider>',
+  },
 }
 
 const DRIVER_PLACEMENT_MAP: Record<string, string> = {
@@ -290,16 +403,18 @@ const DRIVER_PLACEMENT_MAP: Record<string, string> = {
 }
 
 const DRIVER_UNSUPPORTED_FIELDS: Record<string, { anchor: string; msg: string }> = {
-  disableActiveInteraction: { anchor: 'disable-active-interaction', msg: 'Step.disableActiveInteraction → configure the overlay spotlight interactive flag' },
-  popoverClass: { anchor: 'popover-class', msg: 'Step.popoverClass — theme tokens via <ThemeProvider>' },
+  disableActiveInteraction: {
+    anchor: 'disable-active-interaction',
+    msg: 'Step.disableActiveInteraction → configure the overlay spotlight interactive flag',
+  },
+  popoverClass: {
+    anchor: 'popover-class',
+    msg: 'Step.popoverClass — theme tokens via <ThemeProvider>',
+  },
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: per-field dispatch — splitting hides the contract
-function mapDriverStep(
-  j: JSCodeshift,
-  step: ObjectExpression,
-  todoSink: Todo[]
-): ObjectExpression {
+function mapDriverStep(j: JSCodeshift, step: ObjectExpression, todoSink: Todo[]): ObjectExpression {
   const out: Array<ObjectProperty | Property> = []
   let hasTarget = false
 
@@ -357,7 +472,11 @@ function mapDriverStep(
     }
     if (name === 'onDeselected') {
       todoSink.push(
-        emitTodo('driver.js Step.onDeselected → onHide on the migrated step', 'on-deselected', SOURCE)
+        emitTodo(
+          'driver.js Step.onDeselected → onHide on the migrated step',
+          'on-deselected',
+          SOURCE
+        )
       )
       continue
     }
@@ -383,6 +502,45 @@ function mapDriverStep(
   return j.objectExpression(out)
 }
 
+// driver.js popover fields with no shape-affecting migration — each emits a
+// single TODO. Splitting these out keeps `mapDriverPopover` under the
+// noExcessiveCognitiveComplexity threshold.
+const POPOVER_TODO_FIELDS: Record<string, { anchor: string; msgFor: (name: string) => string }> = {
+  align: {
+    anchor: 'align',
+    msgFor: () =>
+      'driver.js popover.align → fold into Tour Kit placement (e.g. top-start, top-end)',
+  },
+  showButtons: { anchor: 'btn-text', msgFor: (n) => btnTextMsg(n) },
+  doneBtnText: { anchor: 'btn-text', msgFor: (n) => btnTextMsg(n) },
+  nextBtnText: { anchor: 'btn-text', msgFor: (n) => btnTextMsg(n) },
+  prevBtnText: { anchor: 'btn-text', msgFor: (n) => btnTextMsg(n) },
+  showProgress: { anchor: 'show-progress', msgFor: (n) => progressMsg(n) },
+  progressText: { anchor: 'show-progress', msgFor: (n) => progressMsg(n) },
+  popoverClass: {
+    anchor: 'popover-class',
+    msgFor: () => 'driver.js popover.popoverClass → theme tokens via <ThemeProvider>',
+  },
+  onPopoverRender: {
+    anchor: 'on-popover-render',
+    msgFor: () => 'driver.js popover.onPopoverRender → render custom JSX in <TourCard /> children',
+  },
+  onNextClick: { anchor: 'on-click', msgFor: (n) => onClickMsg(n) },
+  onPrevClick: { anchor: 'on-click', msgFor: (n) => onClickMsg(n) },
+  onCloseClick: { anchor: 'on-click', msgFor: (n) => onClickMsg(n) },
+}
+
+function btnTextMsg(name: string): string {
+  return `driver.js popover.${name} → pass labels to your <TourNavigation /> slot or omit the slot`
+}
+function progressMsg(name: string): string {
+  return `driver.js popover.${name} → render <TourProgress /> inside <TourCard />`
+}
+function onClickMsg(name: string): string {
+  return `driver.js popover.${name} → handle in your <TourNavigation /> / <TourClose /> slot`
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: per-field dispatch — splitting the title/description/side branches hides the contract
 function mapDriverPopover(
   j: JSCodeshift,
   value: ASTNode,
@@ -399,8 +557,7 @@ function mapDriverPopover(
     return []
   }
   const out: Array<ObjectProperty | Property> = []
-  const obj = value as ObjectExpression
-  for (const prop of obj.properties) {
+  for (const prop of (value as ObjectExpression).properties) {
     if (!isPropLike(prop)) continue
     const name = getKeyName(prop)
     if (!name) continue
@@ -414,81 +571,13 @@ function mapDriverPopover(
       continue
     }
     if (name === 'side') {
-      const literal = readStringLiteral(prop.value as ASTNode)
-      if (literal && DRIVER_PLACEMENT_MAP[literal]) {
-        out.push(
-          j.property('init', j.identifier('placement'), j.literal(DRIVER_PLACEMENT_MAP[literal]) as never)
-        )
-      } else if (literal) {
-        todoSink.push(
-          emitTodo(
-            `driver.js popover.side '${literal}' unrecognized — defaulting to 'top'`,
-            'placement',
-            SOURCE
-          )
-        )
-        out.push(j.property('init', j.identifier('placement'), j.literal('top') as never))
-      }
+      const placementProp = mapDriverPopoverSide(j, prop.value as ASTNode, todoSink)
+      if (placementProp) out.push(placementProp)
       continue
     }
-    if (name === 'align') {
-      todoSink.push(
-        emitTodo(
-          'driver.js popover.align → fold into Tour Kit placement (e.g. top-start, top-end)',
-          'align',
-          SOURCE
-        )
-      )
-      continue
-    }
-    if (name === 'showButtons' || name === 'doneBtnText' || name === 'nextBtnText' || name === 'prevBtnText') {
-      todoSink.push(
-        emitTodo(
-          `driver.js popover.${name} → pass labels to your <TourNavigation /> slot or omit the slot`,
-          'btn-text',
-          SOURCE
-        )
-      )
-      continue
-    }
-    if (name === 'showProgress' || name === 'progressText') {
-      todoSink.push(
-        emitTodo(
-          `driver.js popover.${name} → render <TourProgress /> inside <TourCard />`,
-          'show-progress',
-          SOURCE
-        )
-      )
-      continue
-    }
-    if (name === 'popoverClass') {
-      todoSink.push(
-        emitTodo(
-          'driver.js popover.popoverClass → theme tokens via <ThemeProvider>',
-          'popover-class',
-          SOURCE
-        )
-      )
-      continue
-    }
-    if (name === 'onPopoverRender') {
-      todoSink.push(
-        emitTodo(
-          'driver.js popover.onPopoverRender → render custom JSX in <TourCard /> children',
-          'on-popover-render',
-          SOURCE
-        )
-      )
-      continue
-    }
-    if (name === 'onNextClick' || name === 'onPrevClick' || name === 'onCloseClick') {
-      todoSink.push(
-        emitTodo(
-          `driver.js popover.${name} → handle in your <TourNavigation /> / <TourClose /> slot`,
-          'on-click',
-          SOURCE
-        )
-      )
+    const todoField = POPOVER_TODO_FIELDS[name]
+    if (todoField) {
+      todoSink.push(emitTodo(todoField.msgFor(name), todoField.anchor, SOURCE))
       continue
     }
     todoSink.push(
@@ -500,6 +589,29 @@ function mapDriverPopover(
     )
   }
   return out
+}
+
+// Map `popover.side` to Tour Kit `placement`. Returns null for non-literal
+// values; the consumer drops the slot rather than emitting a guess.
+function mapDriverPopoverSide(
+  j: JSCodeshift,
+  value: ASTNode,
+  todoSink: Todo[]
+): ObjectProperty | Property | null {
+  const literal = readStringLiteral(value)
+  if (!literal) return null
+  const mapped = DRIVER_PLACEMENT_MAP[literal]
+  if (mapped) {
+    return j.property('init', j.identifier('placement'), j.literal(mapped) as never)
+  }
+  todoSink.push(
+    emitTodo(
+      `driver.js popover.side '${literal}' unrecognized — defaulting to 'top'`,
+      'placement',
+      SOURCE
+    )
+  )
+  return j.property('init', j.identifier('placement'), j.literal('top') as never)
 }
 
 // ----- helpers -----

--- a/packages/codemods/src/transforms/from-driver.ts
+++ b/packages/codemods/src/transforms/from-driver.ts
@@ -24,7 +24,7 @@ import type {
   ObjectProperty,
   Property,
 } from 'jscodeshift'
-import { type Todo, emitTodo, todoToComment } from '../lib/todo-emitter'
+import { type Todo, attachLeadingComments, emitTodo } from '../lib/todo-emitter'
 
 export const parser = 'tsx'
 
@@ -49,17 +49,14 @@ export default function transform(file: FileInfo, api: API): string {
   const imports = collectDriverImports(driverImports)
 
   const driverVarNames = new Set<string>()
-  let mutated = false
   if (imports.driverLocal) {
-    if (rewriteDriverCalls(j, root, imports.driverLocal, driverVarNames)) mutated = true
+    rewriteDriverCalls(j, root, imports.driverLocal, driverVarNames)
   }
-  if (rewriteDriverInstanceCalls(j, root, driverVarNames)) mutated = true
+  rewriteDriverInstanceCalls(j, root, driverVarNames)
 
   rewriteDriverImport(j, driverImports)
 
-  return mutated || driverImports.size() > 0
-    ? root.toSource({ quote: 'single', trailingComma: true })
-    : file.source
+  return root.toSource({ quote: 'single', trailingComma: true })
 }
 
 function collectDriverImports(decls: Collection): DriverImports {
@@ -94,8 +91,7 @@ function rewriteDriverCalls(
   root: Collection,
   driverLocal: string,
   driverVarNames: Set<string>
-): boolean {
-  let mutated = false
+): void {
   const driverCallPaths = root
     .find(j.CallExpression, {
       callee: { type: 'Identifier', name: driverLocal },
@@ -133,9 +129,7 @@ function rewriteDriverCalls(
     ]
     attachLeadingComments(replacement, constructorTodos)
     ;(path as ASTPath<unknown>).replace(replacement as unknown as never)
-    mutated = true
   }
-  return mutated
 }
 
 // driver.js instance methods that mutate tour state at runtime. After the
@@ -190,8 +184,7 @@ function rewriteDriverInstanceCalls(
   j: JSCodeshift,
   root: Collection,
   driverVarNames: Set<string>
-): boolean {
-  let mutated = false
+): void {
   const stmtPaths = root
     .find(j.ExpressionStatement, {
       expression: {
@@ -212,18 +205,16 @@ function rewriteDriverInstanceCalls(
     if (!methodName) continue
     const entry = DRIVER_CONTROL_METHODS.get(methodName)
     if (!entry) continue
-    // Only rewrite when the receiver is a known driver(...) binding. This
-    // avoids accidentally clobbering unrelated `.destroy()` / `.drive()`
-    // method calls in the file.
+    // Fail closed: only rewrite when the receiver is a known driver(...)
+    // binding. Method names like `.destroy()` / `.drive()` are common on
+    // unrelated APIs so an unscoped rewrite would silently clobber user code.
     if (callee.object?.type !== 'Identifier') continue
-    if (driverVarNames.size > 0 && !driverVarNames.has(callee.object.name ?? '')) continue
+    if (!driverVarNames.has(callee.object.name ?? '')) continue
 
     const empty = j.emptyStatement()
     attachLeadingComments(empty, [emitTodo(entry.msg, entry.anchor, SOURCE)])
     ;(path as ASTPath<unknown>).replace(empty as unknown as never)
-    mutated = true
   }
-  return mutated
 }
 
 // ----- Step shape mapping -----
@@ -599,7 +590,16 @@ function mapDriverPopoverSide(
   todoSink: Todo[]
 ): ObjectProperty | Property | null {
   const literal = readStringLiteral(value)
-  if (!literal) return null
+  if (!literal) {
+    todoSink.push(
+      emitTodo(
+        'driver.js popover.side is dynamic — set placement manually',
+        'placement',
+        SOURCE
+      )
+    )
+    return null
+  }
   const mapped = DRIVER_PLACEMENT_MAP[literal]
   if (mapped) {
     return j.property('init', j.identifier('placement'), j.literal(mapped) as never)
@@ -634,24 +634,4 @@ function readStringLiteral(node: ASTNode | null | undefined): string | null {
   }
   if (node.type === 'StringLiteral') return (node as { value: string }).value
   return null
-}
-
-interface LineComment {
-  type: 'CommentLine'
-  value: string
-  leading: true
-  trailing: false
-}
-
-function makeLineComment(rawComment: string): LineComment {
-  const stripped = rawComment.startsWith('//') ? rawComment.slice(2).trimStart() : rawComment
-  return { type: 'CommentLine', value: ` ${stripped}`, leading: true, trailing: false }
-}
-
-function attachLeadingComments(node: unknown, todos: Todo[]): void {
-  if (todos.length === 0) return
-  const target = node as { comments?: unknown[] }
-  const existing = (target.comments as unknown[] | undefined) ?? []
-  const additions = todos.map((t) => makeLineComment(todoToComment(t)))
-  target.comments = [...existing, ...additions]
 }

--- a/packages/codemods/src/transforms/from-joyride.ts
+++ b/packages/codemods/src/transforms/from-joyride.ts
@@ -11,7 +11,7 @@
 // hand-port. A transform that mangles user code is worse than no transform.
 
 import type { API, ASTPath, Collection, FileInfo, JSCodeshift } from 'jscodeshift'
-import { type Todo, emitTodo, todoToComment } from '../lib/todo-emitter'
+import { type Todo, attachLeadingComments, emitTodo } from '../lib/todo-emitter'
 
 export const parser = 'tsx'
 
@@ -378,27 +378,3 @@ function rewriteTourComponentUsage(j: JSCodeshift, path: ASTPath): void {
   ;(path as ASTPath<unknown>).replace(nullLiteral as unknown as never)
 }
 
-function attachLeadingComments(node: unknown, todos: Todo[]): void {
-  if (todos.length === 0) return
-  const target = node as { comments?: unknown[] }
-  const existing = (target.comments as unknown[] | undefined) ?? []
-  const additions = todos.map((t) => makeLineComment(todoToComment(t)))
-  target.comments = [...existing, ...additions]
-}
-
-interface LineComment {
-  type: 'CommentLine'
-  value: string
-  leading: true
-  trailing: false
-}
-
-function makeLineComment(rawComment: string): LineComment {
-  const stripped = rawComment.startsWith('//') ? rawComment.slice(2).trimStart() : rawComment
-  return {
-    type: 'CommentLine',
-    value: ` ${stripped}`,
-    leading: true,
-    trailing: false,
-  }
-}

--- a/packages/codemods/src/transforms/from-joyride.ts
+++ b/packages/codemods/src/transforms/from-joyride.ts
@@ -377,4 +377,3 @@ function rewriteTourComponentUsage(j: JSCodeshift, path: ASTPath): void {
   }
   ;(path as ASTPath<unknown>).replace(nullLiteral as unknown as never)
 }
-

--- a/packages/codemods/src/transforms/from-shepherd.ts
+++ b/packages/codemods/src/transforms/from-shepherd.ts
@@ -1,0 +1,517 @@
+// jscodeshift transform — shepherd.js → @tour-kit/react.
+//
+// Approach mirrors from-joyride: deterministic, mechanical rewrites only.
+// Shepherd is class/imperative — `new Shepherd.Tour({...})` then a chain of
+// `.addStep({...})` and a final `.start()`. We RECONSTITUTE the chain into a
+// single `{ id, steps: [...] }` object literal, remove the addStep
+// statements, and emit TODOs above each unsupported callsite. Every Shepherd-
+// only shape becomes a `// TODO:` pointing at a heading in
+// `apps/docs/content/docs/migration/shepherd.mdx`.
+
+import type {
+  API,
+  ASTNode,
+  ASTPath,
+  Collection,
+  FileInfo,
+  JSCodeshift,
+  ObjectExpression,
+  ObjectProperty,
+  Property,
+} from 'jscodeshift'
+import { type Todo, emitTodo, todoToComment } from '../lib/todo-emitter'
+
+export const parser = 'tsx'
+
+const TARGET_MODULE = '@tour-kit/react'
+const SOURCE = 'shepherd' as const
+
+type PropLike = ObjectProperty | Property
+
+interface ShepherdImports {
+  defaultName: string | null
+  tourLocalName: string | null
+}
+
+export default function transform(file: FileInfo, api: API): string {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  const shepherdImports = root.find(j.ImportDeclaration, {
+    source: { value: 'shepherd.js' },
+  })
+  if (shepherdImports.size() === 0) return file.source
+
+  const imports = collectShepherdImports(shepherdImports)
+
+  let mutated = false
+  if (rewriteTourConstructors(j, root, imports)) mutated = true
+  if (rewriteControlCalls(j, root)) mutated = true
+
+  rewriteShepherdImport(j, shepherdImports)
+
+  return mutated || shepherdImports.size() > 0
+    ? root.toSource({ quote: 'single', trailingComma: true })
+    : file.source
+}
+
+function collectShepherdImports(decls: Collection): ShepherdImports {
+  const out: ShepherdImports = { defaultName: null, tourLocalName: null }
+  for (const path of decls.paths()) {
+    const specifiers = path.node.specifiers ?? []
+    for (const spec of specifiers) {
+      if (spec.type === 'ImportDefaultSpecifier' && spec.local) {
+        out.defaultName = spec.local.name
+      } else if (spec.type === 'ImportSpecifier' && spec.imported.name === 'Tour') {
+        out.tourLocalName = spec.local?.name ?? 'Tour'
+      }
+    }
+  }
+  return out
+}
+
+function rewriteShepherdImport(j: JSCodeshift, decls: Collection): void {
+  const paths = decls.paths()
+  for (let idx = 0; idx < paths.length; idx += 1) {
+    const path = paths[idx]
+    if (idx > 0) {
+      j(path).remove()
+      continue
+    }
+    path.node.source = j.literal(TARGET_MODULE)
+    path.node.specifiers = [j.importSpecifier(j.identifier('TourProvider'))]
+    ;(path.node as { importKind?: string }).importKind = 'value'
+  }
+}
+
+// Find `new Shepherd.Tour(...)` and `new Tour(...)` (named import). Each is
+// expected to live inside a VariableDeclarator so we can rewrite the
+// initializer in place; standalone `new` expressions get a TODO and a no-op
+// replacement.
+function rewriteTourConstructors(
+  j: JSCodeshift,
+  root: Collection,
+  imports: ShepherdImports
+): boolean {
+  let mutated = false
+
+  const matches: ASTPath[] = []
+  root.find(j.NewExpression).forEach((path) => {
+    if (isShepherdTourConstructor(path.node, imports)) matches.push(path)
+  })
+  if (matches.length === 0) return false
+
+  for (const path of matches) {
+    if (rewriteOneTourConstructor(j, root, path)) mutated = true
+  }
+  return mutated
+}
+
+function isShepherdTourConstructor(
+  node: ASTNode,
+  imports: ShepherdImports
+): boolean {
+  const ne = node as { type: string; callee?: unknown }
+  if (ne.type !== 'NewExpression') return false
+  const callee = ne.callee as { type?: string; name?: string; object?: { name?: string }; property?: { name?: string } }
+  if (!callee) return false
+  if (
+    callee.type === 'MemberExpression' &&
+    callee.property?.name === 'Tour' &&
+    (imports.defaultName === null || callee.object?.name === imports.defaultName)
+  ) {
+    return true
+  }
+  if (
+    callee.type === 'Identifier' &&
+    imports.tourLocalName !== null &&
+    callee.name === imports.tourLocalName
+  ) {
+    return true
+  }
+  return false
+}
+
+function rewriteOneTourConstructor(
+  j: JSCodeshift,
+  root: Collection,
+  path: ASTPath
+): boolean {
+  const parent = path.parent.node as { type: string }
+  if (parent.type !== 'VariableDeclarator') {
+    // Standalone `new Shepherd.Tour({...})` — rare; replace with an object
+    // literal scaffold + TODO.
+    const replacement = j.objectExpression([
+      j.property('init', j.identifier('id'), j.literal('migrated-tour')),
+      j.property('init', j.identifier('steps'), j.arrayExpression([])),
+    ])
+    attachLeadingComments(replacement, [
+      emitTodo(
+        'Shepherd Tour constructed without a binding — gather addStep() calls into the steps array and register via <TourProvider>',
+        'tour-constructor',
+        SOURCE
+      ),
+    ])
+    ;(path as ASTPath<unknown>).replace(replacement as unknown as never)
+    return true
+  }
+
+  const declarator = parent as { id?: { type?: string; name?: string } }
+  const tourVarName = declarator.id?.type === 'Identifier' ? declarator.id.name : null
+
+  const steps = tourVarName ? collectAddStepCalls(j, root, tourVarName) : []
+  const stepObjects = steps.map((s) => mapShepherdStep(j, s.objectArg, s.todoSink))
+  const allTodos = collectStepTodos(steps)
+
+  const replacement = j.objectExpression([
+    j.property('init', j.identifier('id'), j.literal('migrated-tour')),
+    j.property('init', j.identifier('steps'), j.arrayExpression(stepObjects)),
+  ])
+
+  const constructorTodos: Todo[] = [
+    emitTodo(
+      'Shepherd Tour constructed — register via <TourProvider tours={[migratedTour]}> in an ancestor and call useTour().start() to begin',
+      'tour-constructor',
+      SOURCE
+    ),
+    ...allTodos,
+  ]
+  attachLeadingComments(replacement, constructorTodos)
+
+  ;(path as ASTPath<unknown>).replace(replacement as unknown as never)
+  return true
+}
+
+interface AddStepCollected {
+  objectArg: ObjectExpression | null
+  todoSink: Todo[]
+  path: ASTPath
+}
+
+function collectAddStepCalls(
+  j: JSCodeshift,
+  root: Collection,
+  tourVarName: string
+): AddStepCollected[] {
+  const calls: AddStepCollected[] = []
+  root
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: { type: 'Identifier', name: tourVarName },
+        property: { name: 'addStep' },
+      },
+    })
+    .forEach((path) => {
+      const node = path.node as { arguments: unknown[] }
+      const arg0 = node.arguments[0] as ASTNode | undefined
+      const objectArg =
+        arg0 && (arg0 as { type: string }).type === 'ObjectExpression'
+          ? (arg0 as ObjectExpression)
+          : null
+      const todoSink: Todo[] = []
+      if (!objectArg && arg0) {
+        todoSink.push(
+          emitTodo(
+            'Shepherd .addStep() argument is not an inline object — port the step shape manually',
+            'add-step-dynamic',
+            SOURCE
+          )
+        )
+      }
+      calls.push({ objectArg, todoSink, path })
+
+      // Replace the wrapping ExpressionStatement with a no-op so the array
+      // captures the data and the tour.addStep(...) lines disappear.
+      let stmtPath: ASTPath | null = path.parent
+      while (stmtPath && (stmtPath.node as { type: string }).type !== 'ExpressionStatement') {
+        stmtPath = stmtPath.parent
+      }
+      if (stmtPath) j(stmtPath).remove()
+    })
+  return calls
+}
+
+function collectStepTodos(steps: AddStepCollected[]): Todo[] {
+  const todos: Todo[] = []
+  for (const s of steps) {
+    for (const t of s.todoSink) todos.push(t)
+  }
+  return todos
+}
+
+// Replace `tour.start()` / `.show()` / `.hide()` / `.cancel()` /
+// `.complete()` / `.next()` / `.back()` with an EmptyStatement carrying a
+// TODO comment. The tour object is now a plain literal — these methods would
+// fail tsc otherwise.
+const SHEPHERD_CONTROL_METHODS: ReadonlyMap<string, { anchor: string; msg: string }> = new Map([
+  ['start', { anchor: 'start', msg: 'Shepherd tour.start() → call useTour().start() from a descendant of <TourProvider>' }],
+  ['show', { anchor: 'control-flow', msg: 'Shepherd .show() → useTour().goTo(index) inside a descendant of <TourProvider>' }],
+  ['hide', { anchor: 'control-flow', msg: 'Shepherd .hide() → useTour().stop() inside a descendant of <TourProvider>' }],
+  ['cancel', { anchor: 'control-flow', msg: 'Shepherd .cancel() → useTour().skip() inside a descendant of <TourProvider>' }],
+  ['complete', { anchor: 'control-flow', msg: 'Shepherd .complete() → useTour().complete() inside a descendant of <TourProvider>' }],
+  ['next', { anchor: 'control-flow', msg: 'Shepherd .next() → useTour().next() inside a descendant of <TourProvider>' }],
+  ['back', { anchor: 'control-flow', msg: 'Shepherd .back() → useTour().prev() inside a descendant of <TourProvider>' }],
+])
+
+function rewriteControlCalls(j: JSCodeshift, root: Collection): boolean {
+  let mutated = false
+  root
+    .find(j.ExpressionStatement, {
+      expression: {
+        type: 'CallExpression',
+        callee: { type: 'MemberExpression' },
+      },
+    })
+    .forEach((path) => {
+      const stmt = path.node as {
+        expression: { type: string; callee?: { property?: { name?: string }; object?: { type?: string } } }
+      }
+      const callee = stmt.expression.callee
+      if (!callee) return
+      const methodName = callee.property?.name
+      if (!methodName) return
+      const entry = SHEPHERD_CONTROL_METHODS.get(methodName)
+      if (!entry) return
+      // Only rewrite if the object looks like an identifier reference. We
+      // can't easily tell if it's the tour binding, so be conservative: only
+      // when called on an Identifier whose object type is Identifier.
+      if (callee.object?.type !== 'Identifier') return
+
+      const empty = j.emptyStatement()
+      attachLeadingComments(empty, [emitTodo(entry.msg, entry.anchor, SOURCE)])
+      ;(path as ASTPath<unknown>).replace(empty as unknown as never)
+      mutated = true
+    })
+  return mutated
+}
+
+// ----- Step shape mapping -----
+
+const SHEPHERD_PLACEMENT_MAP: Record<string, string> = {
+  top: 'top',
+  bottom: 'bottom',
+  left: 'left',
+  right: 'right',
+  'top-start': 'top-start',
+  'top-end': 'top-end',
+  'bottom-start': 'bottom-start',
+  'bottom-end': 'bottom-end',
+  'left-start': 'left-start',
+  'left-end': 'left-end',
+  'right-start': 'right-start',
+  'right-end': 'right-end',
+  auto: 'top',
+}
+
+const SHEPHERD_UNSUPPORTED_FIELDS: Record<string, { anchor: string; msg: string }> = {
+  classes: { anchor: 'classes', msg: 'Step.classes — Tour Kit uses theme tokens; port via <ThemeProvider>' },
+  modalOverlayOpeningClass: { anchor: 'modal-overlay-class', msg: 'Step.modalOverlayOpeningClass — configure via <TourOverlay /> slot' },
+  modalOverlayOpeningPadding: { anchor: 'modal-overlay-padding', msg: 'Step.modalOverlayOpeningPadding — pass to the overlay slot' },
+  canClickTarget: { anchor: 'can-click-target', msg: 'Step.canClickTarget → configure the overlay spotlight interactive flag manually' },
+  scrollTo: { anchor: 'scroll-to', msg: 'Step.scrollTo — Tour Kit auto-scrolls; gate manually if you need a custom container' },
+  scrollToHandler: { anchor: 'scroll-to', msg: 'Step.scrollToHandler — wire a custom scroll handler from a descendant' },
+  highlightClass: { anchor: 'highlight-class', msg: 'Step.highlightClass — use theme tokens on the spotlight slot' },
+  when: { anchor: 'when', msg: 'Step.when lifecycle hooks — port to onShow / onHide on the migrated step' },
+  advanceOn: { anchor: 'advance-on', msg: 'Step.advanceOn — wire useTour().next() from your own event handler' },
+  beforeShowPromise: { anchor: 'before-show-promise', msg: 'Step.beforeShowPromise — await before calling useTour().goTo() OR move to a custom onShow' },
+  showOn: { anchor: 'show-on', msg: 'Step.showOn predicate — branch on useTour().currentStepIndex from a descendant' },
+}
+
+// Map a Shepherd step ObjectExpression to a Tour Kit step ObjectExpression.
+// Returns a NEW object expression; collects TODOs into the supplied sink.
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: per-field dispatch — splitting hides the contract
+function mapShepherdStep(
+  j: JSCodeshift,
+  step: ObjectExpression | null,
+  todoSink: Todo[]
+): ObjectExpression {
+  if (!step) return j.objectExpression([])
+
+  const out: Array<ObjectProperty | Property> = []
+  let hasTarget = false
+
+  for (const prop of step.properties) {
+    if (!isPropLike(prop)) continue
+    const name = getKeyName(prop)
+    if (!name) continue
+
+    if (name === 'id') {
+      out.push(j.property('init', j.identifier('id'), prop.value as never))
+      continue
+    }
+    if (name === 'attachTo') {
+      const mapped = mapShepherdAttachTo(j, prop.value as ASTNode, todoSink)
+      if (mapped.target) {
+        out.push(j.property('init', j.identifier('target'), mapped.target as never))
+        hasTarget = true
+      }
+      if (mapped.placement) {
+        out.push(j.property('init', j.identifier('placement'), mapped.placement as never))
+      }
+      continue
+    }
+    if (name === 'text' || name === 'content') {
+      out.push(j.property('init', j.identifier('content'), prop.value as never))
+      continue
+    }
+    if (name === 'title') {
+      out.push(j.property('init', j.identifier('title'), prop.value as never))
+      continue
+    }
+    if (name === 'buttons') {
+      mapShepherdButtons(prop.value as ASTNode, todoSink)
+      continue
+    }
+    if (name in SHEPHERD_UNSUPPORTED_FIELDS) {
+      const entry = SHEPHERD_UNSUPPORTED_FIELDS[name]
+      todoSink.push(emitTodo(entry.msg, entry.anchor, SOURCE))
+      continue
+    }
+    // Unknown field — preserve for visibility and flag.
+    todoSink.push(
+      emitTodo(`Step.${name} unrecognized — verify after migration`, 'unknown-step-field', SOURCE)
+    )
+  }
+
+  if (!hasTarget) {
+    todoSink.push(
+      emitTodo(
+        'Shepherd step had no resolvable attachTo.element — set Step.target to a CSS selector or DOM ref',
+        'target',
+        SOURCE
+      )
+    )
+  }
+  return j.objectExpression(out)
+}
+
+interface MappedAttachTo {
+  target: ASTNode | null
+  placement: ASTNode | null
+}
+
+function mapShepherdAttachTo(
+  j: JSCodeshift,
+  value: ASTNode,
+  todoSink: Todo[]
+): MappedAttachTo {
+  const out: MappedAttachTo = { target: null, placement: null }
+  if ((value as { type: string }).type !== 'ObjectExpression') {
+    todoSink.push(
+      emitTodo(
+        'Shepherd Step.attachTo is dynamic — set target / placement manually',
+        'attach-to-dynamic',
+        SOURCE
+      )
+    )
+    return out
+  }
+  const obj = value as ObjectExpression
+  for (const prop of obj.properties) {
+    if (!isPropLike(prop)) continue
+    const name = getKeyName(prop)
+    if (!name) continue
+    if (name === 'element') {
+      const v = prop.value as ASTNode | null
+      if (!v) continue
+      const t = (v as { type: string }).type
+      if (t === 'Literal' || t === 'StringLiteral' || t === 'TemplateLiteral') {
+        out.target = v
+        continue
+      }
+      if (t === 'ArrowFunctionExpression' || t === 'FunctionExpression') {
+        todoSink.push(
+          emitTodo(
+            'Shepherd Step.attachTo.element is a function — Tour Kit expects a selector string or DOM ref',
+            'attach-to-element-function',
+            SOURCE
+          )
+        )
+        continue
+      }
+      // Identifier / MemberExpression — preserve as-is; consumer verifies.
+      out.target = v
+      continue
+    }
+    if (name === 'on') {
+      const literal = readStringLiteral(prop.value as ASTNode)
+      if (literal && SHEPHERD_PLACEMENT_MAP[literal]) {
+        out.placement = j.literal(SHEPHERD_PLACEMENT_MAP[literal])
+      } else if (literal) {
+        todoSink.push(
+          emitTodo(
+            `Shepherd Step.attachTo.on '${literal}' unrecognized — defaulting to 'top'`,
+            'placement',
+            SOURCE
+          )
+        )
+        out.placement = j.literal('top')
+      }
+      continue
+    }
+  }
+  return out
+}
+
+function mapShepherdButtons(value: ASTNode, todoSink: Todo[]): void {
+  if ((value as { type: string }).type !== 'ArrayExpression') {
+    todoSink.push(
+      emitTodo(
+        'Shepherd Step.buttons is dynamic — wire useTour() controls from a descendant',
+        'buttons',
+        SOURCE
+      )
+    )
+    return
+  }
+  todoSink.push(
+    emitTodo(
+      'Shepherd Step.buttons — Tour Kit fixed Next/Prev/Skip slots; wire custom button actions via <TourCard /> children',
+      'buttons',
+      SOURCE
+    )
+  )
+}
+
+// ----- helpers (local to keep step-mapper.ts pristine per spec rule) -----
+
+function isPropLike(node: ASTNode): node is PropLike {
+  return node.type === 'ObjectProperty' || node.type === 'Property'
+}
+
+function getKeyName(prop: PropLike): string | null {
+  const key = prop.key
+  if (!key) return null
+  if (key.type === 'Identifier') return key.name
+  return readStringLiteral(key)
+}
+
+function readStringLiteral(node: ASTNode | null | undefined): string | null {
+  if (!node) return null
+  if (node.type === 'Literal' && typeof (node as { value: unknown }).value === 'string') {
+    return (node as { value: string }).value
+  }
+  if (node.type === 'StringLiteral') return (node as { value: string }).value
+  return null
+}
+
+interface LineComment {
+  type: 'CommentLine'
+  value: string
+  leading: true
+  trailing: false
+}
+
+function makeLineComment(rawComment: string): LineComment {
+  const stripped = rawComment.startsWith('//') ? rawComment.slice(2).trimStart() : rawComment
+  return { type: 'CommentLine', value: ` ${stripped}`, leading: true, trailing: false }
+}
+
+function attachLeadingComments(node: unknown, todos: Todo[]): void {
+  if (todos.length === 0) return
+  const target = node as { comments?: unknown[] }
+  const existing = (target.comments as unknown[] | undefined) ?? []
+  const additions = todos.map((t) => makeLineComment(todoToComment(t)))
+  target.comments = [...existing, ...additions]
+}

--- a/packages/codemods/src/transforms/from-shepherd.ts
+++ b/packages/codemods/src/transforms/from-shepherd.ts
@@ -294,11 +294,7 @@ const SHEPHERD_CONTROL_METHODS: ReadonlyMap<string, { anchor: string; msg: strin
   ],
 ])
 
-function rewriteControlCalls(
-  j: JSCodeshift,
-  root: Collection,
-  tourVarNames: Set<string>
-): void {
+function rewriteControlCalls(j: JSCodeshift, root: Collection, tourVarNames: Set<string>): void {
   const stmtPaths = root
     .find(j.ExpressionStatement, {
       expression: {
@@ -524,11 +520,7 @@ function mapShepherdAttachToOn(
 ): ASTNode | null {
   if (value && !readStringLiteral(value)) {
     todoSink.push(
-      emitTodo(
-        'Shepherd Step.attachTo.on is dynamic — set placement manually',
-        'placement',
-        SOURCE
-      )
+      emitTodo('Shepherd Step.attachTo.on is dynamic — set placement manually', 'placement', SOURCE)
     )
     return null
   }

--- a/packages/codemods/src/transforms/from-shepherd.ts
+++ b/packages/codemods/src/transforms/from-shepherd.ts
@@ -96,9 +96,9 @@ function rewriteTourConstructors(
   let mutated = false
 
   const matches: ASTPath[] = []
-  root.find(j.NewExpression).forEach((path) => {
+  for (const path of root.find(j.NewExpression).paths()) {
     if (isShepherdTourConstructor(path.node, imports)) matches.push(path)
-  })
+  }
   if (matches.length === 0) return false
 
   for (const path of matches) {
@@ -107,13 +107,15 @@ function rewriteTourConstructors(
   return mutated
 }
 
-function isShepherdTourConstructor(
-  node: ASTNode,
-  imports: ShepherdImports
-): boolean {
+function isShepherdTourConstructor(node: ASTNode, imports: ShepherdImports): boolean {
   const ne = node as { type: string; callee?: unknown }
   if (ne.type !== 'NewExpression') return false
-  const callee = ne.callee as { type?: string; name?: string; object?: { name?: string }; property?: { name?: string } }
+  const callee = ne.callee as {
+    type?: string
+    name?: string
+    object?: { name?: string }
+    property?: { name?: string }
+  }
   if (!callee) return false
   if (
     callee.type === 'MemberExpression' &&
@@ -132,11 +134,7 @@ function isShepherdTourConstructor(
   return false
 }
 
-function rewriteOneTourConstructor(
-  j: JSCodeshift,
-  root: Collection,
-  path: ASTPath
-): boolean {
+function rewriteOneTourConstructor(j: JSCodeshift, root: Collection, path: ASTPath): boolean {
   const parent = path.parent.node as { type: string }
   if (parent.type !== 'VariableDeclarator') {
     // Standalone `new Shepherd.Tour({...})` — rare; replace with an object
@@ -177,7 +175,6 @@ function rewriteOneTourConstructor(
     ...allTodos,
   ]
   attachLeadingComments(replacement, constructorTodos)
-
   ;(path as ASTPath<unknown>).replace(replacement as unknown as never)
   return true
 }
@@ -194,7 +191,7 @@ function collectAddStepCalls(
   tourVarName: string
 ): AddStepCollected[] {
   const calls: AddStepCollected[] = []
-  root
+  const addStepPaths = root
     .find(j.CallExpression, {
       callee: {
         type: 'MemberExpression',
@@ -202,33 +199,34 @@ function collectAddStepCalls(
         property: { name: 'addStep' },
       },
     })
-    .forEach((path) => {
-      const node = path.node as { arguments: unknown[] }
-      const arg0 = node.arguments[0] as ASTNode | undefined
-      const objectArg =
-        arg0 && (arg0 as { type: string }).type === 'ObjectExpression'
-          ? (arg0 as ObjectExpression)
-          : null
-      const todoSink: Todo[] = []
-      if (!objectArg && arg0) {
-        todoSink.push(
-          emitTodo(
-            'Shepherd .addStep() argument is not an inline object — port the step shape manually',
-            'add-step-dynamic',
-            SOURCE
-          )
+    .paths()
+  for (const path of addStepPaths) {
+    const node = path.node as { arguments: unknown[] }
+    const arg0 = node.arguments[0] as ASTNode | undefined
+    const objectArg =
+      arg0 && (arg0 as { type: string }).type === 'ObjectExpression'
+        ? (arg0 as ObjectExpression)
+        : null
+    const todoSink: Todo[] = []
+    if (!objectArg && arg0) {
+      todoSink.push(
+        emitTodo(
+          'Shepherd .addStep() argument is not an inline object — port the step shape manually',
+          'add-step-dynamic',
+          SOURCE
         )
-      }
-      calls.push({ objectArg, todoSink, path })
+      )
+    }
+    calls.push({ objectArg, todoSink, path })
 
-      // Replace the wrapping ExpressionStatement with a no-op so the array
-      // captures the data and the tour.addStep(...) lines disappear.
-      let stmtPath: ASTPath | null = path.parent
-      while (stmtPath && (stmtPath.node as { type: string }).type !== 'ExpressionStatement') {
-        stmtPath = stmtPath.parent
-      }
-      if (stmtPath) j(stmtPath).remove()
-    })
+    // Replace the wrapping ExpressionStatement with a no-op so the array
+    // captures the data and the tour.addStep(...) lines disappear.
+    let stmtPath: ASTPath | null = path.parent
+    while (stmtPath && (stmtPath.node as { type: string }).type !== 'ExpressionStatement') {
+      stmtPath = stmtPath.parent
+    }
+    if (stmtPath) j(stmtPath).remove()
+  }
   return calls
 }
 
@@ -245,44 +243,90 @@ function collectStepTodos(steps: AddStepCollected[]): Todo[] {
 // TODO comment. The tour object is now a plain literal — these methods would
 // fail tsc otherwise.
 const SHEPHERD_CONTROL_METHODS: ReadonlyMap<string, { anchor: string; msg: string }> = new Map([
-  ['start', { anchor: 'start', msg: 'Shepherd tour.start() → call useTour().start() from a descendant of <TourProvider>' }],
-  ['show', { anchor: 'control-flow', msg: 'Shepherd .show() → useTour().goTo(index) inside a descendant of <TourProvider>' }],
-  ['hide', { anchor: 'control-flow', msg: 'Shepherd .hide() → useTour().stop() inside a descendant of <TourProvider>' }],
-  ['cancel', { anchor: 'control-flow', msg: 'Shepherd .cancel() → useTour().skip() inside a descendant of <TourProvider>' }],
-  ['complete', { anchor: 'control-flow', msg: 'Shepherd .complete() → useTour().complete() inside a descendant of <TourProvider>' }],
-  ['next', { anchor: 'control-flow', msg: 'Shepherd .next() → useTour().next() inside a descendant of <TourProvider>' }],
-  ['back', { anchor: 'control-flow', msg: 'Shepherd .back() → useTour().prev() inside a descendant of <TourProvider>' }],
+  [
+    'start',
+    {
+      anchor: 'start',
+      msg: 'Shepherd tour.start() → call useTour().start() from a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'show',
+    {
+      anchor: 'control-flow',
+      msg: 'Shepherd .show() → useTour().goTo(index) inside a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'hide',
+    {
+      anchor: 'control-flow',
+      msg: 'Shepherd .hide() → useTour().stop() inside a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'cancel',
+    {
+      anchor: 'control-flow',
+      msg: 'Shepherd .cancel() → useTour().skip() inside a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'complete',
+    {
+      anchor: 'control-flow',
+      msg: 'Shepherd .complete() → useTour().complete() inside a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'next',
+    {
+      anchor: 'control-flow',
+      msg: 'Shepherd .next() → useTour().next() inside a descendant of <TourProvider>',
+    },
+  ],
+  [
+    'back',
+    {
+      anchor: 'control-flow',
+      msg: 'Shepherd .back() → useTour().prev() inside a descendant of <TourProvider>',
+    },
+  ],
 ])
 
 function rewriteControlCalls(j: JSCodeshift, root: Collection): boolean {
   let mutated = false
-  root
+  const stmtPaths = root
     .find(j.ExpressionStatement, {
       expression: {
         type: 'CallExpression',
         callee: { type: 'MemberExpression' },
       },
     })
-    .forEach((path) => {
-      const stmt = path.node as {
-        expression: { type: string; callee?: { property?: { name?: string }; object?: { type?: string } } }
+    .paths()
+  for (const path of stmtPaths) {
+    const stmt = path.node as {
+      expression: {
+        type: string
+        callee?: { property?: { name?: string }; object?: { type?: string } }
       }
-      const callee = stmt.expression.callee
-      if (!callee) return
-      const methodName = callee.property?.name
-      if (!methodName) return
-      const entry = SHEPHERD_CONTROL_METHODS.get(methodName)
-      if (!entry) return
-      // Only rewrite if the object looks like an identifier reference. We
-      // can't easily tell if it's the tour binding, so be conservative: only
-      // when called on an Identifier whose object type is Identifier.
-      if (callee.object?.type !== 'Identifier') return
+    }
+    const callee = stmt.expression.callee
+    if (!callee) continue
+    const methodName = callee.property?.name
+    if (!methodName) continue
+    const entry = SHEPHERD_CONTROL_METHODS.get(methodName)
+    if (!entry) continue
+    // Only rewrite if the object looks like an identifier reference. We
+    // can't easily tell if it's the tour binding, so be conservative: only
+    // when called on an Identifier whose object type is Identifier.
+    if (callee.object?.type !== 'Identifier') continue
 
-      const empty = j.emptyStatement()
-      attachLeadingComments(empty, [emitTodo(entry.msg, entry.anchor, SOURCE)])
-      ;(path as ASTPath<unknown>).replace(empty as unknown as never)
-      mutated = true
-    })
+    const empty = j.emptyStatement()
+    attachLeadingComments(empty, [emitTodo(entry.msg, entry.anchor, SOURCE)])
+    ;(path as ASTPath<unknown>).replace(empty as unknown as never)
+    mutated = true
+  }
   return mutated
 }
 
@@ -305,17 +349,50 @@ const SHEPHERD_PLACEMENT_MAP: Record<string, string> = {
 }
 
 const SHEPHERD_UNSUPPORTED_FIELDS: Record<string, { anchor: string; msg: string }> = {
-  classes: { anchor: 'classes', msg: 'Step.classes — Tour Kit uses theme tokens; port via <ThemeProvider>' },
-  modalOverlayOpeningClass: { anchor: 'modal-overlay-class', msg: 'Step.modalOverlayOpeningClass — configure via <TourOverlay /> slot' },
-  modalOverlayOpeningPadding: { anchor: 'modal-overlay-padding', msg: 'Step.modalOverlayOpeningPadding — pass to the overlay slot' },
-  canClickTarget: { anchor: 'can-click-target', msg: 'Step.canClickTarget → configure the overlay spotlight interactive flag manually' },
-  scrollTo: { anchor: 'scroll-to', msg: 'Step.scrollTo — Tour Kit auto-scrolls; gate manually if you need a custom container' },
-  scrollToHandler: { anchor: 'scroll-to', msg: 'Step.scrollToHandler — wire a custom scroll handler from a descendant' },
-  highlightClass: { anchor: 'highlight-class', msg: 'Step.highlightClass — use theme tokens on the spotlight slot' },
-  when: { anchor: 'when', msg: 'Step.when lifecycle hooks — port to onShow / onHide on the migrated step' },
-  advanceOn: { anchor: 'advance-on', msg: 'Step.advanceOn — wire useTour().next() from your own event handler' },
-  beforeShowPromise: { anchor: 'before-show-promise', msg: 'Step.beforeShowPromise — await before calling useTour().goTo() OR move to a custom onShow' },
-  showOn: { anchor: 'show-on', msg: 'Step.showOn predicate — branch on useTour().currentStepIndex from a descendant' },
+  classes: {
+    anchor: 'classes',
+    msg: 'Step.classes — Tour Kit uses theme tokens; port via <ThemeProvider>',
+  },
+  modalOverlayOpeningClass: {
+    anchor: 'modal-overlay-class',
+    msg: 'Step.modalOverlayOpeningClass — configure via <TourOverlay /> slot',
+  },
+  modalOverlayOpeningPadding: {
+    anchor: 'modal-overlay-padding',
+    msg: 'Step.modalOverlayOpeningPadding — pass to the overlay slot',
+  },
+  canClickTarget: {
+    anchor: 'can-click-target',
+    msg: 'Step.canClickTarget → configure the overlay spotlight interactive flag manually',
+  },
+  scrollTo: {
+    anchor: 'scroll-to',
+    msg: 'Step.scrollTo — Tour Kit auto-scrolls; gate manually if you need a custom container',
+  },
+  scrollToHandler: {
+    anchor: 'scroll-to',
+    msg: 'Step.scrollToHandler — wire a custom scroll handler from a descendant',
+  },
+  highlightClass: {
+    anchor: 'highlight-class',
+    msg: 'Step.highlightClass — use theme tokens on the spotlight slot',
+  },
+  when: {
+    anchor: 'when',
+    msg: 'Step.when lifecycle hooks — port to onShow / onHide on the migrated step',
+  },
+  advanceOn: {
+    anchor: 'advance-on',
+    msg: 'Step.advanceOn — wire useTour().next() from your own event handler',
+  },
+  beforeShowPromise: {
+    anchor: 'before-show-promise',
+    msg: 'Step.beforeShowPromise — await before calling useTour().goTo() OR move to a custom onShow',
+  },
+  showOn: {
+    anchor: 'show-on',
+    msg: 'Step.showOn predicate — branch on useTour().currentStepIndex from a descendant',
+  },
 }
 
 // Map a Shepherd step ObjectExpression to a Tour Kit step ObjectExpression.
@@ -391,11 +468,7 @@ interface MappedAttachTo {
   placement: ASTNode | null
 }
 
-function mapShepherdAttachTo(
-  j: JSCodeshift,
-  value: ASTNode,
-  todoSink: Todo[]
-): MappedAttachTo {
+function mapShepherdAttachTo(j: JSCodeshift, value: ASTNode, todoSink: Todo[]): MappedAttachTo {
   const out: MappedAttachTo = { target: null, placement: null }
   if ((value as { type: string }).type !== 'ObjectExpression') {
     todoSink.push(
@@ -407,51 +480,57 @@ function mapShepherdAttachTo(
     )
     return out
   }
-  const obj = value as ObjectExpression
-  for (const prop of obj.properties) {
+  for (const prop of (value as ObjectExpression).properties) {
     if (!isPropLike(prop)) continue
     const name = getKeyName(prop)
-    if (!name) continue
     if (name === 'element') {
-      const v = prop.value as ASTNode | null
-      if (!v) continue
-      const t = (v as { type: string }).type
-      if (t === 'Literal' || t === 'StringLiteral' || t === 'TemplateLiteral') {
-        out.target = v
-        continue
-      }
-      if (t === 'ArrowFunctionExpression' || t === 'FunctionExpression') {
-        todoSink.push(
-          emitTodo(
-            'Shepherd Step.attachTo.element is a function — Tour Kit expects a selector string or DOM ref',
-            'attach-to-element-function',
-            SOURCE
-          )
-        )
-        continue
-      }
-      // Identifier / MemberExpression — preserve as-is; consumer verifies.
-      out.target = v
-      continue
-    }
-    if (name === 'on') {
-      const literal = readStringLiteral(prop.value as ASTNode)
-      if (literal && SHEPHERD_PLACEMENT_MAP[literal]) {
-        out.placement = j.literal(SHEPHERD_PLACEMENT_MAP[literal])
-      } else if (literal) {
-        todoSink.push(
-          emitTodo(
-            `Shepherd Step.attachTo.on '${literal}' unrecognized — defaulting to 'top'`,
-            'placement',
-            SOURCE
-          )
-        )
-        out.placement = j.literal('top')
-      }
-      continue
+      out.target = mapShepherdAttachToElement(prop.value as ASTNode | null, todoSink)
+    } else if (name === 'on') {
+      out.placement = mapShepherdAttachToOn(j, prop.value as ASTNode | null, todoSink)
     }
   }
   return out
+}
+
+// Resolve `attachTo.element` → Tour Kit `target`. String literals pass through;
+// functions emit a TODO and resolve to null; other expressions (Identifier /
+// MemberExpression) are preserved verbatim for the consumer to verify.
+function mapShepherdAttachToElement(value: ASTNode | null, todoSink: Todo[]): ASTNode | null {
+  if (!value) return null
+  const t = (value as { type: string }).type
+  if (t === 'Literal' || t === 'StringLiteral' || t === 'TemplateLiteral') return value
+  if (t === 'ArrowFunctionExpression' || t === 'FunctionExpression') {
+    todoSink.push(
+      emitTodo(
+        'Shepherd Step.attachTo.element is a function — Tour Kit expects a selector string or DOM ref',
+        'attach-to-element-function',
+        SOURCE
+      )
+    )
+    return null
+  }
+  return value
+}
+
+// Resolve `attachTo.on` → Tour Kit `placement`. Known values pass through the
+// placement map; unknown literals fall back to 'top' with a TODO.
+function mapShepherdAttachToOn(
+  j: JSCodeshift,
+  value: ASTNode | null,
+  todoSink: Todo[]
+): ASTNode | null {
+  const literal = readStringLiteral(value)
+  if (!literal) return null
+  const mapped = SHEPHERD_PLACEMENT_MAP[literal]
+  if (mapped) return j.literal(mapped)
+  todoSink.push(
+    emitTodo(
+      `Shepherd Step.attachTo.on '${literal}' unrecognized — defaulting to 'top'`,
+      'placement',
+      SOURCE
+    )
+  )
+  return j.literal('top')
 }
 
 function mapShepherdButtons(value: ASTNode, todoSink: Todo[]): void {

--- a/packages/codemods/src/transforms/from-shepherd.ts
+++ b/packages/codemods/src/transforms/from-shepherd.ts
@@ -19,7 +19,7 @@ import type {
   ObjectProperty,
   Property,
 } from 'jscodeshift'
-import { type Todo, emitTodo, todoToComment } from '../lib/todo-emitter'
+import { type Todo, attachLeadingComments, emitTodo } from '../lib/todo-emitter'
 
 export const parser = 'tsx'
 
@@ -44,15 +44,13 @@ export default function transform(file: FileInfo, api: API): string {
 
   const imports = collectShepherdImports(shepherdImports)
 
-  let mutated = false
-  if (rewriteTourConstructors(j, root, imports)) mutated = true
-  if (rewriteControlCalls(j, root)) mutated = true
+  const tourVarNames = new Set<string>()
+  rewriteTourConstructors(j, root, imports, tourVarNames)
+  rewriteControlCalls(j, root, tourVarNames)
 
   rewriteShepherdImport(j, shepherdImports)
 
-  return mutated || shepherdImports.size() > 0
-    ? root.toSource({ quote: 'single', trailingComma: true })
-    : file.source
+  return root.toSource({ quote: 'single', trailingComma: true })
 }
 
 function collectShepherdImports(decls: Collection): ShepherdImports {
@@ -87,24 +85,21 @@ function rewriteShepherdImport(j: JSCodeshift, decls: Collection): void {
 // Find `new Shepherd.Tour(...)` and `new Tour(...)` (named import). Each is
 // expected to live inside a VariableDeclarator so we can rewrite the
 // initializer in place; standalone `new` expressions get a TODO and a no-op
-// replacement.
+// replacement. Captured Identifier-form bindings flow into `tourVarNames` so
+// the control-call rewriter only touches the real tour binding.
 function rewriteTourConstructors(
   j: JSCodeshift,
   root: Collection,
-  imports: ShepherdImports
-): boolean {
-  let mutated = false
-
+  imports: ShepherdImports,
+  tourVarNames: Set<string>
+): void {
   const matches: ASTPath[] = []
   for (const path of root.find(j.NewExpression).paths()) {
     if (isShepherdTourConstructor(path.node, imports)) matches.push(path)
   }
-  if (matches.length === 0) return false
-
   for (const path of matches) {
-    if (rewriteOneTourConstructor(j, root, path)) mutated = true
+    rewriteOneTourConstructor(j, root, path, tourVarNames)
   }
-  return mutated
 }
 
 function isShepherdTourConstructor(node: ASTNode, imports: ShepherdImports): boolean {
@@ -134,7 +129,12 @@ function isShepherdTourConstructor(node: ASTNode, imports: ShepherdImports): boo
   return false
 }
 
-function rewriteOneTourConstructor(j: JSCodeshift, root: Collection, path: ASTPath): boolean {
+function rewriteOneTourConstructor(
+  j: JSCodeshift,
+  root: Collection,
+  path: ASTPath,
+  tourVarNames: Set<string>
+): void {
   const parent = path.parent.node as { type: string }
   if (parent.type !== 'VariableDeclarator') {
     // Standalone `new Shepherd.Tour({...})` — rare; replace with an object
@@ -151,11 +151,12 @@ function rewriteOneTourConstructor(j: JSCodeshift, root: Collection, path: ASTPa
       ),
     ])
     ;(path as ASTPath<unknown>).replace(replacement as unknown as never)
-    return true
+    return
   }
 
   const declarator = parent as { id?: { type?: string; name?: string } }
   const tourVarName = declarator.id?.type === 'Identifier' ? declarator.id.name : null
+  if (tourVarName) tourVarNames.add(tourVarName)
 
   const steps = tourVarName ? collectAddStepCalls(j, root, tourVarName) : []
   const stepObjects = steps.map((s) => mapShepherdStep(j, s.objectArg, s.todoSink))
@@ -176,7 +177,6 @@ function rewriteOneTourConstructor(j: JSCodeshift, root: Collection, path: ASTPa
   ]
   attachLeadingComments(replacement, constructorTodos)
   ;(path as ASTPath<unknown>).replace(replacement as unknown as never)
-  return true
 }
 
 interface AddStepCollected {
@@ -294,8 +294,11 @@ const SHEPHERD_CONTROL_METHODS: ReadonlyMap<string, { anchor: string; msg: strin
   ],
 ])
 
-function rewriteControlCalls(j: JSCodeshift, root: Collection): boolean {
-  let mutated = false
+function rewriteControlCalls(
+  j: JSCodeshift,
+  root: Collection,
+  tourVarNames: Set<string>
+): void {
   const stmtPaths = root
     .find(j.ExpressionStatement, {
       expression: {
@@ -308,7 +311,7 @@ function rewriteControlCalls(j: JSCodeshift, root: Collection): boolean {
     const stmt = path.node as {
       expression: {
         type: string
-        callee?: { property?: { name?: string }; object?: { type?: string } }
+        callee?: { property?: { name?: string }; object?: { type?: string; name?: string } }
       }
     }
     const callee = stmt.expression.callee
@@ -317,17 +320,17 @@ function rewriteControlCalls(j: JSCodeshift, root: Collection): boolean {
     if (!methodName) continue
     const entry = SHEPHERD_CONTROL_METHODS.get(methodName)
     if (!entry) continue
-    // Only rewrite if the object looks like an identifier reference. We
-    // can't easily tell if it's the tour binding, so be conservative: only
-    // when called on an Identifier whose object type is Identifier.
+    // Fail closed: only rewrite when the receiver is a known tour binding.
+    // Method names like `.next()` / `.start()` / `.back()` are common on
+    // unrelated APIs (carousels, iterators, animations) so an unscoped
+    // rewrite would silently clobber user code.
     if (callee.object?.type !== 'Identifier') continue
+    if (!tourVarNames.has(callee.object.name ?? '')) continue
 
     const empty = j.emptyStatement()
     attachLeadingComments(empty, [emitTodo(entry.msg, entry.anchor, SOURCE)])
     ;(path as ASTPath<unknown>).replace(empty as unknown as never)
-    mutated = true
   }
-  return mutated
 }
 
 // ----- Step shape mapping -----
@@ -519,6 +522,16 @@ function mapShepherdAttachToOn(
   value: ASTNode | null,
   todoSink: Todo[]
 ): ASTNode | null {
+  if (value && !readStringLiteral(value)) {
+    todoSink.push(
+      emitTodo(
+        'Shepherd Step.attachTo.on is dynamic — set placement manually',
+        'placement',
+        SOURCE
+      )
+    )
+    return null
+  }
   const literal = readStringLiteral(value)
   if (!literal) return null
   const mapped = SHEPHERD_PLACEMENT_MAP[literal]
@@ -553,7 +566,7 @@ function mapShepherdButtons(value: ASTNode, todoSink: Todo[]): void {
   )
 }
 
-// ----- helpers (local to keep step-mapper.ts pristine per spec rule) -----
+// ----- helpers -----
 
 function isPropLike(node: ASTNode): node is PropLike {
   return node.type === 'ObjectProperty' || node.type === 'Property'
@@ -573,24 +586,4 @@ function readStringLiteral(node: ASTNode | null | undefined): string | null {
   }
   if (node.type === 'StringLiteral') return (node as { value: string }).value
   return null
-}
-
-interface LineComment {
-  type: 'CommentLine'
-  value: string
-  leading: true
-  trailing: false
-}
-
-function makeLineComment(rawComment: string): LineComment {
-  const stripped = rawComment.startsWith('//') ? rawComment.slice(2).trimStart() : rawComment
-  return { type: 'CommentLine', value: ` ${stripped}`, leading: true, trailing: false }
-}
-
-function attachLeadingComments(node: unknown, todos: Todo[]): void {
-  if (todos.length === 0) return
-  const target = node as { comments?: unknown[] }
-  const existing = (target.comments as unknown[] | undefined) ?? []
-  const additions = todos.map((t) => makeLineComment(todoToComment(t)))
-  target.comments = [...existing, ...additions]
 }


### PR DESCRIPTION
## Summary

- Adds `--from shepherd` and `--from driver` to `tour-kit-migrate`, completing the marketing claim _\"migrate from any major React tour library in one command.\"_
- Reuses the Phase 7a infrastructure (CLI, fixture-runner, helpers, todo-emitter) — additive only. Joyride no-regression enforced by the now-parametrized fixture-runner.
- Both transforms hit **100% coverage** on their committed fixture corpora; the `EXPERIMENTAL_TRANSFORMS` set ships empty.

## What's in the box

| | shepherd.js (`--from shepherd`) | driver.js (`--from driver`) |
|---|---|---|
| Import | `import Shepherd from 'shepherd.js'` → `import { TourProvider } from '@tour-kit/react'` | `import { driver } from 'driver.js'` → `import { TourProvider } from '@tour-kit/react'` |
| Constructor | `new Shepherd.Tour({...})` + `.addStep(...)` chain reconstituted into `{ id, steps: [...] }` literal | `driver({ steps: [...] })` reshaped into `{ id, steps: [...] }` literal |
| Step mapping | `attachTo.element` → `target`, `attachTo.on` → `placement`, `text` → `content`, `id` → `id` | `element` → `target`, `popover.{title,description,side}` → `{title,content,placement}` |
| Control flow | `.start()` / `.cancel()` / `.show()` / `.hide()` / `.complete()` / `.next()` / `.back()` → empty statements + TODOs pointing at `useTour()` | `.drive()` / `.destroy()` / `.moveNext()` / `.movePrevious()` / `.moveTo()` → empty statements + TODOs |
| Fixture coverage | 100% (3/3) | 100% (3/3) |

## Other changes

- `todo-emitter` is now source-aware (`joyride` / `shepherd` / `driver`) while preserving the Joyride-default for every existing Phase 7a caller — no churn in `from-joyride.ts`.
- CLI prints `[Tour Kit] <source> transform is experimental. Coverage: <pct>%. Review TODOs carefully.` on stderr when `--from` hits a flagged source. The set is read **live** by tests so experimental status is part of the code review, not buried in a changelog.
- `fixture-runner.test.ts` is parametrized over `{ joyride, shepherd, driver }` with per-source coverage gates, corpus-existence skip, and a Joyride-only pairing assertion (JSX form **and** useJoyride hook form must both be in the pass-set).
- `docs-anchors.test.ts` loops over the three MDX guides; every emitted TODO anchor resolves to a heading.
- Per-source migration guides at `apps/docs/content/docs/migration/{shepherd,driver}.mdx` with anchor coverage matching every TODO the transforms can emit; `meta.json` updated for nav.
- Per-source coverage matrix at `packages/codemods/docs/from-{shepherd,driver}.md`.
- README rewritten to document all three sources with a coverage-status table.
- Changeset filed at `.changeset/phase-7b-shepherd-driver-codemods.md` (`@tour-kit/codemods` minor).

## Test results

```
Test Files  7 passed (7)
     Tests  84 passed (84)
```

- 6 new Shepherd unit cases + 6 new Driver unit cases.
- Parametrized fixture-runner: 37 tests across all three sources (Joyride 17, Shepherd 10, Driver 10).
- CLI: experimental-warning path + new `--from shepherd|driver` recognition.

## Test plan

- [x] `pnpm --filter @tour-kit/codemods typecheck` exits 0
- [x] `pnpm --filter @tour-kit/codemods build` exits 0
- [x] `pnpm --filter @tour-kit/codemods test` exits 0 (84 passed)
- [x] `node dist/bin/tour-kit-migrate.cjs --from shepherd --dry-run __tests__/fixtures/shepherd/` exits 0
- [x] `node dist/bin/tour-kit-migrate.cjs --from driver --dry-run __tests__/fixtures/driver/` exits 0
- [x] Joyride no-regression: 17/17 of Phase 7a's fixture tests still pass via the parametrized runner.
- [x] Every TODO anchor emitted by either new transform resolves to a heading in its MDX guide (verified by `docs-anchors.test.ts`).
- [x] `pnpm --filter docs build` — **pre-existing failure on `main`** at `/legal/privacy/page` (`Cannot read properties of null (reading 'useMemo')`), unrelated to Phase 7b. The MDX content of the new migration pages parses cleanly (verified by the docs-anchors test) and the generated `llms.txt` / `llms-full.txt` show the new pages registered correctly in the Migration section.

🤖 Generated with run-phase skill (Phase 7b)