### PR TITLE
refactor(phase-4): TourAnalytics safeDispatch helper

### DIFF
--- a/packages/analytics/src/__tests__/core/tracker-source-grep.test.ts
+++ b/packages/analytics/src/__tests__/core/tracker-source-grep.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Phase 4 (M4) source-grep gates for `tracker.ts`.
+ *
+ * Co-located with the unit tests so future PRs can't sneak the old
+ * per-method try/catch + `if (this.config.debug)` pattern back in.
+ */
+describe('tracker.ts — Phase 4 source gates (M4)', () => {
+  const src = readFileSync(resolve(__dirname, '../../core/tracker.ts'), 'utf-8')
+
+  it('consolidates debug-gated `logger.error` into a single block (helper-owned)', () => {
+    // The pre-Phase-4 code had this pattern repeated 5 times across lifecycle
+    // methods. The Phase 4 refactor must collapse it to exactly one location
+    // (inside safeDispatch's `report` closure). A separate, unrelated
+    // `if (this.config.debug) { logger.debug(...) }` in `track()` is allowed.
+    const matches = src.match(/if \(this\.config\.debug\) \{[\s\S]{0,200}?logger\.error/g) ?? []
+    expect(matches.length).toBe(1)
+  })
+
+  it('contains 6 `safeDispatch` references (1 definition + 5 call sites)', () => {
+    const matches = src.match(/safeDispatch/g) ?? []
+    expect(matches.length).toBe(6)
+  })
+
+  it('does NOT call console.error directly (routes through logger.error)', () => {
+    expect(src).not.toMatch(/^\s*console\.error/m)
+  })
+})

--- a/packages/analytics/src/__tests__/core/tracker.test.ts
+++ b/packages/analytics/src/__tests__/core/tracker.test.ts
@@ -731,3 +731,291 @@ describe('post-destroy guards', () => {
     expect(destroySpy).toHaveBeenCalledTimes(1)
   })
 })
