### PR TITLE
feat(v2): Phase 8 — License trial tier + dev clarity

### DIFF
--- a/.changeset/phase-8-license-trial.md
+++ b/.changeset/phase-8-license-trial.md
@@ -1,0 +1,14 @@
+---
+'@tour-kit/license': minor
+---
+
+Phase 8 — Trial tier + dev clarity for `@tour-kit/license`.
+
+- Add `<TrialBadge>` — client-derived trial countdown that flips to an Upgrade CTA when `daysLeft <= 3`. Reads from `useLicense().trial` when no `daysLeft` prop is passed.
+- Add `<LicenseDebugPanel>` — dev-only license inspection panel. Renders the literal copy `🟢 Dev bypass active (NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY set, hostname=localhost)` so the dev-bypass state is unambiguous. Returns `null` in production by default.
+- Add `<LicenseTestMode tier="invalid" | "pro" | "free">` — QA-only context override so the watermark, adoption gate, and Pro fallbacks can be verified on a real production-like domain without unsetting env vars. Emits a loud `console.warn` in production and is enforced by a static guard script (`scripts/check-license-test-mode.mjs`) that fails the package test pipeline on application-source imports.
+- Add pure helper `getDaysLeft({ issuedAt, trialDays, validatedAt, serverValidatedAt }, now?)` in `@tour-kit/license/headless`. Anchors to Polar's `last_validated_at` plus local elapsed time to absorb client clock skew.
+- Extend `LicenseProviderProps` with optional `trialDays` and `trialIssuedAt`. Extend `LicenseState` with `serverValidatedAt?: number | null` (parsed from Polar `last_validated_at`). Extend `LicenseContextValue` with `trial: TrialContextValue | null`.
+- Update `polar-client.ts` to map `response.lastValidatedAt` into `state.serverValidatedAt` on validated, expired, and revoked branches. `LicenseCacheSchema` now accepts the optional field; old v1.0.x cache entries continue to parse.
+- The Polar Zod schema does NOT gain a `tier` field — the API doesn't emit one (memory project_polar_api_findings.md #187 / Phase 0 §6). Pinned with `schema-no-tier.regression.test.ts`.
+- New docs page `apps/docs/content/docs/licensing/trial.mdx` covers the trial surface, debug panel, test mode, and the future schema-migration plan when Polar ships server-side trial signalling.

--- a/apps/docs/content/docs/licensing/meta.json
+++ b/apps/docs/content/docs/licensing/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Licensing",
-  "pages": ["index"]
+  "pages": ["index", "trial"]
 }

--- a/apps/docs/content/docs/licensing/trial.mdx
+++ b/apps/docs/content/docs/licensing/trial.mdx
@@ -1,0 +1,143 @@
+---
+title: Trial countdown & test mode
+description: Client-derived trial state, the <TrialBadge> surface, and how to simulate license failure on real domains.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+## 1. Why trial state is client-derived
+
+Polar's `/v1/customer-portal/license-keys/validate` endpoint does **not** emit a
+`tier` field. The wire response only includes `id`, `status`, `benefit_id`,
+`customer`, `key`, `display_key`, `limit_activations`, `usage`, `limit_usage`,
+`validations`, `last_validated_at`, and `expires_at`.
+
+Tour Kit therefore derives trial state on the client. You pass `trialDays` (and
+optionally `trialIssuedAt`) to `<LicenseProvider>`, and the provider computes
+`daysLeft` from the elapsed time since the trial start. To absorb client clock
+skew, the math anchors to Polar's `last_validated_at` (stored on
+`LicenseState.serverValidatedAt`) plus the local elapsed delta from
+`state.validatedAt`. On a machine whose clock is six days fast, the trial
+countdown still tracks server time.
+
+<Callout type="info">
+This is the Phase 0 §6 decision recorded against the Polar API inspection — see
+`tasks/v2-package-polish/phase-0-validation.md`. The Zod schema for the validate
+endpoint deliberately excludes `tier`; a regression test pins this constraint.
+</Callout>
+
+## 2. Adding the trial countdown
+
+Pass `trialDays` to `<LicenseProvider>` and drop `<TrialBadge>` anywhere in the
+tree.
+
+```tsx
+import { LicenseProvider, TrialBadge } from '@tour-kit/license'
+
+export function App() {
+  return (
+    <LicenseProvider
+      licenseKey={process.env.NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY ?? ''}
+      trialDays={14}
+    >
+      <header>
+        <TrialBadge />
+      </header>
+      {/* …app… */}
+    </LicenseProvider>
+  )
+}
+```
+
+The badge renders `"14 days left"`, `"13 days left"`, … down to day 4. On day
+3 it flips to an **Upgrade** anchor pointing at the pricing page. Pass
+`pricingUrl` to override the default destination.
+
+```tsx
+<TrialBadge pricingUrl="https://my.app/upgrade" />
+```
+
+For a headless render-prop, pass `children`:
+
+```tsx
+<TrialBadge>
+  {({ daysLeft, isUrgent }) => (
+    <MyButton variant={isUrgent ? 'destructive' : 'default'}>
+      {isUrgent ? 'Upgrade now' : `${daysLeft} days left`}
+    </MyButton>
+  )}
+</TrialBadge>
+```
+
+If `trialDays` is not configured on `<LicenseProvider>` and you also don't pass
+a `daysLeft` prop, the badge renders `null` and emits a one-time dev warning.
+This is the default for paying customers — no trial, no badge.
+
+## 3. The `<LicenseDebugPanel>`
+
+Drop `<LicenseDebugPanel>` into a `/dev` or `/admin` route. It auto-hides in
+production (returns `null` when `process.env.NODE_ENV === 'production'`) so you
+can leave it mounted permanently.
+
+```tsx
+import { LicenseDebugPanel } from '@tour-kit/license'
+
+export default function DevRoute() {
+  return <LicenseDebugPanel />
+}
+```
+
+When the dev bypass is active (localhost with `NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY`
+set), the panel renders the literal copy:
+
+```
+🟢 Dev bypass active (NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY set, hostname=localhost)
+```
+
+This is intentionally explicit — it replaces the ambiguous v3.x
+`status: valid, renderKey: dev_bypass` console line that demo viewers found
+confusing. On a real domain it falls back to the status/tier/domain line.
+
+## 4. Simulating failure with `<LicenseTestMode>`
+
+`<LicenseTestMode>` is a QA-only provider that overrides the license context
+with a simulated state so you can verify the watermark, adoption gate, and Pro
+fallbacks **on a real production-like domain** — without unsetting your env var
+or hitting the live Polar API.
+
+```tsx
+import { LicenseTestMode, LicenseWatermark } from '@tour-kit/license'
+
+// example file — staging URL
+export default function StagingFailureProbe() {
+  return (
+    <LicenseTestMode tier="invalid">
+      <LicenseWatermark />
+      <MyProFeature />
+    </LicenseTestMode>
+  )
+}
+```
+
+The three accepted `tier` values are `"invalid"`, `"pro"`, and `"free"`.
+
+<Callout type="warn">
+**Do not import `<LicenseTestMode>` from application source.** A package-local
+static guard at `packages/license/scripts/check-license-test-mode.mjs` fails CI
+on any import outside `__tests__/`, `examples/`, or Storybook (`*.stories.tsx`,
+`*.story.tsx`) files. Production use also emits a loud `console.warn`.
+</Callout>
+
+## 5. Future: server-side trial signalling
+
+If Polar adds a server-side `tier` field to the validate response in a future
+API revision, the integration will be additive and non-breaking:
+
+1. `PolarValidateResponseSchema` gains `tier: z.enum([...]).optional()`.
+2. `getDaysLeft` accepts an optional fourth argument and returns the server
+   value when `tier === 'trial'` is present on `LicenseState`.
+3. Existing `trialDays` consumers see zero behaviour change because the helper
+   falls back to the client-side computation when the override is absent.
+
+The override point is marked with `// FUTURE:` in
+`packages/license/src/lib/trial.ts` so the follow-up PR is one focused diff.

