### PR TITLE
feat(v2): Phase 5 — target-as-ref + MultiTourKit compose-mode

### DIFF
--- a/.changeset/phase-5-target-as-ref-compose.md
+++ b/.changeset/phase-5-target-as-ref-compose.md
@@ -1,0 +1,31 @@
+---
+'@tour-kit/core': minor
+'@tour-kit/react': minor
+'@tour-kit/hints': minor
+'@tour-kit/codemods': minor
+---
+
+target-as-ref + MultiTourKit compose-mode (Phase 5 of v2 package polish).
+
+The `target` prop on `TourStep` and `HintConfig` now accepts a third shape —
+a getter function `() => HTMLElement | null` — alongside the existing string
+selector and `RefObject<HTMLElement | null>`. All runtime dereference paths
+(use-step, use-element-position, wait-for-step-target, utils/dom, plus four
+React card/overlay consumers and both hints components) route through a
+single new `resolveTarget` resolver exported from `@tour-kit/core`. The
+union widening is fully backwards-compatible — existing string selectors
+keep working with no console warning, and the resolver is SSR-safe (returns
+null when `document` is undefined instead of throwing).
+
+`<MultiTourKitProvider>` compose-mode is now the documented default: the
+JSDoc example puts every `<Tour>`, `<TourOverlay>`, `<TourCard>`, and `<App />`
+as children of the provider, and `useTour()` resolves through the registry
+from any depth. The provider's runtime behavior is unchanged.
+
+A new best-effort jscodeshift codemod `--from target-to-ref` rewrites
+`target="#foo"` to `target={fooRef}` when a matching `useRef` binding lives
+in the same file. Ambiguous matches get a `TODO(tour-kit): target-to-ref`
+comment instead of a destructive rewrite, and the transform is idempotent
+under re-runs.
+
+Docs page: `/docs/react/target-prop`.

--- a/apps/docs/content/docs/react/meta.json
+++ b/apps/docs/content/docs/react/meta.json
@@ -1,5 +1,15 @@
 {
   "title": "@tour-kit/react",
   "icon": "Component",
-  "pages": ["index", "components", "headless", "adapters", "providers", "hooks", "styling", "target-prop", "types"]
+  "pages": [
+    "index",
+    "components",
+    "headless",
+    "adapters",
+    "providers",
+    "hooks",
+    "styling",
+    "target-prop",
+    "types"
+  ]
 }

--- a/apps/docs/content/docs/react/meta.json
+++ b/apps/docs/content/docs/react/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "@tour-kit/react",
   "icon": "Component",
-  "pages": ["index", "components", "headless", "adapters", "providers", "hooks", "styling", "types"]
+  "pages": ["index", "components", "headless", "adapters", "providers", "hooks", "styling", "target-prop", "types"]
 }

--- a/apps/docs/content/docs/react/target-prop.mdx
+++ b/apps/docs/content/docs/react/target-prop.mdx
@@ -69,9 +69,10 @@ export function Demo() {
 
 ## Getter function (escape hatch)
 
-A `() => HTMLElement | null` thunk is evaluated at step-enter time. Use it
-when the target node is mounted asynchronously (data-fetch boundary, route
-transition) and you don't have a ref to capture it.
+A `() => HTMLElement | null` thunk is evaluated when the active step's
+identity changes — i.e., at step-enter time. Use it when the target node is
+mounted asynchronously (data-fetch boundary, route transition) and you don't
+have a ref to capture it.
 
 ```tsx
 import { Tour, TourStep } from '@tour-kit/react'
@@ -89,6 +90,16 @@ export function Demo() {
   )
 }
 ```
+
+<Callout type="warn" title="Getters are not polled">
+  The getter runs once when the step becomes active. It is **not** observed
+  via `MutationObserver`. If the target node mounts strictly *after* the step
+  activates, the resolver returns `null` and the spotlight stays hidden until
+  the next step transition re-evaluates the getter. For genuinely async DOM,
+  defer `start()` until the node exists, or call `goTo(stepIndex)` again
+  after it mounts. Prefer a `RefObject` when the framework can wire one up —
+  refs cost nothing extra and avoid this gotcha entirely.
+</Callout>
 
 ## Resolution order
 

--- a/apps/docs/content/docs/react/target-prop.mdx
+++ b/apps/docs/content/docs/react/target-prop.mdx
@@ -1,0 +1,123 @@
+---
+title: target Prop
+description: >-
+  Three ways to point a TourStep at a DOM element — selector string,
+  RefObject, or getter function — and the runtime resolution order.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+Every `<TourStep>` and `HintConfig.target` accepts the same three-way union, so
+you can pick whichever shape survives your component's mounting strategy:
+selector string for static markup, `RefObject` for dynamic IDs and portals,
+or a getter function for lazily-mounted nodes. The runtime resolver branches
+on a single `typeof` check — no two shapes overlap.
+
+```ts
+type TourTarget =
+  | string
+  | React.RefObject<HTMLElement | null>
+  | (() => HTMLElement | null)
+```
+
+## Selector string (legacy)
+
+Resolves through `document.querySelector` on every render. Breaks the moment a
+parent serves CSS Modules with mangled class names, mounts the target inside
+a portal, or rotates the `id` between sessions.
+
+```tsx
+import { Tour, TourStep } from '@tour-kit/react'
+
+export function Demo() {
+  return (
+    <Tour id="legacy">
+      <TourStep id="welcome" target="#welcome" title="Welcome" content="…" />
+      <button id="welcome" type="button">Click me</button>
+    </Tour>
+  )
+}
+```
+
+<Callout type="info" title="When to use this">
+  Quick prototypes, sandbox playgrounds, server-rendered markup where the id
+  is guaranteed stable. The string form emits no dev warning — it is supported
+  fallback, not deprecation.
+</Callout>
+
+## RefObject (recommended)
+
+`React.useRef` survives portals, CSS Modules, dynamic ids, and route
+transitions. The same ref can be handed to a child component without leaking
+the underlying DOM id.
+
+```tsx
+import { Tour, TourStep } from '@tour-kit/react'
+import { useRef } from 'react'
+
+export function Demo() {
+  const welcomeRef = useRef<HTMLButtonElement>(null)
+
+  return (
+    <Tour id="ref-mode">
+      <TourStep id="welcome" target={welcomeRef} title="Welcome" content="…" />
+      <button ref={welcomeRef} type="button">Click me</button>
+    </Tour>
+  )
+}
+```
+
+## Getter function (escape hatch)
+
+A `() => HTMLElement | null` thunk is evaluated at step-enter time. Use it
+when the target node is mounted asynchronously (data-fetch boundary, route
+transition) and you don't have a ref to capture it.
+
+```tsx
+import { Tour, TourStep } from '@tour-kit/react'
+
+export function Demo() {
+  return (
+    <Tour id="thunk-mode">
+      <TourStep
+        id="cta"
+        target={() => document.querySelector<HTMLElement>('[data-cy="cta"]')}
+        title="Call to action"
+        content="…"
+      />
+    </Tour>
+  )
+}
+```
+
+## Resolution order
+
+Tour Kit resolves a `TourTarget` through a single `resolveTarget` function
+exported from `@tour-kit/core`. Branches are closed and non-overlapping —
+strings can't carry `.current`, refs aren't callable, and thunks aren't
+strings.
+
+1. `typeof target === 'string'` → `document.querySelector(target)`
+2. `target && typeof target === 'object' && 'current' in target` → `target.current`
+3. `typeof target === 'function'` → `target()`
+
+Anything else (including `undefined`) resolves to `null`, and the existing
+positioning code falls back to its usual retry / fail behavior.
+
+The string branch is SSR-safe: when `document` is undefined (Next.js RSC,
+Remix server render), `resolveTarget` returns `null` instead of throwing.
+
+## Migration codemod
+
+`@tour-kit/codemods` ships a best-effort `target-to-ref` transform that
+rewrites `target="#foo"` to `target={fooRef}` when a matching `useRef`
+binding lives in the same file:
+
+```bash
+pnpm dlx @tour-kit/codemods --from target-to-ref ./src
+```
+
+When the rewrite is ambiguous (no matching ref in scope), the codemod leaves
+the attribute untouched and inserts a `TODO(tour-kit): target-to-ref` comment
+above the JSX element. Re-running the codemod on a migrated file produces a
+zero-diff second pass.

--- a/examples/dashboard-next/components/tour-kit/demo-panel.tsx
+++ b/examples/dashboard-next/components/tour-kit/demo-panel.tsx
@@ -12,10 +12,6 @@ import { useTourActions } from '@tour-kit/core'
 import { LicenseWatermark, useLicense } from '@tour-kit/license'
 import { useSurvey } from '@tour-kit/surveys'
 import {
-  TURNKEY_CES_EVENT,
-  TURNKEY_NPS_EVENT,
-} from '@/components/tour-kit/turnkey-survey-hosts'
-import {
   Bell,
   CheckSquare,
   Compass,

--- a/packages/codemods/__tests__/fixtures/target-to-ref/already-ref.input.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/already-ref.input.tsx
@@ -1,0 +1,11 @@
+import { useRef } from 'react'
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  const someRef = useRef<HTMLDivElement>(null)
+  return (
+    <div>
+      <TourStep id="s1" target={someRef} title="Hi" content="There" />
+    </div>
+  )
+}

--- a/packages/codemods/__tests__/fixtures/target-to-ref/already-ref.output.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/already-ref.output.tsx
@@ -1,0 +1,12 @@
+import { useRef } from 'react'
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  const someRef = useRef<HTMLDivElement>(null)
+  return (
+    <div>
+      <TourStep id="s1" target={someRef} title="Hi" content="There" />
+    </div>
+  )
+}
+

--- a/packages/codemods/__tests__/fixtures/target-to-ref/happy-path-multi.input.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/happy-path-multi.input.tsx
@@ -1,0 +1,18 @@
+import { useRef } from 'react'
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  const heroRef = useRef<HTMLDivElement>(null)
+  const navRef = useRef<HTMLDivElement>(null)
+  const footerRef = useRef<HTMLDivElement>(null)
+  return (
+    <div>
+      <div ref={heroRef} id="hero" />
+      <div ref={navRef} id="nav" />
+      <div ref={footerRef} id="footer" />
+      <TourStep id="s1" target="#hero" title="Hero" content="..." />
+      <TourStep id="s2" target="#nav" title="Nav" content="..." />
+      <TourStep id="s3" target="#footer" title="Footer" content="..." />
+    </div>
+  )
+}

--- a/packages/codemods/__tests__/fixtures/target-to-ref/happy-path-multi.output.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/happy-path-multi.output.tsx
@@ -1,0 +1,19 @@
+import { useRef } from 'react'
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  const heroRef = useRef<HTMLDivElement>(null)
+  const navRef = useRef<HTMLDivElement>(null)
+  const footerRef = useRef<HTMLDivElement>(null)
+  return (
+    <div>
+      <div ref={heroRef} id="hero" />
+      <div ref={navRef} id="nav" />
+      <div ref={footerRef} id="footer" />
+      <TourStep id="s1" target={heroRef} title="Hero" content="..." />
+      <TourStep id="s2" target={navRef} title="Nav" content="..." />
+      <TourStep id="s3" target={footerRef} title="Footer" content="..." />
+    </div>
+  );
+}
+

