### PR TITLE
refactor(phase-2): logger migration + Biome noConsole gate

### DIFF
--- a/packages/ai/src/__tests__/hooks/use-tour-assistant.test.tsx
+++ b/packages/ai/src/__tests__/hooks/use-tour-assistant.test.tsx
@@ -169,7 +169,9 @@ describe('useTourAssistant', () => {
         result.current.askAboutStep()
       })
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('askAboutStep'))
+      // Warn routes through @tour-kit/core logger → (prefix, message).
+      const joined = (consoleWarnSpy.mock.calls[0] ?? []).join(' ')
+      expect(joined).toContain('askAboutStep')
     })
 
     it('is a no-op when tourContextValue is null', () => {

--- a/packages/ai/src/core/events.ts
+++ b/packages/ai/src/core/events.ts
@@ -1,3 +1,4 @@
+import { logger } from '@tour-kit/core'
 import type { AiChatEvent, AiChatEventType } from '../types/events'
 
 /**
@@ -15,10 +16,10 @@ export function emitEvent(
     // If onEvent returns a promise, catch async errors too
     if (result && typeof result.catch === 'function') {
       result.catch((error: unknown) => {
-        console.warn(`[@tour-kit/ai] Async event handler error for '${type}':`, error)
+        logger.warn(`AI: Async event handler error for '${type}':`, error)
       })
     }
   } catch (error) {
-    console.warn(`[@tour-kit/ai] Event handler error for '${type}':`, error)
+    logger.warn(`AI: Event handler error for '${type}':`, error)
   }
 }

--- a/packages/ai/src/hooks/use-persistence.ts
+++ b/packages/ai/src/hooks/use-persistence.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { logger } from '@tour-kit/core'
 import type { UIMessage } from 'ai'
 import { useCallback, useEffect, useRef } from 'react'
 import type { PersistenceAdapter, PersistenceConfig } from '../types/config'
@@ -67,7 +68,7 @@ export function usePersistence(options: UsePersistenceOptions): UsePersistenceRe
       if (onError) {
         onError(err)
       } else {
-        console.warn('[tour-kit/ai] Persistence error:', err)
+        logger.warn('AI: Persistence error:', err)
       }
     },
     [onError]

--- a/packages/ai/src/hooks/use-tour-assistant.ts
+++ b/packages/ai/src/hooks/use-tour-assistant.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { logger } from '@tour-kit/core'
 import { useCallback, useMemo } from 'react'
 import { useAiChatContext } from '../context/ai-chat-context'
 import { type UseAiChatReturn, useAiChat } from './use-ai-chat'
@@ -112,7 +113,7 @@ export function useTourAssistant(): UseTourAssistantReturn {
   const askAboutStep = useCallback(() => {
     if (!tourContext.activeTour || !tourContext.activeStep) {
       if (process.env.NODE_ENV !== 'production') {
-        console.warn('[tour-kit/ai] askAboutStep() called with no active step. Message not sent.')
+        logger.warn('AI: askAboutStep() called with no active step. Message not sent.')
       }
       return
     }

--- a/packages/ai/src/server/route-handler.ts
+++ b/packages/ai/src/server/route-handler.ts
@@ -1,3 +1,4 @@
+import { logger } from '@tour-kit/core'
 import {
   type LanguageModel,
   type UIMessage,
@@ -193,7 +194,7 @@ export function createChatRouteHandler(options: ChatRouteHandlerOptions): {
           // Replace last message with hook result
           processedMessages = [...messages.slice(0, -1), hookResult]
         } catch (error) {
-          console.warn('[@tour-kit/ai] beforeSend hook error:', error)
+          logger.warn('AI: beforeSend hook error:', error)
           emitEvent(options.onEvent, 'error', {
             error: 'beforeSend hook failed',
             source: 'server',
@@ -229,7 +230,7 @@ export function createChatRouteHandler(options: ChatRouteHandlerOptions): {
             try {
               finalText = await options.beforeResponse(text)
             } catch (error) {
-              console.warn('[@tour-kit/ai] beforeResponse hook error:', error)
+              logger.warn('AI: beforeResponse hook error:', error)
               // Use original text on error
             }
           }

--- a/packages/announcements/src/__tests__/sonner-adapter.test.tsx
+++ b/packages/announcements/src/__tests__/sonner-adapter.test.tsx
@@ -101,7 +101,9 @@ describe('sonnerAdapter — sonner absent', () => {
 
     expect(handle).toBeNull()
     expect(warnSpy).toHaveBeenCalledTimes(1)
-    expect(warnSpy.mock.calls[0]?.[0]).toEqual(expect.stringContaining('sonner'))
+    // Warn routes through @tour-kit/core logger → (prefix, message).
+    const joined = (warnSpy.mock.calls[0] ?? []).join(' ')
+    expect(joined).toContain('sonner')
   })
 
   it('does not re-warn on subsequent calls (module-scope flag)', async () => {

--- a/packages/announcements/src/adapters/sonner.ts
+++ b/packages/announcements/src/adapters/sonner.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { logger } from '@tour-kit/core'
 import * as React from 'react'
 import type {
   ToastAdapter,
@@ -10,11 +11,10 @@ import type {
 let warned = false
 function warnOnce(msg: string): void {
   if (warned) return
-  // Allow warnings in production too — consumers benefit from one-time visibility
-  // when they misconfigure (e.g., forgot to render <Toaster />). The warned flag
-  // keeps it bounded to one message per page load.
+  // One-time visibility for misconfiguration. Respects `logger.configure({ level })`
+  // so consumers that silence the logger don't get unexpected console output.
   warned = true
-  console.warn(`[tour-kit] ${msg}`)
+  logger.warn(msg)
 }
 
 /**

--- a/packages/core/src/__tests__/biome-noConsole.integration.test.ts
+++ b/packages/core/src/__tests__/biome-noConsole.integration.test.ts
@@ -1,0 +1,64 @@
+import { execSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+// Integration test: runs the real Biome CLI from the workspace against
+// fixture files. Validates that our biome.json `noConsole` rule + overrides
+// produce the correct pass/fail behavior for the production gate.
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..')
+
+describe('Biome noConsole rule + overrides (integration)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'biome-noconsole-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('flags console.warn in an arbitrary non-overridden source file', () => {
+    const file = join(dir, 'fixture.ts')
+    writeFileSync(file, "console.warn('should fail noConsole')\n")
+    let exitCode = 0
+    try {
+      execSync(`pnpm --silent exec biome lint ${file}`, {
+        cwd: REPO_ROOT,
+        stdio: 'pipe',
+      })
+    } catch (err) {
+      exitCode = (err as { status?: number }).status ?? 1
+    }
+    expect(exitCode).not.toBe(0)
+  })
+
+  it('locks the override list to documented preserve + exempt paths', () => {
+    // Memory #208 / phase-2.md: the override list is the contract.
+    // If a maintainer "fixes" a file by routing through logger but forgets
+    // to drop the override, the file ends up too permissive. Conversely,
+    // if they drop a path that still has loud-by-design console.*,
+    // pnpm lint breaks. This test pins both sides.
+    const config = readFileSync(join(REPO_ROOT, 'tooling/biome/biome.json'), 'utf-8')
+
+    // Preserve list — must remain in the override include array
+    expect(config).toMatch(/packages\/core\/src\/utils\/logger\.ts/)
+    expect(config).toMatch(/packages\/core\/src\/lib\/interpolate\.ts/)
+    expect(config).toMatch(/packages\/core\/src\/context\/tour-provider\.tsx/)
+    expect(config).toMatch(/packages\/analytics\/src\/plugins\/console\.ts/)
+    expect(config).toMatch(/packages\/license\/src\/components\/license-test-mode\.tsx/)
+    expect(config).toMatch(/packages\/license\/src\/components\/license-warning\.tsx/)
+    expect(config).toMatch(/packages\/license\/src\/components\/pro-gate\.tsx/)
+    expect(config).toMatch(/packages\/license\/src\/lib\/domain\.ts/)
+
+    // Exempt CLI surfaces
+    expect(config).toMatch(/packages\/codemods\/src\/cli\.ts/)
+    expect(config).toMatch(/packages\/codemods\/src\/bin/)
+
+    // Rule itself must be present at error level
+    expect(config).toMatch(/"noConsole":\s*\{[^}]*"level":\s*"error"/)
+  })
+})

--- a/packages/core/src/__tests__/lib/segmentation/use-segment.logger.test.tsx
+++ b/packages/core/src/__tests__/lib/segmentation/use-segment.logger.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react'
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SegmentationProvider, useSegment } from '../../../index'
+import type { SegmentSource } from '../../../lib/segmentation/types'
+import { logger } from '../../../utils/logger'
+import { uniqueSegment } from '../../_helpers/unique-segment'
+
+// Wrap renderHook so each test can render against an isolated provider tree
+// without leaking segments between tests.
+function wrapper(segments: Record<string, SegmentSource> = {}) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <SegmentationProvider segments={segments}>{children}</SegmentationProvider>
+  }
+}
+
+describe('useSegment — unknown-segment warn (migrated to logger)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    logger.configure({ level: 'warn' })
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    logger.configure({ level: 'warn' })
+  })
+
+  it('warns once for an unknown segment at default logger level', () => {
+    const seg = uniqueSegment('unk')
+    renderHook(() => useSegment(seg), { wrapper: wrapper({}) })
+    const matched = warnSpy.mock.calls.filter((c: unknown[]) =>
+      String(c[1] ?? '').includes('useSegment')
+    )
+    expect(matched.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('emits no console.warn when logger is silent', () => {
+    logger.configure({ level: 'silent' })
+    const seg = uniqueSegment('unk-silent')
+    renderHook(() => useSegment(seg), { wrapper: wrapper({}) })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes through logger.warn, not direct console.warn', () => {
+    const loggerWarnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    renderHook(() => useSegment(uniqueSegment('routed')), { wrapper: wrapper({}) })
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1)
+    loggerWarnSpy.mockRestore()
+  })
+})

--- a/packages/core/src/__tests__/registry/tour-registry.logger.test.ts
+++ b/packages/core/src/__tests__/registry/tour-registry.logger.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { tourRegistry } from '../../registry/tour-registry'
+import type { RegistryEntry } from '../../registry/tour-registry'
+import { logger } from '../../utils/logger'
+
+function makeEntry(id: string): RegistryEntry {
+  return {
+    id,
+    state: { isActive: false, currentStepId: null, progress: 0 },
+    actions: {
+      start: () => {},
+      stop: () => {},
+      restart: () => {},
+      next: () => {},
+      prev: () => {},
+      goToStep: () => {},
+    },
+  }
+}
+
+describe('tourRegistry duplicate-id registration (migrated to logger)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    tourRegistry.__reset__?.()
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    logger.configure({ level: 'warn' })
+  })
+
+  afterEach(() => {
+    tourRegistry.__reset__?.()
+    errorSpy.mockRestore()
+    logger.configure({ level: 'warn' })
+  })
+
+  it('logs an error when the same id registers twice (default level)', () => {
+    const id = `tour-${Math.random().toString(36).slice(2, 8)}`
+    tourRegistry.register(makeEntry(id))
+    tourRegistry.register(makeEntry(id))
+    const matched = errorSpy.mock.calls.filter((c: unknown[]) =>
+      String(c[1] ?? '').includes('registered twice')
+    )
+    expect(matched.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('emits nothing to console.error when logger is silent', () => {
+    logger.configure({ level: 'silent' })
+    const id = `tour-${Math.random().toString(36).slice(2, 8)}`
+    tourRegistry.register(makeEntry(id))
+    tourRegistry.register(makeEntry(id))
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes through logger.error, not direct console.error', () => {
+    const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {})
+    const id = `tour-${Math.random().toString(36).slice(2, 8)}`
+    tourRegistry.register(makeEntry(id))
+    tourRegistry.register(makeEntry(id))
+    expect(loggerErrorSpy).toHaveBeenCalledTimes(1)
+    loggerErrorSpy.mockRestore()
+  })
+})

--- a/packages/core/src/__tests__/utils/logger.test.ts
+++ b/packages/core/src/__tests__/utils/logger.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { logger } from '../../utils/logger'
+
+// The logger module is a singleton. We restore the default level in
+// afterEach so cross-file ordering does not leak silence into other suites.
+describe('logger.configure level filtering', () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>
+  let infoSpy: ReturnType<typeof vi.spyOn>
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    logger.configure({ level: 'warn' })
+  })
+
+  afterEach(() => {
+    debugSpy.mockRestore()
+    infoSpy.mockRestore()
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    logger.configure({ level: 'warn' })
+  })
+
+  it('silent: suppresses every log method', () => {
+    logger.configure({ level: 'silent' })
+    logger.debug('d')
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+    expect(debugSpy).not.toHaveBeenCalled()
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('error: only error reaches console', () => {
+    logger.configure({ level: 'error' })
+    logger.debug('d')
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+    expect(debugSpy).not.toHaveBeenCalled()
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('warn (default): warn + error reach console; debug/info do not', () => {
+    logger.configure({ level: 'warn' })
+    logger.debug('d')
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+    expect(debugSpy).not.toHaveBeenCalled()
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('info: info + warn + error reach console; debug does not', () => {
+    logger.configure({ level: 'info' })
+    logger.debug('d')
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+    expect(debugSpy).not.toHaveBeenCalled()
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('debug: all four levels reach console', () => {
+    logger.configure({ level: 'debug' })
+    logger.debug('d')
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+    expect(debugSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('configure({ level: "warn" }) restores after a silent block', () => {
+    logger.configure({ level: 'silent' })
+    logger.warn('first — should be silent')
+    expect(warnSpy).not.toHaveBeenCalled()
+
+    logger.configure({ level: 'warn' })
+    logger.warn('second — should reach console')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('prepends the configured prefix on each call', () => {
+    logger.configure({ level: 'warn' })
+    logger.warn('hello')
+    expect(warnSpy).toHaveBeenCalledWith('[tour-kit]', 'hello')
+  })
+
+  it('getConfig returns a snapshot, not a live reference', () => {
+    logger.configure({ level: 'debug', prefix: '[probe]' })
+    const snapshot = logger.getConfig()
+    logger.configure({ level: 'silent' })
+    expect(snapshot.level).toBe('debug')
+    expect(snapshot.prefix).toBe('[probe]')
+  })
+})

--- a/packages/core/src/context/__tests__/tour-provider-diagnose.test.tsx
+++ b/packages/core/src/context/__tests__/tour-provider-diagnose.test.tsx
@@ -76,8 +76,10 @@ describe('<TourProvider> dev-mode warning', () => {
         <span>x</span>
       </TourProvider>
     )
+    // The warn now routes through logger.warn, which forwards as
+    // (prefix, ...args), so the "diagnose" substring lands in args[1].
     const diagnoseCalls = warn.mock.calls.filter((args) =>
-      String(args[0] ?? '').includes('diagnose')
+      args.some((a) => String(a ?? '').includes('diagnose'))
     )
     expect(diagnoseCalls).toHaveLength(1)
   })
@@ -89,8 +91,10 @@ describe('<TourProvider> dev-mode warning', () => {
         <span>x</span>
       </TourProvider>
     )
+    // The warn now routes through logger.warn, which forwards as
+    // (prefix, ...args), so the "diagnose" substring lands in args[1].
     const diagnoseCalls = warn.mock.calls.filter((args) =>
-      String(args[0] ?? '').includes('diagnose')
+      args.some((a) => String(a ?? '').includes('diagnose'))
     )
     expect(diagnoseCalls).toHaveLength(0)
   })
@@ -108,8 +112,10 @@ describe('<TourProvider> production-mode silence', () => {
         <span>x</span>
       </TourProvider>
     )
+    // The warn now routes through logger.warn, which forwards as
+    // (prefix, ...args), so the "diagnose" substring lands in args[1].
     const diagnoseCalls = warn.mock.calls.filter((args) =>
-      String(args[0] ?? '').includes('diagnose')
+      args.some((a) => String(a ?? '').includes('diagnose'))
     )
     expect(diagnoseCalls).toHaveLength(0)
   })

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -429,8 +429,8 @@ export function TourProvider({
     if (diagnoseHintFiredRef.current) return
     if (typeof process === 'undefined' || process.env?.NODE_ENV === 'production') return
     diagnoseHintFiredRef.current = true
-    console.warn(
-      '[Tour Kit] Tip: pass <TourProvider diagnose> in dev to see why a tour did not fire. https://tourkit.dev/docs/core/diagnostic'
+    logger.warn(
+      'Tip: pass <TourProvider diagnose> in dev to see why a tour did not fire. https://tourkit.dev/docs/core/diagnostic'
     )
   }, [])
 

--- a/packages/core/src/lib/segmentation/segmentation.test.tsx
+++ b/packages/core/src/lib/segmentation/segmentation.test.tsx
@@ -37,7 +37,11 @@ describe('SegmentationProvider + useSegment', () => {
       )
       expect(screen.getByTestId('single')).toHaveTextContent('false')
       expect(warnSpy).toHaveBeenCalledOnce()
-      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/\[tour-kit\] useSegment: unknown segment "ghost"/)
+      // The warn now routes through logger.warn, which forwards as
+      // (prefix, message) — assert against joined args so prefix can move.
+      const joined = (warnSpy.mock.calls[0] ?? []).join(' ')
+      expect(joined).toMatch(/useSegment: unknown segment "ghost"/)
+      expect(joined).toMatch(/\[tour-kit\]/)
     })
 
     it('does NOT warn for unknown segment in production', () => {

--- a/packages/core/src/lib/segmentation/use-segment.ts
+++ b/packages/core/src/lib/segmentation/use-segment.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { logger } from '../../utils/logger'
 import { matchesAudience } from '../audience'
 import { useSegmentationContext } from './segmentation-context'
 import type { SegmentSource } from './types'
@@ -58,7 +59,7 @@ export function useSegment(name: string): boolean {
     const seg = segments[name]
     if (!seg) {
       if (process.env.NODE_ENV !== 'production') {
-        console.warn(`[tour-kit] useSegment: unknown segment "${name}"`)
+        logger.warn(`useSegment: unknown segment "${name}"`)
       }
       return false
     }

--- a/packages/core/src/registry/__tests__/tour-registry.test.ts
+++ b/packages/core/src/registry/__tests__/tour-registry.test.ts
@@ -143,9 +143,10 @@ describe('tourRegistry — dev double-id console.error', () => {
     tourRegistry.register(makeEntry('welcome'))
 
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Tour "welcome" registered twice')
-    )
+    // The error now routes through logger.error → (prefix, message),
+    // so the substring lands in the second positional arg.
+    const joined = (consoleErrorSpy.mock.calls[0] ?? []).join(' ')
+    expect(joined).toContain('Tour "welcome" registered twice')
 
     consoleErrorSpy.mockRestore()
   })

--- a/packages/core/src/registry/tour-registry.tsx
+++ b/packages/core/src/registry/tour-registry.tsx
@@ -21,9 +21,11 @@
  *     producing a fresh reference that `useSyncExternalStore` will compare via
  *     `Object.is` and rerender consumers on changes only.
  *   - **Dev double-id is logged, not thrown.** HMR remounts and accidental
- *     double-mounts must not tank DX — emit `console.error`, keep the latest
+ *     double-mounts must not tank DX — log via `logger.error`, keep the latest
  *     registration, and document the behaviour in `imperative-control.mdx`.
  */
+
+import { logger } from '../utils/logger'
 
 /**
  * Live state mirror for a registered tour.
@@ -103,8 +105,8 @@ function register(entry: RegistryEntry): () => void {
   const ref = new WeakRef(entry)
   const existing = entries.get(entry.id)?.deref()
   if (existing && isNonProductionEnv()) {
-    console.error(
-      `[Tour Kit] Tour "${entry.id}" registered twice. Keeping the latest registration.`
+    logger.error(
+      `Tour "${entry.id}" registered twice. Keeping the latest registration.`
     )
   }
   entries.set(entry.id, ref)

--- a/packages/core/src/registry/tour-registry.tsx
+++ b/packages/core/src/registry/tour-registry.tsx
@@ -105,9 +105,7 @@ function register(entry: RegistryEntry): () => void {
   const ref = new WeakRef(entry)
   const existing = entries.get(entry.id)?.deref()
   if (existing && isNonProductionEnv()) {
-    logger.error(
-      `Tour "${entry.id}" registered twice. Keeping the latest registration.`
-    )
+    logger.error(`Tour "${entry.id}" registered twice. Keeping the latest registration.`)
   }
   entries.set(entry.id, ref)
   notify()

--- a/packages/hints/src/context/hints-provider.tsx
+++ b/packages/hints/src/context/hints-provider.tsx
@@ -6,6 +6,7 @@ import {
   canShowAfterDismissal,
   canShowByFrequency,
   createPrefixedStorage,
+  logger,
   safeJSONParse,
 } from '@tour-kit/core'
 import * as React from 'react'
@@ -437,9 +438,7 @@ export function HintsProvider({ children, hints, storage }: HintsProviderProps) 
     const persistedState = frequencyStateRef.current.get(id) ?? emptyFrequencyState()
     if (rule && !canShowByFrequency(persistedState, rule)) {
       if (process.env.NODE_ENV !== 'production') {
-        console.debug(
-          `[tour-kit] showHint("${id}") suppressed by frequency rule ${JSON.stringify(rule)}`
-        )
+        logger.debug(`showHint("${id}") suppressed by frequency rule ${JSON.stringify(rule)}`)
       }
       return
     }

--- a/packages/license/package.json
+++ b/packages/license/package.json
@@ -73,6 +73,7 @@
     "test:license-test-mode-guard": "node scripts/check-license-test-mode.mjs"
   },
   "dependencies": {
+    "@tour-kit/core": "workspace:*",
     "zod": "catalog:"
   },
   "peerDependencies": {

--- a/packages/license/src/__tests__/preserve-loud-warnings.test.tsx
+++ b/packages/license/src/__tests__/preserve-loud-warnings.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Preserve-bucket contract test (refactor train phase 2).
+ *
+ * The phase-2 plan classifies several license warnings as "preserve" —
+ * loud-by-design messages that MUST bypass logger.configure({ level: 'silent' })
+ * so an accidental misconfiguration cannot mute the SDK's enforcement
+ * surface. This file pins the contract: configure the logger silent,
+ * trigger each preserved site, and assert console still fired.
+ *
+ * If a future maintainer "fixes" any of these to route through logger,
+ * the corresponding test fails — that's the gate.
+ */
+
+import { render } from '@testing-library/react'
+import { logger } from '@tour-kit/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LicenseTestMode } from '../components/license-test-mode'
+import { LicenseWarning } from '../components/license-warning'
+
+describe('License preserve-bucket warnings bypass logger.configure', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    logger.configure({ level: 'silent' })
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    logger.configure({ level: 'warn' })
+    vi.unstubAllEnvs()
+  })
+
+  it('<LicenseTestMode> still warns in production under logger.silent', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    render(
+      <LicenseTestMode tier="invalid">
+        <div />
+      </LicenseTestMode>
+    )
+    const matched = warnSpy.mock.calls.filter((c: unknown[]) =>
+      String(c[0] ?? '').includes('<LicenseTestMode> active in production')
+    )
+    expect(matched.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('<LicenseWarning> still warns in dev under logger.silent', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    render(<LicenseWarning />)
+    const matched = warnSpy.mock.calls.filter((c: unknown[]) =>
+      String(c[0] ?? '').includes('Tour Kit Pro without a valid license')
+    )
+    expect(matched.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/packages/license/src/__tests__/trial-badge.test.tsx
+++ b/packages/license/src/__tests__/trial-badge.test.tsx
@@ -116,7 +116,11 @@ describe('<TrialBadge>', () => {
       expect(container.firstChild).toBeNull()
     })
     expect(warnSpy).toHaveBeenCalled()
-    expect(warnSpy.mock.calls[0]?.[0]).toContain('<TrialBadge>')
+    // The warn now routes through @tour-kit/core's logger, which prepends
+    // '[tour-kit]' as the first arg. The TrialBadge message lands as the
+    // second arg. (Phase 2 logger migration.)
+    const args = warnSpy.mock.calls[0] ?? []
+    expect(args.join(' ')).toContain('<TrialBadge>')
     warnSpy.mockRestore()
   })
 

--- a/packages/license/src/components/trial-badge.tsx
+++ b/packages/license/src/components/trial-badge.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { logger } from '@tour-kit/core'
 import { useContext } from 'react'
 import { LicenseContext } from '../context/license-context'
 
@@ -40,7 +41,7 @@ export function TrialBadge({
 
   if (resolved === undefined) {
     if (process.env.NODE_ENV !== 'production') {
-      console.warn(
+      logger.warn(
         '<TrialBadge> rendered without trialDays — pass trialDays to <LicenseProvider> to enable the trial countdown surface.'
       )
     }

--- a/packages/license/src/context/license-context.tsx
+++ b/packages/license/src/context/license-context.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { logger } from '@tour-kit/core'
 import { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { clearCache, hasFreshCache } from '../lib/cache'
 import { getCurrentDomain, isDevEnvironment } from '../lib/domain'
@@ -141,7 +142,7 @@ export function LicenseProvider({
     if (trialDays === undefined) return null
     if (trialDays <= 0) {
       if (process.env.NODE_ENV !== 'production') {
-        console.warn('<LicenseProvider> received non-positive trialDays; ignoring')
+        logger.warn('<LicenseProvider> received non-positive trialDays; ignoring')
       }
       return null
     }

--- a/packages/license/tsconfig.json
+++ b/packages/license/tsconfig.json
@@ -1,12 +1,8 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tooling/tsconfig/react-library.json",
   "compilerOptions": {
-    "lib": ["ES2020", "DOM"],
     "outDir": "./dist",
-    "rootDir": "./src",
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "react-jsx"
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]

--- a/packages/license/tsup.config.ts
+++ b/packages/license/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   dts: true,
   clean: true,
-  external: ['react', 'react-dom'],
+  external: ['react', 'react-dom', '@tour-kit/core'],
   treeshake: true,
   splitting: false,
   minify: true,

--- a/packages/media/src/components/media-slot.test.tsx
+++ b/packages/media/src/components/media-slot.test.tsx
@@ -147,9 +147,9 @@ describe('MediaSlot reduced-motion behavior', () => {
   it('GIF without poster emits a dev-only console.warn', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     render(<MediaSlot src="/animation.gif" />)
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('GIF rendered without poster under prefers-reduced-motion: reduce')
-    )
+    // Warn now routes through @tour-kit/core logger → (prefix, message).
+    const joined = (warn.mock.calls[0] ?? []).join(' ')
+    expect(joined).toContain('GIF rendered without poster under prefers-reduced-motion: reduce')
     warn.mockRestore()
   })
 

--- a/packages/media/src/components/media-slot.tsx
+++ b/packages/media/src/components/media-slot.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useReducedMotion } from '@tour-kit/core'
+import { logger, useReducedMotion } from '@tour-kit/core'
 import * as React from 'react'
 import {
   type MediaSlotType,
@@ -206,7 +206,7 @@ function renderDispatch(props: DispatchProps): React.ReactElement {
       )
     case 'gif':
       if (prefersReducedMotion && !poster && process.env.NODE_ENV !== 'production') {
-        console.warn('[MediaSlot] GIF rendered without poster under prefers-reduced-motion: reduce')
+        logger.warn('MediaSlot: GIF rendered without poster under prefers-reduced-motion: reduce')
       }
       return (
         <GifPlayer

--- a/packages/react/src/__tests__/components/card/tour-card-classic.test.tsx
+++ b/packages/react/src/__tests__/components/card/tour-card-classic.test.tsx
@@ -119,10 +119,11 @@ describe('TourCard variant="classic" opt-out', () => {
     const { a, b } = nextIds()
     const user = userEvent.setup()
 
+    // Warn now routes through @tour-kit/core logger → (prefix, message),
+    // so the deprecation substring may land in either arg.
     const countDeprecationWarns = () =>
-      warnSpy.mock.calls.filter(
-        (call: unknown[]) =>
-          typeof call[0] === 'string' && /variant="classic">? is deprecated/.test(call[0])
+      warnSpy.mock.calls.filter((call: unknown[]) =>
+        /variant="classic">? is deprecated/.test(call.map((a) => String(a ?? '')).join(' '))
       ).length
 
     const tour = makeTwoStepTour(a, b)

--- a/packages/react/src/components/card/tour-card.tsx
+++ b/packages/react/src/components/card/tour-card.tsx
@@ -11,6 +11,7 @@ import {
 } from '@floating-ui/react'
 import {
   type Placement,
+  logger,
   resolveTarget,
   useFocusTrap,
   useReducedMotion,
@@ -122,8 +123,8 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
       if (process.env.NODE_ENV === 'production') return
       if (warnedClassicStepIds.has(currentStep.id)) return
       warnedClassicStepIds.add(currentStep.id)
-      console.warn(
-        '[tour-kit/react] <TourCard variant="classic"> is deprecated and will be removed in the next major. See https://usertourkit.com/docs/react/components/tour-card-migration'
+      logger.warn(
+        'react: <TourCard variant="classic"> is deprecated and will be removed in the next major. See https://usertourkit.com/docs/react/components/tour-card-migration'
       )
     }, [variant, currentStep?.id])
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1060,6 +1060,9 @@ importers:
 
   packages/license:
     dependencies:
+      '@tour-kit/core':
+        specifier: workspace:*
+        version: link:../core
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -11130,7 +11133,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -11163,7 +11166,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11178,7 +11181,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/tooling/biome/biome.json
+++ b/tooling/biome/biome.json
@@ -22,7 +22,13 @@
       },
       "suspicious": {
         "noExplicitAny": "warn",
-        "noArrayIndexKey": "warn"
+        "noArrayIndexKey": "warn",
+        "noConsole": {
+          "level": "error",
+          "options": {
+            "allow": []
+          }
+        }
       },
       "a11y": {
         "recommended": true,
@@ -49,5 +55,40 @@
     "formatter": {
       "trailingCommas": "none"
     }
-  }
+  },
+  "overrides": [
+    {
+      "include": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "**/__tests__/**",
+        "**/tsup.config.ts",
+        "**/vitest.config.ts",
+        "**/playwright.config.ts",
+        "reports/**",
+        "apps/docs/app/api/**",
+        "apps/tour-kit-mcp/**",
+        "examples/**",
+        "packages/core/src/utils/logger.ts",
+        "packages/core/src/lib/interpolate.ts",
+        "packages/core/src/context/tour-provider.tsx",
+        "packages/analytics/src/plugins/console.ts",
+        "packages/license/src/components/license-test-mode.tsx",
+        "packages/license/src/components/license-warning.tsx",
+        "packages/license/src/components/pro-gate.tsx",
+        "packages/license/src/lib/domain.ts",
+        "packages/codemods/src/cli.ts",
+        "packages/codemods/src/bin/**"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Refactor train phase 2 — make production-runtime logging configurable
without breaking the loud-by-design enforcement surfaces, and lock the
contract with a Biome rule so the gate cannot drift.

- Migrates **15 production `console.warn` / `console.error` / `console.debug` sites** across `core`, `react`, `hints`, `announcements`, `media`, `ai`, `license` to `@tour-kit/core`'s `logger`. After this PR, `logger.configure({ level: 'silent' })` silences all of them in one place — that's the contract `pnpm lint` now enforces.
- Adds `@tour-kit/core` as a `@tour-kit/license` dependency (with tsup `external` so there's no double-bundling) so license dev warnings can route through the shared logger. License build size delta ≈ 0 KB (core stays external).
- Adds `suspicious/noConsole: { level: error, allow: [] }` to `tooling/biome/biome.json` with explicit overrides for:
  - **Preserve list** (must stay loud, bypass logger): `core/utils/logger.ts`, `core/lib/interpolate.ts` (the `warnOnMissing: true` opt-in), `core/context/tour-provider.tsx` (test-bridge warn), `analytics/plugins/console.ts`, `license/components/{license-test-mode,license-warning,pro-gate}.tsx`, `license/lib/domain.ts`.
  - **Exempt** (CLI / build / examples / tests / scripts): `codemods/{cli.ts,bin}`, `**/tsup.config.ts`, `**/__tests__/**`, `reports/**`, `apps/docs/app/api/**`, `apps/tour-kit-mcp/**`, `examples/**`.
- Pins the contract from both directions with five new test files: exhaustive `logger.test.ts`, three-test triples for the use-segment + tour-registry migrated sites, a preserve-bucket `LicenseTestMode` + `LicenseWarning` "loud-survives-silent" contract, and a real-Biome-CLI integration test that locks the override-list paths.
- Updates eight existing test files whose assertions read the message as `args[0]`; the logger now forwards `(prefix, message)` so the substring search now spans the args array.

### Decisions

| Gate | Choice | One-line rationale |
|---|---|---|
| License → core dep | **Add core dep** | One-place logger configure is the whole point of the phase; size impact negligible since core stays external in tsup. |
| `interpolate.ts:warnOnMissing` | **Preserve** | `warnOnMissing: true` is an explicit opt-in to warnings; silencing via logger contradicts the caller's intent. |
| `tour-provider:432` (diagnose nudge) | **Migrate** | The original audit grep `(warn\|error\|log\|info)` did not classify this site; it's a dev-only DX warn that should respect silence. The line 1704 test-bridge call remains preserved. |
| `hints-provider:440` (`console.debug`) | **Migrate** | Same — caught only by Biome because the audit grep was missing `debug`. |

### Before / after audit

`rg "console\.(warn|error|log|info)" packages --glob '*.{ts,tsx}' --glob '!**/dist/**' --glob '!**/__tests__/**' --glob '!**/*.test.*' --glob '!**/*.spec.*' --glob '!**/__spikes__/**'`

| State | Hits | Files |
|---|---|---|
| Before | **52** | 26 |
| After  | **35** | 14 (all documented preserve/exempt; the lint command now blocks any new one) |

The remaining 14 files are exactly the documented preserve + exempt list. A handful of the matches are inside JSDoc comments (e.g. `tour-registry.tsx:81`, `tourkit-provider.tsx:68`) which Biome does not lint — the rule + override list catches anything in executable code.

### Validation

- `pnpm lint` → 0 errors (with the new `noConsole` rule live)
- `pnpm typecheck` → 29/29 packages
- `pnpm build` (affected packages) → 9/9
- `pnpm --filter @tour-kit/{core,react,hints,announcements,media,ai,license,checklists,surveys,adoption,scheduling,analytics,playwright,testing-library} test` → all green (~3,700 tests)
- Audit re-run → only documented preserve + exempt paths remain

### Rollback

`git revert <merge-commit-sha>` undoes the whole train. If only the Biome rule needs to soften, drop `noConsole` to `"warn"` in `tooling/biome/biome.json` without reverting the migrated logger calls — the runtime behavior is independent.

## Test plan
- [ ] CI passes lint, typecheck, test, build across the workspace
- [ ] License bundle size diff < 2 KB gzipped (manual check via `pnpm --filter @tour-kit/license build` output)
- [ ] Verify in a consumer app: `logger.configure({ level: 'silent' })` silences a use-segment unknown-segment warn; `LicenseTestMode` still warns loudly