--- a/packages/license/package.json
+++ b/packages/license/package.json
@@ -67,9 +67,10 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "test": "vitest run",
+    "test": "vitest run && pnpm test:license-test-mode-guard",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:license-test-mode-guard": "node scripts/check-license-test-mode.mjs"
   },
   "dependencies": {
     "zod": "catalog:"

--- a/packages/license/scripts/check-license-test-mode.mjs
+++ b/packages/license/scripts/check-license-test-mode.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Static guard: forbid `LicenseTestMode` imports outside __tests__/, examples/,
+// and Storybook files. Run from the repository root or from the package root;
+// the script walks `src/` and `examples/` under the current working directory.
+//
+// Exits 1 with stderr listing offending files when a violation is detected.
+// Wired into `pnpm --filter @tour-kit/license test` via package.json scripts.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import process from 'node:process'
+
+const ALLOWED_PATTERNS = [
+  /(^|[\\/])__tests__[\\/]/,
+  /(^|[\\/])examples[\\/]/,
+  /\.stories\.(t|j)sx?$/,
+  /\.story\.(t|j)sx?$/,
+]
+
+const SOURCE_DIRS = ['src', 'examples']
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.next', '.turbo', 'coverage'])
+
+function walk(dir) {
+  /** @type {string[]} */
+  const out = []
+  let entries
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return out
+  }
+  for (const name of entries) {
+    if (SKIP_DIRS.has(name)) continue
+    const full = join(dir, name)
+    let st
+    try {
+      st = statSync(full)
+    } catch {
+      continue
+    }
+    if (st.isDirectory()) {
+      out.push(...walk(full))
+    } else if (/\.(ts|tsx|js|jsx)$/.test(full)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function isAllowed(filePath) {
+  const normalized = filePath.replaceAll(sep, '/')
+  return ALLOWED_PATTERNS.some((re) => re.test(normalized))
+}
+
+// Match any import or re-export statement that mentions LicenseTestMode from
+// @tour-kit/license. Tolerates multi-line imports.
+const IMPORT_RE =
+  /(?:import|export)\s*(?:\{[^}]*\bLicenseTestMode\b[^}]*\}|\*\s+as\s+\w+)\s*from\s*['"]@tour-kit\/license(?:\/[^'"]*)?['"]/m
+
+const cwd = process.cwd()
+const offenders = []
+
+for (const dirName of SOURCE_DIRS) {
+  const dir = join(cwd, dirName)
+  let st
+  try {
+    st = statSync(dir)
+  } catch {
+    continue
+  }
+  if (!st.isDirectory()) continue
+
+  for (const file of walk(dir)) {
+    const rel = relative(cwd, file)
+    if (isAllowed(rel)) continue
+    let contents
+    try {
+      contents = readFileSync(file, 'utf8')
+    } catch {
+      continue
+    }
+    if (IMPORT_RE.test(contents)) {
+      offenders.push(rel)
+    }
+  }
+}
+
+if (offenders.length > 0) {
+  process.stderr.write(
+    "'LicenseTestMode' may only be imported from __tests__/, examples/, or Storybook (*.stories.tsx, *.story.tsx) files:\n"
+  )
+  for (const offender of offenders) {
+    process.stderr.write(`  - ${offender}\n`)
+  }
+  process.exit(1)
+}

--- a/packages/license/src/__tests__/license-debug-panel.test.tsx
+++ b/packages/license/src/__tests__/license-debug-panel.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LicenseDebugPanel } from '../components/license-debug-panel'
+import { LicenseProvider } from '../context/license-context'
+
+vi.mock('../lib/polar-client', () => ({
+  validateLicenseKey: vi.fn(),
+}))
+
+vi.mock('../lib/domain', () => ({
+  isDevEnvironment: vi.fn(),
+  getCurrentDomain: vi.fn(),
+}))
+
+vi.mock('../lib/cache', () => ({
+  clearCache: vi.fn(),
+  hasFreshCache: vi.fn().mockReturnValue(false),
+}))
+
+import { getCurrentDomain, isDevEnvironment } from '../lib/domain'
+import { validateLicenseKey } from '../lib/polar-client'
+
+const mockValidate = vi.mocked(validateLicenseKey)
+const mockIsDev = vi.mocked(isDevEnvironment)
+const mockGetDomain = vi.mocked(getCurrentDomain)
+
+describe('<LicenseDebugPanel>', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDev.mockReturnValue(true)
+    mockGetDomain.mockReturnValue('localhost')
+    vi.stubEnv('NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY', 'test-key')
+    vi.stubEnv('NODE_ENV', 'development')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.clearAllMocks()
+  })
+
+  it('renders the EXACT dev-bypass copy (literal — no regex)', async () => {
+    render(
+      <LicenseProvider licenseKey="test-key">
+        <LicenseDebugPanel />
+      </LicenseProvider>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          '🟢 Dev bypass active (NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY set, hostname=localhost)'
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('returns null in production', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const { container } = render(
+      <LicenseProvider licenseKey="test-key">
+        <LicenseDebugPanel />
+      </LicenseProvider>
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the trial line when trial slice is present in context', async () => {
+    render(
+      <LicenseProvider licenseKey="test-key" trialDays={14}>
+        <LicenseDebugPanel />
+      </LicenseProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/Trial:/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/14/)).toBeInTheDocument()
+  })
+
+  it('renders status line (not dev-bypass line) when renderKey !== "dev_bypass"', async () => {
+    mockIsDev.mockReturnValue(false)
+    mockGetDomain.mockReturnValue('example.com')
+    mockValidate.mockResolvedValue({
+      status: 'invalid',
+      tier: 'free',
+      activations: 0,
+      maxActivations: 0,
+      domain: null,
+      expiresAt: null,
+      validatedAt: Date.now(),
+      serverValidatedAt: null,
+      renderKey: undefined,
+    })
+
+    render(
+      <LicenseProvider licenseKey="test-key">
+        <LicenseDebugPanel />
+      </LicenseProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Status:/)).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/Dev bypass active/)).not.toBeInTheDocument()
+  })
+})

--- a/packages/license/src/__tests__/license-state.test.ts
+++ b/packages/license/src/__tests__/license-state.test.ts
@@ -64,6 +64,7 @@ describe('createUnlicensedState', () => {
       domain: null,
       expiresAt: null,
       validatedAt: 123,
+      serverValidatedAt: null,
       renderKey: undefined,
     })
   })
@@ -92,6 +93,7 @@ describe('createDevBypassState', () => {
       domain: null,
       expiresAt: null,
       validatedAt: 456,
+      serverValidatedAt: null,
       renderKey: 'dev_bypass',
     })
   })