--- a/packages/codemods/__tests__/fixtures/target-to-ref/happy-path-single.input.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/happy-path-single.input.tsx
@@ -1,0 +1,11 @@
+import { useRef } from 'react'
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  const welcomeRef = useRef<HTMLDivElement>(null)
+  return (
+    <div ref={welcomeRef}>
+      <TourStep id="s1" target="#welcome" title="Hi" content="There" />
+    </div>
+  )
+}

--- a/packages/codemods/__tests__/fixtures/target-to-ref/happy-path-single.output.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/happy-path-single.output.tsx
@@ -1,0 +1,12 @@
+import { useRef } from 'react'
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  const welcomeRef = useRef<HTMLDivElement>(null)
+  return (
+    <div ref={welcomeRef}>
+      <TourStep id="s1" target={welcomeRef} title="Hi" content="There" />
+    </div>
+  );
+}
+

--- a/packages/codemods/__tests__/fixtures/target-to-ref/mixed-bag.input.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/mixed-bag.input.tsx
@@ -1,0 +1,13 @@
+import { useRef } from 'react'
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  const heroRef = useRef<HTMLDivElement>(null)
+  return (
+    <div>
+      <div ref={heroRef} id="hero" />
+      <TourStep id="s1" target="#hero" title="Hero" content="..." />
+      <TourStep id="s2" target="#orphan" title="Orphan" content="..." />
+    </div>
+  )
+}

--- a/packages/codemods/__tests__/fixtures/target-to-ref/mixed-bag.output.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/mixed-bag.output.tsx
@@ -1,0 +1,15 @@
+import { useRef } from 'react'
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  const heroRef = useRef<HTMLDivElement>(null)
+  return (
+    <div>
+      <div ref={heroRef} id="hero" />
+      <TourStep id="s1" target={heroRef} title="Hero" content="..." />
+      {/* TODO(tour-kit): target-to-ref — no matching useRef binding found; pass a RefObject<HTMLElement> or a () => HTMLElement getter */
+      }<TourStep id="s2" target="#orphan" title="Orphan" content="..." />
+    </div>
+  );
+}
+

--- a/packages/codemods/__tests__/fixtures/target-to-ref/no-ref-in-scope.input.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/no-ref-in-scope.input.tsx
@@ -1,0 +1,9 @@
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  return (
+    <div>
+      <TourStep id="s1" target="#missing" title="Hi" content="There" />
+    </div>
+  )
+}

--- a/packages/codemods/__tests__/fixtures/target-to-ref/no-ref-in-scope.output.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/no-ref-in-scope.output.tsx
@@ -1,0 +1,11 @@
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  return (
+    <div>
+      {/* TODO(tour-kit): target-to-ref — no matching useRef binding found; pass a RefObject<HTMLElement> or a () => HTMLElement getter */
+      }<TourStep id="s1" target="#missing" title="Hi" content="There" />
+    </div>
+  );
+}
+

--- a/packages/codemods/__tests__/fixtures/target-to-ref/top-level-no-ref.input.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/top-level-no-ref.input.tsx
@@ -1,0 +1,5 @@
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  return <TourStep id="s1" target="#orphan" title="Hi" content="There" />
+}

--- a/packages/codemods/__tests__/fixtures/target-to-ref/top-level-no-ref.output.tsx
+++ b/packages/codemods/__tests__/fixtures/target-to-ref/top-level-no-ref.output.tsx
@@ -1,0 +1,5 @@
+import { TourStep } from '@tour-kit/react'
+
+export function App() {
+  return <TourStep id="s1" target="#orphan" title="Hi" content="There" />
+}

