### PR TITLE
refactor(phase-3): dead position API + hidden-step union + priority comparator

### DIFF
--- a/.changeset/phase-3-refactor-train.md
+++ b/.changeset/phase-3-refactor-train.md
@@ -1,0 +1,38 @@
+---
+'@tour-kit/core': major
+'@tour-kit/react': major
+'@tour-kit/announcements': minor
+---
+
+Phase 3 (refactor train) — Dead position API removal, hidden-step type tightening, announcements priority comparator.
+
+**Workstream A — `@tour-kit/core` / `@tour-kit/react` BREAKING:**
+
+Removed from public barrels (no production callers found in `packages`, `apps`, `examples`, or sibling `tourkit-dash`):
+
+- `calculatePosition`
+- `calculatePositionWithCollision`
+- `wouldOverflow`
+- `getFallbackPlacements`
+- `PositionResult` (type)
+
+`ElementPositionResult` (the deliberately similar but unrelated type consumed by `useElementPosition`) is preserved. The math functions still live in `packages/core/src/utils/position.ts` for internal use; only the public exports are gone.
+
+**Workstream B — `@tour-kit/announcements` improvement:**
+
+- New `createAnnouncementComparator(order, weights, sequenceById)` helper in `@tour-kit/announcements/core/priority-queue`. Replaces an inline `priorityOrder: Record<string, number>` literal in `<AnnouncementsProvider>` that hardcoded `{ critical: 0, high: 1, normal: 2, low: 3 }` and ignored both `QueueConfig.priorityWeights` and `priorityOrder: 'fifo' | 'lifo'`.
+- New `AnnouncementScheduler.queueConfig` getter (`Readonly<QueueConfig>`). Provider now reads queue config through a public getter instead of poking the private `schedulerRef.current.config` field.
+- Custom `priorityWeights` and `priorityOrder: 'fifo' | 'lifo'` now actually drive auto-show ordering. This is a behavior fix for users who relied on the previous (broken) default-weight behavior.
+
+**Workstream C — `@tour-kit/core` API surface widening (mostly back-compat):**
+
+- `TourStep` is now a discriminated union: `TourStep = VisibleTourStep | HiddenTourStep`.
+- `VisibleTourStep` requires `target` and `content` (matches the previous required surface).
+- `HiddenTourStep` declares `target?: never`, `content?: never`, `title?: never`, `placement?: never`, `advanceOn?: never` so authoring `{ kind: 'hidden', target: '#x' }` is a TypeScript error — mirroring the runtime check in `validateTour`.
+- New `isVisibleStep(step): step is VisibleTourStep` type guard (runtime + type-level).
+- New named exports `VisibleTourStep`, `HiddenTourStep`, and `isVisibleStep` from `@tour-kit/core`.
+- `createStep` / `createNamedStep` return `VisibleTourStep` (was `TourStep`) — hidden steps were never constructable via this helper.
+- `validateTour` no longer uses the `as unknown as Record<string, unknown>` cast; reads `step[field]` directly through the narrowed `HiddenTourStep` branch.
+- `waitForStepTarget(step, opts)` now takes `VisibleTourStep` (was `TourStep`). The provider already narrowed before calling it.
+
+Hidden step callers that read UI fields (`target`, `content`, etc.) need to narrow with `step.kind !== 'hidden'` or `isVisibleStep(step)` before access. This was a silent bug surface before — the union enforces it now.

--- a/apps/docs/public/context/core.txt
+++ b/apps/docs/public/context/core.txt
@@ -48,6 +48,8 @@ Types:
     Direction
     TourKitConfig
     TourStep
+    VisibleTourStep
+    HiddenTourStep
     StepOptions
     StepIdOf
     AudienceProp
@@ -83,7 +85,6 @@ Types:
     UseFlowSessionReturn
     UseBroadcastReturn
     UseAdvanceOnOptions
-    PositionResult
     LogLevel
     LoggerConfig
     ThrottledFunction
@@ -170,6 +171,8 @@ Utilities:
     // Runtime target resolver (Phase 5) — single source of truth for
   // string/ref/getter dereference across hooks and React consumers.
   resolveTarget
+    // Step union discriminator (Phase 3 — refactor train).
+  isVisibleStep
     dispatchAdvanceEvent
     getElement
     isElementVisible
@@ -180,11 +183,7 @@ Utilities:
     getElementRect
     getViewportDimensions
     parsePlacement
-    calculatePosition
-    wouldOverflow
     getOppositeSide
-    getFallbackPlacements
-    calculatePositionWithCollision
     getDocumentDirection
     mirrorSide
     mirrorAlignment

--- a/apps/docs/public/context/react.txt
+++ b/apps/docs/public/context/react.txt
@@ -197,7 +197,6 @@ Utilities:
     createStorageAdapter
     createPrefixedStorage
     safeJSONParse
-    calculatePosition
     defaultSpotlightConfig
     defaultKeyboardConfig
     defaultPersistenceConfig

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -1,4 +1,4 @@
-# userTourKit v0.14.0 — Generated 2026-05-22T02:23:02Z
+# userTourKit v0.14.0 — Generated 2026-05-22T04:55:49Z
 
 # Feature Adoption Tracking
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,4 +1,4 @@
-# userTourKit v0.14.0 — Generated 2026-05-22T02:23:02Z
+# userTourKit v0.14.0 — Generated 2026-05-22T04:55:49Z
 
 # userTourKit
 

--- a/packages/announcements/src/__tests__/context/announcements-provider-priority.test.tsx
+++ b/packages/announcements/src/__tests__/context/announcements-provider-priority.test.tsx
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Phase 3 (refactor train) — grep gate co-located with the test that the
+// inline `priorityOrder: Record<string, number>` literal in
+// `<AnnouncementsProvider>` was replaced with `createAnnouncementComparator`
+// from `core/priority-queue.ts`. Co-located so a future refactor that
+// re-introduces the literal trips the gate.
+const __here = dirname(fileURLToPath(import.meta.url))
+const PROVIDER_PATH = resolve(__here, '../../context/announcements-provider.tsx')
+
+describe('announcements-provider.tsx — no inline priorityOrder literal', () => {
+  const source = readFileSync(PROVIDER_PATH, 'utf-8')
+
+  it('does not contain `priorityOrder: Record<string, number>`', () => {
+    expect(source).not.toMatch(/priorityOrder:\s*Record<string,\s*number>/)
+  })
+
+  it('does not contain the hardcoded { critical: 0, high: 1, ...} object literal', () => {
+    // Conservative match — flags reintroduction of the specific shape.
+    expect(source).not.toMatch(/critical:\s*0[\s\S]{0,40}low:\s*3/)
+  })
+
+  it('imports createAnnouncementComparator from core/priority-queue', () => {
+    expect(source).toMatch(/createAnnouncementComparator/)
+    expect(source).toMatch(/from\s+['"]\.\.\/core\/priority-queue['"]/)
+  })
+
+  it('does not reach into schedulerRef.current.config (private field)', () => {
+    expect(source).not.toMatch(/schedulerRef\.current\.config\b/)
+  })
+
+  it('uses the public queueConfig getter on the scheduler', () => {
+    expect(source).toMatch(/schedulerRef\.current\.queueConfig\b/)
+  })
+})

--- a/packages/announcements/src/__tests__/core/priority-queue.test.ts
+++ b/packages/announcements/src/__tests__/core/priority-queue.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { PriorityQueue } from '../../core/priority-queue'
+import { createAnnouncementComparator, PriorityQueue } from '../../core/priority-queue'
+import type { AnnouncementConfig, AnnouncementPriority } from '../../types/announcement'
 import { DEFAULT_QUEUE_CONFIG } from '../../types/queue'
 
 describe('PriorityQueue', () => {
@@ -192,3 +193,131 @@ describe('PriorityQueue', () => {
     })
   })
 })