--- a/packages/license/src/__tests__/license-test-mode-guard.test.ts
+++ b/packages/license/src/__tests__/license-test-mode-guard.test.ts
@@ -1,0 +1,62 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const guardScript = resolve(here, '../../scripts/check-license-test-mode.mjs')
+
+const IMPORT_LINE = `import { LicenseTestMode } from '@tour-kit/license'\n`
+
+function fixtureDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'license-guard-'))
+  mkdirSync(join(dir, 'src'))
+  mkdirSync(join(dir, 'src', '__tests__'))
+  mkdirSync(join(dir, 'examples'))
+  return dir
+}
+
+function runGuard(cwd: string) {
+  return spawnSync('node', [guardScript], { cwd, encoding: 'utf8' })
+}
+
+describe('check-license-test-mode.mjs', () => {
+  it('rejects LicenseTestMode imports from application source', () => {
+    const dir = fixtureDir()
+    writeFileSync(join(dir, 'src', 'app.tsx'), IMPORT_LINE)
+    const result = runGuard(dir)
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('LicenseTestMode')
+    expect(result.stderr).toContain('may only be imported')
+  })
+
+  it('allows imports from __tests__ paths', () => {
+    const dir = fixtureDir()
+    writeFileSync(join(dir, 'src', '__tests__', 'foo.test.tsx'), IMPORT_LINE)
+    const result = runGuard(dir)
+    expect(result.status).toBe(0)
+  })
+
+  it('allows imports from examples/ paths', () => {
+    const dir = fixtureDir()
+    writeFileSync(join(dir, 'examples', 'app.tsx'), IMPORT_LINE)
+    const result = runGuard(dir)
+    expect(result.status).toBe(0)
+  })
+
+  it('allows imports from *.stories.tsx files', () => {
+    const dir = fixtureDir()
+    writeFileSync(join(dir, 'src', 'Demo.stories.tsx'), IMPORT_LINE)
+    const result = runGuard(dir)
+    expect(result.status).toBe(0)
+  })
+
+  it('allows imports from *.story.tsx files', () => {
+    const dir = fixtureDir()
+    writeFileSync(join(dir, 'src', 'Demo.story.tsx'), IMPORT_LINE)
+    const result = runGuard(dir)
+    expect(result.status).toBe(0)
+  })
+})

--- a/packages/license/src/__tests__/license-test-mode.integration.test.tsx
+++ b/packages/license/src/__tests__/license-test-mode.integration.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function findWatermark() {
+  return document.body.querySelector('[data-tourkit-watermark]')
+}
+
+describe('<LicenseTestMode> integration', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('tier="invalid" → useIsPro() false + watermark present', async () => {
+    const { LicenseTestMode } = await import('../components/license-test-mode')
+    const { LicenseWatermark } = await import('../components/license-watermark')
+    const { useIsPro } = await import('../hooks/use-is-pro')
+
+    function ProGateProbe() {
+      const isPro = useIsPro()
+      return <span data-testid="probe">is-pro: {String(isPro)}</span>
+    }
+
+    const { getByTestId } = render(
+      <LicenseTestMode tier="invalid">
+        <LicenseWatermark />
+        <ProGateProbe />
+      </LicenseTestMode>
+    )
+
+    await waitFor(() => {
+      expect(findWatermark()).not.toBeNull()
+    })
+    expect(getByTestId('probe')).toHaveTextContent('is-pro: false')
+  })
+
+  it('tier="pro" → useIsPro() true', async () => {
+    const { LicenseTestMode } = await import('../components/license-test-mode')
+    const { useIsPro } = await import('../hooks/use-is-pro')
+
+    function ProGateProbe() {
+      const isPro = useIsPro()
+      return <span data-testid="probe">is-pro: {String(isPro)}</span>
+    }
+
+    const { getByTestId } = render(
+      <LicenseTestMode tier="pro">
+        <ProGateProbe />
+      </LicenseTestMode>
+    )
+
+    expect(getByTestId('probe')).toHaveTextContent('is-pro: true')
+  })
+
+  it('tier="free" → useIsPro() false', async () => {
+    const { LicenseTestMode } = await import('../components/license-test-mode')
+    const { useIsPro } = await import('../hooks/use-is-pro')
+
+    function ProGateProbe() {
+      const isPro = useIsPro()
+      return <span data-testid="probe">is-pro: {String(isPro)}</span>
+    }
+
+    const { getByTestId } = render(
+      <LicenseTestMode tier="free">
+        <ProGateProbe />
+      </LicenseTestMode>
+    )
+
+    expect(getByTestId('probe')).toHaveTextContent('is-pro: false')
+  })
+})

--- a/packages/license/src/__tests__/license-test-mode.production-warning.test.tsx
+++ b/packages/license/src/__tests__/license-test-mode.production-warning.test.tsx
@@ -1,0 +1,42 @@
+import { render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LicenseTestMode } from '../components/license-test-mode'
+
+describe('<LicenseTestMode> production warning', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    vi.unstubAllEnvs()
+  })
+
+  it('warns exactly once in production with the documented substring', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    render(
+      <LicenseTestMode tier="invalid">
+        <div />
+      </LicenseTestMode>
+    )
+    const productionCalls = warnSpy.mock.calls.filter((call) =>
+      String(call[0] ?? '').includes('<LicenseTestMode> active in production')
+    )
+    expect(productionCalls).toHaveLength(1)
+  })
+
+  it('does not warn in development', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    render(
+      <LicenseTestMode tier="invalid">
+        <div />
+      </LicenseTestMode>
+    )
+    const productionCalls = warnSpy.mock.calls.filter((call) =>
+      String(call[0] ?? '').includes('<LicenseTestMode> active in production')
+    )
+    expect(productionCalls).toHaveLength(0)
+  })
+})

--- a/packages/license/src/__tests__/schema-no-tier.regression.test.ts
+++ b/packages/license/src/__tests__/schema-no-tier.regression.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { PolarValidateResponseSchema } from '../lib/schemas'
+
+// Pins the wire-contract decision from Phase 0 §6 / memory #187:
+// Polar /v1/customer-portal/license-keys/validate has NO `tier` field.
+// Trial state is client-derived; do not add `tier` to this schema.
+describe('PolarValidateResponseSchema regression (memory #187, Phase 0 §6)', () => {
+  it('does NOT include a `tier` field — Polar API has no tier; trial is client-derived', () => {
+    expect('tier' in PolarValidateResponseSchema.shape).toBe(false)
+  })
+})