+
+// ─── Phase 4: safeDispatch helper ─────────────────────────────────────────────
+
+function throwingPlugin(method: AnalyticsPluginMethod, msg = 'sync-boom'): AnalyticsPlugin {
+  return createMockPlugin({
+    name: `throwing-${method}`,
+    [method]: vi.fn(() => {
+      throw new Error(msg)
+    }),
+  } as Partial<AnalyticsPlugin>)
+}
+
+function rejectingPlugin(method: AnalyticsPluginMethod, msg = 'async-boom'): AnalyticsPlugin {
+  return createMockPlugin({
+    name: `rejecting-${method}`,
+    [method]: vi.fn().mockRejectedValue(new Error(msg)),
+  } as Partial<AnalyticsPlugin>)
+}
+
+type AnalyticsPluginMethod = 'init' | 'track' | 'identify' | 'flush' | 'destroy'
+
+async function microtask() {
+  // Drain microtask queue so fire-and-forget rejections surface
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('TourAnalytics.safeDispatch (Phase 4)', () => {
+  let loggerErrorSpy: ReturnType<typeof vi.spyOn>
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
+    loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {})
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    loggerErrorSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  describe('error isolation (US-1)', () => {
+    it('continues to next plugin when track throws synchronously', async () => {
+      const bad = throwingPlugin('track')
+      const good = createMockPlugin({ name: 'good' })
+      const tracker = new TourAnalytics(
+        createConfig({
+          plugins: [bad, good],
+          debug: true,
+        })
+      )
+      await vi.runAllTimersAsync()
+
+      tracker.track('tour_started', { tourId: 't1' })
+      await microtask()
+
+      expect(bad.track).toHaveBeenCalledTimes(1)
+      expect(good.track).toHaveBeenCalledTimes(1)
+    })
+
+    it('continues to next plugin when track rejects asynchronously', async () => {
+      const bad = rejectingPlugin('track')
+      const good = createMockPlugin({ name: 'good' })
+      const tracker = new TourAnalytics(
+        createConfig({
+          plugins: [bad, good],
+          debug: true,
+        })
+      )
+      await vi.runAllTimersAsync()
+
+      tracker.track('tour_started', { tourId: 't1' })
+      await microtask()
+
+      expect(bad.track).toHaveBeenCalledTimes(1)
+      expect(good.track).toHaveBeenCalledTimes(1)
+      expect(loggerErrorSpy).toHaveBeenCalled()
+      expect(loggerErrorSpy.mock.calls[0]?.[0]).toMatch(/track/)
+    })
+
+    it('continues to next plugin when init throws (sequential await mode)', async () => {
+      const bad = throwingPlugin('init')
+      const good = createMockPlugin({ name: 'good' })
+      new TourAnalytics(
+        createConfig({
+          plugins: [bad, good],
+          debug: true,
+        })
+      )
+      await vi.runAllTimersAsync()
+
+      expect(bad.init).toHaveBeenCalledTimes(1)
+      expect(good.init).toHaveBeenCalledTimes(1)
+    })
+
+    it('catches rejected init promise without halting downstream plugins', async () => {
+      const bad = rejectingPlugin('init')
+      const good = createMockPlugin({ name: 'good' })
+      new TourAnalytics(
+        createConfig({
+          plugins: [bad, good],
+          debug: true,
+        })
+      )
+      await vi.runAllTimersAsync()
+
+      expect(bad.init).toHaveBeenCalledTimes(1)
+      expect(good.init).toHaveBeenCalledTimes(1)
+      expect(loggerErrorSpy.mock.calls[0]?.[0]).toMatch(/init/)
+    })
+  })
+
+  describe('debug routing (US-3)', () => {
+    it('does NOT log when debug: false', async () => {
+      const tracker = new TourAnalytics(
+        createConfig({
+          plugins: [rejectingPlugin('track')],
+          debug: false,
+        })
+      )
+      await vi.runAllTimersAsync()
+
+      tracker.track('tour_started', { tourId: 't1' })
+      await microtask()
+
+      expect(loggerErrorSpy).not.toHaveBeenCalled()
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    })
+
+    it('logs via logger.error (not direct console.error) when debug: true', async () => {
+      const tracker = new TourAnalytics(
+        createConfig({
+          plugins: [rejectingPlugin('track')],
+          debug: true,
+        })
+      )
+      await vi.runAllTimersAsync()
+
+      tracker.track('tour_started', { tourId: 't1' })
+      await microtask()
+
+      expect(loggerErrorSpy).toHaveBeenCalled()
+      // logger.error routes through console.error internally; the assertion that
+      // matters is that the helper went through `logger`, asserted above.
+    })
+  })
+
+  describe('destroy ordering (US-2, memory #46 regression)', () => {
+    it('still calls plugin destroy hooks AFTER destroyed=true is set', async () => {
+      let observedDestroyedFlag: boolean | null = null
+      let tracker: TourAnalytics | null = null
+      const plugin = createMockPlugin({
+        destroy: vi.fn(() => {
+          observedDestroyedFlag = (tracker as unknown as { destroyed: boolean }).destroyed
+        }),
+      })
+      tracker = new TourAnalytics(createConfig({ plugins: [plugin] }))
+      await vi.runAllTimersAsync()
+
+      tracker.destroy()
+      await microtask()
+
+      expect(plugin.destroy).toHaveBeenCalledTimes(1)
+      expect(observedDestroyedFlag).toBe(true)
+    })
+
+    it('post-destroy track is a no-op for plugins', async () => {
+      const plugin = createMockPlugin()
+      const tracker = new TourAnalytics(createConfig({ plugins: [plugin] }))
+      await vi.runAllTimersAsync()
+      tracker.destroy()
+      await microtask()
+      ;(plugin.track as ReturnType<typeof vi.fn>).mockClear()
+
+      tracker.track('tour_started', { tourId: 't' })
+      await microtask()
+
+      expect(plugin.track).not.toHaveBeenCalled()
+    })
+
+    it('second destroy() call is a no-op', async () => {
+      const plugin = createMockPlugin()
+      const tracker = new TourAnalytics(createConfig({ plugins: [plugin] }))
+      await vi.runAllTimersAsync()
+      tracker.destroy()
+      await microtask()
+      tracker.destroy()
+      await microtask()
+
+      expect(plugin.destroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('post-destroy flush is a no-op', async () => {
+      const plugin = createMockPlugin()
+      const tracker = new TourAnalytics(createConfig({ plugins: [plugin] }))
+      await vi.runAllTimersAsync()
+      tracker.destroy()
+      ;(plugin.flush as ReturnType<typeof vi.fn>).mockClear()
+
+      await tracker.flush()
+
+      expect(plugin.flush).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('track parallelism (US-4)', () => {
+    it('fire-and-forget — both plugins called synchronously even with slow async track', async () => {
+      let resolveA: (() => void) | null = null
+      let resolveB: (() => void) | null = null
+      const slowA = createMockPlugin({
+        name: 'A',
+        track: vi.fn(
+          () =>
+            new Promise<void>((r) => {
+              resolveA = r
+            })
+        ),
+      })
+      const slowB = createMockPlugin({
+        name: 'B',
+        track: vi.fn(
+          () =>
+            new Promise<void>((r) => {
+              resolveB = r
+            })
+        ),
+      })
+      const tracker = new TourAnalytics(createConfig({ plugins: [slowA, slowB] }))
+      await vi.runAllTimersAsync()
+
+      tracker.track('tour_started', { tourId: 't' })
+      // Without awaiting anything, BOTH plugin track mocks should already be called
+      expect(slowA.track).toHaveBeenCalledTimes(1)
+      expect(slowB.track).toHaveBeenCalledTimes(1)
+      ;(resolveA as (() => void) | null)?.()
+      ;(resolveB as (() => void) | null)?.()
+      await microtask()
+    })
+  })
+
+  describe('flush serial-await (US-5)', () => {
+    it('awaits each plugin flush in order', async () => {
+      const order: string[] = []
+      const a = createMockPlugin({
+        name: 'A',
+        flush: vi.fn(async () => {
+          order.push('A')
+        }),
+      })
+      const b = createMockPlugin({
+        name: 'B',
+        flush: vi.fn(async () => {
+          order.push('B')
+        }),
+      })
+      const tracker = new TourAnalytics(createConfig({ plugins: [a, b] }))
+      await vi.runAllTimersAsync()
+
+      await tracker.flush()
+      expect(order).toEqual(['A', 'B'])
+    })
+
+    it('a rejecting plugin flush does not stop the next plugin', async () => {
+      const order: string[] = []
+      const bad = rejectingPlugin('flush')
+      const good = createMockPlugin({
+        name: 'good',
+        flush: vi.fn(async () => {
+          order.push('good')
+        }),
+      })
+      const tracker = new TourAnalytics(
+        createConfig({
+          plugins: [bad, good],
+          debug: true,
+        })
+      )
+      await vi.runAllTimersAsync()
+
+      await tracker.flush()
+      expect(order).toEqual(['good'])
+      expect(loggerErrorSpy.mock.calls[0]?.[0]).toMatch(/flush/)
+    })
+  })
+})

--- a/packages/analytics/src/__tests__/core/tracker.test.ts
+++ b/packages/analytics/src/__tests__/core/tracker.test.ts
@@ -876,8 +876,10 @@ describe('TourAnalytics.safeDispatch (Phase 4)', () => {
       await microtask()
 
       expect(loggerErrorSpy).toHaveBeenCalled()
-      // logger.error routes through console.error internally; the assertion that
-      // matters is that the helper went through `logger`, asserted above.
+      // logger.error is mocked above, so it does NOT delegate to console.error in
+      // this test. The negative assertion catches a regression where someone
+      // bypasses logger and writes console.error directly.
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
     })
   })
 
@@ -977,23 +979,29 @@ describe('TourAnalytics.safeDispatch (Phase 4)', () => {
   describe('flush serial-await (US-5)', () => {
     it('awaits each plugin flush in order', async () => {
       const order: string[] = []
+      // Yield a microtask before recording so a parallel/non-awaiting dispatch
+      // would interleave the pushes — only true serial-await keeps them ordered.
       const a = createMockPlugin({
         name: 'A',
         flush: vi.fn(async () => {
-          order.push('A')
+          order.push('A:start')
+          await Promise.resolve()
+          order.push('A:end')
         }),
       })
       const b = createMockPlugin({
         name: 'B',
         flush: vi.fn(async () => {
-          order.push('B')
+          order.push('B:start')
+          await Promise.resolve()
+          order.push('B:end')
         }),
       })
       const tracker = new TourAnalytics(createConfig({ plugins: [a, b] }))
       await vi.runAllTimersAsync()
 
       await tracker.flush()
-      expect(order).toEqual(['A', 'B'])
+      expect(order).toEqual(['A:start', 'A:end', 'B:start', 'B:end'])
     })
 
     it('a rejecting plugin flush does not stop the next plugin', async () => {

--- a/packages/analytics/src/core/tracker.ts
+++ b/packages/analytics/src/core/tracker.ts
@@ -3,6 +3,16 @@ import type { TourEvent, TourEventData, TourEventName } from '../types/events'
 import type { AnalyticsConfig, AnalyticsPlugin } from '../types/plugin'
 import { type EventQueue, createEventQueue } from './event-queue'
 
+type DispatchMode = 'await' | 'fire-and-forget'
+
+type AnalyticsPluginMethod = 'init' | 'track' | 'identify' | 'flush' | 'destroy'
+
+interface SafeDispatchOptions {
+  mode: DispatchMode
+  /** When true, dispatch even if `this.destroyed` is already set (used by `destroy()` itself). */
+  allowDestroyed?: boolean
+}
+
 /**
  * Main analytics tracker class
  */
@@ -38,15 +48,7 @@ export class TourAnalytics {
   private async init() {
     if (this.initialized) return
 
-    for (const plugin of this.plugins) {
-      try {
-        await plugin.init?.()
-      } catch (error) {
-        if (this.config.debug) {
-          logger.error(`Analytics: Failed to init plugin ${plugin.name}:`, error)
-        }
-      }
-    }
+    await this.safeDispatch('init', 'init plugin', [], { mode: 'await' })
 
     if (this.config.userId) {
       this.identify(this.config.userId, this.config.userProperties)
@@ -58,17 +60,11 @@ export class TourAnalytics {
   /**
    * Identify a user
    */
-  identify(userId: string, properties?: Record<string, unknown>) {
+  identify(userId: string, properties?: Record<string, unknown>): void {
     if (this.destroyed) return
-    for (const plugin of this.plugins) {
-      try {
-        plugin.identify?.(userId, properties)
-      } catch (error) {
-        if (this.config.debug) {
-          logger.error(`Analytics: Failed to identify in ${plugin.name}:`, error)
-        }
-      }
-    }
+    void this.safeDispatch('identify', 'identify in', [userId, properties], {
+      mode: 'fire-and-forget',
+    })
   }
 
   /**
@@ -101,17 +97,11 @@ export class TourAnalytics {
   /**
    * Dispatch events to all plugins
    */
-  private dispatchEvents(events: TourEvent[]) {
+  private dispatchEvents(events: TourEvent[]): void {
     for (const event of events) {
-      for (const plugin of this.plugins) {
-        try {
-          plugin.track(event)
-        } catch (error) {
-          if (this.config.debug) {
-            logger.error(`Analytics: Failed to track in ${plugin.name}:`, error)
-          }
-        }
-      }
+      void this.safeDispatch('track', 'track in', [event], {
+        mode: 'fire-and-forget',
+      })
     }
   }
 
@@ -279,40 +269,71 @@ export class TourAnalytics {
   /**
    * Flush all queued events
    */
-  async flush() {
+  async flush(): Promise<void> {
     if (this.destroyed) return
     // Flush internal event queue first
     this.eventQueue?.flush()
 
     // Then flush plugin queues
-    for (const plugin of this.plugins) {
-      try {
-        await plugin.flush?.()
-      } catch (error) {
-        if (this.config.debug) {
-          logger.error(`Analytics: Failed to flush ${plugin.name}:`, error)
-        }
-      }
-    }
+    await this.safeDispatch('flush', 'flush', [], { mode: 'await' })
   }
 
   /**
    * Destroy tracker and clean up
    */
-  destroy() {
+  destroy(): void {
     if (this.destroyed) return
     this.destroyed = true
     // Clean up event queue
     this.eventQueue?.destroy()
     this.eventQueue = null
 
+    void this.safeDispatch('destroy', 'destroy', [], {
+      mode: 'fire-and-forget',
+      allowDestroyed: true,
+    })
+  }
+
+  /**
+   * Dispatch a lifecycle method to every plugin with uniform error handling.
+   *
+   * Preserves the prior behavior:
+   * - One throwing/rejecting plugin does not stop downstream plugins.
+   * - Sync throws and async rejections are reported through the same path.
+   * - `track` and `identify` are fire-and-forget; `init` and `flush` await sequentially.
+   * - `destroy()` opts in via `allowDestroyed: true` so plugin destroy hooks still run
+   *   after `this.destroyed` is set (see memory #46 — short-circuiting here would
+   *   silently drop the destroy event).
+   */
+  private async safeDispatch<M extends AnalyticsPluginMethod>(
+    method: M,
+    errorLabel: string,
+    args: Parameters<NonNullable<AnalyticsPlugin[M]>>,
+    options: SafeDispatchOptions
+  ): Promise<void> {
+    if (!options.allowDestroyed && this.destroyed) return
+
+    const report = (pluginName: string, error: unknown): void => {
+      if (this.config.debug) {
+        logger.error(`Analytics: Failed to ${errorLabel} ${pluginName}:`, error)
+      }
+    }
+
     for (const plugin of this.plugins) {
+      const fn = plugin[method] as ((...a: unknown[]) => void | Promise<void>) | undefined
+      if (!fn) continue
       try {
-        plugin.destroy?.()
-      } catch (error) {
-        if (this.config.debug) {
-          logger.error(`Analytics: Failed to destroy ${plugin.name}:`, error)
+        const result = fn.apply(plugin, args as unknown[])
+        if (result instanceof Promise) {
+          const handled = result.catch((err: unknown) => {
+            report(plugin.name, err)
+          })
+          if (options.mode === 'await') {
+            await handled
+          }
         }
+      } catch (error) {
+        report(plugin.name, error)
       }
     }
   }


### PR DESCRIPTION
## Summary

- Collapses the repeated plugin `try/catch` + debug-gated `logger.error` pattern across five lifecycle methods (`init`, `identify`, `dispatchEvents`, `flush`, `destroy`) into a single private `safeDispatch` helper in `packages/analytics/src/core/tracker.ts`.
- Preserves dispatch timing exactly: `init`/`flush` stay sequential-await; `identify`/`track` stay fire-and-forget; `destroy()` opts in via `allowDestroyed: true` so plugin destroy hooks still fire **after** `this.destroyed` is set (regression guard for memory #46).
- Adds 13 targeted tests covering error isolation, debug routing, destroy ordering, `track` parallelism, and `flush` serial-await, plus a source-grep gate (M4) that pins the consolidation.

## Behavior preserved

| Method | Mode | Return |
| --- | --- | --- |
| `init` | await | private promise |
| `identify` | fire-and-forget | `void` |
| `dispatchEvents` / `track` | fire-and-forget | `void` |
| `flush` | await | `Promise<void>` |
| `destroy` | fire-and-forget with `allowDestroyed: true` | `void` |

Error message wording matches existing strings byte-for-byte (`"Failed to init plugin <name>:"`, `"Failed to identify in <name>:"`, etc.) so all pre-existing tests in `tracker.test.ts` and `multi-plugin.test.tsx` continue to pass unchanged.

## Test plan

- [x] `pnpm --filter @tour-kit/analytics test` — 216 passed, 11 skipped (was 200 + 11; +13 new + 3 source-grep)
- [x] `pnpm --filter @tour-kit/analytics typecheck` — clean
- [x] `pnpm --filter @tour-kit/analytics build` — clean
- [x] `pnpm lint` (repo-wide biome) — clean
- [x] `rg "safeDispatch" packages/analytics/src/core/tracker.ts` — 6 matches (1 def + 5 call sites)
- [x] Existing `multi-plugin.test.tsx` integration regression net continues to pass unchanged
- [x] Source-grep gate (`tracker-source-grep.test.ts`) prevents the per-method error pattern from creeping back in

## Notes

- `if (this.config.debug)` still appears twice in `tracker.ts` — once inside the helper's error report, and once for the unrelated `logger.debug` event log in `track()`. The plan's literal "exactly one" wording assumed only the error pattern; the source-grep test was tightened to specifically match the debug-gated `logger.error` block (which now appears exactly once, in `safeDispatch`).
- Helper uses `M extends 'init' | 'track' | 'identify' | 'flush' | 'destroy'` and `Parameters<NonNullable<AnalyticsPlugin[M]>>` for type-safe args; only one `as unknown[]` cast is used internally to call `fn.apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)