+
+// Phase 3 (refactor train) — comparator used by the provider's auto-show
+// effect to replace an inline `priorityOrder` literal that ignored
+// `QueueConfig.priorityWeights` and `priorityOrder: 'fifo' | 'lifo'`.
+describe('createAnnouncementComparator', () => {
+  const ann = (
+    id: string,
+    priority: AnnouncementPriority
+  ): Pick<AnnouncementConfig, 'id' | 'priority'> => ({ id, priority })
+
+  const sequenceById = (ids: string[]) => new Map(ids.map((id, i) => [id, i]))
+
+  const defaultWeights = DEFAULT_QUEUE_CONFIG.priorityWeights
+
+  describe("order: 'priority' with default weights (critical=1000 > high=100 > normal=10 > low=1)", () => {
+    it('sorts higher-priority items first', () => {
+      const cmp = createAnnouncementComparator(
+        'priority',
+        defaultWeights,
+        sequenceById(['a', 'b', 'c', 'd'])
+      )
+      const list = [
+        ann('a', 'normal'),
+        ann('b', 'critical'),
+        ann('c', 'low'),
+        ann('d', 'high'),
+      ]
+      list.sort(cmp)
+      expect(list.map((x) => x.id)).toEqual(['b', 'd', 'a', 'c'])
+    })
+
+    it("treats missing priority as 'normal'", () => {
+      const cmp = createAnnouncementComparator(
+        'priority',
+        defaultWeights,
+        sequenceById(['a', 'b'])
+      )
+      const list = [
+        { id: 'a' } as Pick<AnnouncementConfig, 'id' | 'priority'>,
+        ann('b', 'low'),
+      ]
+      list.sort(cmp)
+      expect(list.map((x) => x.id)).toEqual(['a', 'b']) // normal > low
+    })
+
+    it('breaks priority ties by insertion sequence (FIFO)', () => {
+      const cmp = createAnnouncementComparator(
+        'priority',
+        defaultWeights,
+        sequenceById(['a', 'b', 'c'])
+      )
+      const list = [ann('c', 'normal'), ann('a', 'normal'), ann('b', 'normal')]
+      list.sort(cmp)
+      expect(list.map((x) => x.id)).toEqual(['a', 'b', 'c'])
+    })
+  })
+
+  describe('custom weights override defaults (regression: not hardcoded)', () => {
+    it('respects inverted weights — low first, critical last', () => {
+      const cmp = createAnnouncementComparator(
+        'priority',
+        { critical: 1, high: 10, normal: 100, low: 1000 },
+        sequenceById(['a', 'b', 'c', 'd'])
+      )
+      const list = [
+        ann('a', 'critical'),
+        ann('b', 'low'),
+        ann('c', 'normal'),
+        ann('d', 'high'),
+      ]
+      list.sort(cmp)
+      expect(list.map((x) => x.id)).toEqual(['b', 'c', 'd', 'a'])
+    })
+  })
+
+  describe("order: 'fifo'", () => {
+    it('sorts purely by insertion sequence, ignoring priority', () => {
+      const cmp = createAnnouncementComparator(
+        'fifo',
+        defaultWeights,
+        sequenceById(['first', 'second', 'third'])
+      )
+      const list = [
+        ann('third', 'critical'),
+        ann('second', 'low'),
+        ann('first', 'normal'),
+      ]
+      list.sort(cmp)
+      expect(list.map((x) => x.id)).toEqual(['first', 'second', 'third'])
+    })
+  })
+
+  describe("order: 'lifo'", () => {
+    it('reverses insertion sequence, ignoring priority', () => {
+      const cmp = createAnnouncementComparator(
+        'lifo',
+        defaultWeights,
+        sequenceById(['first', 'second', 'third'])
+      )
+      const list = [
+        ann('first', 'critical'),
+        ann('second', 'low'),
+        ann('third', 'normal'),
+      ]
+      list.sort(cmp)
+      expect(list.map((x) => x.id)).toEqual(['third', 'second', 'first'])
+    })
+  })
+
+  describe('parity with PriorityQueue for ties', () => {
+    it("'priority' order matches PriorityQueue ordering for equal priorities", () => {
+      const queue = new PriorityQueue(DEFAULT_QUEUE_CONFIG)
+      queue.enqueue('a', 'normal')
+      queue.enqueue('b', 'normal')
+      queue.enqueue('c', 'normal')
+
+      const cmp = createAnnouncementComparator(
+        'priority',
+        defaultWeights,
+        sequenceById(['a', 'b', 'c'])
+      )
+      const list = [ann('a', 'normal'), ann('b', 'normal'), ann('c', 'normal')]
+      list.sort(cmp)
+      expect(list.map((x) => x.id)).toEqual(queue.getIds())
+    })
+  })
+})
+

--- a/packages/announcements/src/__tests__/core/priority-queue.test.ts
+++ b/packages/announcements/src/__tests__/core/priority-queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createAnnouncementComparator, PriorityQueue } from '../../core/priority-queue'
+import { PriorityQueue, createAnnouncementComparator } from '../../core/priority-queue'
 import type { AnnouncementConfig, AnnouncementPriority } from '../../types/announcement'
 import { DEFAULT_QUEUE_CONFIG } from '../../types/queue'
 
@@ -214,26 +214,14 @@ describe('createAnnouncementComparator', () => {
         defaultWeights,
         sequenceById(['a', 'b', 'c', 'd'])
       )
-      const list = [
-        ann('a', 'normal'),
-        ann('b', 'critical'),
-        ann('c', 'low'),
-        ann('d', 'high'),
-      ]
+      const list = [ann('a', 'normal'), ann('b', 'critical'), ann('c', 'low'), ann('d', 'high')]
       list.sort(cmp)
       expect(list.map((x) => x.id)).toEqual(['b', 'd', 'a', 'c'])
     })
 
     it("treats missing priority as 'normal'", () => {
-      const cmp = createAnnouncementComparator(
-        'priority',
-        defaultWeights,
-        sequenceById(['a', 'b'])
-      )
-      const list = [
-        { id: 'a' } as Pick<AnnouncementConfig, 'id' | 'priority'>,
-        ann('b', 'low'),
-      ]
+      const cmp = createAnnouncementComparator('priority', defaultWeights, sequenceById(['a', 'b']))
+      const list = [{ id: 'a' } as Pick<AnnouncementConfig, 'id' | 'priority'>, ann('b', 'low')]
       list.sort(cmp)
       expect(list.map((x) => x.id)).toEqual(['a', 'b']) // normal > low
     })
@@ -257,12 +245,7 @@ describe('createAnnouncementComparator', () => {
         { critical: 1, high: 10, normal: 100, low: 1000 },
         sequenceById(['a', 'b', 'c', 'd'])
       )
-      const list = [
-        ann('a', 'critical'),
-        ann('b', 'low'),
-        ann('c', 'normal'),
-        ann('d', 'high'),
-      ]
+      const list = [ann('a', 'critical'), ann('b', 'low'), ann('c', 'normal'), ann('d', 'high')]
       list.sort(cmp)
       expect(list.map((x) => x.id)).toEqual(['b', 'c', 'd', 'a'])
     })
@@ -275,11 +258,7 @@ describe('createAnnouncementComparator', () => {
         defaultWeights,
         sequenceById(['first', 'second', 'third'])
       )
-      const list = [
-        ann('third', 'critical'),
-        ann('second', 'low'),
-        ann('first', 'normal'),
-      ]
+      const list = [ann('third', 'critical'), ann('second', 'low'), ann('first', 'normal')]
       list.sort(cmp)
       expect(list.map((x) => x.id)).toEqual(['first', 'second', 'third'])
     })
@@ -292,11 +271,7 @@ describe('createAnnouncementComparator', () => {
         defaultWeights,
         sequenceById(['first', 'second', 'third'])
       )
-      const list = [
-        ann('first', 'critical'),
-        ann('second', 'low'),
-        ann('third', 'normal'),
-      ]
+      const list = [ann('first', 'critical'), ann('second', 'low'), ann('third', 'normal')]
       list.sort(cmp)
       expect(list.map((x) => x.id)).toEqual(['third', 'second', 'first'])
     })
@@ -320,4 +295,3 @@ describe('createAnnouncementComparator', () => {
     })
   })
 })
-