--- a/packages/codemods/src/__tests__/target-to-ref.test.ts
+++ b/packages/codemods/src/__tests__/target-to-ref.test.ts
@@ -26,6 +26,10 @@ const FIXTURES = [
   'no-ref-in-scope',
   'already-ref',
   'mixed-bag',
+  // Top-level `return <TourStep target="#orphan" />` — no JSX children array
+  // available, so the transform leaves the attribute alone (no rewrite, no
+  // TODO) rather than emit a comment that ASI would render unreachable.
+  'top-level-no-ref',
 ] as const
 
 describe('target-to-ref codemod', () => {

--- a/packages/codemods/src/__tests__/target-to-ref.test.ts
+++ b/packages/codemods/src/__tests__/target-to-ref.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Phase 5 — target-to-ref codemod fixture suite.
+ *
+ * Five canonical fixture pairs plus an idempotency assertion. Each pair is
+ * `<name>.input.tsx` → `<name>.output.tsx` under the sibling `fixtures/`
+ * directory. The test reads each input, runs the transform, and compares the
+ * result against the expected output via `normalize` (whitespace-insensitive)
+ * to absorb harmless formatter drift between local + CI runs.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import transform from '../transforms/target-to-ref'
+import { normalize, reparses, runTransform } from './_helpers'
+
+const FIXTURE_DIR = join(__dirname, '..', '..', '__tests__', 'fixtures', 'target-to-ref')
+
+function readFixture(name: string, suffix: 'input' | 'output'): string {
+  return readFileSync(join(FIXTURE_DIR, `${name}.${suffix}.tsx`), 'utf8')
+}
+
+const FIXTURES = [
+  'happy-path-single',
+  'happy-path-multi',
+  'no-ref-in-scope',
+  'already-ref',
+  'mixed-bag',
+] as const
+
+describe('target-to-ref codemod', () => {
+  for (const name of FIXTURES) {
+    it(`fixture: ${name}`, () => {
+      const input = readFixture(name, 'input')
+      const expected = readFixture(name, 'output')
+      const actual = runTransform(transform, input, `${name}.input.tsx`)
+      expect(normalize(actual)).toBe(normalize(expected))
+      expect(reparses(actual)).toBe(true)
+    })
+  }
+
+  it('is idempotent: running twice on happy-path-single yields the same output', () => {
+    const input = readFixture('happy-path-single', 'input')
+    const firstPass = runTransform(transform, input, 'happy-path-single.input.tsx')
+    const secondPass = runTransform(transform, firstPass, 'happy-path-single.input.tsx')
+    expect(normalize(secondPass)).toBe(normalize(firstPass))
+  })
+
+  it('is idempotent: running twice on no-ref-in-scope does not stack TODO comments', () => {
+    const input = readFixture('no-ref-in-scope', 'input')
+    const firstPass = runTransform(transform, input, 'no-ref-in-scope.input.tsx')
+    const secondPass = runTransform(transform, firstPass, 'no-ref-in-scope.input.tsx')
+    const todoCount = (firstPass.match(/target-to-ref/g) ?? []).length
+    const todoCountSecond = (secondPass.match(/target-to-ref/g) ?? []).length
+    expect(todoCount).toBe(1)
+    expect(todoCountSecond).toBe(1)
+  })
+})

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -12,12 +12,7 @@ import replayBridgeToUseTourActions from './transforms/replay-bridge-to-use-tour
 import targetToRef from './transforms/target-to-ref'
 
 export interface CliOptions {
-  from:
-    | 'joyride'
-    | 'shepherd'
-    | 'driver'
-    | 'replay-bridge-to-use-tour-actions'
-    | 'target-to-ref'
+  from: 'joyride' | 'shepherd' | 'driver' | 'replay-bridge-to-use-tour-actions' | 'target-to-ref'
   parser: 'tsx' | 'ts' | 'babel'
   dryRun: boolean
   print: boolean

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -9,9 +9,15 @@ import fromDriver from './transforms/from-driver'
 import fromJoyride from './transforms/from-joyride'
 import fromShepherd from './transforms/from-shepherd'
 import replayBridgeToUseTourActions from './transforms/replay-bridge-to-use-tour-actions'
+import targetToRef from './transforms/target-to-ref'
 
 export interface CliOptions {
-  from: 'joyride' | 'shepherd' | 'driver' | 'replay-bridge-to-use-tour-actions'
+  from:
+    | 'joyride'
+    | 'shepherd'
+    | 'driver'
+    | 'replay-bridge-to-use-tour-actions'
+    | 'target-to-ref'
   parser: 'tsx' | 'ts' | 'babel'
   dryRun: boolean
   print: boolean
@@ -37,6 +43,7 @@ const TRANSFORMS: Partial<Record<CliOptions['from'], JscodeshiftTransform>> = {
   driver: fromDriver as unknown as JscodeshiftTransform,
   'replay-bridge-to-use-tour-actions':
     replayBridgeToUseTourActions as unknown as JscodeshiftTransform,
+  'target-to-ref': targetToRef as unknown as JscodeshiftTransform,
 }
 
 // Sources whose corpus coverage is below the ≥80% ship gate. Members trigger a
@@ -56,6 +63,7 @@ export const TRANSFORM_COVERAGE: Readonly<Record<CliOptions['from'], number>> = 
   shepherd: 100,
   driver: 100,
   'replay-bridge-to-use-tour-actions': 100,
+  'target-to-ref': 100,
 }
 
 const DEFAULT_EXTENSIONS = ['ts', 'tsx', 'js', 'jsx'] as const
@@ -236,7 +244,8 @@ function isFromValue(v: string | undefined): v is CliOptions['from'] {
     v === 'joyride' ||
     v === 'shepherd' ||
     v === 'driver' ||
-    v === 'replay-bridge-to-use-tour-actions'
+    v === 'replay-bridge-to-use-tour-actions' ||
+    v === 'target-to-ref'
   )
 }
 
@@ -302,6 +311,7 @@ function usageMessage(): string {
     '  --from <source>       Migration source. Required. One of:',
     '                          joyride|shepherd|driver — competitor → @tour-kit/react migration.',
     '                          replay-bridge-to-use-tour-actions — v1 window-event → useTourActions(id).start().',
+    "                          target-to-ref — rewrite `target='#id'` to `target={idRef}` when a matching useRef exists.",
     '  --parser <parser>     jscodeshift parser (tsx|ts|babel). Default: tsx.',
     "  --dry-run             Don't write files; only report what would change.",
     '  --print               Print transformed source to stdout.',

--- a/packages/codemods/src/lib/todo-emitter.ts
+++ b/packages/codemods/src/lib/todo-emitter.ts
@@ -1,4 +1,4 @@
-export type TodoSource = 'joyride' | 'shepherd' | 'driver'
+export type TodoSource = 'joyride' | 'shepherd' | 'driver' | 'target-to-ref'
 
 export interface Todo {
   message: string
@@ -7,13 +7,20 @@ export interface Todo {
 }
 
 // Source defaults to 'joyride' so the Phase 7a transform keeps emitting the
-// same URLs it always did — Shepherd/Driver pass an explicit source.
+// same URLs it always did — Shepherd/Driver/target-to-ref pass an explicit source.
 export function emitTodo(message: string, anchor: string, source: TodoSource = 'joyride'): Todo {
   return { message, anchor, source }
 }
 
 export function todoToComment(t: Todo): string {
   const src = t.source ?? 'joyride'
+  // `target-to-ref` is an intra-repo refactor codemod, not a competitor
+  // migration — there's no `/migration/target-to-ref` page on the docs site.
+  // Phase 5 §5.3 specifies the prefix `TODO(tour-kit): target-to-ref` so
+  // grepping after a migration finds the open todos.
+  if (src === 'target-to-ref') {
+    return `// TODO(tour-kit): target-to-ref — ${t.message}`
+  }
   return `// TODO: ${t.message} — see https://tourkit.dev/migration/${src}#${t.anchor}`
 }
 

--- a/packages/codemods/src/lib/todo-emitter.ts
+++ b/packages/codemods/src/lib/todo-emitter.ts
@@ -1,4 +1,4 @@
-export type TodoSource = 'joyride' | 'shepherd' | 'driver' | 'target-to-ref'
+export type TodoSource = 'joyride' | 'shepherd' | 'driver'
 
 export interface Todo {
   message: string
@@ -7,20 +7,13 @@ export interface Todo {
 }
 
 // Source defaults to 'joyride' so the Phase 7a transform keeps emitting the
-// same URLs it always did — Shepherd/Driver/target-to-ref pass an explicit source.
+// same URLs it always did — Shepherd/Driver pass an explicit source.
 export function emitTodo(message: string, anchor: string, source: TodoSource = 'joyride'): Todo {
   return { message, anchor, source }
 }
 
 export function todoToComment(t: Todo): string {
   const src = t.source ?? 'joyride'
-  // `target-to-ref` is an intra-repo refactor codemod, not a competitor
-  // migration — there's no `/migration/target-to-ref` page on the docs site.
-  // Phase 5 §5.3 specifies the prefix `TODO(tour-kit): target-to-ref` so
-  // grepping after a migration finds the open todos.
-  if (src === 'target-to-ref') {
-    return `// TODO(tour-kit): target-to-ref — ${t.message}`
-  }
   return `// TODO: ${t.message} — see https://tourkit.dev/migration/${src}#${t.anchor}`
 }
 

--- a/packages/codemods/src/transforms/target-to-ref.ts
+++ b/packages/codemods/src/transforms/target-to-ref.ts
@@ -1,0 +1,185 @@
+// jscodeshift transform — best-effort `target="#foo"` → `target={fooRef}`.
+//
+// Phase 5 of v2-package-polish: the `target` prop on `<TourStep>` widened
+// from `string | RefObject` to also accept `() => HTMLElement | null`. This
+// codemod rewrites legacy selector-string call sites that already declare a
+// matching `useRef` binding in the same file, and leaves a TODO comment when
+// the right binding can't be located. It is intentionally conservative —
+// false-positive rewrites cost more than a missed migration, since the
+// resulting code still works under the widened union.
+//
+// Heuristic:
+//   - Find JSX attributes named `target` whose value is a StringLiteral of
+//     the shape `'#identifier'` (matches /^#[A-Za-z_][\w-]*$/).
+//   - Look for a `const <name>Ref = useRef(...)` binding anywhere in the
+//     same source file (any scope — files this small don't have shadowing
+//     issues in practice).
+//   - Match → rewrite the attribute to `target={<name>Ref}`.
+//   - No match → attach a leading TODO comment via the shared todo-emitter
+//     helper. The attribute itself is untouched.
+//
+// Idempotency:
+//   - Attributes whose value is already a `JSXExpressionContainer` are
+//     skipped (running the codemod twice on migrated code is a no-op).
+//   - The TODO comment is only attached when the JSX opening element does
+//     not already carry a `target-to-ref` TODO in its leading comments.
+
+import type { API, ASTPath, FileInfo, JSCodeshift } from 'jscodeshift'
+
+export const parser = 'tsx'
+
+const SELECTOR_RE = /^#([A-Za-z_][\w-]*)$/
+const TODO_MARKER = 'target-to-ref'
+const TODO_TEXT =
+  ' TODO(tour-kit): target-to-ref — no matching useRef binding found; pass a RefObject<HTMLElement> or a () => HTMLElement getter '
+
+export default function transform(file: FileInfo, api: API): string {
+  const j: JSCodeshift = api.jscodeshift
+  const root = j(file.source)
+
+  const refNames = collectUseRefNames(j, root)
+
+  const attrs = root.find(j.JSXAttribute, {
+    name: { type: 'JSXIdentifier', name: 'target' },
+  })
+
+  attrs.forEach((path) => {
+    const node = path.node
+    const value = node.value
+    if (!value) return
+
+    // Already migrated (target={someExpr}) — idempotent skip.
+    if (value.type === 'JSXExpressionContainer') return
+
+    const literal = readStringLiteralValue(value)
+    if (literal === null) return
+
+    const match = SELECTOR_RE.exec(literal)
+    if (!match) {
+      // Non-`#identifier` selector — leave alone (CSS combinators, data-cy,
+      // etc. need manual review, but the codemod has no opinion here).
+      return
+    }
+    const bareId = match[1]
+    const candidate = `${bareId}Ref`
+
+    if (refNames.has(candidate)) {
+      node.value = j.jsxExpressionContainer(j.identifier(candidate))
+      return
+    }
+
+    attachTodoIfNew(j, path)
+  })
+
+  return root.toSource({ quote: 'single', trailingComma: true })
+}
+
+// Collect every identifier bound to a `useRef(...)` call in the file. We
+// match `const x = useRef(...)` and `const x = React.useRef(...)`. Loose by
+// design — a `useRef` import alias survives the match because we read the
+// binding name, not the callee identifier.
+function collectUseRefNames(j: JSCodeshift, root: ReturnType<JSCodeshift>): Set<string> {
+  const names = new Set<string>()
+  root
+    .find(j.VariableDeclarator, {
+      init: { type: 'CallExpression' },
+    })
+    .forEach((path) => {
+      const init = path.node.init as { type: string; callee?: unknown } | null
+      if (!init || init.type !== 'CallExpression') return
+      const callee = init.callee as
+        | { type: 'Identifier'; name?: string }
+        | { type: 'MemberExpression'; property?: { name?: string } }
+        | undefined
+      if (!callee) return
+      let calleeName: string | undefined
+      if (callee.type === 'Identifier') {
+        calleeName = (callee as { name?: string }).name
+      } else if (callee.type === 'MemberExpression') {
+        calleeName = (callee as { property?: { name?: string } }).property?.name
+      }
+      if (calleeName !== 'useRef') return
+      const id = path.node.id
+      if (id.type === 'Identifier') {
+        names.add(id.name)
+      }
+    })
+  return names
+}
+
+function readStringLiteralValue(value: unknown): string | null {
+  const v = value as { type?: string; value?: unknown; expression?: { type?: string; value?: unknown } } | null
+  if (!v) return null
+  if (v.type === 'StringLiteral' && typeof v.value === 'string') return v.value
+  if (v.type === 'Literal' && typeof v.value === 'string') return v.value
+  // Wrapped in {"..."} — JSXExpressionContainer holding a literal. We
+  // intentionally do NOT rewrite this shape (already-expression form).
+  return null
+}
+
+// Insert a JSX-safe block comment as a preceding sibling of the target
+// JSXElement. Line comments (`// ...`) and bare block comments are not legal
+// JSX-child grammar — they must be wrapped in `{/* ... */}` (i.e. a
+// JSXExpressionContainer holding a JSXEmptyExpression whose `.comments`
+// array carries a CommentBlock node).
+function attachTodoIfNew(j: JSCodeshift, attrPath: ASTPath<unknown>): void {
+  // attrPath: JSXAttribute → parent: JSXOpeningElement → parent: JSXElement.
+  const openingPath = attrPath.parent
+  if (!openingPath?.node) return
+  const elementPath = openingPath.parent
+  if (!elementPath?.node) return
+
+  // Find the JSXElement's parent container (a JSXElement, JSXFragment, or
+  // ArrowFunction/return statement). Inserting as a sibling requires the
+  // parent to have a `children` array; otherwise we attach a leading line
+  // comment on the JSXElement (recast renders it above the JS expression).
+  const containerPath = elementPath.parent
+  const containerNode = containerPath?.node as
+    | { type?: string; children?: Array<unknown> }
+    | undefined
+
+  if (containerNode && Array.isArray(containerNode.children)) {
+    // Idempotency: don't re-insert if a TODO block comment already precedes
+    // the element.
+    const idx = containerNode.children.indexOf(elementPath.node as unknown)
+    if (idx > 0) {
+      const prev = containerNode.children[idx - 1] as
+        | { type?: string; expression?: { comments?: Array<{ value?: string }> } }
+        | undefined
+      const prevComments = prev?.expression?.comments
+      if (prevComments?.some((c) => typeof c.value === 'string' && c.value.includes(TODO_MARKER))) {
+        return
+      }
+    }
+    const emptyExpr = j.jsxEmptyExpression()
+    ;(emptyExpr as { comments?: Array<unknown> }).comments = [
+      {
+        type: 'CommentBlock',
+        value: TODO_TEXT,
+        leading: true,
+        trailing: false,
+      },
+    ]
+    const todoNode = j.jsxExpressionContainer(emptyExpr)
+    containerNode.children.splice(idx, 0, todoNode as unknown)
+    return
+  }
+
+  // Fallback: top-level JSX element (e.g. `return <TourStep .../>`). Attach
+  // as a leading line comment on the JSXElement — recast renders it above
+  // the JS expression, which is legal in JS but would be illegal if the
+  // JSXElement were inside another JSX node. We've already excluded that
+  // case above.
+  const elNode = elementPath.node as { comments?: Array<{ value?: string }> }
+  const existing = elNode.comments ?? []
+  if (existing.some((c) => typeof c.value === 'string' && c.value.includes(TODO_MARKER))) {
+    return
+  }
+  const lineComment = {
+    type: 'CommentLine',
+    value: TODO_TEXT,
+    leading: true,
+    trailing: false,
+  } as unknown as { value?: string }
+  elNode.comments = [...existing, lineComment]
+}

--- a/packages/codemods/src/transforms/target-to-ref.ts
+++ b/packages/codemods/src/transforms/target-to-ref.ts
@@ -138,48 +138,37 @@ function attachTodoIfNew(j: JSCodeshift, attrPath: ASTPath<unknown>): void {
     | { type?: string; children?: Array<unknown> }
     | undefined
 
-  if (containerNode && Array.isArray(containerNode.children)) {
-    // Idempotency: don't re-insert if a TODO block comment already precedes
-    // the element.
-    const idx = containerNode.children.indexOf(elementPath.node as unknown)
-    if (idx > 0) {
-      const prev = containerNode.children[idx - 1] as
-        | { type?: string; expression?: { comments?: Array<{ value?: string }> } }
-        | undefined
-      const prevComments = prev?.expression?.comments
-      if (prevComments?.some((c) => typeof c.value === 'string' && c.value.includes(TODO_MARKER))) {
-        return
-      }
-    }
-    const emptyExpr = j.jsxEmptyExpression()
-    ;(emptyExpr as { comments?: Array<unknown> }).comments = [
-      {
-        type: 'CommentBlock',
-        value: TODO_TEXT,
-        leading: true,
-        trailing: false,
-      },
-    ]
-    const todoNode = j.jsxExpressionContainer(emptyExpr)
-    containerNode.children.splice(idx, 0, todoNode as unknown)
+  if (!containerNode || !Array.isArray(containerNode.children)) {
+    // Top-level JSX (e.g. `return <TourStep target="#orphan" />`). There's no
+    // JSX children array to splice a `{/* */}` sibling into, and bare line
+    // comments aren't safe — recast would emit them between `return` and the
+    // JSXElement, where ASI silently turns the return into an `undefined`
+    // bail-out. Better to leave the attribute untouched and let the developer
+    // notice the un-rewritten selector at PR review time.
     return
   }
 
-  // Fallback: top-level JSX element (e.g. `return <TourStep .../>`). Attach
-  // as a leading line comment on the JSXElement — recast renders it above
-  // the JS expression, which is legal in JS but would be illegal if the
-  // JSXElement were inside another JSX node. We've already excluded that
-  // case above.
-  const elNode = elementPath.node as { comments?: Array<{ value?: string }> }
-  const existing = elNode.comments ?? []
-  if (existing.some((c) => typeof c.value === 'string' && c.value.includes(TODO_MARKER))) {
-    return
+  // Idempotency: don't re-insert if a TODO block comment already precedes
+  // the element.
+  const idx = containerNode.children.indexOf(elementPath.node as unknown)
+  if (idx > 0) {
+    const prev = containerNode.children[idx - 1] as
+      | { type?: string; expression?: { comments?: Array<{ value?: string }> } }
+      | undefined
+    const prevComments = prev?.expression?.comments
+    if (prevComments?.some((c) => typeof c.value === 'string' && c.value.includes(TODO_MARKER))) {
+      return
+    }
   }
-  const lineComment = {
-    type: 'CommentLine',
-    value: TODO_TEXT,
-    leading: true,
-    trailing: false,
-  } as unknown as { value?: string }
-  elNode.comments = [...existing, lineComment]
+  const emptyExpr = j.jsxEmptyExpression()
+  ;(emptyExpr as { comments?: Array<unknown> }).comments = [
+    {
+      type: 'CommentBlock',
+      value: TODO_TEXT,
+      leading: true,
+      trailing: false,
+    },
+  ]
+  const todoNode = j.jsxExpressionContainer(emptyExpr)
+  containerNode.children.splice(idx, 0, todoNode as unknown)
 }

--- a/packages/codemods/src/transforms/target-to-ref.ts
+++ b/packages/codemods/src/transforms/target-to-ref.ts
@@ -37,11 +37,18 @@ export default function transform(file: FileInfo, api: API): string {
   const j: JSCodeshift = api.jscodeshift
   const root = j(file.source)
 
-  const refNames = collectUseRefNames(j, root)
-
   const attrs = root.find(j.JSXAttribute, {
     name: { type: 'JSXIdentifier', name: 'target' },
   })
+
+  // Cheap early-out: a file with no `target=` attributes has nothing this
+  // transform can rewrite. Returning `file.source` (rather than reserializing
+  // via toSource) avoids recast's whitespace normalization marking the file
+  // as "changed" in `--dry-run --verbose` reports for unrelated source files.
+  if (attrs.size() === 0) return file.source
+
+  const refNames = collectUseRefNames(j, root)
+  let mutated = false
 
   attrs.forEach((path) => {
     const node = path.node
@@ -65,11 +72,19 @@ export default function transform(file: FileInfo, api: API): string {
 
     if (refNames.has(candidate)) {
       node.value = j.jsxExpressionContainer(j.identifier(candidate))
+      mutated = true
       return
     }
 
-    attachTodoIfNew(j, path)
+    if (attachTodoIfNew(j, path)) {
+      mutated = true
+    }
   })
+
+  // Second early-out: every `target=` attribute matched a no-op branch (already
+  // an expression, non-`#id` selector, or top-level JSX with no insertable
+  // parent). Skip reserialization for the same reason as above.
+  if (!mutated) return file.source
 
   return root.toSource({ quote: 'single', trailingComma: true })
 }
@@ -122,17 +137,20 @@ function readStringLiteralValue(value: unknown): string | null {
 // JSX-child grammar — they must be wrapped in `{/* ... */}` (i.e. a
 // JSXExpressionContainer holding a JSXEmptyExpression whose `.comments`
 // array carries a CommentBlock node).
-function attachTodoIfNew(j: JSCodeshift, attrPath: ASTPath<unknown>): void {
+// Returns true when a TODO comment was actually inserted (the caller uses
+// this to decide whether to reserialize the file). Returns false for both
+// "no safe insertion point" and "idempotent skip — TODO already present".
+function attachTodoIfNew(j: JSCodeshift, attrPath: ASTPath<unknown>): boolean {
   // attrPath: JSXAttribute → parent: JSXOpeningElement → parent: JSXElement.
   const openingPath = attrPath.parent
-  if (!openingPath?.node) return
+  if (!openingPath?.node) return false
   const elementPath = openingPath.parent
-  if (!elementPath?.node) return
+  if (!elementPath?.node) return false
 
   // Find the JSXElement's parent container (a JSXElement, JSXFragment, or
   // ArrowFunction/return statement). Inserting as a sibling requires the
-  // parent to have a `children` array; otherwise we attach a leading line
-  // comment on the JSXElement (recast renders it above the JS expression).
+  // parent to have a `children` array; otherwise we leave the attribute
+  // untouched (see comment in the early return below).
   const containerPath = elementPath.parent
   const containerNode = containerPath?.node as
     | { type?: string; children?: Array<unknown> }
@@ -145,7 +163,7 @@ function attachTodoIfNew(j: JSCodeshift, attrPath: ASTPath<unknown>): void {
     // JSXElement, where ASI silently turns the return into an `undefined`
     // bail-out. Better to leave the attribute untouched and let the developer
     // notice the un-rewritten selector at PR review time.
-    return
+    return false
   }
 
   // Idempotency: don't re-insert if a TODO block comment already precedes
@@ -157,7 +175,7 @@ function attachTodoIfNew(j: JSCodeshift, attrPath: ASTPath<unknown>): void {
       | undefined
     const prevComments = prev?.expression?.comments
     if (prevComments?.some((c) => typeof c.value === 'string' && c.value.includes(TODO_MARKER))) {
-      return
+      return false
     }
   }
   const emptyExpr = j.jsxEmptyExpression()
@@ -171,4 +189,5 @@ function attachTodoIfNew(j: JSCodeshift, attrPath: ASTPath<unknown>): void {
   ]
   const todoNode = j.jsxExpressionContainer(emptyExpr)
   containerNode.children.splice(idx, 0, todoNode as unknown)
+  return true
 }

--- a/packages/codemods/src/transforms/target-to-ref.ts
+++ b/packages/codemods/src/transforms/target-to-ref.ts
@@ -50,22 +50,22 @@ export default function transform(file: FileInfo, api: API): string {
   const refNames = collectUseRefNames(j, root)
   let mutated = false
 
-  attrs.forEach((path) => {
+  for (const path of attrs.paths()) {
     const node = path.node
     const value = node.value
-    if (!value) return
+    if (!value) continue
 
     // Already migrated (target={someExpr}) — idempotent skip.
-    if (value.type === 'JSXExpressionContainer') return
+    if (value.type === 'JSXExpressionContainer') continue
 
     const literal = readStringLiteralValue(value)
-    if (literal === null) return
+    if (literal === null) continue
 
     const match = SELECTOR_RE.exec(literal)
     if (!match) {
       // Non-`#identifier` selector — leave alone (CSS combinators, data-cy,
       // etc. need manual review, but the codemod has no opinion here).
-      return
+      continue
     }
     const bareId = match[1]
     const candidate = `${bareId}Ref`
@@ -73,13 +73,13 @@ export default function transform(file: FileInfo, api: API): string {
     if (refNames.has(candidate)) {
       node.value = j.jsxExpressionContainer(j.identifier(candidate))
       mutated = true
-      return
+      continue
     }
 
     if (attachTodoIfNew(j, path)) {
       mutated = true
     }
-  })
+  }
 
   // Second early-out: every `target=` attribute matched a no-op branch (already
   // an expression, non-`#id` selector, or top-level JSX with no insertable
@@ -95,35 +95,38 @@ export default function transform(file: FileInfo, api: API): string {
 // binding name, not the callee identifier.
 function collectUseRefNames(j: JSCodeshift, root: ReturnType<JSCodeshift>): Set<string> {
   const names = new Set<string>()
-  root
-    .find(j.VariableDeclarator, {
-      init: { type: 'CallExpression' },
-    })
-    .forEach((path) => {
-      const init = path.node.init as { type: string; callee?: unknown } | null
-      if (!init || init.type !== 'CallExpression') return
-      const callee = init.callee as
-        | { type: 'Identifier'; name?: string }
-        | { type: 'MemberExpression'; property?: { name?: string } }
-        | undefined
-      if (!callee) return
-      let calleeName: string | undefined
-      if (callee.type === 'Identifier') {
-        calleeName = (callee as { name?: string }).name
-      } else if (callee.type === 'MemberExpression') {
-        calleeName = (callee as { property?: { name?: string } }).property?.name
-      }
-      if (calleeName !== 'useRef') return
-      const id = path.node.id
-      if (id.type === 'Identifier') {
-        names.add(id.name)
-      }
-    })
+  const decls = root.find(j.VariableDeclarator, {
+    init: { type: 'CallExpression' },
+  })
+  for (const path of decls.paths()) {
+    const init = path.node.init as { type: string; callee?: unknown } | null
+    if (!init || init.type !== 'CallExpression') continue
+    const callee = init.callee as
+      | { type: 'Identifier'; name?: string }
+      | { type: 'MemberExpression'; property?: { name?: string } }
+      | undefined
+    if (!callee) continue
+    let calleeName: string | undefined
+    if (callee.type === 'Identifier') {
+      calleeName = (callee as { name?: string }).name
+    } else if (callee.type === 'MemberExpression') {
+      calleeName = (callee as { property?: { name?: string } }).property?.name
+    }
+    if (calleeName !== 'useRef') continue
+    const id = path.node.id
+    if (id.type === 'Identifier') {
+      names.add(id.name)
+    }
+  }
   return names
 }
 
 function readStringLiteralValue(value: unknown): string | null {
-  const v = value as { type?: string; value?: unknown; expression?: { type?: string; value?: unknown } } | null
+  const v = value as {
+    type?: string
+    value?: unknown
+    expression?: { type?: string; value?: unknown }
+  } | null
   if (!v) return null
   if (v.type === 'StringLiteral' && typeof v.value === 'string') return v.value
   if (v.type === 'Literal' && typeof v.value === 'string') return v.value

--- a/packages/core/src/__tests__/types/target.test.ts
+++ b/packages/core/src/__tests__/types/target.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveTarget } from '../../types/target'
+
+describe('resolveTarget', () => {
+  let savedDocument: typeof globalThis.document
+
+  beforeEach(() => {
+    savedDocument = globalThis.document
+    document.body.innerHTML = '<div id="x">hello</div>'
+  })
+
+  afterEach(() => {
+    // Restore the jsdom `document` reference first — the SSR test stubs it to
+    // `undefined`, so any `document.*` access in cleanup would throw.
+    vi.unstubAllGlobals()
+    ;(globalThis as { document: typeof globalThis.document }).document = savedDocument
+    document.body.innerHTML = ''
+  })
+
+  it('string selector → document.querySelector', () => {
+    const el = document.getElementById('x')
+    expect(resolveTarget('#x')).toBe(el)
+  })
+
+  it('RefObject with .current set → returns the element', () => {
+    const el = document.getElementById('x')
+    if (!el) throw new Error('fixture missing')
+    expect(resolveTarget({ current: el })).toBe(el)
+  })
+
+  it('RefObject with .current null → returns null', () => {
+    expect(resolveTarget({ current: null })).toBeNull()
+  })
+
+  it('thunk returning element → returns the element', () => {
+    const el = document.getElementById('x')
+    if (!el) throw new Error('fixture missing')
+    expect(resolveTarget(() => el)).toBe(el)
+  })
+
+  it('thunk returning null → returns null', () => {
+    expect(resolveTarget(() => null)).toBeNull()
+  })
+
+  it('SSR-safe: returns null when document is undefined and does NOT throw', () => {
+    vi.stubGlobal('document', undefined)
+    expect(() => resolveTarget('#x')).not.toThrow()
+    expect(resolveTarget('#x')).toBeNull()
+  })
+})

--- a/packages/core/src/__tests__/utils/dom.test.ts
+++ b/packages/core/src/__tests__/utils/dom.test.ts
@@ -51,6 +51,16 @@ describe('DOM Utilities', () => {
       const ref = { current: null }
       expect(getElement(ref)).toBeNull()
     })
+
+    it('returns element from getter thunk', () => {
+      const div = document.createElement('div')
+      container.appendChild(div)
+      expect(getElement(() => div)).toBe(div)
+    })
+
+    it('returns null from getter thunk that returns null', () => {
+      expect(getElement(() => null)).toBeNull()
+    })
   })
 
   describe('isElementVisible', () => {

--- a/packages/core/src/hooks/use-element-position.ts
+++ b/packages/core/src/hooks/use-element-position.ts
@@ -16,9 +16,7 @@ export interface ElementPositionResult {
  * already hold the resolved node. Resolution flows through `getElement`, which
  * delegates the union branches to `resolveTarget`.
  */
-export function useElementPosition(
-  target: TourTarget | HTMLElement | null
-): ElementPositionResult {
+export function useElementPosition(target: TourTarget | HTMLElement | null): ElementPositionResult {
   const [element, setElement] = useState<HTMLElement | null>(null)
   const [rect, setRect] = useState<DOMRect | null>(null)
   const [scrollParent, setScrollParent] = useState<HTMLElement | Window | null>(null)

--- a/packages/core/src/hooks/use-element-position.ts
+++ b/packages/core/src/hooks/use-element-position.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { getScrollParent } from '../utils/dom'
+import type { TourTarget } from '../types/target'
+import { getElement, getScrollParent } from '../utils/dom'
 import { throttleRAF } from '../utils/throttle'
 
 export interface ElementPositionResult {
@@ -9,7 +10,15 @@ export interface ElementPositionResult {
   update: () => void
 }
 
-export function useElementPosition(target: string | HTMLElement | null): ElementPositionResult {
+/**
+ * Subscribe to a target's position. Accepts every `TourTarget` shape (string
+ * selector, `RefObject`, getter) plus a direct `HTMLElement` for callers that
+ * already hold the resolved node. Resolution flows through `getElement`, which
+ * delegates the union branches to `resolveTarget`.
+ */
+export function useElementPosition(
+  target: TourTarget | HTMLElement | null
+): ElementPositionResult {
   const [element, setElement] = useState<HTMLElement | null>(null)
   const [rect, setRect] = useState<DOMRect | null>(null)
   const [scrollParent, setScrollParent] = useState<HTMLElement | Window | null>(null)
@@ -17,22 +26,9 @@ export function useElementPosition(target: string | HTMLElement | null): Element
 
   // Resolve target to element
   useEffect(() => {
-    if (!target) {
-      setElement(null)
-      setScrollParent(null)
-      return
-    }
-
-    if (typeof target === 'string') {
-      const el = document.querySelector<HTMLElement>(target)
-      setElement(el)
-      if (el) {
-        setScrollParent(getScrollParent(el))
-      }
-    } else {
-      setElement(target)
-      setScrollParent(getScrollParent(target))
-    }
+    const el = getElement(target)
+    setElement(el)
+    setScrollParent(el ? getScrollParent(el) : null)
   }, [target])
 
   const update = useCallback(() => {

--- a/packages/core/src/hooks/use-step.ts
+++ b/packages/core/src/hooks/use-step.ts
@@ -29,13 +29,7 @@ export function useStep(stepId: string): UseStepReturn {
   const [isVisible, setIsVisible] = useState(false)
   const [hasCompleted, setHasCompleted] = useState(false)
 
-  const target = step?.target
-  const targetSelector = typeof target === 'string' ? target : null
-  const targetRef = typeof target === 'object' ? target?.current : null
-
-  const { element: targetElement, rect: targetRect } = useElementPosition(
-    targetSelector ?? targetRef
-  )
+  const { element: targetElement, rect: targetRect } = useElementPosition(step?.target ?? null)
 
   useEffect(() => {
     if (isActive) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,9 @@ export type {
   StepIdOf,
   AudienceProp,
   TourStepMedia,
+  TourTarget,
+  TourTargetRef,
+  TourTargetGetter,
   Tour,
   TourOptions,
   TourState,
@@ -60,6 +63,9 @@ export {
   defaultA11yConfig,
   defaultScrollConfig,
   initialTourState,
+  // Runtime target resolver (Phase 5) — single source of truth for
+  // string/ref/getter dereference across hooks and React consumers.
+  resolveTarget,
 } from './types'
 
 // Context

--- a/packages/core/src/lib/wait-for-step-target.ts
+++ b/packages/core/src/lib/wait-for-step-target.ts
@@ -5,6 +5,7 @@
  */
 
 import type { TourStep } from '../types/step'
+import { resolveTarget } from '../types/target'
 import { waitForElement } from '../utils/dom'
 
 /**
@@ -70,13 +71,15 @@ export async function waitForStepTarget(
 ): Promise<HTMLElement> {
   const timeout = opts.timeoutMs ?? 3000
 
+  // Ref / getter targets resolve synchronously through `resolveTarget`. There's
+  // no selector to observe for, so a null result is an immediate failure.
   if (typeof step.target !== 'string') {
-    const el = step.target?.current
+    const el = resolveTarget(step.target)
     if (el) return el
     throw new TourRouteError({
       code: 'TARGET_NOT_FOUND',
       route: opts.route,
-      message: `Step "${step.id}" target ref not populated on route "${opts.route}".`,
+      message: `Step "${step.id}" target ref/getter not populated on route "${opts.route}".`,
     })
   }
 

--- a/packages/core/src/types/hints.ts
+++ b/packages/core/src/types/hints.ts
@@ -3,12 +3,13 @@ import type { FrequencyRule } from '../lib/frequency'
 import type { LocalizedText } from '../lib/localized-text'
 import type { Placement } from './config'
 import type { AudienceProp } from './step'
+import type { TourTarget } from './target'
 
 export type HotspotPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'center'
 
 export interface HintConfig {
   id: string
-  target: string | React.RefObject<HTMLElement | null>
+  target: TourTarget
   /** Optional title rendered above the content (Phase 3a). */
   title?: LocalizedText
   content: React.ReactNode | LocalizedText

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -41,6 +41,10 @@ export {
 // Step types
 export type { TourStep, StepOptions, StepIdOf, AudienceProp, TourStepMedia } from './step'
 
+// Target types + runtime resolver (Phase 5)
+export type { TourTarget, TourTargetRef, TourTargetGetter } from './target'
+export { resolveTarget } from './target'
+
 // Tour types
 export type { Tour, TourOptions } from './tour'
 

--- a/packages/core/src/types/step.ts
+++ b/packages/core/src/types/step.ts
@@ -4,6 +4,7 @@ import type { AudienceCondition } from './audience'
 import type { Branch } from './branch'
 import type { Placement } from './config'
 import type { TourCallbackContext } from './state'
+import type { TourTarget } from './target'
 
 /**
  * Structural alias of `MediaSlotProps` from `@tour-kit/media`. Re-declared
@@ -60,7 +61,7 @@ export interface TourStep<TId extends string = string> {
    * @default 'visible'
    */
   kind?: 'visible' | 'hidden'
-  target: string | React.RefObject<HTMLElement | null>
+  target: TourTarget
   /**
    * Step title. Accepts a plain string (interpolated via `interpolate`),
    * a `{ key: string }` dictionary lookup (resolved via `useT()`), or any

--- a/packages/core/src/types/target.ts
+++ b/packages/core/src/types/target.ts
@@ -1,0 +1,47 @@
+import type * as React from 'react'
+
+export type TourTargetRef = React.RefObject<HTMLElement | null>
+export type TourTargetGetter = () => HTMLElement | null
+
+/**
+ * Three accepted shapes for `target` on a `TourStep` / `HintConfig`:
+ *
+ *   - selector string (legacy; runs `document.querySelector` at resolve time)
+ *   - `RefObject` (recommended; survives portals, CSS modules, dynamic ids)
+ *   - getter function (escape hatch for lazily-mounted DOM)
+ *
+ * Backwards-compat: string form is documented as fallback only and emits NO
+ * dev warning. Existing string selectors continue to resolve through
+ * `document.querySelector` unchanged.
+ */
+export type TourTarget = string | TourTargetRef | TourTargetGetter
+
+/**
+ * Resolve a `TourTarget` to a live `HTMLElement` (or `null` when missing).
+ *
+ * Branch order (closed, non-overlapping):
+ *
+ *   1. `typeof t === 'string'`                          → `document.querySelector(t)`
+ *   2. `t && typeof t === 'object' && 'current' in t`   → `t.current`
+ *   3. `typeof t === 'function'`                        → `t()`
+ *
+ * Strings can't carry `.current`, refs are objects with `.current`, thunks are
+ * callables — no branch overlaps with another. Returns `HTMLElement | null`,
+ * never `undefined`.
+ *
+ * SSR-safe: when `document` is not defined (Next.js RSC, Remix server render),
+ * the string branch returns `null` without throwing.
+ */
+export function resolveTarget(t: TourTarget): HTMLElement | null {
+  if (typeof t === 'string') {
+    if (typeof document === 'undefined') return null
+    return document.querySelector<HTMLElement>(t)
+  }
+  if (t && typeof t === 'object' && 'current' in t) {
+    return t.current
+  }
+  if (typeof t === 'function') {
+    return t()
+  }
+  return null
+}

--- a/packages/core/src/utils/dom.ts
+++ b/packages/core/src/utils/dom.ts
@@ -11,8 +11,13 @@ import { resolveTarget, type TourTarget } from '../types/target'
  */
 export function getElement(target: TourTarget | HTMLElement | null): HTMLElement | null {
   if (!target) return null
-  if (target instanceof HTMLElement) return target
-  return resolveTarget(target)
+  // SSR-safe instanceof — `HTMLElement` is undefined on bare Node, and
+  // `instanceof undefined` throws TypeError. `resolveTarget` already
+  // SSR-guards its own string branch; this matches that contract. Under
+  // SSR no live `HTMLElement` instance can exist anyway, so the fall-through
+  // path is defensive only.
+  if (typeof HTMLElement !== 'undefined' && target instanceof HTMLElement) return target
+  return resolveTarget(target as TourTarget)
 }
 
 /**

--- a/packages/core/src/utils/dom.ts
+++ b/packages/core/src/utils/dom.ts
@@ -1,4 +1,4 @@
-import { resolveTarget, type TourTarget } from '../types/target'
+import { type TourTarget, resolveTarget } from '../types/target'
 
 /**
  * Safely get an element from various target shapes.

--- a/packages/core/src/utils/dom.ts
+++ b/packages/core/src/utils/dom.ts
@@ -1,22 +1,18 @@
-import type React from 'react'
+import { resolveTarget, type TourTarget } from '../types/target'
 
 /**
- * Safely get an element from various target types
+ * Safely get an element from various target shapes.
+ *
+ * Accepts the full `TourTarget` union (string selector, `RefObject`, or
+ * getter function), plus the legacy direct `HTMLElement` passthrough used by
+ * internal callers that already hold the resolved node. Selector / ref / getter
+ * branches delegate to `resolveTarget` so the resolver stays the single source
+ * of truth.
  */
-export function getElement(
-  target: string | HTMLElement | React.RefObject<HTMLElement | null> | null
-): HTMLElement | null {
+export function getElement(target: TourTarget | HTMLElement | null): HTMLElement | null {
   if (!target) return null
-
-  if (typeof target === 'string') {
-    return document.querySelector<HTMLElement>(target)
-  }
-
-  if ('current' in target) {
-    return target.current
-  }
-
-  return target
+  if (target instanceof HTMLElement) return target
+  return resolveTarget(target)
 }
 
 /**

--- a/packages/hints/src/components/headless/hint.tsx
+++ b/packages/hints/src/components/headless/hint.tsx
@@ -51,11 +51,8 @@ export function HintHeadless({
   const hotspotRef = React.useRef<HTMLButtonElement>(null)
 
   const targetSelector = typeof target === 'string' ? target : null
-  const targetRef = typeof target === 'object' ? target?.current : null
 
-  const { element: targetElement, rect: targetRect } = useElementPosition(
-    targetSelector ?? targetRef
-  )
+  const { element: targetElement, rect: targetRect } = useElementPosition(target ?? null)
 
   // Fire autoShow exactly once for this hint instance.
   // Re-running on every render (when show/onShow identities change) loops.

--- a/packages/hints/src/components/hint.tsx
+++ b/packages/hints/src/components/hint.tsx
@@ -93,11 +93,8 @@ export const Hint = React.forwardRef<HTMLButtonElement, HintProps>(
     }, [ref])
 
     const targetSelector = typeof target === 'string' ? target : null
-    const targetRefElement = typeof target === 'object' ? target?.current : null
 
-    const { element: targetElement, rect: targetRect } = useElementPosition(
-      targetSelector ?? targetRefElement
-    )
+    const { element: targetElement, rect: targetRect } = useElementPosition(target ?? null)
 
     // Fire autoShow exactly once for this hint instance.
     // Re-running on every render (when show/onShow identities change) loops.

--- a/packages/react/src/__tests__/components/card/tour-card.target-back-compat.test.tsx
+++ b/packages/react/src/__tests__/components/card/tour-card.target-back-compat.test.tsx
@@ -6,18 +6,19 @@
  * thunk. Each variant must:
  *
  *   - render the active dialog without throwing
- *   - resolve the same target node, attached to floating-ui via `refs.setReference`
- *   - never emit a `console.warn` (Phase 0 §3 sign-off: string form is fallback,
- *     not deprecation)
+ *   - resolve the target node — verified via a probe that captures
+ *     `resolveTarget(currentStep.target)` at step-enter time
+ *   - never emit a target-related `console.warn` (Phase 0 §3 sign-off:
+ *     string form is fallback, not deprecation)
  *
- * jsdom does not provide real layout, so we assert the dialog's presence and
- * the `console.warn` contract — `resolveTarget` unit tests cover branch
- * correctness, and the existing Floating UI tests cover positioning.
+ * jsdom does not compute layout, so we don't assert geometry overlap. The
+ * resolver branch matrix is covered by `target.test.ts` — here we prove the
+ * *React-tree integration* lights up identically for all three shapes.
  */
 
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { type Tour, TourProvider, useTour } from '@tour-kit/core'
+import { type Tour, TourProvider, resolveTarget, useTour } from '@tour-kit/core'
 import * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TourCard } from '../../../components/card/tour-card'
@@ -32,9 +33,26 @@ function Starter() {
   )
 }
 
+// Captures `resolveTarget(currentStep.target)` whenever the active step
+// changes, so the test can assert "the resolver actually returned the right
+// node" rather than just "the dialog rendered." Without this, a regression
+// that made `resolveTarget` always return null would still pass — `<TourCard>`
+// mounts the dialog whenever `isActive`, independent of target resolution.
+function ResolvedTargetProbe({ onResolve }: { onResolve: (el: HTMLElement | null) => void }) {
+  const { currentStep, isActive } = useTour()
+  React.useEffect(() => {
+    if (!isActive || !currentStep) return
+    onResolve(resolveTarget(currentStep.target))
+  }, [isActive, currentStep, onResolve])
+  return null
+}
+
 // Mounts the target node + captures its ref so a single React subtree can hand
 // the same node to TourProvider as either a selector, a ref, or a thunk.
-function TargetMount({ id, refOut }: { id: string; refOut?: { current: HTMLElement | null } }) {
+function TargetMount({
+  id,
+  refOut,
+}: { id: string; refOut?: { current: HTMLElement | null } }) {
   return (
     <div
       id={id}
@@ -45,6 +63,18 @@ function TargetMount({ id, refOut }: { id: string; refOut?: { current: HTMLEleme
       Target
     </div>
   )
+}
+
+// Phase 0 §3 sign-off: legacy string form is fallback, not deprecated — no
+// `target`-related dev warning may fire. Unrelated dev tips (e.g. the
+// `diagnose` hint) are allowed; we filter rather than assert zero calls.
+function expectNoTargetWarns(spy: ReturnType<typeof vi.spyOn>) {
+  const offenders = spy.mock.calls.filter((args: unknown[]) =>
+    args.some(
+      (a: unknown) => typeof a === 'string' && (a.includes('target') || a.includes('deprecat'))
+    )
+  )
+  expect(offenders).toEqual([])
 }
 
 describe('TourCard backwards-compat across target shapes', () => {
@@ -61,6 +91,7 @@ describe('TourCard backwards-compat across target shapes', () => {
 
   it('renders the active dialog when target is a legacy string selector', async () => {
     const user = userEvent.setup()
+    const resolved: Array<HTMLElement | null> = []
     const tour: Tour = {
       id: 'bc-string',
       steps: [{ id: 's1', target: '#a', title: 'Hello', content: 'There' }],
@@ -71,6 +102,7 @@ describe('TourCard backwards-compat across target shapes', () => {
         <TargetMount id="a" />
         <TourOverlay />
         <TourCard />
+        <ResolvedTargetProbe onResolve={(el) => resolved.push(el)} />
         <Starter />
       </TourProvider>
     )
@@ -78,20 +110,13 @@ describe('TourCard backwards-compat across target shapes', () => {
     await user.click(screen.getByText('Start'))
     const dialog = await screen.findByRole('dialog')
     expect(dialog).toBeTruthy()
-    // Phase 0 §3 sign-off: legacy string form is fallback, not deprecated —
-    // no `target`-related dev warning may fire. Unrelated dev tips (e.g. the
-    // `diagnose` hint) are allowed; we filter rather than assert zero calls.
-    const targetRelatedWarns = warnSpy.mock.calls.filter((args: unknown[]) =>
-      args.some(
-        (arg: unknown) =>
-          typeof arg === 'string' && (arg.includes('target') || arg.includes('deprecat'))
-      )
-    )
-    expect(targetRelatedWarns).toEqual([])
+    expect(resolved[0]).toBe(document.getElementById('a'))
+    expectNoTargetWarns(warnSpy)
   })
 
   it('renders the active dialog when target is a RefObject', async () => {
     const user = userEvent.setup()
+    const resolved: Array<HTMLElement | null> = []
 
     function App() {
       const ref = React.useRef<HTMLElement | null>(null)
@@ -107,6 +132,7 @@ describe('TourCard backwards-compat across target shapes', () => {
           <TargetMount id="a" refOut={ref} />
           <TourOverlay />
           <TourCard />
+          <ResolvedTargetProbe onResolve={(el) => resolved.push(el)} />
           <Starter />
         </TourProvider>
       )
@@ -116,20 +142,13 @@ describe('TourCard backwards-compat across target shapes', () => {
     await user.click(screen.getByText('Start'))
     const dialog = await screen.findByRole('dialog')
     expect(dialog).toBeTruthy()
-    // Phase 0 §3 sign-off: legacy string form is fallback, not deprecated —
-    // no `target`-related dev warning may fire. Unrelated dev tips (e.g. the
-    // `diagnose` hint) are allowed; we filter rather than assert zero calls.
-    const targetRelatedWarns = warnSpy.mock.calls.filter((args: unknown[]) =>
-      args.some(
-        (arg: unknown) =>
-          typeof arg === 'string' && (arg.includes('target') || arg.includes('deprecat'))
-      )
-    )
-    expect(targetRelatedWarns).toEqual([])
+    expect(resolved[0]).toBe(document.getElementById('a'))
+    expectNoTargetWarns(warnSpy)
   })
 
   it('renders the active dialog when target is a getter thunk', async () => {
     const user = userEvent.setup()
+    const resolved: Array<HTMLElement | null> = []
     const tour: Tour = {
       id: 'bc-thunk',
       steps: [
@@ -147,6 +166,7 @@ describe('TourCard backwards-compat across target shapes', () => {
         <TargetMount id="a" />
         <TourOverlay />
         <TourCard />
+        <ResolvedTargetProbe onResolve={(el) => resolved.push(el)} />
         <Starter />
       </TourProvider>
     )
@@ -154,15 +174,7 @@ describe('TourCard backwards-compat across target shapes', () => {
     await user.click(screen.getByText('Start'))
     const dialog = await screen.findByRole('dialog')
     expect(dialog).toBeTruthy()
-    // Phase 0 §3 sign-off: legacy string form is fallback, not deprecated —
-    // no `target`-related dev warning may fire. Unrelated dev tips (e.g. the
-    // `diagnose` hint) are allowed; we filter rather than assert zero calls.
-    const targetRelatedWarns = warnSpy.mock.calls.filter((args: unknown[]) =>
-      args.some(
-        (arg: unknown) =>
-          typeof arg === 'string' && (arg.includes('target') || arg.includes('deprecat'))
-      )
-    )
-    expect(targetRelatedWarns).toEqual([])
+    expect(resolved[0]).toBe(document.getElementById('a'))
+    expectNoTargetWarns(warnSpy)
   })
 })

--- a/packages/react/src/__tests__/components/card/tour-card.target-back-compat.test.tsx
+++ b/packages/react/src/__tests__/components/card/tour-card.target-back-compat.test.tsx
@@ -49,10 +49,7 @@ function ResolvedTargetProbe({ onResolve }: { onResolve: (el: HTMLElement | null
 
 // Mounts the target node + captures its ref so a single React subtree can hand
 // the same node to TourProvider as either a selector, a ref, or a thunk.
-function TargetMount({
-  id,
-  refOut,
-}: { id: string; refOut?: { current: HTMLElement | null } }) {
+function TargetMount({ id, refOut }: { id: string; refOut?: { current: HTMLElement | null } }) {
   return (
     <div
       id={id}

--- a/packages/react/src/__tests__/components/card/tour-card.target-back-compat.test.tsx
+++ b/packages/react/src/__tests__/components/card/tour-card.target-back-compat.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Phase 5 — backwards-compat parity for the widened `TourTarget` union.
+ *
+ * Mounts the same single-step tour three times: once with a legacy string
+ * selector, once with a `RefObject<HTMLElement | null>`, once with a getter
+ * thunk. Each variant must:
+ *
+ *   - render the active dialog without throwing
+ *   - resolve the same target node, attached to floating-ui via `refs.setReference`
+ *   - never emit a `console.warn` (Phase 0 §3 sign-off: string form is fallback,
+ *     not deprecation)
+ *
+ * jsdom does not provide real layout, so we assert the dialog's presence and
+ * the `console.warn` contract — `resolveTarget` unit tests cover branch
+ * correctness, and the existing Floating UI tests cover positioning.
+ */
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { type Tour, TourProvider, useTour } from '@tour-kit/core'
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TourCard } from '../../../components/card/tour-card'
+import { TourOverlay } from '../../../components/overlay/tour-overlay'
+
+function Starter() {
+  const { start } = useTour()
+  return (
+    <button type="button" onClick={() => start()}>
+      Start
+    </button>
+  )
+}
+
+// Mounts the target node + captures its ref so a single React subtree can hand
+// the same node to TourProvider as either a selector, a ref, or a thunk.
+function TargetMount({ id, refOut }: { id: string; refOut?: { current: HTMLElement | null } }) {
+  return (
+    <div
+      id={id}
+      ref={(node) => {
+        if (refOut) refOut.current = node
+      }}
+    >
+      Target
+    </div>
+  )
+}
+
+describe('TourCard backwards-compat across target shapes', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('renders the active dialog when target is a legacy string selector', async () => {
+    const user = userEvent.setup()
+    const tour: Tour = {
+      id: 'bc-string',
+      steps: [{ id: 's1', target: '#a', title: 'Hello', content: 'There' }],
+    }
+
+    render(
+      <TourProvider tours={[tour]}>
+        <TargetMount id="a" />
+        <TourOverlay />
+        <TourCard />
+        <Starter />
+      </TourProvider>
+    )
+
+    await user.click(screen.getByText('Start'))
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toBeTruthy()
+    // Phase 0 §3 sign-off: legacy string form is fallback, not deprecated —
+    // no `target`-related dev warning may fire. Unrelated dev tips (e.g. the
+    // `diagnose` hint) are allowed; we filter rather than assert zero calls.
+    const targetRelatedWarns = warnSpy.mock.calls.filter((args: unknown[]) =>
+      args.some(
+        (arg: unknown) =>
+          typeof arg === 'string' && (arg.includes('target') || arg.includes('deprecat'))
+      )
+    )
+    expect(targetRelatedWarns).toEqual([])
+  })
+
+  it('renders the active dialog when target is a RefObject', async () => {
+    const user = userEvent.setup()
+
+    function App() {
+      const ref = React.useRef<HTMLElement | null>(null)
+      const tour = React.useMemo<Tour>(
+        () => ({
+          id: 'bc-ref',
+          steps: [{ id: 's1', target: ref, title: 'Hello', content: 'There' }],
+        }),
+        []
+      )
+      return (
+        <TourProvider tours={[tour]}>
+          <TargetMount id="a" refOut={ref} />
+          <TourOverlay />
+          <TourCard />
+          <Starter />
+        </TourProvider>
+      )
+    }
+
+    render(<App />)
+    await user.click(screen.getByText('Start'))
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toBeTruthy()
+    // Phase 0 §3 sign-off: legacy string form is fallback, not deprecated —
+    // no `target`-related dev warning may fire. Unrelated dev tips (e.g. the
+    // `diagnose` hint) are allowed; we filter rather than assert zero calls.
+    const targetRelatedWarns = warnSpy.mock.calls.filter((args: unknown[]) =>
+      args.some(
+        (arg: unknown) =>
+          typeof arg === 'string' && (arg.includes('target') || arg.includes('deprecat'))
+      )
+    )
+    expect(targetRelatedWarns).toEqual([])
+  })
+
+  it('renders the active dialog when target is a getter thunk', async () => {
+    const user = userEvent.setup()
+    const tour: Tour = {
+      id: 'bc-thunk',
+      steps: [
+        {
+          id: 's1',
+          target: () => document.getElementById('a'),
+          title: 'Hello',
+          content: 'There',
+        },
+      ],
+    }
+
+    render(
+      <TourProvider tours={[tour]}>
+        <TargetMount id="a" />
+        <TourOverlay />
+        <TourCard />
+        <Starter />
+      </TourProvider>
+    )
+
+    await user.click(screen.getByText('Start'))
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toBeTruthy()
+    // Phase 0 §3 sign-off: legacy string form is fallback, not deprecated —
+    // no `target`-related dev warning may fire. Unrelated dev tips (e.g. the
+    // `diagnose` hint) are allowed; we filter rather than assert zero calls.
+    const targetRelatedWarns = warnSpy.mock.calls.filter((args: unknown[]) =>
+      args.some(
+        (arg: unknown) =>
+          typeof arg === 'string' && (arg.includes('target') || arg.includes('deprecat'))
+      )
+    )
+    expect(targetRelatedWarns).toEqual([])
+  })
+})

--- a/packages/react/src/__tests__/components/provider/multi-tour-kit-compose.test.tsx
+++ b/packages/react/src/__tests__/components/provider/multi-tour-kit-compose.test.tsx
@@ -1,0 +1,74 @@
+import { render, renderHook } from '@testing-library/react'
+import { useTour } from '@tour-kit/core'
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+import {
+  MultiTourKitProvider,
+  useTourRegistryContext,
+} from '../../../components/provider/tourkit-provider'
+import { Tour } from '../../../components/tour/tour'
+import { TourStep } from '../../../components/tour/tour-step'
+
+// Wrap children five `<div>`s deep — proves registry lookup survives nesting.
+function DeepWrapper({ children }: { children: ReactNode }) {
+  return (
+    <MultiTourKitProvider>
+      <Tour id="x">
+        <TourStep id="s1" target="#a" title="Hi" content="There" />
+      </Tour>
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>{children}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </MultiTourKitProvider>
+  )
+}
+
+describe('<MultiTourKitProvider> compose-mode', () => {
+  it('useTour() from a deeply-nested child returns a controller (not null, not thrown)', () => {
+    const { result } = renderHook(() => useTour(), { wrapper: DeepWrapper })
+    expect(result.current).toBeDefined()
+    expect(result.current.isActive).toBe(false)
+  })
+
+  it('registry exposes the registered tour id', () => {
+    const { result } = renderHook(() => useTourRegistryContext(), { wrapper: DeepWrapper })
+    const ids = result.current.tours.map((t) => t.id)
+    expect(ids).toContain('x')
+  })
+
+  it('re-rendering the registrar leaf does not duplicate the registry entry', () => {
+    const Registrar = () => (
+      <Tour id="dup">
+        <TourStep id="s1" target="#a" title="Hi" content="There" />
+      </Tour>
+    )
+    function RegistryProbe() {
+      const ctx = useTourRegistryContext()
+      return <div data-testid="ids">{ctx.tours.map((t) => t.id).join(',')}</div>
+    }
+
+    const { rerender, getByTestId } = render(
+      <MultiTourKitProvider>
+        <Registrar key="r1" />
+        <RegistryProbe />
+      </MultiTourKitProvider>
+    )
+
+    expect(getByTestId('ids').textContent).toBe('dup')
+
+    rerender(
+      <MultiTourKitProvider>
+        <Registrar key="r2" />
+        <RegistryProbe />
+      </MultiTourKitProvider>
+    )
+
+    expect(getByTestId('ids').textContent).toBe('dup')
+  })
+})

--- a/packages/react/src/__tests__/components/provider/multi-tour-kit-compose.test.tsx
+++ b/packages/react/src/__tests__/components/provider/multi-tour-kit-compose.test.tsx
@@ -42,33 +42,44 @@ describe('<MultiTourKitProvider> compose-mode', () => {
     expect(ids).toContain('x')
   })
 
-  it('re-rendering the registrar leaf does not duplicate the registry entry', () => {
-    const Registrar = () => (
-      <Tour id="dup">
-        <TourStep id="s1" target="#a" title="Hi" content="There" />
-      </Tour>
-    )
+  it('re-registering the same id with a new tour object never grows the registry', () => {
+    // Same-instance re-render with a prop that forces a fresh `tour` identity
+    // each pass. Pins the contract: regardless of whether the implementation
+    // routes through cleanup→register OR the `if (exists) replace` branch in
+    // `tourkit-provider.tsx` registerTour, the registry must stay at exactly
+    // one entry. Assertion includes a `|${count}` suffix so a regression that
+    // appends without dedup surfaces as a count mismatch, not a string-id one.
+    function Registrar({ contentVersion }: { contentVersion: number }) {
+      return (
+        <Tour id="dup">
+          <TourStep id="s1" target="#a" title="Hi" content={`There v${contentVersion}`} />
+        </Tour>
+      )
+    }
     function RegistryProbe() {
       const ctx = useTourRegistryContext()
-      return <div data-testid="ids">{ctx.tours.map((t) => t.id).join(',')}</div>
+      const ids = ctx.tours.map((t) => t.id).join(',')
+      const count = ctx.tours.length
+      return <div data-testid="ids">{`${ids}|${count}`}</div>
     }
 
     const { rerender, getByTestId } = render(
       <MultiTourKitProvider>
-        <Registrar key="r1" />
+        <Registrar contentVersion={1} />
         <RegistryProbe />
       </MultiTourKitProvider>
     )
 
-    expect(getByTestId('ids').textContent).toBe('dup')
+    expect(getByTestId('ids').textContent).toBe('dup|1')
 
     rerender(
       <MultiTourKitProvider>
-        <Registrar key="r2" />
+        <Registrar contentVersion={2} />
         <RegistryProbe />
       </MultiTourKitProvider>
     )
 
-    expect(getByTestId('ids').textContent).toBe('dup')
+    // Same id, new tour identity → registry must stay at one entry, not two.
+    expect(getByTestId('ids').textContent).toBe('dup|1')
   })
 })

--- a/packages/react/src/components/card/tour-card.tsx
+++ b/packages/react/src/components/card/tour-card.tsx
@@ -9,7 +9,13 @@ import {
   shift,
   useFloating,
 } from '@floating-ui/react'
-import { type Placement, resolveTarget, useFocusTrap, useReducedMotion, useTour } from '@tour-kit/core'
+import {
+  type Placement,
+  resolveTarget,
+  useFocusTrap,
+  useReducedMotion,
+  useTour,
+} from '@tour-kit/core'
 import { cn } from '@tour-kit/core'
 import { MediaSlot } from '@tour-kit/media'
 import * as React from 'react'

--- a/packages/react/src/components/card/tour-card.tsx
+++ b/packages/react/src/components/card/tour-card.tsx
@@ -9,7 +9,7 @@ import {
   shift,
   useFloating,
 } from '@floating-ui/react'
-import { type Placement, useFocusTrap, useReducedMotion, useTour } from '@tour-kit/core'
+import { type Placement, resolveTarget, useFocusTrap, useReducedMotion, useTour } from '@tour-kit/core'
 import { cn } from '@tour-kit/core'
 import { MediaSlot } from '@tour-kit/media'
 import * as React from 'react'
@@ -81,11 +81,7 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
 
     const targetElement = React.useMemo(() => {
       if (!currentStep?.target) return null
-      if (typeof currentStep.target === 'string') {
-        if (typeof document === 'undefined') return null
-        return document.querySelector<HTMLElement>(currentStep.target)
-      }
-      return currentStep.target.current
+      return resolveTarget(currentStep.target)
     }, [currentStep?.target])
 
     const { refs, floatingStyles, context } = useFloating({

--- a/packages/react/src/components/headless/tour-card.tsx
+++ b/packages/react/src/components/headless/tour-card.tsx
@@ -9,7 +9,7 @@ import {
   shift,
   useFloating,
 } from '@floating-ui/react'
-import { type Placement, useFocusTrap, useTour } from '@tour-kit/core'
+import { type Placement, resolveTarget, useFocusTrap, useTour } from '@tour-kit/core'
 import * as React from 'react'
 import { TourPortal } from '../primitives/tour-portal'
 
@@ -63,11 +63,7 @@ export function TourCardHeadless({ className, style, children, render }: TourCar
 
   const targetElement = React.useMemo(() => {
     if (!currentStep?.target) return null
-    if (typeof currentStep.target === 'string') {
-      if (typeof document === 'undefined') return null
-      return document.querySelector<HTMLElement>(currentStep.target)
-    }
-    return currentStep.target.current
+    return resolveTarget(currentStep.target)
   }, [currentStep?.target])
 
   const { refs, floatingStyles, context } = useFloating({

--- a/packages/react/src/components/headless/tour-overlay.tsx
+++ b/packages/react/src/components/headless/tour-overlay.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePrefersReducedMotion, useSpotlight, useTour } from '@tour-kit/core'
+import { resolveTarget, usePrefersReducedMotion, useSpotlight, useTour } from '@tour-kit/core'
 import * as React from 'react'
 import { TourPortal } from '../primitives/tour-portal'
 
@@ -36,11 +36,7 @@ export function TourOverlayHeadless({
 
   const targetElement = React.useMemo(() => {
     if (!currentStep?.target) return null
-    if (typeof currentStep.target === 'string') {
-      if (typeof document === 'undefined') return null
-      return document.querySelector<HTMLElement>(currentStep.target)
-    }
-    return currentStep.target.current
+    return resolveTarget(currentStep.target)
   }, [currentStep?.target])
 
   React.useEffect(() => {

--- a/packages/react/src/components/overlay/tour-overlay.tsx
+++ b/packages/react/src/components/overlay/tour-overlay.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePrefersReducedMotion, useSpotlight, useTour } from '@tour-kit/core'
+import { resolveTarget, usePrefersReducedMotion, useSpotlight, useTour } from '@tour-kit/core'
 import { cn } from '@tour-kit/core'
 import * as React from 'react'
 import { TourPortal } from '../primitives/tour-portal'
@@ -21,11 +21,7 @@ export const TourOverlay = React.forwardRef<HTMLDivElement, TourOverlayProps>(
 
     const targetElement = React.useMemo(() => {
       if (!currentStep?.target) return null
-      if (typeof currentStep.target === 'string') {
-        if (typeof document === 'undefined') return null
-        return document.querySelector<HTMLElement>(currentStep.target)
-      }
-      return currentStep.target.current
+      return resolveTarget(currentStep.target)
     }, [currentStep?.target])
 
     React.useEffect(() => {

--- a/packages/react/src/components/provider/tourkit-provider.tsx
+++ b/packages/react/src/components/provider/tourkit-provider.tsx
@@ -57,6 +57,12 @@ export interface MultiTourKitProviderProps {
 /**
  * Multi-tour provider that manages multiple tours with shared UI.
  *
+ * **Compose-mode is the documented default.** Every consuming component —
+ * `<Tour>`, `<TourOverlay>`, `<TourCard>`, and your `<App />` — sits as a
+ * child of `<MultiTourKitProvider>` so `useTour()` resolves via the shared
+ * registry regardless of nesting depth. Sibling-style placement (where a
+ * `<Tour>` is rendered outside the provider) is not supported.
+ *
  * @example
  * ```tsx
  * <MultiTourKitProvider onTourComplete={(id) => console.log(`${id} completed!`)}>
@@ -71,6 +77,10 @@ export interface MultiTourKitProviderProps {
  *   <App />
  * </MultiTourKitProvider>
  * ```
+ *
+ * A `useTour()` call from any descendant — no matter how deeply nested —
+ * returns the active controller. Re-registering the same tour id is
+ * idempotent: existing entries are replaced rather than duplicated.
  */
 export function MultiTourKitProvider({
   children,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,8 @@ export { TourArrow } from './components/primitives/tour-arrow'
 export {
   MultiTourKitProvider,
   type MultiTourKitProviderProps,
+  useTourRegistryContext,
+  useTourRegistryContextOptional,
 } from './components/provider/tourkit-provider'
 
 // Theme


### PR DESCRIPTION
## Summary

Phase 5 of v2 package polish, per `tasks/v2-package-polish/phase-5.md`:

1. **Widen `TourStep.target` / `HintConfig.target`** from `string | RefObject<HTMLElement | null>` to also accept `() => HTMLElement | null` (a getter thunk). A new `resolveTarget` resolver in `@tour-kit/core/types/target.ts` is the single source of truth — every dereference (hooks, lib, utils, four React card/overlay consumers, two hints consumers) routes through it. SSR-safe (`document === undefined` returns `null` instead of throwing). Backwards-compatible: existing string selectors keep working with **no** console warning.

2. **`<MultiTourKitProvider>` compose-mode** — codify the canonical pattern in the provider's JSDoc and pin the contract with a five-deep `renderHook` test for `useTour()`. `useTourRegistryContext` is now exported from `@tour-kit/react`. No public API change.

3. **`--from target-to-ref` codemod** — best-effort jscodeshift transform that rewrites `target="#foo"` to `target={fooRef}` when a matching `useRef` binding lives in the same file. Ambiguous matches get a JSX-safe `{/* TODO(tour-kit): target-to-ref ... */}` sibling comment. Idempotent: re-running produces a zero-diff second pass and never stacks duplicate TODOs.

4. **Docs** — new `/docs/react/target-prop` page with one runnable code block per target shape plus the documented resolution order.

5. **Drive-by fix** — collapses duplicate `TURNKEY_CES_EVENT` / `TURNKEY_NPS_EVENT` imports in `examples/dashboard-next/components/tour-kit/demo-panel.tsx` (pre-existing on main since commit e8c4b22, was blocking `pnpm typecheck` at the repo root).

## Verification

- `pnpm typecheck` — 29 / 29 packages pass.
- `pnpm --filter @tour-kit/core test` — 865 pass, 3 skipped.
- `pnpm --filter @tour-kit/react test` — 473 pass.
- `pnpm --filter @tour-kit/hints test` — 291 pass.
- `pnpm --filter @tour-kit/codemods test` — 103 pass (5 fixture cases + 2 idempotency cases for `target-to-ref`).
- Audit grep returns zero matches:
  ```
  rg "target:.*string \\|.*RefObject|currentStep\\.target\\.current|step\\.target\\.current|document\\.querySelector<HTMLElement>\\(.*target" packages/core/src packages/react/src
  ```

The `pnpm --filter @tour-kit/docs build` fails on `/legal/terms` prerender, but the same failure reproduces on bare main (confirmed via `git stash` + rebuild) — unrelated to Phase 5.

## Test plan

- [x] CI typecheck across all 29 packages
- [x] CI runs `@tour-kit/core`, `@tour-kit/react`, `@tour-kit/hints`, `@tour-kit/codemods` test suites
- [x] Manually verify `<TourStep target={ref} />` and `<TourStep target={() => el} />` render the spotlight over the right element in the dashboard-next example
- [x] Manually run `pnpm dlx @tour-kit/codemods --from target-to-ref --dry-run ./examples/dashboard-next` to confirm the codemod does not falsely rewrite anything in real code