### PR TITLE
fix(license): render children during loading to prevent SSR blackout

### DIFF
--- a/.changeset/license-gate-ssr-default.md
+++ b/.changeset/license-gate-ssr-default.md
@@ -1,0 +1,9 @@
+---
+'@tour-kit/license': patch
+---
+
+Fix Pro-package SSR blackout in `<LicenseGate>` loading state.
+
+`LicenseProvider` validates the license inside a `useEffect`, which never fires during server rendering. That left `context.isLoading` `true` on every SSR pass, and `<LicenseGate>` (used internally by all 8 Pro packages since 1.1.0) returned `null` whenever no explicit `loading` prop was passed — wiping the entire Pro subtree from server HTML and forcing a pop-in on hydration. The release smoke app caught this as a missing `data-smoke-ok` marker on the curl probe.
+
+The loading branch now defaults to `children` instead of `null`. Consumers who want a skeleton during validation can still pass `loading={<Skeleton />}`; the watermark only renders once the gate decision is known.

--- a/apps/docs/lib/comparisons.ts
+++ b/apps/docs/lib/comparisons.ts
@@ -5823,10 +5823,8 @@ export const BLOG_POSTS: BlogMeta[] = [
   },
   {
     slug: 'may-2026-release-update',
-    title:
-      'userTourKit May 2026 release: codemods, testing helpers, and a soft-gate license',
-    metaTitle:
-      'userTourKit May 2026 release notes: codemods, testing-library, soft-gate license',
+    title: 'userTourKit May 2026 release: codemods, testing helpers, and a soft-gate license',
+    metaTitle: 'userTourKit May 2026 release notes: codemods, testing-library, soft-gate license',
     description:
       'Five phases shipped: @tour-kit/testing-library, @tour-kit/playwright, three migration codemods (Joyride, Shepherd, Driver), license soft-gate with try-before-buy watermark, and a Phase 8 QA pass covering analytics, accessibility, and autostart.',
     keywords: [

--- a/packages/license/src/__tests__/license-gate.test.tsx
+++ b/packages/license/src/__tests__/license-gate.test.tsx
@@ -145,7 +145,7 @@ describe('LicenseGate', () => {
     expect(screen.queryByTestId('pro-content')).not.toBeInTheDocument()
   })
 
-  it('renders null when no loading slot provided and loading', () => {
+  it('renders children when no loading slot provided and loading (SSR-safe default)', () => {
     mockValidate.mockImplementation(() => new Promise(() => {}))
 
     render(
@@ -156,7 +156,8 @@ describe('LicenseGate', () => {
       </LicenseProvider>
     )
 
-    expect(screen.queryByTestId('pro-content')).not.toBeInTheDocument()
+    expect(screen.getByTestId('pro-content')).toBeInTheDocument()
+    expect(findWatermark()).toBeNull()
   })
 
   it('renders children plus badge when tier is free but pro is required', async () => {
@@ -359,5 +360,25 @@ describe('LicenseGate', () => {
         </LicenseGate>
       )
     }).not.toThrow()
+  })
+
+  it('renderToString emits children inside a LicenseProvider (no SSR blackout)', () => {
+    // Provider starts in the loading state and validates inside `useEffect`,
+    // which never runs on the server. The gate must render `children` in that
+    // state or every Pro provider's subtree disappears from SSR HTML — the
+    // exact regression Plan 12C inherits and the release smoke probe caught.
+    mockIsDev.mockReturnValue(false)
+    mockValidate.mockImplementation(() => new Promise(() => {}))
+
+    const html = renderToString(
+      <LicenseProvider licenseKey="TOURKIT_key">
+        <LicenseGate require="pro">
+          <div data-ssr-marker="pro">Pro Feature</div>
+        </LicenseGate>
+      </LicenseProvider>
+    )
+
+    expect(html).toContain('data-ssr-marker="pro"')
+    expect(html).toContain('Pro Feature')
   })
 })

--- a/packages/license/src/components/license-gate.tsx
+++ b/packages/license/src/components/license-gate.tsx
@@ -31,7 +31,11 @@ export function LicenseGate({ require: _require, children, fallback, loading }: 
     )
   }
 
-  if (context.isLoading) return <>{loading ?? null}</>
+  // Loading default is children, not null: `useEffect` doesn't fire during SSR,
+  // so the loading state is the *only* state the server ever sees. Returning
+  // null here blanks every Pro provider's subtree in SSR HTML and forces a
+  // post-hydration pop-in. Consumers who want a skeleton still pass `loading`.
+  if (context.isLoading) return <>{loading ?? children}</>
   if (!context.isGated) return <>{children}</>
   if (fallback) return <>{fallback}</>
 


### PR DESCRIPTION
## Summary

`LicenseProvider` validates the license inside `useEffect`, which never fires during SSR. That left `context.isLoading === true` on every server pass, and `<LicenseGate>` (used internally by all 8 Pro packages since `@tour-kit/license@1.1.0`) returned `null` whenever no explicit `loading` prop was passed — wiping the entire Pro subtree from server HTML and forcing a pop-in on hydration.

The release smoke app at `apps/smoke` caught this as a missing `data-smoke-ok` marker on the `curl` probe — the page returned 200 but the body was empty for the providers subtree.

The loading branch now defaults to `children` instead of `null`. Consumers who want a skeleton during validation can still pass `loading={<Skeleton />}`; the watermark only renders once the gate decision is known.

Adds a `renderToString` regression test that fails if anyone reintroduces the SSR blackout.

## Test plan

- [x] `pnpm --filter @tour-kit/license test` — 137/137 pass (1 new SSR-emits-children test).
- [x] `pnpm --filter @tour-kit/license typecheck` — clean.
- [x] `pnpm --filter @tour-kit/license build` — clean; dist sizes unchanged.
- [ ] Post-publish smoke (CI release workflow) finds `data-smoke-ok` in SSR HTML against `@tour-kit/license@1.1.2`.
- [ ] Visual check: Next.js consumer app's Pro components render in SSR HTML (no first-paint blank).

## Why this is a real production bug, not just a CI flake

Every Next.js / Remix consumer of `@tour-kit/{adoption,ai,analytics,announcements,checklists,media,scheduling,surveys}` since `1.1.0` sees blank Pro UI on first paint, then it pops in after hydration. Sentry sees no error because SSR completes successfully with 200. Honeycomb sees no anomaly because the request trace is normal. The only way to catch this class of bug is a synthetic SSR-marker probe — which is exactly what `apps/smoke` does, and what should be added to the Plan 13 deploy runbook as a canary.

## Sequencing note

Lands a `@tour-kit/license` patch bump (`1.1.2`). The follow-up cloud-JWT PR (#TBD) inherits this fix — without it, the JWT validation path (which adds JWKS + revocation fetches) would lengthen the loading window and make the SSR blackout even more visible.