--- a/packages/announcements/src/__tests__/core/scheduler-queue-config.test.ts
+++ b/packages/announcements/src/__tests__/core/scheduler-queue-config.test.ts
@@ -7,12 +7,8 @@ describe('AnnouncementScheduler.queueConfig — Phase 3 public getter', () => {
   it('returns the active config (default)', () => {
     const scheduler = new AnnouncementScheduler(DEFAULT_QUEUE_CONFIG)
 
-    expect(scheduler.queueConfig.priorityWeights).toEqual(
-      DEFAULT_QUEUE_CONFIG.priorityWeights
-    )
-    expect(scheduler.queueConfig.priorityOrder).toBe(
-      DEFAULT_QUEUE_CONFIG.priorityOrder
-    )
+    expect(scheduler.queueConfig.priorityWeights).toEqual(DEFAULT_QUEUE_CONFIG.priorityWeights)
+    expect(scheduler.queueConfig.priorityOrder).toBe(DEFAULT_QUEUE_CONFIG.priorityOrder)
   })
 
   it('returns the custom weights passed to the constructor', () => {

--- a/packages/announcements/src/__tests__/core/scheduler-queue-config.test.ts
+++ b/packages/announcements/src/__tests__/core/scheduler-queue-config.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { AnnouncementScheduler } from '../../core/scheduler'
+import type { QueueConfig } from '../../types/queue'
+import { DEFAULT_QUEUE_CONFIG } from '../../types/queue'
+
+describe('AnnouncementScheduler.queueConfig — Phase 3 public getter', () => {
+  it('returns the active config (default)', () => {
+    const scheduler = new AnnouncementScheduler(DEFAULT_QUEUE_CONFIG)
+
+    expect(scheduler.queueConfig.priorityWeights).toEqual(
+      DEFAULT_QUEUE_CONFIG.priorityWeights
+    )
+    expect(scheduler.queueConfig.priorityOrder).toBe(
+      DEFAULT_QUEUE_CONFIG.priorityOrder
+    )
+  })
+
+  it('returns the custom weights passed to the constructor', () => {
+    const customWeights = { critical: 1, high: 10, normal: 100, low: 1000 }
+    const customConfig: QueueConfig = {
+      ...DEFAULT_QUEUE_CONFIG,
+      priorityWeights: customWeights,
+      priorityOrder: 'fifo',
+    }
+
+    const scheduler = new AnnouncementScheduler(customConfig)
+
+    expect(scheduler.queueConfig.priorityWeights).toEqual(customWeights)
+    expect(scheduler.queueConfig.priorityOrder).toBe('fifo')
+  })
+
+  it('reflects updates after updateConfig()', () => {
+    const scheduler = new AnnouncementScheduler(DEFAULT_QUEUE_CONFIG)
+    expect(scheduler.queueConfig.priorityOrder).toBe('priority')
+
+    scheduler.updateConfig({ ...DEFAULT_QUEUE_CONFIG, priorityOrder: 'lifo' })
+
+    expect(scheduler.queueConfig.priorityOrder).toBe('lifo')
+  })
+
+  it('exposes a Readonly view (type-level)', () => {
+    const scheduler = new AnnouncementScheduler(DEFAULT_QUEUE_CONFIG)
+    const cfg = scheduler.queueConfig
+
+    // @ts-expect-error — Readonly<QueueConfig> blocks mutation at the type level
+    cfg.priorityOrder = 'lifo'
+  })
+})

--- a/packages/announcements/src/__tests__/hooks/auto-show.test.tsx
+++ b/packages/announcements/src/__tests__/hooks/auto-show.test.tsx
@@ -196,6 +196,105 @@ describe('AnnouncementsProvider — autoShow', () => {
     expect(result.current.queue).toContain('minor')
   })
 
+  // Phase 3 (refactor train) — auto-show ordering must be driven by the
+  // configured `priorityWeights` and `priorityOrder`, not by the previously
+  // hardcoded `{ critical: 0, high: 1, normal: 2, low: 3 }` literal.
+  describe('Phase 3 — autoShow priority is config-driven', () => {
+    it('inverted priorityWeights re-order which announcement shows first', async () => {
+      const critical: AnnouncementConfig = {
+        id: 'critical',
+        variant: 'modal',
+        title: 'Critical',
+        priority: 'critical',
+      }
+      const low: AnnouncementConfig = {
+        id: 'low',
+        variant: 'modal',
+        title: 'Low',
+        priority: 'low',
+      }
+
+      const { result } = renderHook(() => useAnnouncementsContext(), {
+        wrapper: makeWrapper([critical, low], {
+          queueConfig: {
+            maxConcurrent: 1,
+            stackBehavior: 'queue',
+            // Invert: 'low' is most important, 'critical' is least.
+            // If the provider still used the hardcoded literal, 'critical'
+            // would auto-show first. With the comparator wired to
+            // priorityWeights, 'low' wins.
+            priorityWeights: { critical: 1, high: 10, normal: 100, low: 1000 },
+          },
+        }),
+      })
+
+      await waitFor(() => {
+        expect(result.current.activeAnnouncement).toBe('low')
+      })
+      expect(result.current.queue).toContain('critical')
+    })
+
+    it("priorityOrder 'fifo' shows insertion-order first regardless of priority", async () => {
+      const high: AnnouncementConfig = {
+        id: 'first-in',
+        variant: 'modal',
+        title: 'First',
+        priority: 'low',
+      }
+      const critical: AnnouncementConfig = {
+        id: 'second-in',
+        variant: 'modal',
+        title: 'Second',
+        priority: 'critical',
+      }
+
+      const { result } = renderHook(() => useAnnouncementsContext(), {
+        wrapper: makeWrapper([high, critical], {
+          queueConfig: {
+            maxConcurrent: 1,
+            stackBehavior: 'queue',
+            priorityOrder: 'fifo',
+          },
+        }),
+      })
+
+      await waitFor(() => {
+        expect(result.current.activeAnnouncement).toBe('first-in')
+      })
+      expect(result.current.queue).toContain('second-in')
+    })
+
+    it("priorityOrder 'lifo' shows the last-registered announcement first", async () => {
+      const a: AnnouncementConfig = {
+        id: 'first',
+        variant: 'modal',
+        title: 'First',
+        priority: 'critical',
+      }
+      const b: AnnouncementConfig = {
+        id: 'second',
+        variant: 'modal',
+        title: 'Second',
+        priority: 'low',
+      }
+
+      const { result } = renderHook(() => useAnnouncementsContext(), {
+        wrapper: makeWrapper([a, b], {
+          queueConfig: {
+            maxConcurrent: 1,
+            stackBehavior: 'queue',
+            priorityOrder: 'lifo',
+          },
+        }),
+      })
+
+      await waitFor(() => {
+        expect(result.current.activeAnnouncement).toBe('second')
+      })
+      expect(result.current.queue).toContain('first')
+    })
+  })
+
   it('autoShow:false never fires until show() is called explicitly', async () => {
     const onShow = vi.fn()
     const config: AnnouncementConfig = {

--- a/packages/announcements/src/context/announcements-provider.tsx
+++ b/packages/announcements/src/context/announcements-provider.tsx
@@ -1,6 +1,7 @@
 import { useAnalyticsOptional } from '@tour-kit/analytics'
 import { LicenseGate } from '@tour-kit/license'
 import * as React from 'react'
+import { createAnnouncementComparator } from '../core/priority-queue'
 import { AnnouncementScheduler } from '../core/scheduler'
 import { useFilteredAnnouncements } from '../hooks/use-filtered-announcements'
 import {
@@ -449,15 +450,14 @@ export function AnnouncementsProvider({
 
     if (eligible.length === 0) return
 
-    const priorityOrder: Record<string, number> = {
-      critical: 0,
-      high: 1,
-      normal: 2,
-      low: 3,
-    }
+    // Phase 3 (refactor train) — sort auto-show candidates by the configured
+    // `priorityOrder` + `priorityWeights` (no more hardcoded critical/high/
+    // normal/low literal). `sequenceById` carries the insertion order from
+    // `filteredAnnouncements` so fifo / lifo break ties deterministically.
+    const queueCfg = schedulerRef.current.queueConfig
+    const sequenceById = new Map(filteredAnnouncements.map((a, index) => [a.id, index]))
     eligible.sort(
-      (a, b) =>
-        (priorityOrder[a.priority ?? 'normal'] ?? 2) - (priorityOrder[b.priority ?? 'normal'] ?? 2)
+      createAnnouncementComparator(queueCfg.priorityOrder, queueCfg.priorityWeights, sequenceById)
     )
 
     for (const config of eligible) {

--- a/packages/announcements/src/core/priority-queue.ts
+++ b/packages/announcements/src/core/priority-queue.ts
@@ -1,4 +1,4 @@
-import type { AnnouncementPriority } from '../types/announcement'
+import type { AnnouncementConfig, AnnouncementPriority } from '../types/announcement'
 import type { PriorityOrder, QueueConfig, QueueItem } from '../types/queue'
 
 /**
@@ -163,6 +163,51 @@ export function createComparator(
         return a.sequence - b.sequence
       case 'lifo':
         return b.sequence - a.sequence
+      default:
+        return 0
+    }
+  }
+}
+
+/**
+ * Comparator for announcements at the provider boundary.
+ *
+ * Phase 3 (refactor train) — replaces the inline `priorityOrder` literal in
+ * `<AnnouncementsProvider>` that duplicated `QueueConfig.priorityWeights` and
+ * ignored the `priorityOrder: 'priority' | 'fifo' | 'lifo'` setting.
+ *
+ * Works on a lightweight pick of `AnnouncementConfig` because the provider
+ * doesn't have `QueueItem`s yet — they're only minted when the scheduler
+ * enqueues. The `sequenceById` map carries the original insertion order from
+ * the filtered announcements list so `fifo` / `lifo` can break ties
+ * deterministically.
+ */
+export function createAnnouncementComparator(
+  order: PriorityOrder,
+  weights: Record<AnnouncementPriority, number>,
+  sequenceById: ReadonlyMap<string, number>
+): (
+  a: Pick<AnnouncementConfig, 'id' | 'priority'>,
+  b: Pick<AnnouncementConfig, 'id' | 'priority'>
+) => number {
+  return (a, b) => {
+    const seqA = sequenceById.get(a.id) ?? 0
+    const seqB = sequenceById.get(b.id) ?? 0
+    switch (order) {
+      case 'priority': {
+        const weightA = weights[a.priority ?? 'normal']
+        const weightB = weights[b.priority ?? 'normal']
+        if (weightA !== weightB) {
+          // Higher weight = higher priority, comes first
+          return weightB - weightA
+        }
+        // Tie-break by insertion order (FIFO)
+        return seqA - seqB
+      }
+      case 'fifo':
+        return seqA - seqB
+      case 'lifo':
+        return seqB - seqA
       default:
         return 0
     }

--- a/packages/announcements/src/core/scheduler.ts
+++ b/packages/announcements/src/core/scheduler.ts
@@ -204,4 +204,15 @@ export class AnnouncementScheduler {
   get autoShow(): boolean {
     return this.config.autoShow
   }
+
+  /**
+   * Read-only view of the active queue configuration.
+   *
+   * Phase 3 (refactor train) — exposed so callers (notably the provider's
+   * auto-show effect) can drive ordering from `priorityWeights` /
+   * `priorityOrder` without reaching into the private `config` field.
+   */
+  get queueConfig(): Readonly<QueueConfig> {
+    return this.config
+  }
 }

--- a/packages/core/src/__tests__/barrel-exports.test.ts
+++ b/packages/core/src/__tests__/barrel-exports.test.ts
@@ -29,6 +29,43 @@ describe('@tour-kit/core barrel', () => {
   it('exports createMemoryStorage', () => {
     expect(typeof core.createMemoryStorage).toBe('function')
   })
+
+  // Phase 3 (refactor train) — dead position API removed from public barrel.
+  // Keep this list aligned with packages/core/src/utils/index.ts.
+  describe('Phase 3 — dead position exports removed', () => {
+    it.each([
+      'calculatePosition',
+      'calculatePositionWithCollision',
+      'wouldOverflow',
+      'getFallbackPlacements',
+      'PositionResult',
+    ])('does not export %s from @tour-kit/core', (name) => {
+      expect(core).not.toHaveProperty(name)
+    })
+
+    it('STILL exports useElementPosition (companion API survives)', () => {
+      expect(typeof core.useElementPosition).toBe('function')
+    })
+  })
+
+  // Phase 3 — hidden-step union exports.
+  describe('Phase 3 — hidden-step union types exported', () => {
+    // Runtime check: the union is type-only, but we can verify both names
+    // resolve through the runtime barrel by constructing values.
+    it('VisibleTourStep and HiddenTourStep are usable from core', () => {
+      const visible: import('../index').VisibleTourStep = {
+        id: 'v1',
+        target: '#x',
+        content: 'hi',
+      }
+      const hidden: import('../index').HiddenTourStep = {
+        id: 'h1',
+        kind: 'hidden',
+      }
+      expect(visible.id).toBe('v1')
+      expect(hidden.id).toBe('h1')
+    })
+  })
 })
 
 // Build-artifact assertion — runs only when `pnpm --filter @tour-kit/core

--- a/packages/core/src/__tests__/lib/no-as-unknown-cast.test.ts
+++ b/packages/core/src/__tests__/lib/no-as-unknown-cast.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Phase 3 (refactor train) — source-level grep gate co-located with the test.
+// The `as unknown as Record<string, unknown>` cast in `validateTour` was
+// needed when `TourStep` lacked the hidden-branch type. Now that
+// `HiddenTourStep` declares the forbidden fields as `?: never`, the cast is
+// removable — and this gate prevents Phase 4/5 from re-introducing it.
+
+const __here = dirname(fileURLToPath(import.meta.url))
+const VALIDATE_TOUR_PATH = resolve(__here, '../../lib/validate-tour.ts')
+
+describe('validate-tour.ts source — Phase 3 grep gate', () => {
+  const source = readFileSync(VALIDATE_TOUR_PATH, 'utf-8')
+
+  it('does not contain `as unknown as Record<string, unknown>`', () => {
+    expect(source).not.toMatch(/as unknown as Record<string, unknown>/)
+  })
+
+  it('reads step[field] without a cast', () => {
+    expect(source).toMatch(/step\[field\]/)
+  })
+})

--- a/packages/core/src/__tests__/types/hidden-step.test-d.ts
+++ b/packages/core/src/__tests__/types/hidden-step.test-d.ts
@@ -1,0 +1,65 @@
+// Phase 3 (refactor train) — Hidden-step type tightening.
+//
+// Vitest doesn't run `*.test-d.ts` files at runtime — they're compiled by
+// `pnpm --filter @tour-kit/core typecheck:types`. The `@ts-expect-error`
+// directives FAIL the build if the offending statement still compiles.
+
+import { expectTypeOf } from 'vitest'
+import type { HiddenTourStep, TourStep, VisibleTourStep } from '../../types/step'
+
+// ─── Visible authoring compiles ─────────────────────────────────────────────
+const visible: VisibleTourStep = {
+  id: 'v1',
+  target: '#anchor',
+  content: 'Hi',
+  title: 'Welcome',
+  placement: 'bottom',
+  advanceOn: { event: 'click', selector: '#next' },
+}
+expectTypeOf(visible).toMatchTypeOf<VisibleTourStep>()
+
+// Visible step without optional UI fields still compiles
+const visibleMinimal: VisibleTourStep = { id: 'v2', target: '#x', content: 'x' }
+expectTypeOf(visibleMinimal).toMatchTypeOf<VisibleTourStep>()
+
+// ─── Hidden authoring without UI fields compiles ────────────────────────────
+const hidden: HiddenTourStep = { id: 'h1', kind: 'hidden' }
+expectTypeOf(hidden).toMatchTypeOf<HiddenTourStep>()
+
+// Hidden step with lifecycle / branching callbacks compiles
+const hiddenWithLifecycle: HiddenTourStep = {
+  id: 'h2',
+  kind: 'hidden',
+  onEnter: async () => {},
+  onNext: 'next-step',
+}
+expectTypeOf(hiddenWithLifecycle).toMatchTypeOf<HiddenTourStep>()
+
+// ─── Hidden authoring with forbidden UI fields fails ────────────────────────
+// @ts-expect-error — hidden step cannot have `target`
+const _bad1: HiddenTourStep = { id: 'h3', kind: 'hidden', target: '#x' }
+
+// @ts-expect-error — hidden step cannot have `content`
+const _bad2: HiddenTourStep = { id: 'h4', kind: 'hidden', content: 'x' }
+
+// @ts-expect-error — hidden step cannot have `title`
+const _bad3: HiddenTourStep = { id: 'h5', kind: 'hidden', title: 'Nope' }
+
+// @ts-expect-error — hidden step cannot have `placement`
+const _bad4: HiddenTourStep = { id: 'h6', kind: 'hidden', placement: 'bottom' }
+
+// prettier-ignore
+// @ts-expect-error — hidden step cannot have `advanceOn`
+const _bad5: HiddenTourStep = { id: 'h7', kind: 'hidden', advanceOn: { event: 'click' } }
+
+// ─── Mixed TourStep[] accepts both branches ─────────────────────────────────
+const _mixed: TourStep[] = [visible, hidden, hiddenWithLifecycle, visibleMinimal]
+expectTypeOf<TourStep[]>().toMatchTypeOf<TourStep[]>()
+
+// Keep references so unused-var noise doesn't drown out the type errors.
+void _bad1
+void _bad2
+void _bad3
+void _bad4
+void _bad5
+void _mixed

--- a/packages/core/src/__tests__/types/tour-step-union.test-d.ts
+++ b/packages/core/src/__tests__/types/tour-step-union.test-d.ts
@@ -1,0 +1,21 @@
+// Phase 3 (refactor train) — `TourStep` is a discriminated union; downstream
+// consumers can `Extract<TourStep, { kind: 'hidden' }>` and narrow without
+// re-deriving the union locally.
+
+import { expectTypeOf } from 'vitest'
+import type { HiddenTourStep, TourStep, VisibleTourStep } from '../../types/step'
+
+// `TourStep` equals `VisibleTourStep | HiddenTourStep`.
+expectTypeOf<TourStep>().toEqualTypeOf<VisibleTourStep | HiddenTourStep>()
+
+// `Extract` over the discriminator narrows to exactly one branch.
+expectTypeOf<Extract<TourStep, { kind: 'hidden' }>>().toEqualTypeOf<HiddenTourStep>()
+
+// `Exclude` over the discriminator gives the complementary branch.
+// Note: VisibleTourStep has `kind?: 'visible'` so excluding 'hidden' yields
+// the visible branch.
+expectTypeOf<Exclude<TourStep, { kind: 'hidden' }>>().toEqualTypeOf<VisibleTourStep>()
+
+// Generic step ids flow through both branches.
+type IdsUnion = TourStep<'welcome' | 'pricing'>['id']
+expectTypeOf<IdsUnion>().toEqualTypeOf<'welcome' | 'pricing'>()

--- a/packages/core/src/__tests__/utils/barrel-utils.test.ts
+++ b/packages/core/src/__tests__/utils/barrel-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import * as utilsBarrel from '../../utils'
+
+describe('@tour-kit/core/utils barrel — Phase 3 dead position exports', () => {
+  it.each([
+    'calculatePosition',
+    'calculatePositionWithCollision',
+    'wouldOverflow',
+    'getFallbackPlacements',
+    'PositionResult',
+  ])('does not export %s', (name) => {
+    expect(utilsBarrel).not.toHaveProperty(name)
+  })
+
+  it('STILL exports neighbours that share the file (parsePlacement, getOppositeSide)', () => {
+    // These are surviving exports from utils/position.ts. The Phase 3 cut is
+    // scoped to the dead public-API names — these helpers are still public.
+    expect(typeof utilsBarrel.parsePlacement).toBe('function')
+    expect(typeof utilsBarrel.getOppositeSide).toBe('function')
+  })
+})

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -7,6 +7,7 @@ import { useRoutePersistence } from '../hooks/use-route-persistence'
 import { explainTour } from '../lib/diagnostic'
 import { TourValidationError, validateTour } from '../lib/validate-tour'
 import { TourRouteError, waitForStepTarget } from '../lib/wait-for-step-target'
+import { isVisibleStep } from '../types/step'
 import { tourRegistry } from '../registry/tour-registry'
 import type {
   BranchContext,
@@ -676,7 +677,7 @@ export function TourProvider({
           endTimer()
           return
         }
-        if (targetStep) {
+        if (targetStep && isVisibleStep(targetStep)) {
           await waitForStepTarget(targetStep, {
             route,
             timeoutMs: targetStep.waitTimeout ?? 3000,

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -7,7 +7,6 @@ import { useRoutePersistence } from '../hooks/use-route-persistence'
 import { explainTour } from '../lib/diagnostic'
 import { TourValidationError, validateTour } from '../lib/validate-tour'
 import { TourRouteError, waitForStepTarget } from '../lib/wait-for-step-target'
-import { isVisibleStep } from '../types/step'
 import { tourRegistry } from '../registry/tour-registry'
 import type {
   BranchContext,
@@ -21,6 +20,7 @@ import type {
 import { defaultPersistenceConfig } from '../types/config'
 import type { DiagnosticContext, DiagnosticGate, EligibilityReport } from '../types/diagnostic'
 import type { MultiPagePersistenceConfig, RouterAdapter } from '../types/router'
+import { isVisibleStep } from '../types/step'
 import type { TestBridge } from '../types/test-bridge'
 import {
   isBranchToTour,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,8 @@ export type {
   Direction,
   TourKitConfig,
   TourStep,
+  VisibleTourStep,
+  HiddenTourStep,
   StepOptions,
   StepIdOf,
   AudienceProp,
@@ -66,6 +68,8 @@ export {
   // Runtime target resolver (Phase 5) — single source of truth for
   // string/ref/getter dereference across hooks and React consumers.
   resolveTarget,
+  // Step union discriminator (Phase 3 — refactor train).
+  isVisibleStep,
 } from './types'
 
 // Context

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,11 +125,7 @@ export {
   getElementRect,
   getViewportDimensions,
   parsePlacement,
-  calculatePosition,
-  wouldOverflow,
   getOppositeSide,
-  getFallbackPlacements,
-  calculatePositionWithCollision,
   getDocumentDirection,
   mirrorSide,
   mirrorAlignment,
@@ -169,7 +165,6 @@ export {
   throttleLeading,
 } from './utils'
 export type {
-  PositionResult,
   LogLevel,
   LoggerConfig,
   ThrottledFunction,

--- a/packages/core/src/lib/diagnostic.ts
+++ b/packages/core/src/lib/diagnostic.ts
@@ -12,7 +12,7 @@ import type {
   EligibilityReport,
   GateReason,
 } from '../types/diagnostic'
-import { type AudienceProp, isVisibleStep, type VisibleTourStep } from '../types/step'
+import { type AudienceProp, type VisibleTourStep, isVisibleStep } from '../types/step'
 import type { Tour } from '../types/tour'
 import { explainAudience } from './audience'
 import { TourValidationError, validateTour } from './validate-tour'

--- a/packages/core/src/lib/diagnostic.ts
+++ b/packages/core/src/lib/diagnostic.ts
@@ -12,7 +12,7 @@ import type {
   EligibilityReport,
   GateReason,
 } from '../types/diagnostic'
-import type { AudienceProp, TourStep } from '../types/step'
+import { type AudienceProp, isVisibleStep, type VisibleTourStep } from '../types/step'
 import type { Tour } from '../types/tour'
 import { explainAudience } from './audience'
 import { TourValidationError, validateTour } from './validate-tour'
@@ -116,8 +116,8 @@ function gateRoute(tour: Tour, ctx: DiagnosticContext): GateReason {
   }
 }
 
-function firstVisibleStep(tour: Tour): TourStep | undefined {
-  return tour.steps.find((s) => s.kind !== 'hidden')
+function firstVisibleStep(tour: Tour): VisibleTourStep | undefined {
+  return tour.steps.find(isVisibleStep)
 }
 
 function gateTarget(tour: Tour, ctx: DiagnosticContext): GateReason {

--- a/packages/core/src/lib/validate-tour.ts
+++ b/packages/core/src/lib/validate-tour.ts
@@ -25,12 +25,18 @@ export class TourValidationError extends Error {
  *
  * Currently enforces: hidden steps must not declare UI fields. Throws a
  * `TourValidationError` whose message names the offending step id and field.
+ *
+ * Phase 3 (refactor train) — TS now rejects authored hidden steps with
+ * `target`/`content`/`title`/`placement`/`advanceOn` via `?: never` on
+ * `HiddenTourStep`, so this runtime pass exists to protect untyped JSON /
+ * `as any` boundaries. The fields are typed as `never` on the narrowed
+ * branch, so reading them returns `undefined` without needing a cast.
  */
 export function validateTour(tour: Tour): void {
   for (const step of tour.steps) {
     if (step.kind !== 'hidden') continue
     for (const field of FORBIDDEN_HIDDEN_FIELDS) {
-      if ((step as unknown as Record<string, unknown>)[field] != null) {
+      if (step[field] != null) {
         throw new TourValidationError({
           code: 'INVALID_HIDDEN_STEP',
           stepId: step.id,

--- a/packages/core/src/lib/wait-for-step-target.ts
+++ b/packages/core/src/lib/wait-for-step-target.ts
@@ -4,7 +4,7 @@
  * MutationObserver-based `waitForElement` — does NOT re-implement it.
  */
 
-import type { TourStep } from '../types/step'
+import type { VisibleTourStep } from '../types/step'
 import { resolveTarget } from '../types/target'
 import { waitForElement } from '../utils/dom'
 
@@ -66,7 +66,7 @@ export interface WaitForStepTargetOptions {
  *   selector to observe for.
  */
 export async function waitForStepTarget(
-  step: TourStep,
+  step: VisibleTourStep,
   opts: WaitForStepTargetOptions
 ): Promise<HTMLElement> {
   const timeout = opts.timeoutMs ?? 3000

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -39,7 +39,16 @@ export {
 } from './config'
 
 // Step types
-export type { TourStep, StepOptions, StepIdOf, AudienceProp, TourStepMedia } from './step'
+export type {
+  TourStep,
+  VisibleTourStep,
+  HiddenTourStep,
+  StepOptions,
+  StepIdOf,
+  AudienceProp,
+  TourStepMedia,
+} from './step'
+export { isVisibleStep } from './step'
 
 // Target types + runtime resolver (Phase 5)
 export type { TourTarget, TourTargetRef, TourTargetGetter } from './target'

--- a/packages/core/src/types/step.ts
+++ b/packages/core/src/types/step.ts
@@ -39,68 +39,18 @@ export interface TourStepMedia {
 export type AudienceProp = AudienceCondition[] | { segment: string }
 
 /**
- * Single step in a tour.
- *
- * `TId` defaults to `string` so existing call sites (`TourStep`, `TourStep[]`)
- * keep working unchanged. Authors who want compile-time step-id narrowing pass
- * a literal-string union: `TourStep<'welcome' | 'pricing'>`. The canonical
- * inference pattern is `[...] as const satisfies ReadonlyArray<TourStep>`
- * combined with `StepIdOf<typeof steps>` (see below).
+ * Fields shared by both visible and hidden steps. Hidden steps run lifecycle
+ * callbacks and branching without mounting any DOM — everything UI-rendering
+ * lives on `VisibleTourStep` instead.
  */
-export interface TourStep<TId extends string = string> {
+interface BaseTourStep<TId extends string = string> {
   id: TId
-  /**
-   * Step kind. Hidden steps run lifecycle callbacks (`onEnter`, `onShow`) and
-   * branching logic (`onNext`) without mounting a DOM element. Useful for
-   * trait-based forks or completion gates.
-   *
-   * Hidden steps must NOT declare any of `target`, `content`, `title`,
-   * `placement`, or `advanceOn` — `validateTour` throws at provider mount
-   * otherwise.
-   *
-   * @default 'visible'
-   */
-  kind?: 'visible' | 'hidden'
-  target: TourTarget
-  /**
-   * Step title. Accepts a plain string (interpolated via `interpolate`),
-   * a `{ key: string }` dictionary lookup (resolved via `useT()`), or any
-   * `ReactNode` for arbitrary JSX. Strings without `{{var}}` tokens render
-   * unchanged — the widening is back-compat-safe.
-   */
-  title?: React.ReactNode | LocalizedText
-  /**
-   * Optional short description rendered above `content`. i18n-friendly:
-   * accepts string (interpolated) or `{ key }` (translated).
-   */
-  description?: LocalizedText
-  content: React.ReactNode
   /**
    * Filter this step out for users who don't match. Accepts the legacy
    * `AudienceCondition[]` array (evaluated via `matchesAudience`) or the
    * `{ segment: 'name' }` object (resolved via `useSegments`).
    */
   audience?: AudienceProp
-  /**
-   * Optional media (video / GIF / Lottie / image) rendered above the step
-   * description by `<TourCard>`. Auto-detects the embed provider via URL
-   * pattern matching unless `type` is explicit.
-   */
-  media?: TourStepMedia
-  placement?: Placement
-  offset?: [number, number]
-  showNavigation?: boolean
-  showClose?: boolean
-  showProgress?: boolean
-  className?: string
-  spotlightPadding?: number
-  spotlightRadius?: number
-  interactive?: boolean
-  advanceOn?: {
-    event: 'click' | 'input' | 'custom'
-    selector?: string
-    handler?: () => boolean
-  }
   // Multi-page support
   route?: string
   routeDelay?: number
@@ -161,7 +111,93 @@ export interface TourStep<TId extends string = string> {
   onAction?: Record<string, Branch>
 }
 
-export type StepOptions<TId extends string = string> = Omit<TourStep<TId>, 'id'>
+/**
+ * A step that mounts a tooltip / spotlight against a target element.
+ *
+ * `target` and `content` are required so authors get a compile-time error if
+ * they forget either — `validateTour` enforces the same at runtime.
+ */
+export interface VisibleTourStep<TId extends string = string> extends BaseTourStep<TId> {
+  /** @default 'visible' */
+  kind?: 'visible'
+  target: TourTarget
+  /**
+   * Step title. Accepts a plain string (interpolated via `interpolate`),
+   * a `{ key: string }` dictionary lookup (resolved via `useT()`), or any
+   * `ReactNode` for arbitrary JSX. Strings without `{{var}}` tokens render
+   * unchanged — the widening is back-compat-safe.
+   */
+  title?: React.ReactNode | LocalizedText
+  /**
+   * Optional short description rendered above `content`. i18n-friendly:
+   * accepts string (interpolated) or `{ key }` (translated).
+   */
+  description?: LocalizedText
+  content: React.ReactNode
+  /**
+   * Optional media (video / GIF / Lottie / image) rendered above the step
+   * description by `<TourCard>`. Auto-detects the embed provider via URL
+   * pattern matching unless `type` is explicit.
+   */
+  media?: TourStepMedia
+  placement?: Placement
+  offset?: [number, number]
+  showNavigation?: boolean
+  showClose?: boolean
+  showProgress?: boolean
+  className?: string
+  spotlightPadding?: number
+  spotlightRadius?: number
+  interactive?: boolean
+  advanceOn?: {
+    event: 'click' | 'input' | 'custom'
+    selector?: string
+    handler?: () => boolean
+  }
+}
+
+/**
+ * A step that runs lifecycle callbacks and branching without rendering UI.
+ *
+ * Useful for trait-based forks (`onEnter` reads context, `onNext` returns a
+ * branch) and completion gates. Authoring a hidden step with any UI field
+ * (`target`, `content`, `title`, `placement`, `advanceOn`) fails at compile
+ * time via `?: never`, mirroring the runtime check in `validateTour`.
+ */
+export interface HiddenTourStep<TId extends string = string> extends BaseTourStep<TId> {
+  kind: 'hidden'
+  target?: never
+  content?: never
+  title?: never
+  placement?: never
+  advanceOn?: never
+}
+
+/**
+ * Single step in a tour — `VisibleTourStep | HiddenTourStep` discriminated by
+ * the `kind` field. Hidden steps run lifecycle callbacks (`onEnter`, `onShow`)
+ * and branching logic (`onNext`) without mounting a DOM element.
+ *
+ * `TId` defaults to `string` so existing call sites (`TourStep`, `TourStep[]`)
+ * keep working unchanged. Authors who want compile-time step-id narrowing pass
+ * a literal-string union: `TourStep<'welcome' | 'pricing'>`. The canonical
+ * inference pattern is `[...] as const satisfies ReadonlyArray<TourStep>`
+ * combined with `StepIdOf<typeof steps>` (see below).
+ */
+export type TourStep<TId extends string = string> = VisibleTourStep<TId> | HiddenTourStep<TId>
+
+export type StepOptions<TId extends string = string> = Omit<VisibleTourStep<TId>, 'id'>
+
+/**
+ * Type guard narrowing a `TourStep` to the visible branch of the union.
+ * Useful for `Array.find` / `filter` callbacks where TypeScript otherwise
+ * keeps the result as the full union.
+ */
+export function isVisibleStep<TId extends string>(
+  step: TourStep<TId>
+): step is VisibleTourStep<TId> {
+  return step.kind !== 'hidden'
+}
 
 /**
  * Extract the literal-id union from a const-tuple of steps.

--- a/packages/core/src/utils/create-step.ts
+++ b/packages/core/src/utils/create-step.ts
@@ -1,15 +1,17 @@
-import type { StepOptions, TourStep } from '../types'
+import type { StepOptions, VisibleTourStep } from '../types'
 
 let stepIdCounter = 0
 
 /**
- * Create a step with auto-generated ID
+ * Create a visible step with auto-generated ID. `target` and `content` are
+ * required — hidden steps should be authored as object literals because they
+ * don't share this surface.
  */
 export function createStep(
-  target: TourStep['target'],
-  content: TourStep['content'],
+  target: VisibleTourStep['target'],
+  content: VisibleTourStep['content'],
   options?: Partial<StepOptions>
-): TourStep {
+): VisibleTourStep {
   return {
     id: `step-${++stepIdCounter}`,
     target,
@@ -19,14 +21,14 @@ export function createStep(
 }
 
 /**
- * Create a step with explicit ID
+ * Create a visible step with an explicit ID.
  */
 export function createNamedStep(
   id: string,
-  target: TourStep['target'],
-  content: TourStep['content'],
+  target: VisibleTourStep['target'],
+  content: VisibleTourStep['content'],
   options?: Partial<StepOptions>
-): TourStep {
+): VisibleTourStep {
   return {
     id,
     target,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -11,16 +11,11 @@ export {
   getElementRect,
   getViewportDimensions,
   parsePlacement,
-  calculatePosition,
-  wouldOverflow,
   getOppositeSide,
-  getFallbackPlacements,
-  calculatePositionWithCollision,
   getDocumentDirection,
   mirrorSide,
   mirrorAlignment,
   mirrorPlacementForRTL,
-  type PositionResult,
 } from './position'
 
 export {

--- a/packages/react/src/__tests__/barrel-exports.test.ts
+++ b/packages/react/src/__tests__/barrel-exports.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import * as reactBarrel from '../index'
+
+describe('@tour-kit/react barrel — Phase 3 dead position exports', () => {
+  it('does not export calculatePosition (removed from re-export list)', () => {
+    expect(reactBarrel).not.toHaveProperty('calculatePosition')
+  })
+
+  it('STILL re-exports useElementPosition from core (companion API survives)', () => {
+    expect(typeof reactBarrel.useElementPosition).toBe('function')
+  })
+})

--- a/packages/react/src/__tests__/components/card/tour-card.target-back-compat.test.tsx
+++ b/packages/react/src/__tests__/components/card/tour-card.target-back-compat.test.tsx
@@ -41,7 +41,7 @@ function Starter() {
 function ResolvedTargetProbe({ onResolve }: { onResolve: (el: HTMLElement | null) => void }) {
   const { currentStep, isActive } = useTour()
   React.useEffect(() => {
-    if (!isActive || !currentStep) return
+    if (!isActive || !currentStep || currentStep.kind === 'hidden') return
     onResolve(resolveTarget(currentStep.target))
   }, [isActive, currentStep, onResolve])
   return null

--- a/packages/react/src/components/card/tour-card.tsx
+++ b/packages/react/src/components/card/tour-card.tsx
@@ -11,6 +11,7 @@ import {
 } from '@floating-ui/react'
 import {
   type Placement,
+  isVisibleStep,
   logger,
   resolveTarget,
   useFocusTrap,
@@ -86,16 +87,23 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
     const reducedMotion = useReducedMotion()
     const { containerRef, activate, deactivate } = useFocusTrap(isActive)
 
+    // Phase 3 (refactor train) — TourStep is now a discriminated union;
+    // hidden steps don't render UI so we narrow to the visible branch here
+    // and bail out below. The provider already skips hidden steps on advance,
+    // so this is a defensive narrow for typing rather than a runtime gate.
+    const visibleStep =
+      currentStep && isVisibleStep(currentStep) ? currentStep : null
+
     const targetElement = React.useMemo(() => {
-      if (!currentStep?.target) return null
-      return resolveTarget(currentStep.target)
-    }, [currentStep?.target])
+      if (!visibleStep?.target) return null
+      return resolveTarget(visibleStep.target)
+    }, [visibleStep?.target])
 
     const { refs, floatingStyles, context } = useFloating({
       open: isActive,
-      placement: toFloatingPlacement(currentStep?.placement),
+      placement: toFloatingPlacement(visibleStep?.placement),
       middleware: [
-        offset(currentStep?.offset?.[1] ?? 12),
+        offset(visibleStep?.offset?.[1] ?? 12),
         flip({ fallbackAxisSideDirection: 'start' }),
         shift({ padding: 8 }),
         arrow({ element: arrowRef }),
@@ -119,23 +127,23 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
 
     // Emit deprecation warning once per step id when classic variant is in use.
     React.useEffect(() => {
-      if (variant !== 'classic' || !currentStep?.id) return
+      if (variant !== 'classic' || !visibleStep?.id) return
       if (process.env.NODE_ENV === 'production') return
-      if (warnedClassicStepIds.has(currentStep.id)) return
-      warnedClassicStepIds.add(currentStep.id)
+      if (warnedClassicStepIds.has(visibleStep.id)) return
+      warnedClassicStepIds.add(visibleStep.id)
       logger.warn(
         'react: <TourCard variant="classic"> is deprecated and will be removed in the next major. See https://usertourkit.com/docs/react/components/tour-card-migration'
       )
-    }, [variant, currentStep?.id])
+    }, [variant, visibleStep?.id])
 
-    const resolvedTitle = useResolvedText(currentStep?.title)
-    const resolvedDescription = useResolvedText(currentStep?.description)
+    const resolvedTitle = useResolvedText(visibleStep?.title)
+    const resolvedDescription = useResolvedText(visibleStep?.description)
 
-    if (!isActive || !currentStep) return null
+    if (!isActive || !visibleStep) return null
 
-    const showNavigation = currentStep.showNavigation ?? true
-    const showClose = currentStep.showClose ?? true
-    const showProgress = currentStep.showProgress ?? true
+    const showNavigation = visibleStep.showNavigation ?? true
+    const showClose = visibleStep.showClose ?? true
+    const showProgress = visibleStep.showProgress ?? true
 
     const isRefreshed = variant !== 'classic'
     const indicatorEnabled = showStepIndicator ?? isRefreshed
@@ -166,7 +174,7 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
             tourCardVariants({ size, variant }),
             'z-50',
             !reducedMotion && 'transition-[transform,top,left] duration-150 ease-out',
-            currentStep.className,
+            visibleStep.className,
             className
           )}
           {...props}
@@ -178,23 +186,23 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
           role="dialog"
           aria-modal="true"
           aria-label={ariaLabel}
-          data-tour-step={currentStep.id}
+          data-tour-step={visibleStep.id}
           data-tour-variant={variant}
         >
           <TourCardHeader
             title={resolvedTitle}
-            titleId={`tour-step-title-${currentStep.id}`}
+            titleId={`tour-step-title-${visibleStep.id}`}
             showClose={showClose}
             stepIndicator={stepIndicator}
           />
 
-          {currentStep.media && (
+          {visibleStep.media && (
             <div className="px-4" data-slot="tour-card-media">
-              <MediaSlot {...currentStep.media} />
+              <MediaSlot {...visibleStep.media} />
             </div>
           )}
 
-          <TourCardContent content={currentStep.content} description={resolvedDescription} />
+          <TourCardContent content={visibleStep.content} description={resolvedDescription} />
 
           <TourCardFooter
             currentStep={currentStepIndex + 1}

--- a/packages/react/src/components/card/tour-card.tsx
+++ b/packages/react/src/components/card/tour-card.tsx
@@ -91,8 +91,7 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
     // hidden steps don't render UI so we narrow to the visible branch here
     // and bail out below. The provider already skips hidden steps on advance,
     // so this is a defensive narrow for typing rather than a runtime gate.
-    const visibleStep =
-      currentStep && isVisibleStep(currentStep) ? currentStep : null
+    const visibleStep = currentStep && isVisibleStep(currentStep) ? currentStep : null
 
     const targetElement = React.useMemo(() => {
       if (!visibleStep?.target) return null

--- a/packages/react/src/components/headless/tour-card.tsx
+++ b/packages/react/src/components/headless/tour-card.tsx
@@ -9,7 +9,7 @@ import {
   shift,
   useFloating,
 } from '@floating-ui/react'
-import { type Placement, resolveTarget, useFocusTrap, useTour } from '@tour-kit/core'
+import { isVisibleStep, type Placement, resolveTarget, useFocusTrap, useTour } from '@tour-kit/core'
 import * as React from 'react'
 import { TourPortal } from '../primitives/tour-portal'
 
@@ -61,16 +61,21 @@ export function TourCardHeadless({ className, style, children, render }: TourCar
   const arrowRef = React.useRef<SVGSVGElement>(null)
   const { containerRef, activate, deactivate } = useFocusTrap(isActive)
 
+  // Phase 3 (refactor train) — narrow to the visible branch of the TourStep
+  // discriminated union; hidden steps never render a card.
+  const visibleStep =
+    currentStep && isVisibleStep(currentStep) ? currentStep : null
+
   const targetElement = React.useMemo(() => {
-    if (!currentStep?.target) return null
-    return resolveTarget(currentStep.target)
-  }, [currentStep?.target])
+    if (!visibleStep?.target) return null
+    return resolveTarget(visibleStep.target)
+  }, [visibleStep?.target])
 
   const { refs, floatingStyles, context } = useFloating({
     open: isActive,
-    placement: toFloatingPlacement(currentStep?.placement),
+    placement: toFloatingPlacement(visibleStep?.placement),
     middleware: [
-      offset(currentStep?.offset?.[1] ?? 12),
+      offset(visibleStep?.offset?.[1] ?? 12),
       flip({ fallbackAxisSideDirection: 'start' }),
       shift({ padding: 8 }),
       arrow({ element: arrowRef }),
@@ -92,11 +97,11 @@ export function TourCardHeadless({ className, style, children, render }: TourCar
     }
   }, [isActive, activate, deactivate])
 
-  if (!isActive || !currentStep) return null
+  if (!isActive || !visibleStep) return null
 
   const renderProps: TourCardRenderProps = {
     isActive,
-    currentStep,
+    currentStep: visibleStep,
     currentStepIndex,
     totalSteps,
     isFirstStep,
@@ -130,7 +135,7 @@ export function TourCardHeadless({ className, style, children, render }: TourCar
         // biome-ignore lint/a11y/useSemanticElements: Using div for floating-ui positioning compatibility
         role="dialog"
         aria-modal="true"
-        aria-labelledby={`tour-step-title-${currentStep.id}`}
+        aria-labelledby={`tour-step-title-${visibleStep.id}`}
       >
         {children}
       </div>

--- a/packages/react/src/components/headless/tour-card.tsx
+++ b/packages/react/src/components/headless/tour-card.tsx
@@ -9,7 +9,7 @@ import {
   shift,
   useFloating,
 } from '@floating-ui/react'
-import { isVisibleStep, type Placement, resolveTarget, useFocusTrap, useTour } from '@tour-kit/core'
+import { type Placement, isVisibleStep, resolveTarget, useFocusTrap, useTour } from '@tour-kit/core'
 import * as React from 'react'
 import { TourPortal } from '../primitives/tour-portal'
 
@@ -63,8 +63,7 @@ export function TourCardHeadless({ className, style, children, render }: TourCar
 
   // Phase 3 (refactor train) — narrow to the visible branch of the TourStep
   // discriminated union; hidden steps never render a card.
-  const visibleStep =
-    currentStep && isVisibleStep(currentStep) ? currentStep : null
+  const visibleStep = currentStep && isVisibleStep(currentStep) ? currentStep : null
 
   const targetElement = React.useMemo(() => {
     if (!visibleStep?.target) return null

--- a/packages/react/src/components/headless/tour-overlay.tsx
+++ b/packages/react/src/components/headless/tour-overlay.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { resolveTarget, usePrefersReducedMotion, useSpotlight, useTour } from '@tour-kit/core'
+import {
+  isVisibleStep,
+  resolveTarget,
+  usePrefersReducedMotion,
+  useSpotlight,
+  useTour,
+} from '@tour-kit/core'
 import * as React from 'react'
 import { TourPortal } from '../primitives/tour-portal'
 
@@ -34,22 +40,27 @@ export function TourOverlayHeadless({
   const { overlayStyle, cutoutStyle, show, hide, targetRect } = useSpotlight()
   const prefersReducedMotion = usePrefersReducedMotion()
 
+  // Phase 3 (refactor train) — narrow to the visible branch of the TourStep
+  // discriminated union; hidden steps have no spotlight settings.
+  const visibleStep =
+    currentStep && isVisibleStep(currentStep) ? currentStep : null
+
   const targetElement = React.useMemo(() => {
-    if (!currentStep?.target) return null
-    return resolveTarget(currentStep.target)
-  }, [currentStep?.target])
+    if (!visibleStep?.target) return null
+    return resolveTarget(visibleStep.target)
+  }, [visibleStep?.target])
 
   React.useEffect(() => {
     if (isActive && targetElement) {
       show(targetElement, {
-        padding: currentStep?.spotlightPadding,
-        borderRadius: currentStep?.spotlightRadius,
+        padding: visibleStep?.spotlightPadding,
+        borderRadius: visibleStep?.spotlightRadius,
         animate: !prefersReducedMotion,
       })
     } else {
       hide()
     }
-  }, [isActive, targetElement, currentStep, show, hide, prefersReducedMotion])
+  }, [isActive, targetElement, visibleStep, show, hide, prefersReducedMotion])
 
   if (!isActive) return null
 
@@ -58,7 +69,7 @@ export function TourOverlayHeadless({
     overlayStyle,
     cutoutStyle,
     targetRect,
-    interactive: currentStep?.interactive ?? false,
+    interactive: visibleStep?.interactive ?? false,
   }
 
   if (render) {
@@ -79,7 +90,7 @@ export function TourOverlayHeadless({
             className={cutoutClassName}
             style={{
               ...cutoutStyle,
-              pointerEvents: currentStep?.interactive ? 'auto' : 'none',
+              pointerEvents: visibleStep?.interactive ? 'auto' : 'none',
               ...customCutoutStyle,
             }}
           />

--- a/packages/react/src/components/headless/tour-overlay.tsx
+++ b/packages/react/src/components/headless/tour-overlay.tsx
@@ -42,8 +42,7 @@ export function TourOverlayHeadless({
 
   // Phase 3 (refactor train) — narrow to the visible branch of the TourStep
   // discriminated union; hidden steps have no spotlight settings.
-  const visibleStep =
-    currentStep && isVisibleStep(currentStep) ? currentStep : null
+  const visibleStep = currentStep && isVisibleStep(currentStep) ? currentStep : null
 
   const targetElement = React.useMemo(() => {
     if (!visibleStep?.target) return null

--- a/packages/react/src/components/overlay/tour-overlay.tsx
+++ b/packages/react/src/components/overlay/tour-overlay.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { resolveTarget, usePrefersReducedMotion, useSpotlight, useTour } from '@tour-kit/core'
+import {
+  isVisibleStep,
+  resolveTarget,
+  usePrefersReducedMotion,
+  useSpotlight,
+  useTour,
+} from '@tour-kit/core'
 import { cn } from '@tour-kit/core'
 import * as React from 'react'
 import { TourPortal } from '../primitives/tour-portal'
@@ -19,22 +25,27 @@ export const TourOverlay = React.forwardRef<HTMLDivElement, TourOverlayProps>(
     const { overlayStyle, cutoutStyle, show, hide, targetRect } = useSpotlight()
     const prefersReducedMotion = usePrefersReducedMotion()
 
+    // Phase 3 (refactor train) — narrow to the visible branch of the TourStep
+    // discriminated union; hidden steps have no target / spotlight settings.
+    const visibleStep =
+      currentStep && isVisibleStep(currentStep) ? currentStep : null
+
     const targetElement = React.useMemo(() => {
-      if (!currentStep?.target) return null
-      return resolveTarget(currentStep.target)
-    }, [currentStep?.target])
+      if (!visibleStep?.target) return null
+      return resolveTarget(visibleStep.target)
+    }, [visibleStep?.target])
 
     React.useEffect(() => {
       if (isActive && targetElement) {
         show(targetElement, {
-          padding: currentStep?.spotlightPadding,
-          borderRadius: currentStep?.spotlightRadius,
+          padding: visibleStep?.spotlightPadding,
+          borderRadius: visibleStep?.spotlightRadius,
           animate: !prefersReducedMotion,
         })
       } else {
         hide()
       }
-    }, [isActive, targetElement, currentStep, show, hide, prefersReducedMotion])
+    }, [isActive, targetElement, visibleStep, show, hide, prefersReducedMotion])
 
     if (!isActive) return null
 
@@ -46,7 +57,7 @@ export const TourOverlay = React.forwardRef<HTMLDivElement, TourOverlayProps>(
           style={{
             ...overlayStyle,
             // When interactive, allow clicks to pass through the overlay to page elements
-            pointerEvents: currentStep?.interactive ? 'none' : overlayStyle.pointerEvents,
+            pointerEvents: visibleStep?.interactive ? 'none' : overlayStyle.pointerEvents,
           }}
           onClick={onClick}
           aria-hidden="true"

--- a/packages/react/src/components/overlay/tour-overlay.tsx
+++ b/packages/react/src/components/overlay/tour-overlay.tsx
@@ -27,8 +27,7 @@ export const TourOverlay = React.forwardRef<HTMLDivElement, TourOverlayProps>(
 
     // Phase 3 (refactor train) — narrow to the visible branch of the TourStep
     // discriminated union; hidden steps have no target / spotlight settings.
-    const visibleStep =
-      currentStep && isVisibleStep(currentStep) ? currentStep : null
+    const visibleStep = currentStep && isVisibleStep(currentStep) ? currentStep : null
 
     const targetElement = React.useMemo(() => {
       if (!visibleStep?.target) return null

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -170,7 +170,6 @@ export {
   createStorageAdapter,
   createPrefixedStorage,
   safeJSONParse,
-  calculatePosition,
 } from '@tour-kit/core'
 
 // Default configs


### PR DESCRIPTION
## Summary

Phase 3 of the refactor train — three independent MED cleanups in one PR.

### Workstream A — Position public API removal
Remove dead `calculatePosition` / `calculatePositionWithCollision` / `wouldOverflow` / `getFallbackPlacements` / `PositionResult` from public barrels (`@tour-kit/core`, `@tour-kit/core/utils`, `@tour-kit/react`). No production callers found in the monorepo or sibling `tourkit-dash`. Math functions stay in `packages/core/src/utils/position.ts` for internal use. `ElementPositionResult` (deliberately similar but distinct symbol) is preserved.

### Workstream B — Announcements priority comparator
Replace the inline `priorityOrder: Record<string, number>` literal in `<AnnouncementsProvider>` auto-show sort with `createAnnouncementComparator` from `core/priority-queue.ts`. The hardcoded literal ignored both `QueueConfig.priorityWeights` and `priorityOrder: 'fifo' | 'lifo'`. New `AnnouncementScheduler.queueConfig` getter (`Readonly<QueueConfig>`) so the provider no longer pokes the private `config` field. **Behavior fix**: custom priority weights and FIFO/LIFO ordering now actually drive auto-show order.

### Workstream C — Hidden-step type tightening
Split `TourStep` into `VisibleTourStep | HiddenTourStep` discriminated union. `HiddenTourStep` declares forbidden UI fields (`target`, `content`, `title`, `placement`, `advanceOn`) as `?: never` so TypeScript rejects `{ kind: 'hidden', target: '#x' }` — mirroring the existing `validateTour` runtime check. `validateTour` no longer needs the `as unknown as Record<string, unknown>` cast. New `isVisibleStep` type guard exported from core.

## Test plan
- [x] `pnpm --filter @tour-kit/core test` — 927 passed, 3 skipped
- [x] `pnpm --filter @tour-kit/core typecheck:types` — 0 errors (covers `*.test-d.ts`)
- [x] `pnpm --filter @tour-kit/announcements test` — 313 passed
- [x] `pnpm --filter @tour-kit/react test` — green
- [x] `pnpm typecheck` — 29/29
- [x] `pnpm build` — 21/21
- [x] `pnpm test` — 37/37
- [x] Grep gates clean:
  - `rg -n "calculatePosition|calculatePositionWithCollision|wouldOverflow|getFallbackPlacements|PositionResult" packages/core/src/index.ts packages/core/src/utils/index.ts packages/react/src/index.ts` → only `ElementPositionResult` (intended survivor)
  - `rg -n "priorityOrder: Record" packages/announcements/src/context/announcements-provider.tsx` → 0
  - `rg -n "as unknown as Record<string, unknown>" packages/core/src/lib/validate-tour.ts` → 0
- [x] Sibling-repo audit: `rg "calculatePosition|wouldOverflow|getFallbackPlacements" /home/domidex/projects/tourkit-dash` → 0 hits

## Changeset
`.changeset/phase-3-refactor-train.md` — major for `@tour-kit/core` and `@tour-kit/react` (public API removal + union shape change), minor for `@tour-kit/announcements` (helper + behavior fix).

## Commits
- `refactor(phase-3-A): remove dead position API from public barrels`
- `refactor(phase-3-B): announcements priority comparator helper`
- `refactor(phase-3-C): hidden-step type tightening + remove unsafe cast`