--- a/packages/license/src/__tests__/trial-badge.test.tsx
+++ b/packages/license/src/__tests__/trial-badge.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LicenseProvider } from '../context/license-context'
+import { TrialBadge } from '../components/trial-badge'
+
+vi.mock('../lib/polar-client', () => ({
+  validateLicenseKey: vi.fn(),
+}))
+
+vi.mock('../lib/domain', () => ({
+  isDevEnvironment: vi.fn(),
+  getCurrentDomain: vi.fn().mockReturnValue('example.com'),
+}))
+
+vi.mock('../lib/cache', () => ({
+  clearCache: vi.fn(),
+  hasFreshCache: vi.fn().mockReturnValue(false),
+}))
+
+import { isDevEnvironment } from '../lib/domain'
+import { validateLicenseKey } from '../lib/polar-client'
+import type { LicenseState } from '../types'
+
+const mockValidate = vi.mocked(validateLicenseKey)
+const mockIsDev = vi.mocked(isDevEnvironment)
+
+const DAY = 86_400_000
+
+function makeState(now: number): LicenseState {
+  return {
+    status: 'valid',
+    tier: 'pro',
+    activations: 1,
+    maxActivations: 5,
+    domain: 'example.com',
+    expiresAt: null,
+    validatedAt: now,
+    serverValidatedAt: now,
+    renderKey: 'lk_test',
+  }
+}
+
+describe('<TrialBadge>', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsDev.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  it('renders "14 days left" when daysLeft={14}', () => {
+    render(<TrialBadge daysLeft={14} />)
+    expect(screen.getByText('14 days left')).toBeInTheDocument()
+  })
+
+  it('renders "4 days left" when daysLeft={4} (above threshold)', () => {
+    render(<TrialBadge daysLeft={4} />)
+    expect(screen.getByText('4 days left')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /upgrade/i })).not.toBeInTheDocument()
+  })
+
+  it.each([3, 1, 0])('becomes Upgrade <a> at daysLeft=%i', (daysLeft) => {
+    render(<TrialBadge daysLeft={daysLeft} />)
+    const link = screen.getByRole('link', { name: /upgrade/i })
+    expect(link).toBeInTheDocument()
+    expect(link.getAttribute('href')).toBeTruthy()
+    expect(link.getAttribute('href')).not.toBe('#')
+  })
+
+  it('honors custom pricingUrl on the Upgrade anchor', () => {
+    render(<TrialBadge daysLeft={2} pricingUrl="https://my.example/upgrade" />)
+    const link = screen.getByRole('link', { name: /upgrade/i })
+    expect(link.getAttribute('href')).toBe('https://my.example/upgrade')
+  })
+
+  it('reads daysLeft from useLicense().trial when no prop is passed', async () => {
+    const issuedAt = Date.now()
+    mockValidate.mockResolvedValue(makeState(issuedAt))
+
+    render(
+      <LicenseProvider licenseKey="TOURKIT_key" trialDays={14} trialIssuedAt={issuedAt}>
+        <TrialBadge />
+      </LicenseProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('14 days left')).toBeInTheDocument()
+    })
+  })
+
+  it('renders null and warns in dev when no trialDays in context and no prop', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubEnv('NODE_ENV', 'development')
+    mockValidate.mockResolvedValue({
+      status: 'valid',
+      tier: 'pro',
+      activations: 1,
+      maxActivations: 5,
+      domain: 'example.com',
+      expiresAt: null,
+      validatedAt: Date.now(),
+      serverValidatedAt: null,
+      renderKey: 'lk_test',
+    })
+
+    const { container } = render(
+      <LicenseProvider licenseKey="TOURKIT_key">
+        <TrialBadge />
+      </LicenseProvider>
+    )
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull()
+    })
+    expect(warnSpy).toHaveBeenCalled()
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('<TrialBadge>')
+    warnSpy.mockRestore()
+  })
+
+  it('headless render-prop receives { daysLeft, isTrialing, isUrgent }', () => {
+    const renderProp = vi.fn(({ daysLeft }: { daysLeft: number }) => (
+      <span data-testid="custom-render">days={daysLeft}</span>
+    ))
+    render(<TrialBadge daysLeft={7}>{renderProp}</TrialBadge>)
+    expect(renderProp).toHaveBeenCalled()
+    const arg = renderProp.mock.calls[0]?.[0]
+    expect(arg).toEqual({ daysLeft: 7, isTrialing: true, isUrgent: false })
+    expect(screen.getByTestId('custom-render')).toHaveTextContent('days=7')
+  })
+
+  it('transitions from countdown to Upgrade across day boundary via system-time jump', async () => {
+    const issuedAt = ISO_FIXED
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(issuedAt)
+    mockValidate.mockResolvedValue({
+      status: 'valid',
+      tier: 'pro',
+      activations: 1,
+      maxActivations: 5,
+      domain: 'example.com',
+      expiresAt: null,
+      validatedAt: issuedAt,
+      serverValidatedAt: issuedAt,
+      renderKey: 'lk_test',
+    })
+
+    const { rerender } = render(
+      <LicenseProvider licenseKey="TOURKIT_key" trialDays={14} trialIssuedAt={issuedAt}>
+        <TrialBadge />
+      </LicenseProvider>
+    )
+
+    // First-tick: still in trial
+    await waitFor(() => {
+      expect(screen.getByText('14 days left')).toBeInTheDocument()
+    })
+
+    // Jump 11 days — re-mount via fresh state to recompute trial slice
+    vi.setSystemTime(issuedAt + 11 * DAY)
+    mockValidate.mockResolvedValue({
+      status: 'valid',
+      tier: 'pro',
+      activations: 1,
+      maxActivations: 5,
+      domain: 'example.com',
+      expiresAt: null,
+      validatedAt: issuedAt + 11 * DAY,
+      serverValidatedAt: issuedAt + 11 * DAY,
+      renderKey: 'lk_test',
+    })
+    rerender(
+      <LicenseProvider
+        key="rebuild"
+        licenseKey="TOURKIT_key2"
+        trialDays={14}
+        trialIssuedAt={issuedAt}
+      >
+        <TrialBadge />
+      </LicenseProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /upgrade/i })).toBeInTheDocument()
+    })
+  })
+})
+
+const ISO_FIXED = 1_700_000_000_000

--- a/packages/license/src/__tests__/trial-badge.test.tsx
+++ b/packages/license/src/__tests__/trial-badge.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { LicenseProvider } from '../context/license-context'
 import { TrialBadge } from '../components/trial-badge'
+import { LicenseProvider } from '../context/license-context'
 
 vi.mock('../lib/polar-client', () => ({
   validateLicenseKey: vi.fn(),

--- a/packages/license/src/__tests__/trial.test.ts
+++ b/packages/license/src/__tests__/trial.test.ts
@@ -15,27 +15,18 @@ describe('getDaysLeft', () => {
     [14, 15, 0],
     [14, 30, 0],
     [14, -5, 14],
-  ])(
-    'trialDays=%i, daysElapsed=%i → %i',
-    (trialDays, daysElapsed, expected) => {
-      const validatedAt = ISSUED + daysElapsed * DAY
-      const serverValidatedAt = ISSUED + daysElapsed * DAY
-      expect(
-        getDaysLeft(
-          { issuedAt: ISSUED, trialDays, validatedAt, serverValidatedAt },
-          validatedAt
-        )
-      ).toBe(expected)
-    }
-  )
+  ])('trialDays=%i, daysElapsed=%i → %i', (trialDays, daysElapsed, expected) => {
+    const validatedAt = ISSUED + daysElapsed * DAY
+    const serverValidatedAt = ISSUED + daysElapsed * DAY
+    expect(
+      getDaysLeft({ issuedAt: ISSUED, trialDays, validatedAt, serverValidatedAt }, validatedAt)
+    ).toBe(expected)
+  })
 
   it('falls back to `now` when serverValidatedAt is null', () => {
     const now = ISSUED + 5 * DAY
     expect(
-      getDaysLeft(
-        { issuedAt: ISSUED, trialDays: 14, validatedAt: 0, serverValidatedAt: null },
-        now
-      )
+      getDaysLeft({ issuedAt: ISSUED, trialDays: 14, validatedAt: 0, serverValidatedAt: null }, now)
     ).toBe(9)
   })
 
@@ -70,10 +61,7 @@ describe('getDaysLeft', () => {
     const serverValidatedAt = ISSUED
     const now = validatedAt - 10 * DAY
     expect(
-      getDaysLeft(
-        { issuedAt: ISSUED, trialDays: 14, validatedAt, serverValidatedAt },
-        now
-      )
+      getDaysLeft({ issuedAt: ISSUED, trialDays: 14, validatedAt, serverValidatedAt }, now)
     ).toBe(14)
   })
 })

