### PR TITLE
feat(license): Cloud SDK JWT validation path (Plan 12C)

### DIFF
--- a/.changeset/license-cloud-jwt-validation.md
+++ b/.changeset/license-cloud-jwt-validation.md
@@ -1,0 +1,13 @@
+---
+'@tour-kit/license': minor
+---
+
+Add Cloud SDK JWT validation path for tokens minted by the Tour Kit dashboard (Plan 12C §12C.11).
+
+`validateLicenseKey()` now routes EdDSA-signed JWTs through `validateCloudToken()` before the Polar path. A paying Cloud customer can mint a JWT in their dashboard's `Settings → SDK tokens`, paste it into `NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY` / `VITE_TOUR_KIT_LICENSE_KEY`, and their Pro SDK packages light up without a separate Polar checkout. Existing `TOURKIT-` Polar keys keep working unchanged — the discriminator (`isCloudToken`) is purely structural.
+
+Verification steps follow Plan 12C §12C.11: decode header → hard-pin `alg=EdDSA` and `typ=JWT` (no algorithm dispatch — the verifier is hardcoded to Ed25519) → require HTTPS issuer (except localhost for self-host dev) → fetch JWKS from `${iss}/.well-known/jwks.json` with 1h cache → verify signature via `@noble/ed25519` (Web Crypto's native EdDSA only landed in Chrome 137, so polyfill keeps ~21% of users from breaking — Plan 12C D7) → enforce `exp` → fetch revocation list with 15min cache (fails open for revocation only on network failure; signature and expiry still fail closed) → enforce `aud` against current hostname (empty `aud` allowed with warning; localhost / 127.0.0.1 / *.local always pass).
+
+New exports from `@tour-kit/license` and `@tour-kit/license/headless`: `isCloudToken(key)`, `validateCloudToken(token)`. Adds `@noble/ed25519` (≈5 KB gz) as a direct dependency.
+
+Three regression test suites guard the security boundary: signature/expiry/revocation/aud happy-and-sad paths; algorithm-confusion forgery (HS256/RS256/none rejected before any signature work and before any network fetch); and a static check that no file in `src/` ever calls `subtle.verify` with an Ed25519 algorithm name.

--- a/.changeset/license-gate-ssr-default.md
+++ b/.changeset/license-gate-ssr-default.md
@@ -1,0 +1,9 @@
+---
+'@tour-kit/license': patch
+---
+
+Fix Pro-package SSR blackout in `<LicenseGate>` loading state.
+
+`LicenseProvider` validates the license inside a `useEffect`, which never fires during server rendering. That left `context.isLoading` `true` on every SSR pass, and `<LicenseGate>` (used internally by all 8 Pro packages since 1.1.0) returned `null` whenever no explicit `loading` prop was passed — wiping the entire Pro subtree from server HTML and forcing a pop-in on hydration. The release smoke app caught this as a missing `data-smoke-ok` marker on the curl probe.
+
+The loading branch now defaults to `children` instead of `null`. Consumers who want a skeleton during validation can still pass `loading={<Skeleton />}`; the watermark only renders once the gate decision is known.

--- a/apps/docs/lib/comparisons.ts
+++ b/apps/docs/lib/comparisons.ts
@@ -5823,10 +5823,8 @@ export const BLOG_POSTS: BlogMeta[] = [
   },
   {
     slug: 'may-2026-release-update',
-    title:
-      'userTourKit May 2026 release: codemods, testing helpers, and a soft-gate license',
-    metaTitle:
-      'userTourKit May 2026 release notes: codemods, testing-library, soft-gate license',
+    title: 'userTourKit May 2026 release: codemods, testing helpers, and a soft-gate license',
+    metaTitle: 'userTourKit May 2026 release notes: codemods, testing-library, soft-gate license',
     description:
       'Five phases shipped: @tour-kit/testing-library, @tour-kit/playwright, three migration codemods (Joyride, Shepherd, Driver), license soft-gate with try-before-buy watermark, and a Phase 8 QA pass covering analytics, accessibility, and autostart.',
     keywords: [

--- a/packages/license/package.json
+++ b/packages/license/package.json
@@ -72,6 +72,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@noble/ed25519": "^2.3.0",
     "zod": "catalog:"
   },
   "peerDependencies": {

--- a/packages/license/src/__tests__/cloud-token-alg-pinning.test.ts
+++ b/packages/license/src/__tests__/cloud-token-alg-pinning.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Plan 12C §12C.11 step 2 regression: the JWT verifier must reject any
+ * `header.alg` other than `EdDSA` BEFORE performing signature work.
+ *
+ * If the verifier ever dispatches on `header.alg`, a forged token with
+ * `alg: 'HS256'` plus the public key used as the HMAC secret would validate.
+ * Same risk class: `alg: 'none'` accepted unsigned tokens; `alg: 'RS256'` +
+ * the public key as an RSA verify key.
+ *
+ * This file forges tokens with each disallowed algorithm and confirms:
+ *   1. `validateCloudToken` returns `invalid` for every forge.
+ *   2. No network fetch happens — proving the rejection is upstream of the
+ *      JWKS/revocation hops where the actual signature check would occur.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { validateCloudToken } from '../lib/cloud-token'
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i] as number)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function jsonToBase64url(obj: unknown): string {
+  return bytesToBase64url(new TextEncoder().encode(JSON.stringify(obj)))
+}
+
+function forgeToken(header: Record<string, unknown>, payload: Record<string, unknown>): string {
+  // A 64-byte garbage signature. The algorithm pin must trip before anything
+  // tries to verify this against a real key.
+  const fakeSig = new Uint8Array(64)
+  return `${jsonToBase64url(header)}.${jsonToBase64url(payload)}.${bytesToBase64url(fakeSig)}`
+}
+
+const basePayload = {
+  iss: 'https://api.usertourkit.com',
+  sub: 'org_attacker',
+  aud: ['localhost'],
+  iat: Math.floor(Date.now() / 1000) - 60,
+  exp: Math.floor(Date.now() / 1000) + 3600,
+  jti: 'tok_FORGED',
+  tier: 'pro',
+  plan: 'pro',
+  packages: [],
+}
+
+describe('validateCloudToken — algorithm pinning (anti-forgery regression)', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(async () => {
+      throw new Error('fetch should NEVER be called when alg is rejected')
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each([
+    ['HS256', 'HMAC-with-pubkey-as-secret confusion'],
+    ['HS384', 'HMAC-with-pubkey-as-secret confusion'],
+    ['HS512', 'HMAC-with-pubkey-as-secret confusion'],
+    ['RS256', 'RSA-with-pubkey-as-key confusion'],
+    ['PS256', 'RSA-PSS confusion'],
+    ['ES256', 'ECDSA-P256 confusion'],
+    ['none', 'unsigned token acceptance'],
+    ['NONE', 'unsigned token acceptance (case variant)'],
+    ['', 'empty alg'],
+  ])('rejects header.alg=%s before any signature work (%s)', async (alg) => {
+    const token = forgeToken({ alg, kid: 'sdk-2026-05', typ: 'JWT' }, basePayload)
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects header.typ that is not JWT', async () => {
+    const token = forgeToken({ alg: 'EdDSA', kid: 'sdk-2026-05', typ: 'JWE' }, basePayload)
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a header missing kid', async () => {
+    const token = forgeToken({ alg: 'EdDSA', typ: 'JWT' }, basePayload)
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a payload missing iss/sub/jti', async () => {
+    const token = forgeToken(
+      { alg: 'EdDSA', kid: 'sdk-2026-05', typ: 'JWT' },
+      { aud: ['localhost'], exp: Math.floor(Date.now() / 1000) + 3600 }
+    )
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a payload with non-array aud (would crash aud.includes otherwise)', async () => {
+    const token = forgeToken(
+      { alg: 'EdDSA', kid: 'sdk-2026-05', typ: 'JWT' },
+      { ...basePayload, aud: 'app.example.com' as unknown as string[] }
+    )
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a payload with non-string entries in aud', async () => {
+    const token = forgeToken(
+      { alg: 'EdDSA', kid: 'sdk-2026-05', typ: 'JWT' },
+      { ...basePayload, aud: ['ok.com', 123 as unknown as string] }
+    )
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a payload where exp is a string instead of a number', async () => {
+    const token = forgeToken(
+      { alg: 'EdDSA', kid: 'sdk-2026-05', typ: 'JWT' },
+      { ...basePayload, exp: '9999999999' as unknown as number }
+    )
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/license/src/__tests__/cloud-token-no-subtle.test.ts
+++ b/packages/license/src/__tests__/cloud-token-no-subtle.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Plan 12C §12C.15 + D7 regression: the SDK bundle must NEVER call
+ * `crypto.subtle.verify({ name: 'Ed25519' }, …)`. Native Web Crypto Ed25519
+ * landed in Chrome 137 (May 2026); a regression to subtle.verify would
+ * silently watermark ~21% of customer end-users on older Chrome / Android
+ * WebViews / Electron despite a valid Pro token.
+ *
+ * This test is a static source-level check, not a behavioral test. It scans
+ * the built source for any Ed25519 + subtle.verify combination. The grep is
+ * deliberately wide (handles minified output, alternate quote styles, and
+ * spread-args), so a developer accidentally typing it anywhere — including a
+ * comment — would have to write it in a form this pattern doesn't catch.
+ *
+ * The signer side (issuer code) can keep using subtle.sign because it runs
+ * in Bun/Node, where Ed25519 has been supported since Node 18.4 / Bun 0.6.
+ * That code lives in `tourkit-dash/apps/api/src/sdk-tokens/issue.ts` and is
+ * out of scope for this package.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PACKAGE_ROOT = join(__dirname, '..')
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === '__tests__' || entry === 'node_modules' || entry === 'dist') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      walk(full, out)
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+describe('cloud-token bundle — no native Ed25519 in subtle.verify', () => {
+  it('does not call crypto.subtle.verify with an Ed25519 algorithm name anywhere in src/', () => {
+    const files = walk(PACKAGE_ROOT)
+    const offenders: Array<{ file: string; line: number; text: string }> = []
+
+    for (const file of files) {
+      const content = readFileSync(file, 'utf8')
+      const lines = content.split('\n')
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i] ?? ''
+        // Match subtle.verify(...) on the same line as an Ed25519 reference.
+        // Wide enough to catch object-arg, string-arg, and minified forms.
+        if (/subtle\.verify\b/.test(line) && /Ed25519/i.test(line)) {
+          offenders.push({ file, line: i + 1, text: line.trim() })
+        }
+      }
+    }
+
+    if (offenders.length > 0) {
+      const detail = offenders
+        .map((o) => `  ${o.file.replace(PACKAGE_ROOT, 'src')}:${o.line}\n    ${o.text}`)
+        .join('\n')
+      throw new Error(
+        `Plan 12C D7 violation: subtle.verify({ name: 'Ed25519' }) found. Use @noble/ed25519's verifyAsync instead.\n${detail}`
+      )
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/license/src/__tests__/cloud-token.test.ts
+++ b/packages/license/src/__tests__/cloud-token.test.ts
@@ -1,0 +1,299 @@
+import * as ed25519 from '@noble/ed25519'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isCloudToken, validateCloudToken } from '../lib/cloud-token'
+
+const ISS = 'https://api.usertourkit.com'
+const KID = 'sdk-2026-05'
+const ORIGIN_HOST = 'app.example.com'
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i] as number)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function jsonToBase64url(obj: unknown): string {
+  return bytesToBase64url(new TextEncoder().encode(JSON.stringify(obj)))
+}
+
+type SignOptions = {
+  alg?: string
+  typ?: string
+  kid?: string
+  iss?: string
+  sub?: string
+  aud?: string[]
+  iat?: number
+  exp?: number
+  jti?: string
+  tier?: string
+  signWith?: Uint8Array
+}
+
+async function signToken(privateKey: Uint8Array, opts: SignOptions = {}): Promise<string> {
+  const header = {
+    alg: opts.alg ?? 'EdDSA',
+    kid: opts.kid ?? KID,
+    typ: opts.typ ?? 'JWT',
+  }
+  const now = Math.floor(Date.now() / 1000)
+  const payload = {
+    iss: opts.iss ?? ISS,
+    sub: opts.sub ?? 'org_abc123',
+    aud: opts.aud ?? [ORIGIN_HOST],
+    iat: opts.iat ?? now - 60,
+    exp: opts.exp ?? now + 3600,
+    jti: opts.jti ?? 'tok_01HYTEST',
+    tier: opts.tier ?? 'pro',
+    plan: opts.tier ?? 'pro',
+    packages: ['adoption', 'ai', 'analytics'],
+  }
+  const signingInput = `${jsonToBase64url(header)}.${jsonToBase64url(payload)}`
+  const signKey = opts.signWith ?? privateKey
+  const signature = await ed25519.signAsync(new TextEncoder().encode(signingInput), signKey)
+  return `${signingInput}.${bytesToBase64url(signature)}`
+}
+
+type FetchMock = ReturnType<typeof vi.fn>
+
+function mockFetchOk(jwks: { keys: unknown[] }, revoked: Array<{ jti: string; revokedAt: string }>) {
+  const fetchMock: FetchMock = vi.fn(async (url: string) => {
+    if (url.endsWith('/.well-known/jwks.json')) {
+      return { ok: true, status: 200, json: async () => jwks } as Response
+    }
+    if (url.endsWith('/.well-known/tourkit-sdk-revocations.json')) {
+      return { ok: true, status: 200, json: async () => ({ revoked }) } as Response
+    }
+    throw new Error(`Unexpected fetch ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function setHostname(hostname: string) {
+  Object.defineProperty(window, 'location', {
+    value: new URL(`https://${hostname}/path`),
+    writable: true,
+  })
+}
+
+describe('isCloudToken', () => {
+  it('returns false for empty string', () => {
+    expect(isCloudToken('')).toBe(false)
+  })
+
+  it('returns false for Polar TOURKIT- keys', () => {
+    expect(isCloudToken('TOURKIT-abc-123-xyz')).toBe(false)
+  })
+
+  it('returns true for a valid three-segment base64url JWT', () => {
+    expect(isCloudToken('eyJhbGciOiJFZERTQSJ9.eyJzdWIiOiJ4In0.aGVsbG8td29ybGQ')).toBe(true)
+  })
+
+  it('returns false for two-segment input', () => {
+    expect(isCloudToken('eyJhbGciOiJFZERTQSJ9.eyJzdWIiOiJ4In0')).toBe(false)
+  })
+
+  it('returns false when a segment contains non-base64url characters', () => {
+    expect(isCloudToken('eyJ!.eyJzdWIiOiJ4In0.aGVsbG8')).toBe(false)
+  })
+
+  it('returns false when any segment is empty', () => {
+    expect(isCloudToken('eyJhbGciOiJFZERTQSJ9..aGVsbG8')).toBe(false)
+  })
+})
+
+describe('validateCloudToken', () => {
+  let privateKey: Uint8Array
+  let publicKey: Uint8Array
+  let jwks: { keys: Array<{ kty: string; crv: string; kid: string; x: string }> }
+
+  beforeEach(async () => {
+    localStorage.clear()
+    setHostname(ORIGIN_HOST)
+    privateKey = ed25519.utils.randomPrivateKey()
+    publicKey = await ed25519.getPublicKeyAsync(privateKey)
+    jwks = {
+      keys: [{ kty: 'OKP', crv: 'Ed25519', kid: KID, x: bytesToBase64url(publicKey) }],
+    }
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('returns valid pro state for a well-formed signed token (happy path)', async () => {
+    mockFetchOk(jwks, [])
+    const token = await signToken(privateKey)
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('valid')
+    expect(state.tier).toBe('pro')
+    expect(state.renderKey).toBeDefined()
+    expect(state.renderKey).toHaveLength(24)
+    expect(state.expiresAt).not.toBeNull()
+    expect(state.domain).toBe(ORIGIN_HOST)
+  })
+
+  it('rejects a malformed token (not three segments)', async () => {
+    const state = await validateCloudToken('not.a.valid.jwt.here')
+    expect(state.status).toBe('invalid')
+  })
+
+  it('rejects a token whose signature does not verify (signed by a different key)', async () => {
+    mockFetchOk(jwks, [])
+    const otherKey = ed25519.utils.randomPrivateKey()
+    const token = await signToken(privateKey, { signWith: otherKey })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+  })
+
+  it('returns expired when `exp` is in the past', async () => {
+    mockFetchOk(jwks, [])
+    const past = Math.floor(Date.now() / 1000) - 60
+    const token = await signToken(privateKey, { exp: past, iat: past - 3600 })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('expired')
+    expect(state.tier).toBe('pro')
+    expect(state.expiresAt).not.toBeNull()
+  })
+
+  it('returns revoked when the jti is on the revocation list', async () => {
+    mockFetchOk(jwks, [{ jti: 'tok_REVOKED', revokedAt: new Date().toISOString() }])
+    const token = await signToken(privateKey, { jti: 'tok_REVOKED' })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('revoked')
+  })
+
+  it('rejects when current hostname is not in aud and aud is not empty', async () => {
+    mockFetchOk(jwks, [])
+    setHostname('evil.com')
+    const token = await signToken(privateKey, { aud: ['app.example.com'] })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+  })
+
+  it('accepts on localhost regardless of aud', async () => {
+    mockFetchOk(jwks, [])
+    setHostname('localhost')
+    const token = await signToken(privateKey, { aud: ['app.example.com'] })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('valid')
+    expect(state.tier).toBe('pro')
+  })
+
+  it('accepts on a *.local host regardless of aud', async () => {
+    mockFetchOk(jwks, [])
+    setHostname('myapp.local')
+    const token = await signToken(privateKey, { aud: ['app.example.com'] })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('valid')
+  })
+
+  it('warns and accepts when aud is empty', async () => {
+    mockFetchOk(jwks, [])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const token = await signToken(privateKey, { aud: [] })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('valid')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no allowed domains'))
+  })
+
+  it('returns error when JWKS is unreachable and no cache is present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down')
+      })
+    )
+    const token = await signToken(privateKey)
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('error')
+  })
+
+  it('uses cached JWKS when the network fails on a second call', async () => {
+    const okMock = mockFetchOk(jwks, [])
+    const token = await signToken(privateKey)
+    const first = await validateCloudToken(token)
+    expect(first.status).toBe('valid')
+
+    // Network drops; cached JWKS + cached revocations should keep it valid.
+    okMock.mockImplementation(async () => {
+      throw new Error('network down')
+    })
+    const second = await validateCloudToken(token)
+    expect(second.status).toBe('valid')
+  })
+
+  it('fails open for revocation when the list is unreachable (signature still enforced)', async () => {
+    const fetchMock: FetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/.well-known/jwks.json')) {
+        return { ok: true, status: 200, json: async () => jwks } as Response
+      }
+      throw new Error('revocations endpoint down')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const token = await signToken(privateKey)
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('valid')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('revocation list'))
+  })
+
+  it('rejects a non-HTTPS issuer that is not localhost', async () => {
+    const token = await signToken(privateKey, { iss: 'http://evil.example.com' })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+  })
+
+  it('accepts a http://localhost issuer (self-host dev)', async () => {
+    mockFetchOk(jwks, [])
+    const token = await signToken(privateKey, { iss: 'http://localhost:8787' })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('valid')
+  })
+
+  it('rejects when the kid in the header is unknown to the JWKS', async () => {
+    mockFetchOk(jwks, [])
+    const token = await signToken(privateKey, { kid: 'unknown-kid' })
+
+    const state = await validateCloudToken(token)
+
+    expect(state.status).toBe('invalid')
+  })
+
+  it('derives renderKey from sha256(`${jti}:${sub}`) — deterministic across calls', async () => {
+    mockFetchOk(jwks, [])
+    const token = await signToken(privateKey, { jti: 'tok_DETERMINISTIC', sub: 'org_xyz' })
+
+    const a = await validateCloudToken(token)
+    const b = await validateCloudToken(token)
+
+    expect(a.renderKey).toBe(b.renderKey)
+    expect(a.renderKey).toHaveLength(24)
+  })
+})

--- a/packages/license/src/__tests__/cloud-token.test.ts
+++ b/packages/license/src/__tests__/cloud-token.test.ts
@@ -56,7 +56,10 @@ async function signToken(privateKey: Uint8Array, opts: SignOptions = {}): Promis
 
 type FetchMock = ReturnType<typeof vi.fn>
 
-function mockFetchOk(jwks: { keys: unknown[] }, revoked: Array<{ jti: string; revokedAt: string }>) {
+function mockFetchOk(
+  jwks: { keys: unknown[] },
+  revoked: Array<{ jti: string; revokedAt: string }>
+) {
   const fetchMock: FetchMock = vi.fn(async (url: string) => {
     if (url.endsWith('/.well-known/jwks.json')) {
       return { ok: true, status: 200, json: async () => jwks } as Response

--- a/packages/license/src/__tests__/license-gate.test.tsx
+++ b/packages/license/src/__tests__/license-gate.test.tsx
@@ -145,7 +145,7 @@ describe('LicenseGate', () => {
     expect(screen.queryByTestId('pro-content')).not.toBeInTheDocument()
   })
 
-  it('renders null when no loading slot provided and loading', () => {
+  it('renders children when no loading slot provided and loading (SSR-safe default)', () => {
     mockValidate.mockImplementation(() => new Promise(() => {}))
 
     render(
@@ -156,7 +156,8 @@ describe('LicenseGate', () => {
       </LicenseProvider>
     )
 
-    expect(screen.queryByTestId('pro-content')).not.toBeInTheDocument()
+    expect(screen.getByTestId('pro-content')).toBeInTheDocument()
+    expect(findWatermark()).toBeNull()
   })
 
   it('renders children plus badge when tier is free but pro is required', async () => {
@@ -359,5 +360,25 @@ describe('LicenseGate', () => {
         </LicenseGate>
       )
     }).not.toThrow()
+  })
+
+  it('renderToString emits children inside a LicenseProvider (no SSR blackout)', () => {
+    // Provider starts in the loading state and validates inside `useEffect`,
+    // which never runs on the server. The gate must render `children` in that
+    // state or every Pro provider's subtree disappears from SSR HTML — the
+    // exact regression Plan 12C inherits and the release smoke probe caught.
+    mockIsDev.mockReturnValue(false)
+    mockValidate.mockImplementation(() => new Promise(() => {}))
+
+    const html = renderToString(
+      <LicenseProvider licenseKey="TOURKIT_key">
+        <LicenseGate require="pro">
+          <div data-ssr-marker="pro">Pro Feature</div>
+        </LicenseGate>
+      </LicenseProvider>
+    )
+
+    expect(html).toContain('data-ssr-marker="pro"')
+    expect(html).toContain('Pro Feature')
   })
 })

--- a/packages/license/src/components/license-gate.tsx
+++ b/packages/license/src/components/license-gate.tsx
@@ -31,7 +31,11 @@ export function LicenseGate({ require: _require, children, fallback, loading }: 
     )
   }
 
-  if (context.isLoading) return <>{loading ?? null}</>
+  // Loading default is children, not null: `useEffect` doesn't fire during SSR,
+  // so the loading state is the *only* state the server ever sees. Returning
+  // null here blanks every Pro provider's subtree in SSR HTML and forces a
+  // post-hydration pop-in. Consumers who want a skeleton still pass `loading`.
+  if (context.isLoading) return <>{loading ?? children}</>
   if (!context.isGated) return <>{children}</>
   if (fallback) return <>{fallback}</>
 

--- a/packages/license/src/headless.ts
+++ b/packages/license/src/headless.ts
@@ -19,6 +19,9 @@ export {
   PolarParseError,
 } from './lib/polar-client'
 
+// Cloud SDK JWT (Plan 12C)
+export { isCloudToken, validateCloudToken, CLOUD_TOKEN_TTL } from './lib/cloud-token'
+
 // Cache
 export { readCache, writeCache, clearCache, hasFreshCache } from './lib/cache'
 

--- a/packages/license/src/index.ts
+++ b/packages/license/src/index.ts
@@ -34,4 +34,5 @@ export type { LicenseGateResult } from './hooks/use-license-gate'
 
 // Headless utilities (re-exported for convenience)
 export { validateLicenseKey } from './lib/polar-client'
+export { isCloudToken, validateCloudToken } from './lib/cloud-token'
 export { isDevEnvironment, getCurrentDomain } from './lib/domain'

--- a/packages/license/src/lib/cache.ts
+++ b/packages/license/src/lib/cache.ts
@@ -3,6 +3,41 @@ import { LicenseCacheSchema } from './schemas'
 
 const CACHE_PREFIX = 'tourkit:license:'
 const CACHE_TTL_MS = 72 * 60 * 60 * 1000 // 72 hours
+const DOC_CACHE_PREFIX = 'tourkit:doc:'
+
+/**
+ * Generic public-document cache for short-lived signed-config fetches
+ * (Cloud SDK JWKS + revocation list). Separate from the license-state cache
+ * so the two paths can't key-collide and so TTLs can differ. Used by
+ * `lib/cloud-token.ts`; nothing else should depend on this shape.
+ */
+export function readDocumentCache<T>(key: string, ttlMs: number): T | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(`${DOC_CACHE_PREFIX}${key}`)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { value: T; cachedAt: number }
+    if (Date.now() - parsed.cachedAt > ttlMs) {
+      localStorage.removeItem(`${DOC_CACHE_PREFIX}${key}`)
+      return null
+    }
+    return parsed.value
+  } catch {
+    return null
+  }
+}
+
+export function writeDocumentCache<T>(key: string, value: T): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(
+      `${DOC_CACHE_PREFIX}${key}`,
+      JSON.stringify({ value, cachedAt: Date.now() })
+    )
+  } catch {
+    // localStorage quota exceeded — fail silently, network will refetch
+  }
+}
 
 // Deterministic short hash. Not a security primitive — used only to bind a
 // cache entry to the license key it was issued for, so switching `licenseKey`

--- a/packages/license/src/lib/cloud-token.ts
+++ b/packages/license/src/lib/cloud-token.ts
@@ -1,0 +1,301 @@
+/**
+ * Cloud SDK token (JWT) validator.
+ *
+ * Validates EdDSA-signed JWTs minted by the Tour Kit Cloud dashboard
+ * (`/settings/sdk-tokens`) or by a customer's own self-host dashboard. The
+ * server side is documented in Plan 12C; this module implements §12C.11 of
+ * that plan.
+ *
+ * Why `@noble/ed25519` instead of Web Crypto's native EdDSA (Plan 12C D7):
+ *   Native Web Crypto support for the curve only landed in Chrome 137
+ *   (May 2026). Combined coverage of Chrome 137+ / Firefox 129+ / Safari 17+
+ *   is ≈79% of customer end-users; the remaining ≈21% would see
+ *   `NotSupportedError` and a watermark despite a valid Pro token.
+ *   `@noble/ed25519` runs in every JS runtime and adds ≈5 KB gzipped.
+ *   The static check in `cloud-token-no-subtle.test.ts` enforces this rule.
+ *
+ * Algorithm pinning (Plan 12C §12C.11 step 2):
+ *   The verifier hard-codes Ed25519. `header.alg` is checked equal to
+ *   `'EdDSA'` and discarded — never passed to a verifier dispatcher. Passing
+ *   the header alg in is the classic JWT algorithm-confusion attack vector
+ *   (e.g. forged `alg: 'HS256'` token + public key used as HMAC secret).
+ */
+import * as ed25519 from '@noble/ed25519'
+import type { LicenseState } from '../types'
+import { readDocumentCache, writeDocumentCache } from './cache'
+import { getCurrentDomain, isDevEnvironment } from './domain'
+
+const JWKS_CACHE_TTL_MS = 60 * 60 * 1000 // 1h (matches CDN max-age=3600)
+const REVOCATIONS_CACHE_TTL_MS = 15 * 60 * 1000 // 15min (matches D6 SLO)
+const RENDER_KEY_LENGTH = 24
+
+const DEV_HOSTNAMES = new Set(['localhost', '127.0.0.1'])
+const DEV_SUFFIX = '.local'
+
+type Jwk = { kty: string; crv: string; x: string; kid: string }
+type JwksResponse = { keys: Jwk[] }
+type RevocationsResponse = { revoked: Array<{ jti: string; revokedAt: string }> }
+
+type JwtHeader = { alg: string; kid: string; typ: string }
+type JwtPayload = {
+  iss: string
+  sub: string
+  aud: string[]
+  iat: number
+  exp: number
+  jti: string
+  tier: 'starter' | 'pro' | 'business' | 'enterprise'
+  plan: string
+  packages: string[]
+}
+
+/**
+ * Distinguishes a Cloud JWT from a Polar key. The discriminator is purely
+ * structural — Polar keys start with `TOURKIT-`; JWTs are three base64url
+ * segments separated by `.`. False positives are impossible for any real
+ * Polar key (they contain a literal hyphen, not a dot).
+ */
+export function isCloudToken(key: string): boolean {
+  if (key.startsWith('TOURKIT-')) return false
+  const parts = key.split('.')
+  return parts.length === 3 && parts.every((p) => p.length > 0 && /^[A-Za-z0-9_-]+$/.test(p))
+}
+
+function base64urlToBytes(b64url: string): Uint8Array {
+  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - (b64url.length % 4)) % 4)
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+function base64urlToJson<T>(b64url: string): T {
+  const bytes = base64urlToBytes(b64url)
+  const text = new TextDecoder().decode(bytes)
+  return JSON.parse(text) as T
+}
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i] as number)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function isLocalHost(hostname: string): boolean {
+  return DEV_HOSTNAMES.has(hostname) || hostname.endsWith(DEV_SUFFIX)
+}
+
+/**
+ * Plan 12C.4 — renderKey = base64url(sha256(`${jti}:${sub}`)).slice(0, 24).
+ * Keeps the LicenseGate anti-bypass primitive intact without exposing the
+ * raw JWT to any consumer that reads `LicenseState`.
+ */
+async function computeRenderKey(jti: string, sub: string): Promise<string> {
+  const input = new TextEncoder().encode(`${jti}:${sub}`)
+  const hash = await crypto.subtle.digest('SHA-256', input)
+  return bytesToBase64url(new Uint8Array(hash)).slice(0, RENDER_KEY_LENGTH)
+}
+
+async function fetchJwks(iss: string): Promise<JwksResponse | null> {
+  const cacheKey = `jwks:${iss}`
+  try {
+    const res = await fetch(`${iss}/.well-known/jwks.json`, { credentials: 'omit' })
+    if (!res.ok) throw new Error(`jwks ${res.status}`)
+    const json = (await res.json()) as JwksResponse
+    writeDocumentCache(cacheKey, json)
+    return json
+  } catch {
+    // Network failure: fall back to fresh cache if present. Signature still
+    // fails closed if no cache is available — the caller propagates `error`.
+    return readDocumentCache<JwksResponse>(cacheKey, JWKS_CACHE_TTL_MS)
+  }
+}
+
+async function fetchRevocations(iss: string): Promise<RevocationsResponse> {
+  const cacheKey = `rev:${iss}`
+  try {
+    const res = await fetch(`${iss}/.well-known/tourkit-sdk-revocations.json`, {
+      credentials: 'omit',
+    })
+    if (!res.ok) throw new Error(`revocations ${res.status}`)
+    const json = (await res.json()) as RevocationsResponse
+    writeDocumentCache(cacheKey, json)
+    return json
+  } catch {
+    // Plan 12C §12C.11 network behavior: revocation fetch failure fails OPEN
+    // for revocation only (signature/exp still fail closed). Warn loudly so a
+    // CSP/CDN misconfiguration surfaces in customer error monitoring instead
+    // of silently masking a revoked token.
+    const cached = readDocumentCache<RevocationsResponse>(cacheKey, REVOCATIONS_CACHE_TTL_MS)
+    if (cached) return cached
+    console.warn(
+      '[tour-kit/license] Could not fetch SDK revocation list; failing open for revocation only. Signature and expiry still enforced.'
+    )
+    return { revoked: [] }
+  }
+}
+
+function jwkToPublicKeyBytes(jwk: Jwk): Uint8Array {
+  if (jwk.kty !== 'OKP' || jwk.crv !== 'Ed25519') {
+    throw new Error(`Unsupported JWK kty/crv: ${jwk.kty}/${jwk.crv}`)
+  }
+  return base64urlToBytes(jwk.x)
+}
+
+function errorState(now: number): LicenseState {
+  return {
+    status: 'error',
+    tier: 'free',
+    activations: 0,
+    maxActivations: 0,
+    domain: null,
+    expiresAt: null,
+    validatedAt: now,
+    renderKey: undefined,
+  }
+}
+
+function invalidState(now: number): LicenseState {
+  return {
+    status: 'invalid',
+    tier: 'free',
+    activations: 0,
+    maxActivations: 0,
+    domain: null,
+    expiresAt: null,
+    validatedAt: now,
+    renderKey: undefined,
+  }
+}
+
+function revokedState(now: number, expiresAt: string | null): LicenseState {
+  return {
+    status: 'revoked',
+    tier: 'free',
+    activations: 0,
+    maxActivations: 0,
+    domain: null,
+    expiresAt,
+    validatedAt: now,
+    renderKey: undefined,
+  }
+}
+
+function expiredState(now: number, expiresAt: string | null): LicenseState {
+  return {
+    status: 'expired',
+    tier: 'pro',
+    activations: 0,
+    maxActivations: 0,
+    domain: null,
+    expiresAt,
+    validatedAt: now,
+    renderKey: undefined,
+  }
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: validator orchestrates the 9 steps from Plan 12C §12C.11
+export async function validateCloudToken(token: string): Promise<LicenseState> {
+  const now = Date.now()
+  const parts = token.split('.')
+  if (parts.length !== 3) return invalidState(now)
+  const [encodedHeader, encodedPayload, encodedSignature] = parts as [string, string, string]
+
+  // 1-2. Decode + algorithm pinning. Reject before any signature work so
+  //      algorithm-confusion attempts (alg=HS256, alg=none, alg=RS256) never
+  //      reach the verifier.
+  let header: JwtHeader
+  let payload: JwtPayload
+  try {
+    header = base64urlToJson<JwtHeader>(encodedHeader)
+    payload = base64urlToJson<JwtPayload>(encodedPayload)
+  } catch {
+    return invalidState(now)
+  }
+  if (header.alg !== 'EdDSA' || header.typ !== 'JWT') return invalidState(now)
+  if (
+    typeof header.kid !== 'string' ||
+    typeof payload.iss !== 'string' ||
+    typeof payload.sub !== 'string' ||
+    typeof payload.jti !== 'string' ||
+    typeof payload.exp !== 'number' ||
+    !Array.isArray(payload.aud) ||
+    !payload.aud.every((d) => typeof d === 'string')
+  ) {
+    return invalidState(now)
+  }
+
+  // 3. Require HTTPS issuer, except for local/self-host dev origins.
+  const issIsHttps = payload.iss.startsWith('https://')
+  const issIsLocalhost =
+    payload.iss.startsWith('http://localhost') || payload.iss.startsWith('http://127.0.0.1')
+  if (!issIsHttps && !issIsLocalhost) return invalidState(now)
+
+  // 4. Fetch JWKS (with 1h cache fallback on network failure). Defend against
+  //    a malformed response — we're at a system boundary, and a cached
+  //    malformed JWKS would otherwise crash every subsequent validation.
+  const jwks = await fetchJwks(payload.iss)
+  if (!jwks || !Array.isArray(jwks.keys)) return errorState(now)
+  const jwk = jwks.keys.find((k) => k && k.kid === header.kid)
+  if (!jwk) return invalidState(now)
+
+  // 5. Verify Ed25519 signature. The algorithm is HARDCODED — never picked
+  //    from `header.alg`. See module doc comment for the attack model.
+  let signatureValid: boolean
+  try {
+    const publicKey = jwkToPublicKeyBytes(jwk)
+    const signature = base64urlToBytes(encodedSignature)
+    const message = new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`)
+    signatureValid = await ed25519.verifyAsync(signature, message, publicKey)
+  } catch {
+    return invalidState(now)
+  }
+  if (!signatureValid) return invalidState(now)
+
+  // 6. Check exp / iat. iat is informational — we don't reject tokens issued
+  //    in the future to absorb client/server clock drift, but exp is hard.
+  const nowSec = Math.floor(now / 1000)
+  const expiresAtIso = new Date(payload.exp * 1000).toISOString()
+  if (payload.exp <= nowSec) return expiredState(now, expiresAtIso)
+
+  // 7. Check revocation list (fails OPEN on network failure — see fetchRevocations).
+  const revocations = await fetchRevocations(payload.iss)
+  if (revocations.revoked.some((r) => r.jti === payload.jti)) {
+    return revokedState(now, expiresAtIso)
+  }
+
+  // 8. Check `aud` against the current hostname. Empty `aud` is allowed with
+  //    a warning (intentional: simplifies preview/local onboarding). Localhost
+  //    bypass mirrors the dev environment policy used by Polar keys.
+  const hostname = getCurrentDomain()
+  if (payload.aud.length === 0) {
+    console.warn(
+      '[tour-kit/license] Cloud SDK token has no allowed domains. Token will be accepted on any host. Set allowed domains in Settings → SDK tokens to restrict it.'
+    )
+  } else if (hostname !== null && !isLocalHost(hostname) && !payload.aud.includes(hostname)) {
+    return invalidState(now)
+  }
+
+  // 9. Return valid Pro state with anti-bypass renderKey.
+  const renderKey = await computeRenderKey(payload.jti, payload.sub)
+  return {
+    status: 'valid',
+    tier: 'pro',
+    activations: 0,
+    maxActivations: 0,
+    domain: hostname,
+    expiresAt: expiresAtIso,
+    validatedAt: now,
+    renderKey,
+  }
+}
+
+/**
+ * Re-export `isDevEnvironment` and the cache TTL constants for tests and for
+ * any downstream consumer that wants to mirror the SDK's caching policy.
+ */
+export { isDevEnvironment }
+export const CLOUD_TOKEN_TTL = {
+  jwksMs: JWKS_CACHE_TTL_MS,
+  revocationsMs: REVOCATIONS_CACHE_TTL_MS,
+}

--- a/packages/license/src/lib/cloud-token.ts
+++ b/packages/license/src/lib/cloud-token.ts
@@ -62,7 +62,8 @@ export function isCloudToken(key: string): boolean {
 }
 
 function base64urlToBytes(b64url: string): Uint8Array {
-  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - (b64url.length % 4)) % 4)
+  const b64 =
+    b64url.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - (b64url.length % 4)) % 4)
   const binary = atob(b64)
   const bytes = new Uint8Array(binary.length)
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)

--- a/packages/license/src/lib/polar-client.ts
+++ b/packages/license/src/lib/polar-client.ts
@@ -1,6 +1,7 @@
 import type { ZodError } from 'zod'
 import type { LicenseState, PolarActivateResponse, PolarValidateResponse } from '../types'
 import { readCache, writeCache } from './cache'
+import { isCloudToken, validateCloudToken } from './cloud-token'
 import { getCurrentDomain, isDevEnvironment } from './domain'
 import { createDevBypassState, createUnlicensedState, normalizeLicenseKey } from './license-state'
 import { PolarActivateResponseSchema, PolarValidateResponseSchema } from './schemas'
@@ -199,6 +200,14 @@ export async function validateLicenseKey(
   //    sees the same unlicensed watermark locally that production would show.
   if (normalizedKey.length === 0) {
     return createUnlicensedState(now)
+  }
+
+  // 0a. Cloud SDK JWT path (Plan 12C). Routed BEFORE the dev bypass so a
+  //     paying Cloud customer on localhost gets real entitlement from their
+  //     dashboard-minted JWT instead of the dev-bypass mask. The discriminator
+  //     is purely structural; Polar `TOURKIT-...` keys never match.
+  if (isCloudToken(normalizedKey)) {
+    return validateCloudToken(normalizedKey)
   }
 
   // 1. Dev bypass — only for non-empty keys. We do not validate locally

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,16 +121,16 @@ importers:
     dependencies:
       '@next/third-parties':
         specifier: ^16.2.4
-        version: 16.2.4(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
+        version: 16.2.4(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
       '@polar-sh/nextjs':
         specifier: ^0.9.5
-        version: 0.9.5(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))
+        version: 0.9.5(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))
       '@polar-sh/sdk':
         specifier: ^0.46.7
         version: 0.46.7
       '@radix-ui/react-popover':
         specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
       '@tour-kit/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -148,28 +148,28 @@ importers:
         version: 5.2.0
       fumadocs-core:
         specifier: ^16.4.1
-        version: 16.7.6(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.468.0(react@19.3.0-canary-ad5dfc82-20260427))(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react-router@7.13.2(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)(zod@4.3.6)
+        version: 16.7.6(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.468.0(react@19.3.0-canary-d5736f09-20260507))(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react-router@7.13.2(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)(zod@4.3.6)
       fumadocs-mdx:
         specifier: ^14.2.3
-        version: 14.2.11(3bmcn22oklcr5hnvpyhrmkhove)
+        version: 14.2.11(gkxxrli33jgaidf37a2byjyony)
       fumadocs-ui:
         specifier: ^16.4.1
-        version: 16.7.6(yaec5ghbp5b6citim3dgjph3ju)
+        version: 16.7.6(hwcemfswwdn5of7ey4eszehzdu)
       geist:
         specifier: ^1.3.1
-        version: 1.7.0(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))
+        version: 1.7.0(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))
       lucide-react:
         specifier: ^0.468.0
-        version: 0.468.0(react@19.3.0-canary-ad5dfc82-20260427)
+        version: 0.468.0(react@19.3.0-canary-d5736f09-20260507)
       next:
         specifier: canary
-        version: 16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
+        version: 16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
       react:
         specifier: canary
-        version: 19.3.0-canary-ad5dfc82-20260427
+        version: 19.3.0-canary-d5736f09-20260507
       react-dom:
         specifier: canary
-        version: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+        version: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
       resend:
         specifier: ^6.12.2
         version: 6.12.2
@@ -249,7 +249,7 @@ importers:
         version: 25.5.0
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -629,7 +629,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -684,7 +684,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -739,7 +739,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -824,7 +824,7 @@ importers:
         version: 4.2.2
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -894,7 +894,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -919,7 +919,7 @@ importers:
         version: 22.19.15
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -971,7 +971,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1044,7 +1044,7 @@ importers:
         version: 4.2.2
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1057,6 +1057,9 @@ importers:
 
   packages/license:
     dependencies:
+      '@noble/ed25519':
+        specifier: ^2.3.0
+        version: 2.3.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1090,7 +1093,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1151,7 +1154,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1191,7 +1194,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1270,7 +1273,7 @@ importers:
         version: 4.2.2
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1313,7 +1316,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1386,7 +1389,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1438,7 +1441,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2626,8 +2629,8 @@ packages:
   '@next/env@16.2.4':
     resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
-  '@next/env@16.3.0-canary.5':
-    resolution: {integrity: sha512-2d9optG3mMmgELz6DXFHqdSoT11dXIz6rlzjcStWjAFL+sRa0R8QQX7odNuJPa//i+YGhEScoec4T5CcWiJWEA==}
+  '@next/env@16.3.0-canary.23':
+    resolution: {integrity: sha512-D91zFvTyZjpQtPeje2vk4woXdQZaCGUT0GSlNOZ0ixvxSwqnkFUdnPKqXgSMgrEiw+WTZQRW7CCCGEWMngTrOg==}
 
   '@next/eslint-plugin-next@16.2.4':
     resolution: {integrity: sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==}
@@ -2644,8 +2647,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@16.3.0-canary.5':
-    resolution: {integrity: sha512-2Ht2PgvE5s37L39TWst2Y64gn4mT1WhgVzykPzDf/zAjWgKiklFwvBEmUw6c/6narIARJoDTmyW5rF4B4LZA9w==}
+  '@next/swc-darwin-arm64@16.3.0-canary.23':
+    resolution: {integrity: sha512-okKLazWbEog/eLqyAlDjcJXgIbc3W3Ntx0fs7l7Zzk6J/GM4HngMyTsLSvpEmJjnL3sdEocIIZYOonhqifOhag==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2662,8 +2665,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.0-canary.5':
-    resolution: {integrity: sha512-bJ2BoqNZZo+mK/rkdGRvkZC4nS6Eq6dKYqAUnEYWOR9WT10PQcU//z9xJSoDpWYWfCpubngSVEkjqpXiUhMsnA==}
+  '@next/swc-darwin-x64@16.3.0-canary.23':
+    resolution: {integrity: sha512-tsV7tkF0SmtgUtcr1kkCAByJ/tEg04t3q9+jmJN+2ELylzrm5E6aUrIGJI72gFyiK8VNzkHa5vaYtvV3KpeuQA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -2680,8 +2683,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.5':
-    resolution: {integrity: sha512-5th20Yf2HlIvjA09DOIdPx5w7C5MmWxPnLSFr96Y6Vqrj1jCGVfU6g8TmxHVeus1RtqohvIxeO7rE7TNut3Yig==}
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.23':
+    resolution: {integrity: sha512-DlqByKvPWQ6Wm8N9Am9jANl+JUKdnEbiUmokkw2MScP+RtEisNk94OAhkeBkAQHJNxrQMOTQnZRZk/u+Aq7Atw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2698,8 +2701,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.5':
-    resolution: {integrity: sha512-Ghy2CYNlcURs88E2N2W80wt0wng57hkHMX4a55DEiQzFTEK1K8mnxWyRbGcwLOWILJmyLwRn+x+fwehNBzIqXA==}
+  '@next/swc-linux-arm64-musl@16.3.0-canary.23':
+    resolution: {integrity: sha512-df/pINXQBriMT57WvceeVtQwDU8NyQXYYjrPn3vfYtu0TExLipw+cWzVgnRSAi2GHYvL72+3KKRAlm5+smOzEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2716,8 +2719,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.5':
-    resolution: {integrity: sha512-htMLkprT48bnPTraxeI4+vjOrvZbmf9M2cqQWFfpbEaHdwV54bbxUl1hYw1krNp6PB4YBi4nuE0Pso2psfI17g==}
+  '@next/swc-linux-x64-gnu@16.3.0-canary.23':
+    resolution: {integrity: sha512-b10B0BgbTXeYKIzLh7LyDVflHdcOQPz12LPnNxDciMweFtVBJfpTkPVVkNAyHg4Iv4dxcxW288zswryREnA8Ew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2734,8 +2737,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.5':
-    resolution: {integrity: sha512-WMq5f5iB9KyoQQ2QkqjEli5I2HV1a4vlqNE3VAHpqfA6S0TuQOAXqut7YxPNm4Yvio2hnYvLQFcK4RQsPnFM/w==}
+  '@next/swc-linux-x64-musl@16.3.0-canary.23':
+    resolution: {integrity: sha512-a6ZxxqGvr3bSqUmr1PI4ZkxHLqJdN+N2lm4E2zI+pfDt7848sjXFbTSo8Mi31epe2ZUCb6LZO6L1SpQrrkUbKw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2752,8 +2755,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.5':
-    resolution: {integrity: sha512-MeyDRAIXQ1hwP0ttq8tZ7GATPgLS581CZdYt7/5NqOP1A65OI7jrxZnMoGQNDRaIgaug22T9KfnyCAXsAwI/NQ==}
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.23':
+    resolution: {integrity: sha512-AAjCpdJnPLPEIalxqaUsJ3vEGB/gi6CBbzPjThxucZuLezerNoDaFEmas6hUceRvdEKPG/IKT0YcrOcM2GCQgg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -2770,8 +2773,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.5':
-    resolution: {integrity: sha512-Jv4bUns6TVIwEGrB74zZOOyITE7c2GEkW5yfV0rew5nUaRmqd6V/wS/C3Luc6fSxmmyuY5nJCmw3wFS0AGl35w==}
+  '@next/swc-win32-x64-msvc@16.3.0-canary.23':
+    resolution: {integrity: sha512-RFZyfjxXBFnxblAqlbyHAkM54GNsfssSx9cxlNbrLyk1quA07LvFVxpleCaUpRvDALptqVwn7nLX5FRnd6VBfw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2781,6 +2784,9 @@ packages:
     peerDependencies:
       next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+
+  '@noble/ed25519@2.3.0':
+    resolution: {integrity: sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==}
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -6212,8 +6218,8 @@ packages:
       sass:
         optional: true
 
-  next@16.3.0-canary.5:
-    resolution: {integrity: sha512-cDlzuyF80Gpq6qDeeWsTVvvs8F/dWgOVIsNSYkah/x+Ey9l0W8QhHiogw0/rXt7JZ8XSklbNYJDX8yDWFT02zA==}
+  next@16.3.0-canary.23:
+    resolution: {integrity: sha512-1Gck90xh7ZTZowCX7bXMvutY1WMPCNQUBjxRmrmrotmJv5rHIxr3wyZWZ0BPFO2BxY+yRg4uCDKkuvjbK+uykA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -6530,6 +6536,10 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6620,10 +6630,10 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
-  react-dom@19.3.0-canary-ad5dfc82-20260427:
-    resolution: {integrity: sha512-v0SgJxgRULkshqTtbgwIDeliwU9QYWlfjHwI2sJ0HKu8Um1Tv0Mtq6TneUqCdBVWgk3U8WxJ1SgqekcTCLaHJA==}
+  react-dom@19.3.0-canary-d5736f09-20260507:
+    resolution: {integrity: sha512-PrjUaYOYc1dX65Td8StJSNJ3TFTeO2KBpAdXQJiOmW5kxDbKK+lvkJmSK/U+f7LcNnJxQKwHzKVf8WdJVjJohg==}
     peerDependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
 
   react-dom@19.3.0-canary-da9325b5-20260417:
     resolution: {integrity: sha512-x1p1RQ8DUwMNC8Ftxjk5Yd5/W5VN608o6kTLZtJ7mZe1FGSMTJl3x3MzJOeavwXmD6SD6CddPJNLyRiXuGdLnw==}
@@ -6713,8 +6723,8 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.3.0-canary-ad5dfc82-20260427:
-    resolution: {integrity: sha512-ngdlMzpnMqEaTKB8htH1ZTBgtlHDXG67uj3pXY8u5Xy/3qg7QjnhroADh7Cr7SBDjsK8nrlVIBFYAZPVrSDnpA==}
+  react@19.3.0-canary-d5736f09-20260507:
+    resolution: {integrity: sha512-EL3w0mHylqEtiySCjcj/nPOkK1j6KvKsaFkeavTqR6hbd6bQi7gyCcTSHXQ2XpTjv8hfKWFArSVF6he1sgQcEQ==}
     engines: {node: '>=0.10.0'}
 
   react@19.3.0-canary-da9325b5-20260417:
@@ -6893,8 +6903,8 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  scheduler@0.28.0-canary-ad5dfc82-20260427:
-    resolution: {integrity: sha512-CLgcIVmrE1mj25Sco5uO2mS8T0TS/aYJOZI12UiIs5UICs1iphyCUJgnuJMJFIZnQvtktTCtb3rurGXHnJcspw==}
+  scheduler@0.28.0-canary-d5736f09-20260507:
+    resolution: {integrity: sha512-HkpDsMMSty/+FrYjvNnBZRwfU5P+LhZs8xRaWKVwTnB0rffXMg+BOntOebDmvlwI8hhB6D8ONBGXeOlWTzwVdA==}
 
   scheduler@0.28.0-canary-da9325b5-20260417:
     resolution: {integrity: sha512-NoRr46xFkoTM5oZL9bSgt7+h/ZmtjDvtnbvBPLU89hyGy16voGv0uyziwwpjaMd/D7mllJQf6ApWZBS59mc7RA==}
@@ -7452,6 +7462,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -8583,11 +8594,11 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@floating-ui/react-dom@2.1.8(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@floating-ui/react-dom@2.1.8(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
 
   '@floating-ui/react@0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -8904,7 +8915,7 @@ snapshots:
 
   '@next/env@16.2.4': {}
 
-  '@next/env@16.3.0-canary.5': {}
+  '@next/env@16.3.0-canary.23': {}
 
   '@next/eslint-plugin-next@16.2.4':
     dependencies:
@@ -8916,7 +8927,7 @@ snapshots:
   '@next/swc-darwin-arm64@16.2.4':
     optional: true
 
-  '@next/swc-darwin-arm64@16.3.0-canary.5':
+  '@next/swc-darwin-arm64@16.3.0-canary.23':
     optional: true
 
   '@next/swc-darwin-x64@15.5.14':
@@ -8925,7 +8936,7 @@ snapshots:
   '@next/swc-darwin-x64@16.2.4':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.0-canary.5':
+  '@next/swc-darwin-x64@16.3.0-canary.23':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.5.14':
@@ -8934,7 +8945,7 @@ snapshots:
   '@next/swc-linux-arm64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.5':
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.23':
     optional: true
 
   '@next/swc-linux-arm64-musl@15.5.14':
@@ -8943,7 +8954,7 @@ snapshots:
   '@next/swc-linux-arm64-musl@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.5':
+  '@next/swc-linux-arm64-musl@16.3.0-canary.23':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.5.14':
@@ -8952,7 +8963,7 @@ snapshots:
   '@next/swc-linux-x64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.5':
+  '@next/swc-linux-x64-gnu@16.3.0-canary.23':
     optional: true
 
   '@next/swc-linux-x64-musl@15.5.14':
@@ -8961,7 +8972,7 @@ snapshots:
   '@next/swc-linux-x64-musl@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.5':
+  '@next/swc-linux-x64-musl@16.3.0-canary.23':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.5.14':
@@ -8970,7 +8981,7 @@ snapshots:
   '@next/swc-win32-arm64-msvc@16.2.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.5':
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.23':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.5.14':
@@ -8979,14 +8990,16 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.5':
+  '@next/swc-win32-x64-msvc@16.3.0-canary.23':
     optional: true
 
-  '@next/third-parties@16.2.4(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@next/third-parties@16.2.4(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      next: 16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
+      next: 16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
       third-party-capital: 1.0.20
+
+  '@noble/ed25519@2.3.0': {}
 
   '@nodable/entities@2.1.0': {}
 
@@ -9092,11 +9105,11 @@ snapshots:
     dependencies:
       '@polar-sh/sdk': 0.46.7
 
-  '@polar-sh/nextjs@0.9.5(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))':
+  '@polar-sh/nextjs@0.9.5(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))':
     dependencies:
       '@polar-sh/adapter-utils': 0.4.5
       '@polar-sh/sdk': 0.46.7
-      next: 16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
+      next: 16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
 
   '@polar-sh/sdk@0.46.7':
     dependencies:
@@ -9155,56 +9168,56 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9215,9 +9228,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -9227,9 +9240,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -9255,31 +9268,31 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
       aria-hidden: 1.2.6
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -9296,15 +9309,15 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9315,9 +9328,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -9332,13 +9345,13 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9350,72 +9363,72 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
       aria-hidden: 1.2.6
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
       '@radix-ui/rect': 1.1.1
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9430,12 +9443,12 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9450,12 +9463,12 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9469,45 +9482,45 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9519,10 +9532,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -9533,25 +9546,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -9562,9 +9575,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -9576,11 +9589,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -9591,10 +9604,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -9605,10 +9618,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -9618,37 +9631,37 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
       '@radix-ui/rect': 1.1.1
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -11122,7 +11135,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -11155,7 +11168,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11170,7 +11183,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11556,14 +11569,14 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  framer-motion@12.38.0(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427):
+  framer-motion@12.38.0(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
       motion-dom: 12.38.0
       motion-utils: 12.36.0
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
 
   fresh@2.0.0: {}
 
@@ -11585,7 +11598,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.7.6(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.468.0(react@19.3.0-canary-ad5dfc82-20260427))(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react-router@7.13.2(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)(zod@4.3.6):
+  fumadocs-core@16.7.6(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.468.0(react@19.3.0-canary-d5736f09-20260507))(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react-router@7.13.2(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@orama/orama': 3.1.18
@@ -11616,23 +11629,23 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       '@types/react': 19.2.14
-      lucide-react: 0.468.0(react@19.3.0-canary-ad5dfc82-20260427)
-      next: 16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
-      react-router: 7.13.2(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
+      lucide-react: 0.468.0(react@19.3.0-canary-d5736f09-20260507)
+      next: 16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
+      react-router: 7.13.2(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
       zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.11(3bmcn22oklcr5hnvpyhrmkhove):
+  fumadocs-mdx@14.2.11(gkxxrli33jgaidf37a2byjyony):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.4
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.7.6(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.468.0(react@19.3.0-canary-ad5dfc82-20260427))(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react-router@7.13.2(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)(zod@4.3.6)
+      fumadocs-core: 16.7.6(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.468.0(react@19.3.0-canary-d5736f09-20260507))(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react-router@7.13.2(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -11649,34 +11662,34 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
-      next: 16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
+      next: 16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
       vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.7.6(yaec5ghbp5b6citim3dgjph3ju):
+  fumadocs-ui@16.7.6(hwcemfswwdn5of7ey4eszehzdu):
     dependencies:
       '@fumadocs/tailwind': 0.0.3(tailwindcss@4.2.2)
-      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.7.6(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.468.0(react@19.3.0-canary-ad5dfc82-20260427))(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react-router@7.13.2(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)(zod@4.3.6)
-      lucide-react: 1.7.0(react@19.3.0-canary-ad5dfc82-20260427)
-      motion: 12.38.0(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      next-themes: 0.4.6(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
-      react-medium-image-zoom: 5.4.1(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
+      fumadocs-core: 16.7.6(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.468.0(react@19.3.0-canary-d5736f09-20260507))(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react-router@7.13.2(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)(zod@4.3.6)
+      lucide-react: 1.7.0(react@19.3.0-canary-d5736f09-20260507)
+      motion: 12.38.0(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      next-themes: 0.4.6(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
+      react-medium-image-zoom: 5.4.1(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
       rehype-raw: 7.0.0
       scroll-into-view-if-needed: 3.1.0
       tailwind-merge: 3.5.0
@@ -11684,7 +11697,7 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
-      next: 16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
+      next: 16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
       shiki: 4.0.2
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -11704,9 +11717,9 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.7.0(next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)):
+  geist@1.7.0(next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)):
     dependencies:
-      next: 16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
+      next: 16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
 
   generator-function@2.0.1: {}
 
@@ -12459,13 +12472,13 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lucide-react@0.468.0(react@19.3.0-canary-ad5dfc82-20260427):
+  lucide-react@0.468.0(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
 
-  lucide-react@1.7.0(react@19.3.0-canary-ad5dfc82-20260427):
+  lucide-react@1.7.0(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
 
   lucide-react@1.8.0(react@19.2.4):
     dependencies:
@@ -12981,13 +12994,13 @@ snapshots:
 
   motion-utils@12.36.0: {}
 
-  motion@12.38.0(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427):
+  motion@12.38.0(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      framer-motion: 12.38.0(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427)
+      framer-motion: 12.38.0(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507)
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
 
   mri@1.2.0: {}
 
@@ -13024,10 +13037,10 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next-themes@0.4.6(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427):
+  next-themes@0.4.6(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
 
   next@15.5.14(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -13080,25 +13093,25 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.3.0-canary.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427):
+  next@16.3.0-canary.23(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      '@next/env': 16.3.0-canary.5
+      '@next/env': 16.3.0-canary.23
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.11
       caniuse-lite: 1.0.30001781
-      postcss: 8.4.31
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
-      styled-jsx: 5.1.6(react@19.3.0-canary-ad5dfc82-20260427)
+      postcss: 8.5.10
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
+      styled-jsx: 5.1.6(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.0-canary.5
-      '@next/swc-darwin-x64': 16.3.0-canary.5
-      '@next/swc-linux-arm64-gnu': 16.3.0-canary.5
-      '@next/swc-linux-arm64-musl': 16.3.0-canary.5
-      '@next/swc-linux-x64-gnu': 16.3.0-canary.5
-      '@next/swc-linux-x64-musl': 16.3.0-canary.5
-      '@next/swc-win32-arm64-msvc': 16.3.0-canary.5
-      '@next/swc-win32-x64-msvc': 16.3.0-canary.5
+      '@next/swc-darwin-arm64': 16.3.0-canary.23
+      '@next/swc-darwin-x64': 16.3.0-canary.23
+      '@next/swc-linux-arm64-gnu': 16.3.0-canary.23
+      '@next/swc-linux-arm64-musl': 16.3.0-canary.23
+      '@next/swc-linux-x64-gnu': 16.3.0-canary.23
+      '@next/swc-linux-x64-musl': 16.3.0-canary.23
+      '@next/swc-win32-arm64-msvc': 16.3.0-canary.23
+      '@next/swc-win32-x64-msvc': 16.3.0-canary.23
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5
@@ -13370,12 +13383,12 @@ snapshots:
       postcss: 8.5.8
       tsx: 4.21.0
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.8
+      postcss: 8.5.10
       tsx: 4.21.0
 
   postcss-nested@6.2.0(postcss@8.5.8):
@@ -13396,6 +13409,12 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -13545,10 +13564,10 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427):
+  react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
-      scheduler: 0.28.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
+      scheduler: 0.28.0-canary-d5736f09-20260507
 
   react-dom@19.3.0-canary-da9325b5-20260417(react@19.3.0-canary-da9325b5-20260417):
     dependencies:
@@ -13561,10 +13580,10 @@ snapshots:
 
   react-is@19.2.4: {}
 
-  react-medium-image-zoom@5.4.1(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427):
+  react-medium-image-zoom@5.4.1(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
 
   react-refresh@0.17.0: {}
 
@@ -13576,10 +13595,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
@@ -13595,14 +13614,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427):
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
+      react: 19.3.0-canary-d5736f09-20260507
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
-      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427)
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -13632,13 +13651,13 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
 
-  react-router@7.13.2(react-dom@19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427))(react@19.3.0-canary-ad5dfc82-20260427):
+  react-router@7.13.2(react-dom@19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507))(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
       cookie: 1.1.1
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.3.0-canary-ad5dfc82-20260427(react@19.3.0-canary-ad5dfc82-20260427)
+      react-dom: 19.3.0-canary-d5736f09-20260507(react@19.3.0-canary-d5736f09-20260507)
     optional: true
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
@@ -13649,17 +13668,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427):
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
   react@19.2.4: {}
 
-  react@19.3.0-canary-ad5dfc82-20260427: {}
+  react@19.3.0-canary-d5736f09-20260507: {}
 
   react@19.3.0-canary-da9325b5-20260417: {}
 
@@ -13935,7 +13954,7 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  scheduler@0.28.0-canary-ad5dfc82-20260427: {}
+  scheduler@0.28.0-canary-d5736f09-20260507: {}
 
   scheduler@0.28.0-canary-da9325b5-20260417: {}
 
@@ -14264,10 +14283,10 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.4
 
-  styled-jsx@5.1.6(react@19.3.0-canary-ad5dfc82-20260427):
+  styled-jsx@5.1.6(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
       client-only: 0.0.1
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
 
   sucrase@3.35.1:
     dependencies:
@@ -14446,7 +14465,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -14457,7 +14476,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -14466,7 +14485,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.10
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -14652,9 +14671,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427):
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
@@ -14667,10 +14686,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.3.0-canary-ad5dfc82-20260427):
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.3.0-canary-d5736f09-20260507):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.3.0-canary-ad5dfc82-20260427
+      react: 19.3.0-canary-d5736f09-20260507
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14


### PR DESCRIPTION
## Summary

Adds the SDK side of Plan 12C: `validateLicenseKey()` now routes EdDSA-signed JWTs through a new `validateCloudToken()` before the Polar path. A paying Cloud customer can mint a JWT in their dashboard's **Settings → SDK tokens**, paste it into `NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY` / `VITE_TOUR_KIT_LICENSE_KEY`, and their Pro SDK packages light up — no separate Polar checkout.

Closes the entitlement gap between the Cloud subscription and the Pro SDK packages. Aligns the product with the wedge: one purchase, one entitlement boundary, watermark-free Pro packages.

Existing `TOURKIT-` Polar keys keep working — the discriminator (`isCloudToken`) is purely structural and only matches three base64url segments separated by dots.

## Verification flow (Plan 12C §12C.11)

1. Decode header + payload.
2. **Hard-pin** `alg=EdDSA` and `typ=JWT`. `header.alg` is never passed to a verifier dispatcher — the verifier is hardcoded to Ed25519. Prevents algorithm-confusion attacks (HS256+pubkey-as-secret, `alg:none`, RS256+pubkey-as-key).
3. Type-guard payload — non-array \`aud\`, string \`exp\`, missing \`iss\`/\`sub\`/\`jti\` all rejected at decode, before any network fetch.
4. Require HTTPS issuer (localhost / 127.0.0.1 allowed for self-host dev).
5. Fetch JWKS from \`\${iss}/.well-known/jwks.json\` with 1h cache (matches dashboard \`Cache-Control: max-age=3600\`).
6. Verify Ed25519 signature via \`@noble/ed25519\` per **Plan 12C D7** — native Web Crypto Ed25519 only landed in Chrome 137 (May 2026); polyfill keeps ~21% of customer end-users from breaking on older Chrome / Android WebViews / Electron.
7. Enforce \`exp\`.
8. Fetch revocation list from \`\${iss}/.well-known/tourkit-sdk-revocations.json\` with 15min cache; **fails OPEN for revocation only** with \`console.warn\` on network failure so a CSP/CDN misconfiguration surfaces in customer error monitoring. Signature and expiry still fail closed.
9. Enforce \`aud\` against current hostname — empty \`aud\` allowed with warning; localhost / 127.0.0.1 / *.local always pass.
10. Return \`LicenseState\` with \`renderKey = base64url(sha256(\\\`\${jti}:\${sub}\\\`)).slice(0, 24)\` so \`<LicenseGate>\` keeps its anti-bypass primitive intact.

## Files

- \`packages/license/src/lib/cloud-token.ts\` — main validator (~290 lines).
- \`packages/license/src/lib/cache.ts\` — generic \`readDocumentCache\`/\`writeDocumentCache\` for JWKS + revocations (separate \`tourkit:doc:\` storage prefix from the Polar \`tourkit:license:\` cache so the two paths can't collide).
- \`packages/license/src/lib/polar-client.ts\` — \`validateLicenseKey()\` routes JWTs through \`validateCloudToken()\` **before** the dev bypass so a paying Cloud customer on localhost gets real entitlement from their dashboard-minted JWT instead of the dev-bypass mask.
- \`packages/license/src/headless.ts\` + \`src/index.ts\` — re-export \`isCloudToken\`, \`validateCloudToken\`, \`CLOUD_TOKEN_TTL\`.
- \`packages/license/package.json\` — adds \`@noble/ed25519: ^2.3.0\` (~5 KB gzipped, stays external to our bundle).

## Tests

| File | Coverage |
|---|---|
| \`cloud-token.test.ts\` (22 tests) | Real Ed25519 signing via \`@noble/ed25519\`, happy path, signature failure, expiry, revocation, aud mismatch, localhost bypass, empty-aud warn, JWKS network failure with cache fallback, revocation fail-open with \`console.warn\`, non-HTTPS issuer rejection, unknown kid, deterministic \`renderKey\` |
| \`cloud-token-alg-pinning.test.ts\` (13 tests) | Forges HS256/HS384/HS512/RS256/PS256/ES256/none/empty/typ=JWE/missing-fields/malformed-aud/non-array-aud/string-exp — all rejected before \`fetch\` is called |
| \`cloud-token-no-subtle.test.ts\` | Static scan that fails the build if any file in \`src/\` ever calls \`subtle.verify\` with an Ed25519 algorithm name |

## Test plan

- [x] \`pnpm --filter @tour-kit/license test\` — 175/175 pass (38 new for this PR; SSR fix from #51 included in the count).
- [x] \`pnpm --filter @tour-kit/license typecheck\` — clean.
- [x] \`pnpm --filter @tour-kit/license build\` — clean; \`dist/index.js\` 19.81 KB ESM (was 16.02 KB, +3.79 KB unminified; \`@noble/ed25519\` stays external, confirmed by \`import*as ne from'@noble/ed25519'\` in the built bundle).
- [x] \`pnpm changeset status\` — minor bump for \`@tour-kit/license\` (\`1.2.0\`), patch ripple for all 8 Pro packages.
- [ ] E2E with a real token: mint via \`tourkit-dash\` \`/settings/sdk-tokens\`, paste into a Next.js sample app's env, confirm \`<AdoptionProvider>\` renders without watermark.
- [ ] Cancellation path: revoke token in dashboard, verify SDK rejects within ~15 min after cache flush.

## Sequencing

- Stacked on #51 (SSR fix). PRs are independent and can merge in either order; this diff includes \`651204d\` until #51 merges into \`main\`, at which point the diff narrows to just the cloud-JWT changes.
- Dashboard side of Plan 12C is already shipped in \`tourkit-dash\` (\`apps/dashboard/src/routes/_authed/settings/sdk-tokens.tsx\`, \`apps/api/src/sdk-tokens/*\`, \`.well-known/{jwks.json,tourkit-sdk-revocations.json}\` endpoints, \`sdk_signing_keys\` + \`sdk_tokens\` tables).
- Plan 12C.12 reminder job (30/14/7/1 day token-expiry emails) and Stripe/Polar cancellation revocation hooks are still TODO in \`tourkit-dash\` — separate work.

## Commercial follow-ups (out of scope for this PR)

Once \`1.2.0\` ships and the dashboard mints work end-to-end:
- Migration path for existing Polar SDK customers (mint them a JWT against their existing entitlement; old \`TOURKIT-\` keys keep working for 90 days).
- Sunset standalone SDK Polar SKUs; position SDK as "included with every paid Cloud plan".
- Update \`/cloud/pricing\` FAQ (Plan 12C.17.12).