### PR TITLE
fix(core): a11y announcer survives detach between announce and cleanup

### DIFF
--- a/packages/core/src/__tests__/utils/a11y.test.ts
+++ b/packages/core/src/__tests__/utils/a11y.test.ts
@@ -82,6 +82,19 @@ describe('announce', () => {
     const announcers = document.querySelectorAll('[role="status"]')
     expect(announcers).toHaveLength(2)
   })
+
+  it('does not throw when announcer is detached before cleanup runs', () => {
+    announce('orphaned message')
+    const announcer = document.querySelector('[role="status"]')
+    expect(announcer).toBeInTheDocument()
+
+    // Simulate an SPA route swap that empties document.body between the
+    // announce call and the 1s cleanup tick. Pre-fix this would throw
+    // NotFoundError when `document.body.removeChild(announcer)` ran.
+    announcer?.remove()
+
+    expect(() => vi.advanceTimersByTime(1000)).not.toThrow()
+  })
 })
 
 describe('generateId', () => {

--- a/packages/core/src/utils/a11y.ts
+++ b/packages/core/src/utils/a11y.ts
@@ -30,9 +30,11 @@ export function announce(message: string, politeness: 'polite' | 'assertive' = '
     announcer.textContent = message
   }, 100)
 
-  // Cleanup
+  // Cleanup — `.remove()` is a no-op when the node is already detached, so it
+  // survives the SPA navigation case where `document.body` is replaced between
+  // the announce and the 1s cleanup tick.
   setTimeout(() => {
-    document.body.removeChild(announcer)
+    announcer.remove()
   }, 1000)
 }
 


### PR DESCRIPTION
## Summary

`announce()` in `packages/core/src/utils/a11y.ts` schedules a 1s cleanup tick that previously called `document.body.removeChild(announcer)`. If the SPA replaces `document.body`'s children between the announce and the cleanup (route swap, content nav, modal that re-mounts the tree, etc.), `removeChild` throws:

```
NotFoundError: Failed to execute 'removeChild' on 'Node':
The node to be removed is not a child of this node.
```

Swap for `announcer.remove()`, which is a no-op when the element has no parent. Same intent, doesn't throw on the corner case.

Surfaced by tk-bug-hunter as the only MED finding across the 15-package cross-repo audit (`pkg-audit-43641e47`).

## Test plan

- [x] Added a regression test (`a11y.test.ts`) that detaches the announcer before the 1s timer fires and asserts no throw.
- [x] All 23 announce/a11y tests pass.
- [x] Full core suite: 928 passed | 3 skipped.
- [x] `pnpm --filter @tour-kit/core typecheck` clean.
- [x] `biome check` clean.

## Risk

LOW. One-line behavior change in a defensive cleanup path; no public API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)