--- a/packages/license/src/__tests__/trial.test.ts
+++ b/packages/license/src/__tests__/trial.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { getDaysLeft } from '../lib/trial'
+
+const DAY = 86_400_000
+const ISSUED = 1_700_000_000_000
+
+describe('getDaysLeft', () => {
+  it.each<[number, number, number]>([
+    [14, 0, 14],
+    [14, 1, 13],
+    [14, 7, 7],
+    [14, 11, 3],
+    [14, 13, 1],
+    [14, 14, 0],
+    [14, 15, 0],
+    [14, 30, 0],
+    [14, -5, 14],
+  ])(
+    'trialDays=%i, daysElapsed=%i → %i',
+    (trialDays, daysElapsed, expected) => {
+      const validatedAt = ISSUED + daysElapsed * DAY
+      const serverValidatedAt = ISSUED + daysElapsed * DAY
+      expect(
+        getDaysLeft(
+          { issuedAt: ISSUED, trialDays, validatedAt, serverValidatedAt },
+          validatedAt
+        )
+      ).toBe(expected)
+    }
+  )
+
+  it('falls back to `now` when serverValidatedAt is null', () => {
+    const now = ISSUED + 5 * DAY
+    expect(
+      getDaysLeft(
+        { issuedAt: ISSUED, trialDays: 14, validatedAt: 0, serverValidatedAt: null },
+        now
+      )
+    ).toBe(9)
+  })
+
+  it('falls back to `now` when serverValidatedAt is undefined', () => {
+    const now = ISSUED + 5 * DAY
+    expect(getDaysLeft({ issuedAt: ISSUED, trialDays: 14, validatedAt: 0 }, now)).toBe(9)
+  })
+
+  it('absorbs forward clock skew via serverValidatedAt anchor', () => {
+    // Local clock was already fast at validation time (says 20 days in)
+    const localValidationTime = ISSUED + 20 * DAY
+    // One real day later, still skewed
+    const skewedNow = localValidationTime + 1 * DAY
+    // Server says we were actually 5 days in
+    const realLastValidated = ISSUED + 5 * DAY
+    expect(
+      getDaysLeft(
+        {
+          issuedAt: ISSUED,
+          trialDays: 14,
+          validatedAt: localValidationTime,
+          serverValidatedAt: realLastValidated,
+        },
+        skewedNow
+      )
+    ).toBe(8)
+  })
+
+  it('clamps negative elapsed (server anchor in the future relative to now)', () => {
+    // server says we are 0 days in, now is in the past relative to validatedAt
+    const validatedAt = ISSUED + 5 * DAY
+    const serverValidatedAt = ISSUED
+    const now = validatedAt - 10 * DAY
+    expect(
+      getDaysLeft(
+        { issuedAt: ISSUED, trialDays: 14, validatedAt, serverValidatedAt },
+        now
+      )
+    ).toBe(14)
+  })
+})

--- a/packages/license/src/components/license-debug-panel.tsx
+++ b/packages/license/src/components/license-debug-panel.tsx
@@ -28,10 +28,7 @@ function readEnvLicenseKey(): boolean {
  * literal copy "🟢 Dev bypass active (NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY set,
  * hostname=localhost)" so it is unambiguous what is happening.
  */
-export function LicenseDebugPanel({
-  className,
-  showInProduction = false,
-}: LicenseDebugPanelProps) {
+export function LicenseDebugPanel({ className, showInProduction = false }: LicenseDebugPanelProps) {
   const ctx = useContext(LicenseContext)
   const inProd = process.env.NODE_ENV === 'production'
   if (inProd && !showInProduction) return null
@@ -51,14 +48,13 @@ export function LicenseDebugPanel({
       <h2>Tour Kit License — Debug</h2>
       {devBypassActive ? (
         <p data-state="dev-bypass">
-          🟢 Dev bypass active (
-          {hasEnvKey ? 'NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY set' : 'no env key'},
+          🟢 Dev bypass active ({hasEnvKey ? 'NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY set' : 'no env key'},
           hostname={localhost ? 'localhost' : 'production'})
         </p>
       ) : (
         <p data-state={state.status}>
-          Status: <strong>{state.status}</strong> · Tier: <strong>{state.tier}</strong> ·
-          Domain: <strong>{state.domain ?? 'unset'}</strong>
+          Status: <strong>{state.status}</strong> · Tier: <strong>{state.tier}</strong> · Domain:{' '}
+          <strong>{state.domain ?? 'unset'}</strong>
         </p>
       )}
       {trial ? (

--- a/packages/license/src/components/license-debug-panel.tsx
+++ b/packages/license/src/components/license-debug-panel.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useContext } from 'react'
+import { LicenseContext } from '../context/license-context'
+import { isDevEnvironment } from '../lib/domain'
+
+export type LicenseDebugPanelProps = {
+  className?: string
+  /**
+   * When false (default), renders null in production. Set true to force-render
+   * at consumer's risk — strongly discouraged. Useful only for staging branches
+   * where NODE_ENV is misconfigured.
+   */
+  showInProduction?: boolean
+}
+
+function readEnvLicenseKey(): boolean {
+  if (typeof process === 'undefined') return false
+  // biome-ignore lint/complexity/useLiteralKeys: dynamic env access avoids bundler inlining
+  return Boolean(process.env?.['NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY'])
+}
+
+/**
+ * Drop into a dev or admin route to inspect the current license state. Renders
+ * nothing in production by default. Specifically replaces the ambiguous
+ * `status: valid, renderKey: dev_bypass` log line that the dashboard-next demo
+ * surfaced as confusing — when dev bypass is active, the panel renders the
+ * literal copy "🟢 Dev bypass active (NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY set,
+ * hostname=localhost)" so it is unambiguous what is happening.
+ */
+export function LicenseDebugPanel({
+  className,
+  showInProduction = false,
+}: LicenseDebugPanelProps) {
+  const ctx = useContext(LicenseContext)
+  const inProd = process.env.NODE_ENV === 'production'
+  if (inProd && !showInProduction) return null
+  if (!ctx) return null
+
+  const { state, trial } = ctx
+  const devBypassActive = state.renderKey === 'dev_bypass'
+  const localhost = isDevEnvironment()
+  const hasEnvKey = readEnvLicenseKey()
+
+  return (
+    <section
+      className={className}
+      data-tourkit-license-debug-panel=""
+      aria-label="Tour Kit license debug panel"
+    >
+      <h2>Tour Kit License — Debug</h2>
+      {devBypassActive ? (
+        <p data-state="dev-bypass">
+          🟢 Dev bypass active (
+          {hasEnvKey ? 'NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY set' : 'no env key'},
+          hostname={localhost ? 'localhost' : 'production'})
+        </p>
+      ) : (
+        <p data-state={state.status}>
+          Status: <strong>{state.status}</strong> · Tier: <strong>{state.tier}</strong> ·
+          Domain: <strong>{state.domain ?? 'unset'}</strong>
+        </p>
+      )}
+      {trial ? (
+        <p data-trial-active={trial.isTrialing}>
+          Trial: <strong>{trial.daysLeft}</strong> days left
+        </p>
+      ) : null}
+    </section>
+  )
+}

--- a/packages/license/src/components/license-test-mode.tsx
+++ b/packages/license/src/components/license-test-mode.tsx
@@ -25,7 +25,6 @@ export function LicenseTestMode(props: LicenseTestModeProps) {
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
-      // biome-ignore lint/suspicious/noConsole: production safety warning
       console.warn(
         '<LicenseTestMode> active in production — this overrides real license state and MUST be removed before deploy.'
       )

--- a/packages/license/src/components/license-test-mode.tsx
+++ b/packages/license/src/components/license-test-mode.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useEffect, useMemo } from 'react'
+import { LicenseContext, LicenseRenderContext } from '../context/license-context'
+import type { LicenseContextValue, LicenseState } from '../types'
+
+export type LicenseTestModeProps =
+  | { tier: 'invalid'; children: React.ReactNode }
+  | { tier: 'pro'; children: React.ReactNode }
+  | { tier: 'free'; children: React.ReactNode }
+
+/**
+ * QA-only: override `<LicenseProvider>` context with a simulated state so the
+ * watermark, adoption gate, and Pro fallbacks can be verified on a real
+ * production-like domain without unsetting `NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY`
+ * or hitting the live Polar API.
+ *
+ * MUST NOT be imported from application src/. Use only in __tests__/ and
+ * examples/. Enforced by `packages/license/scripts/check-license-test-mode.mjs`.
+ * Production use also emits a loud `console.warn` so an accidental ship is
+ * detectable in the browser console.
+ */
+export function LicenseTestMode(props: LicenseTestModeProps) {
+  const { tier, children } = props
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      // biome-ignore lint/suspicious/noConsole: production safety warning
+      console.warn(
+        '<LicenseTestMode> active in production — this overrides real license state and MUST be removed before deploy.'
+      )
+    }
+  }, [])
+
+  const value = useMemo<LicenseContextValue>(() => {
+    const now = Date.now()
+    let state: LicenseState
+    if (tier === 'pro') {
+      state = {
+        status: 'valid',
+        tier: 'pro',
+        activations: 1,
+        maxActivations: 5,
+        domain: 'test-mode.local',
+        expiresAt: null,
+        validatedAt: now,
+        serverValidatedAt: null,
+        renderKey: 'test_mode_pro',
+      }
+    } else if (tier === 'free') {
+      state = {
+        status: 'valid',
+        tier: 'free',
+        activations: 0,
+        maxActivations: 0,
+        domain: null,
+        expiresAt: null,
+        validatedAt: now,
+        serverValidatedAt: null,
+        renderKey: undefined,
+      }
+    } else {
+      state = {
+        status: 'invalid',
+        tier: 'free',
+        activations: 0,
+        maxActivations: 0,
+        domain: null,
+        expiresAt: null,
+        validatedAt: now,
+        serverValidatedAt: null,
+        renderKey: undefined,
+      }
+    }
+
+    return {
+      state,
+      refresh: async () => {},
+      isGated: tier !== 'pro',
+      isLoading: false,
+      gracePeriodActive: false,
+      trial: null,
+    }
+  }, [tier])
+
+  return (
+    <LicenseContext.Provider value={value}>
+      <LicenseRenderContext.Provider value={value.state.renderKey}>
+        {children}
+      </LicenseRenderContext.Provider>
+    </LicenseContext.Provider>
+  )
+}

--- a/packages/license/src/components/trial-badge.tsx
+++ b/packages/license/src/components/trial-badge.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useContext } from 'react'
+import { LicenseContext } from '../context/license-context'
+
+export type TrialBadgeRenderProps = {
+  daysLeft: number
+  isTrialing: boolean
+  isUrgent: boolean
+}
+
+export type TrialBadgeProps = {
+  /** Override daysLeft from context. When omitted, reads from `useLicense().trial.daysLeft`. */
+  daysLeft?: number
+  /** URL the Upgrade CTA links to. Defaults to the @tour-kit/license pricing page. */
+  pricingUrl?: string
+  /** Custom render — receives the resolved daysLeft + isTrialing/isUrgent flags. */
+  children?: (props: TrialBadgeRenderProps) => React.ReactNode
+  className?: string
+}
+
+const UPGRADE_CTA_THRESHOLD = 3
+const DEFAULT_PRICING_URL = 'https://usertourkit.com/pricing'
+
+/**
+ * Trial countdown surface. Renders "{n} days left" when above the threshold;
+ * renders an Upgrade `<a>` when `daysLeft <= 3`. Renders `null` (and warns
+ * once in dev) when no `daysLeft` prop is passed and no `trial` slice exists
+ * on the surrounding `<LicenseProvider>`.
+ */
+export function TrialBadge({
+  daysLeft: daysLeftProp,
+  pricingUrl,
+  children,
+  className,
+}: TrialBadgeProps) {
+  const ctx = useContext(LicenseContext)
+  const fromContext = ctx?.trial?.daysLeft
+  const resolved = daysLeftProp ?? fromContext
+
+  if (resolved === undefined) {
+    if (process.env.NODE_ENV !== 'production') {
+      // biome-ignore lint/suspicious/noConsole: dev-only configuration warning
+      console.warn(
+        '<TrialBadge> rendered without trialDays — pass trialDays to <LicenseProvider> to enable the trial countdown surface.'
+      )
+    }
+    return null
+  }
+
+  const isTrialing = resolved > 0
+  const isUrgent = resolved <= UPGRADE_CTA_THRESHOLD
+
+  if (children) {
+    return <>{children({ daysLeft: resolved, isTrialing, isUrgent })}</>
+  }
+
+  if (!isTrialing || isUrgent) {
+    return (
+      <a
+        href={pricingUrl ?? DEFAULT_PRICING_URL}
+        className={className}
+        data-trial-state="upgrade"
+        aria-label="Upgrade — trial ending soon"
+      >
+        Upgrade
+      </a>
+    )
+  }
+
+  return (
+    <span
+      className={className}
+      data-trial-state="active"
+      aria-label={`${resolved} days left in trial`}
+    >
+      {resolved} days left
+    </span>
+  )
+}

--- a/packages/license/src/components/trial-badge.tsx
+++ b/packages/license/src/components/trial-badge.tsx
@@ -40,7 +40,6 @@ export function TrialBadge({
 
   if (resolved === undefined) {
     if (process.env.NODE_ENV !== 'production') {
-      // biome-ignore lint/suspicious/noConsole: dev-only configuration warning
       console.warn(
         '<TrialBadge> rendered without trialDays — pass trialDays to <LicenseProvider> to enable the trial countdown surface.'
       )

--- a/packages/license/src/context/license-context.tsx
+++ b/packages/license/src/context/license-context.tsx
@@ -9,7 +9,13 @@ import {
   normalizeLicenseKey,
 } from '../lib/license-state'
 import { validateLicenseKey } from '../lib/polar-client'
-import type { LicenseContextValue, LicenseProviderProps, LicenseState } from '../types'
+import { getDaysLeft } from '../lib/trial'
+import type {
+  LicenseContextValue,
+  LicenseProviderProps,
+  LicenseState,
+  TrialContextValue,
+} from '../types'
 
 const LOADING_STATE: LicenseState = {
   status: 'loading',
@@ -19,6 +25,7 @@ const LOADING_STATE: LicenseState = {
   domain: null,
   expiresAt: null,
   validatedAt: 0,
+  serverValidatedAt: null,
   renderKey: undefined,
 }
 
@@ -29,6 +36,8 @@ export const LicenseRenderContext = createContext<string | undefined>(undefined)
 export function LicenseProvider({
   licenseKey,
   organizationId,
+  trialDays,
+  trialIssuedAt,
   children,
   onValidate,
   onError,
@@ -79,6 +88,7 @@ export function LicenseProvider({
         domain: null,
         expiresAt: null,
         validatedAt: Date.now(),
+        serverValidatedAt: null,
         renderKey: undefined,
       }
       setState(errorState)
@@ -125,9 +135,31 @@ export function LicenseProvider({
     return { isGated: true, isLoading: false, gracePeriodActive: false }
   }, [state, licenseKey])
 
+  // Trial slice — client-derived from issuedAt + trialDays because Polar's
+  // validate endpoint has no `tier` field (Phase 0 task 0.6, memory #187).
+  const trial = useMemo<TrialContextValue | null>(() => {
+    if (trialDays === undefined) return null
+    if (trialDays <= 0) {
+      if (process.env.NODE_ENV !== 'production') {
+        // biome-ignore lint/suspicious/noConsole: dev-only configuration warning
+        console.warn('<LicenseProvider> received non-positive trialDays; ignoring')
+      }
+      return null
+    }
+    const issuedAt = trialIssuedAt ?? state.serverValidatedAt ?? state.validatedAt
+    if (!issuedAt || issuedAt <= 0) return null
+    const daysLeft = getDaysLeft({
+      issuedAt,
+      trialDays,
+      validatedAt: state.validatedAt,
+      serverValidatedAt: state.serverValidatedAt,
+    })
+    return { daysLeft, isTrialing: daysLeft > 0 }
+  }, [trialDays, trialIssuedAt, state.validatedAt, state.serverValidatedAt])
+
   const contextValue = useMemo<LicenseContextValue>(
-    () => ({ state, refresh, isGated, isLoading, gracePeriodActive }),
-    [state, refresh, isGated, isLoading, gracePeriodActive]
+    () => ({ state, refresh, isGated, isLoading, gracePeriodActive, trial }),
+    [state, refresh, isGated, isLoading, gracePeriodActive, trial]
   )
 
   return (

--- a/packages/license/src/context/license-context.tsx
+++ b/packages/license/src/context/license-context.tsx
@@ -141,7 +141,6 @@ export function LicenseProvider({
     if (trialDays === undefined) return null
     if (trialDays <= 0) {
       if (process.env.NODE_ENV !== 'production') {
-        // biome-ignore lint/suspicious/noConsole: dev-only configuration warning
         console.warn('<LicenseProvider> received non-positive trialDays; ignoring')
       }
       return null

--- a/packages/license/src/headless.ts
+++ b/packages/license/src/headless.ts
@@ -28,3 +28,7 @@ export {
   isDevEnvironment,
   validateDomainAtRender,
 } from './lib/domain'
+
+// Trial (pure helpers — no React)
+export { getDaysLeft } from './lib/trial'
+export type { TrialConfig } from './lib/trial'

--- a/packages/license/src/index.ts
+++ b/packages/license/src/index.ts
@@ -14,6 +14,7 @@ export type {
   LicenseWarningProps,
   PolarValidateResponse,
   PolarActivateResponse,
+  TrialContextValue,
 } from './types'
 
 // Context and Provider
@@ -25,6 +26,12 @@ export { LicenseWatermark } from './components/license-watermark'
 export { LicenseWarning } from './components/license-warning'
 export { ProGate } from './components/pro-gate'
 export type { ProGateProps } from './components/pro-gate'
+export { TrialBadge } from './components/trial-badge'
+export type { TrialBadgeProps, TrialBadgeRenderProps } from './components/trial-badge'
+export { LicenseDebugPanel } from './components/license-debug-panel'
+export type { LicenseDebugPanelProps } from './components/license-debug-panel'
+export { LicenseTestMode } from './components/license-test-mode'
+export type { LicenseTestModeProps } from './components/license-test-mode'
 
 // Hooks
 export { useLicense } from './hooks/use-license'
@@ -35,3 +42,5 @@ export type { LicenseGateResult } from './hooks/use-license-gate'
 // Headless utilities (re-exported for convenience)
 export { validateLicenseKey } from './lib/polar-client'
 export { isDevEnvironment, getCurrentDomain } from './lib/domain'
+export { getDaysLeft } from './lib/trial'
+export type { TrialConfig } from './lib/trial'

--- a/packages/license/src/lib/license-state.ts
+++ b/packages/license/src/lib/license-state.ts
@@ -35,6 +35,7 @@ export function createUnlicensedState(now: number = Date.now()): LicenseState {
     domain: null,
     expiresAt: null,
     validatedAt: now,
+    serverValidatedAt: null,
     renderKey: undefined,
   }
 }
@@ -54,6 +55,7 @@ export function createDevBypassState(now: number = Date.now()): LicenseState {
     domain: null,
     expiresAt: null,
     validatedAt: now,
+    serverValidatedAt: null,
     renderKey: 'dev_bypass',
   }
 }

--- a/packages/license/src/lib/polar-client.ts
+++ b/packages/license/src/lib/polar-client.ts
@@ -218,6 +218,10 @@ export async function validateLicenseKey(
     const response = await validateKey(normalizedKey, orgId)
 
     // 4. Map Polar status to LicenseState
+    const serverValidatedAt = response.lastValidatedAt
+      ? Date.parse(response.lastValidatedAt) || null
+      : null
+
     if (response.status === 'revoked' || response.status === 'disabled') {
       const state: LicenseState = {
         status: 'revoked',
@@ -227,6 +231,7 @@ export async function validateLicenseKey(
         domain,
         expiresAt: null,
         validatedAt: now,
+        serverValidatedAt,
         renderKey: undefined,
       }
       if (domain) writeCache(domain, state, normalizedKey)
@@ -242,6 +247,7 @@ export async function validateLicenseKey(
         domain,
         expiresAt: response.expiresAt,
         validatedAt: now,
+        serverValidatedAt,
         renderKey: undefined,
       }
       if (domain) writeCache(domain, state, normalizedKey)
@@ -268,6 +274,7 @@ export async function validateLicenseKey(
         domain: null,
         expiresAt: null,
         validatedAt: now,
+        serverValidatedAt: null,
         renderKey: undefined,
       }
     }
@@ -280,6 +287,7 @@ export async function validateLicenseKey(
       domain: activationLabel,
       expiresAt: response.expiresAt,
       validatedAt: now,
+      serverValidatedAt,
       renderKey: generateRenderKey(normalizedKey, activationLabel),
     }
     if (domain) writeCache(domain, state, normalizedKey)
@@ -294,6 +302,7 @@ export async function validateLicenseKey(
         domain: null,
         expiresAt: null,
         validatedAt: now,
+        serverValidatedAt: null,
         renderKey: undefined,
       }
     }
@@ -306,6 +315,7 @@ export async function validateLicenseKey(
         domain: null,
         expiresAt: null,
         validatedAt: now,
+        serverValidatedAt: null,
         renderKey: undefined,
       }
     }
@@ -318,6 +328,7 @@ export async function validateLicenseKey(
         domain: null,
         expiresAt: null,
         validatedAt: now,
+        serverValidatedAt: null,
         renderKey: undefined,
       }
     }
@@ -329,6 +340,7 @@ export async function validateLicenseKey(
       domain: null,
       expiresAt: null,
       validatedAt: now,
+      serverValidatedAt: null,
       renderKey: undefined,
     }
   }

--- a/packages/license/src/lib/schemas.ts
+++ b/packages/license/src/lib/schemas.ts
@@ -64,6 +64,13 @@ export const LicenseCacheSchema = z.object({
     domain: z.string().nullable(),
     expiresAt: z.string().nullable(),
     validatedAt: z.number(),
+    /**
+     * Optional for backward compatibility with v1.0.x cache entries that
+     * predate the Polar server-anchor field. Readers parse cached states
+     * unchanged; writers added in Phase 8 always set it when Polar emits
+     * `last_validated_at`.
+     */
+    serverValidatedAt: z.number().nullable().optional(),
     renderKey: z.string().optional(),
   }),
   cachedAt: z.number(),

--- a/packages/license/src/lib/trial.ts
+++ b/packages/license/src/lib/trial.ts
@@ -1,0 +1,48 @@
+/**
+ * Consumer-supplied trial configuration. Passed to <LicenseProvider trialDays={14} />
+ * along with the implicit `issuedAt` derived from the license's first validation
+ * (or a future server-side field when Polar ships one).
+ *
+ * Polar's /v1/customer-portal/license-keys/validate endpoint does NOT emit a
+ * `tier` field today (confirmed Phase 0 task 0.6, memory project_polar_api_findings.md
+ * entry #187). Trial state is therefore CLIENT-DERIVED. If Polar adds server-side
+ * trial signalling later, getDaysLeft will accept an optional server-provided
+ * override (marked `FUTURE:` below) — additive, non-breaking.
+ */
+export interface TrialConfig {
+  /** Unix ms timestamp of when the trial started. Sourced from license issuance time. */
+  issuedAt: number
+  /** Length of the trial window in whole days. E.g. 14. */
+  trialDays: number
+  /** Local Date.now() timestamp captured when validation ran. */
+  validatedAt: number
+  /** Polar last_validated_at parsed to Unix ms. Null when unavailable. */
+  serverValidatedAt?: number | null
+}
+
+/**
+ * Compute days remaining in the trial window. Uses Polar's server validation
+ * timestamp plus local elapsed time when available, and falls back to `now`
+ * when no server anchor exists. Clamps to [0, trialDays].
+ *
+ * The serverValidatedAt + (now - validatedAt) algebra absorbs client clock
+ * skew: Polar gives the server anchor at validation time; the local clock only
+ * contributes the (now - validatedAt) delta, which on a normal machine is the
+ * real elapsed time and on a skewed machine is the same delta (skew cancels).
+ *
+ * @param config The trial config from <LicenseProvider>.
+ * @param now Override for testing. Defaults to Date.now().
+ * @returns Integer days remaining in [0, trialDays].
+ */
+export function getDaysLeft(config: TrialConfig, now: number = Date.now()): number {
+  const trustedNow =
+    config.serverValidatedAt && config.serverValidatedAt > 0
+      ? config.serverValidatedAt + Math.max(0, now - config.validatedAt)
+      : now
+  const elapsedMs = Math.max(0, trustedNow - config.issuedAt)
+  const elapsedDays = Math.floor(elapsedMs / 86_400_000)
+  const remaining = config.trialDays - elapsedDays
+  // FUTURE: if Polar adds `tier='trial'` to the validate response, accept an
+  // optional serverDaysLeft override here and return it when defined.
+  return Math.max(0, Math.min(config.trialDays, remaining))
+}

--- a/packages/license/src/types/index.ts
+++ b/packages/license/src/types/index.ts
@@ -39,7 +39,18 @@ export type LicenseState = {
   maxActivations: number
   domain: string | null
   expiresAt: string | null
+  /**
+   * Local `Date.now()` captured when validation ran. Used for cache freshness
+   * and the elapsed-time delta in `getDaysLeft`. NOT Polar's server timestamp —
+   * use `serverValidatedAt` for that. Renaming this would break v1.0.x caches.
+   */
   validatedAt: number
+  /**
+   * Polar `last_validated_at` parsed to Unix ms. Null on dev bypass, unlicensed,
+   * invalid, and error states. Used by `getDaysLeft` to anchor trial countdowns
+   * to server time and absorb client clock skew.
+   */
+  serverValidatedAt?: number | null
   renderKey: string | undefined
 }
 
@@ -112,11 +123,21 @@ export type PolarActivateResponse = {
 }
 
 /**
+ * Trial context slice. Null on `LicenseContextValue.trial` when no `trialDays`
+ * is configured on `<LicenseProvider>`. `isTrialing` is `daysLeft > 0`.
+ */
+export type TrialContextValue = {
+  daysLeft: number
+  isTrialing: boolean
+}
+
+/**
  * License context value (used by React integration).
  *
  * `isGated` / `isLoading` / `gracePeriodActive` are derived from `state` and
  * cache freshness once per validation, so consumers never need to read
- * localStorage on every render.
+ * localStorage on every render. `trial` is `null` when no `trialDays` is set
+ * on `<LicenseProvider>`.
  */
 export type LicenseContextValue = {
   state: LicenseState
@@ -124,6 +145,7 @@ export type LicenseContextValue = {
   isGated: boolean
   isLoading: boolean
   gracePeriodActive: boolean
+  trial: TrialContextValue | null
 }
 
 /**
@@ -132,6 +154,21 @@ export type LicenseContextValue = {
 export type LicenseProviderProps = {
   licenseKey: string
   organizationId?: string
+  /**
+   * Optional trial length in days. When set, `<LicenseProvider>` exposes a
+   * `trial` slice on the context and `<TrialBadge>` renders a countdown.
+   * Trial state is CLIENT-DERIVED from `issuedAt + trialDays` because Polar's
+   * `/v1/customer-portal/license-keys/validate` endpoint does not emit a
+   * `tier` field (Phase 0 task 0.6, memory project_polar_api_findings.md #187).
+   */
+  trialDays?: number
+  /**
+   * Optional explicit trial start time (Unix ms). Production trials should
+   * pass a stable signup/license-issued timestamp. When omitted, the provider
+   * falls back to `state.serverValidatedAt ?? state.validatedAt` for demo-only
+   * countdowns.
+   */
+  trialIssuedAt?: number
   children: React.ReactNode
   onValidate?: (state: LicenseState) => void
   onError?: (error: Error) => void


### PR DESCRIPTION
## Summary

Closes the three license-UX gaps surfaced during dashboard-next QA, all inside `@tour-kit/license`:

1. **`<TrialBadge />`** — client-derived trial countdown that flips to an Upgrade CTA at `daysLeft <= 3`. Reads from `useLicense().trial` when no prop is passed; supports a headless render-prop.
2. **`<LicenseDebugPanel />`** — dev-only inspection panel. Renders the literal copy `🟢 Dev bypass active (NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY set, hostname=localhost)` to replace the ambiguous v3.x `status: valid, renderKey: dev_bypass` log line. Returns `null` in production.
3. **`<LicenseTestMode tier="invalid" | "pro" | "free">`** — QA-only provider that overrides the license context with a simulated state so the watermark and `useIsPro()` fallbacks can be verified on a real domain without unsetting `NEXT_PUBLIC_TOUR_KIT_LICENSE_KEY`. Emits a loud `console.warn` in production; package test pipeline runs a static guard script that fails CI on imports outside `__tests__/`, `examples/`, and Storybook files.

Plus the supporting plumbing:

- Pure helper `getDaysLeft({ issuedAt, trialDays, validatedAt, serverValidatedAt }, now?)` — anchors to Polar's `last_validated_at` plus local elapsed delta to absorb client clock skew. Re-exported from `@tour-kit/license/headless`.
- `LicenseProviderProps` gains optional `trialDays` and `trialIssuedAt`. `LicenseState` gains `serverValidatedAt?: number | null` (parsed from Polar `lastValidatedAt`). `LicenseContextValue` gains `trial: TrialContextValue | null`.
- `PolarValidateResponseSchema` deliberately **does not** add a `tier` field — Polar's wire response has no tier (memory `project_polar_api_findings.md` #187 / Phase 0 §6). Pinned with `schema-no-tier.regression.test.ts`.
- New docs page `/docs/licensing/trial` covers the trial surface, debug panel, test mode, and the schema-migration plan for when Polar ships server-side trial signalling.

## Test plan

- [x] `pnpm --filter @tour-kit/license typecheck` exits 0
- [x] `pnpm --filter @tour-kit/license test` — 175/175 tests pass (7 new files + static guard)
- [x] `node packages/license/scripts/check-license-test-mode.mjs` exits 0 on the repository (no application-source imports of `LicenseTestMode`)
- [x] `pnpm --filter @tour-kit/license build` — clean tsup build; gzipped `dist/index.js` is 6.98 KB
- [x] `/docs/licensing/trial` renders in dev (`curl http://localhost:3000/docs/licensing/trial` returns 200) with all three component sections present and the sidebar entry showing under Licensing
- [x] No existing license tests regress; two snapshot tests in `license-state.test.ts` were updated to include the new `serverValidatedAt: null` field

### Notes
- `pnpm --filter docs build` is broken on `main` (pre-existing `demo-client.tsx` module-not-found in `/legal/privacy` and `/demo` routes — verified by building a clean main clone). Trial.mdx was validated via the dev server instead.
- Commits are split into 6 atomic units (helper → state → components → test mode + guard → barrels → docs).