### PR TITLE
refactor(phase-5): TourProvider navigation extraction → tour-engine

### DIFF
--- a/packages/core/src/__tests__/lib/provider-complexity-ignores.test.ts
+++ b/packages/core/src/__tests__/lib/provider-complexity-ignores.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const COMPLEXITY_IGNORE = /noExcessiveCognitiveComplexity/g
+
+describe('Phase 5 — provider complexity ignores (M5 gate)', () => {
+  it('tour-provider keeps exactly 3 noExcessiveCognitiveComplexity ignores (reducer, flow restore, prev)', () => {
+    const src = readFileSync(resolve(__dirname, '../../context/tour-provider.tsx'), 'utf-8')
+    const matches = src.match(COMPLEXITY_IGNORE) ?? []
+    expect(matches.length, 'expected reducer + flow-restore + prev only').toBe(3)
+  })
+})

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -18,12 +18,7 @@ import { validateTour } from '../lib/validate-tour'
 import { waitForStepTarget } from '../lib/wait-for-step-target'
 import type { TourRouteError } from '../lib/wait-for-step-target'
 import { tourRegistry } from '../registry/tour-registry'
-import type {
-  BranchContext,
-  Tour,
-  TourCallbackContext,
-  TourContextValue,
-} from '../types'
+import type { BranchContext, Tour, TourCallbackContext, TourContextValue } from '../types'
 import { defaultPersistenceConfig } from '../types/config'
 import type { DiagnosticContext, DiagnosticGate, EligibilityReport } from '../types/diagnostic'
 import type { MultiPagePersistenceConfig, RouterAdapter } from '../types/router'
@@ -711,14 +706,11 @@ export function TourProvider({
   // async navigation. Wrappers below are stable (empty-deps `useCallback`).
   const engineContextRef = React.useRef<TourEngineContext | null>(null)
 
-  const navigateToStep = React.useCallback(
-    (stepIndex: number): Promise<boolean> => {
-      const ctx = engineContextRef.current
-      if (!ctx) return Promise.resolve(false)
-      return navigateToStepImpl(ctx, stepIndex)
-    },
-    []
-  )
+  const navigateToStep = React.useCallback((stepIndex: number): Promise<boolean> => {
+    const ctx = engineContextRef.current
+    if (!ctx) return Promise.resolve(false)
+    return navigateToStepImpl(ctx, stepIndex)
+  }, [])
 
   // Step ID to index map for branch resolution
   const stepIdMap = React.useMemo(() => {

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -18,7 +18,13 @@ import { validateTour } from '../lib/validate-tour'
 import { waitForStepTarget } from '../lib/wait-for-step-target'
 import type { TourRouteError } from '../lib/wait-for-step-target'
 import { tourRegistry } from '../registry/tour-registry'
-import type { BranchContext, Tour, TourCallbackContext, TourContextValue } from '../types'
+import type {
+  BranchContext,
+  BranchTarget,
+  Tour,
+  TourCallbackContext,
+  TourContextValue,
+} from '../types'
 import { defaultPersistenceConfig } from '../types/config'
 import type { DiagnosticContext, DiagnosticGate, EligibilityReport } from '../types/diagnostic'
 import type { MultiPagePersistenceConfig, RouterAdapter } from '../types/router'
@@ -701,9 +707,20 @@ export function TourProvider({
 
   // ─── Engine context wiring ───────────────────────────────────────────────
   // `navigateToStep` and `handleBranchTarget` live in `../lib/tour-engine/`.
-  // The provider holds `engineContextRef` whose `current` is refreshed every
-  // render so the engine impls read fresh state / data / callbacks across
-  // async navigation. Wrappers below are stable (empty-deps `useCallback`).
+  //
+  // Engine impls are awaited across microtask boundaries. To avoid the stale-
+  // closure trap, the engine context's accessors route through a set of
+  // "live" refs that mirror the latest committed state. Even if an impl
+  // captures `ctx` from render N, calling `ctx.getState()` from render N+1
+  // reads through `stateRef.current` which has already been refreshed.
+  //
+  // `engineContextRef` itself is rebuilt each render so non-getter fields
+  // (router, callbacks) stay current; the getters all read through the same
+  // long-lived refs.
+  const stateRef = React.useRef<TourReducerState>(state)
+  const currentTourLiveRef = React.useRef<Tour | null>(null)
+  const dataRef = React.useRef<Record<string, unknown>>(data)
+  const stepIdMapRef = React.useRef<Map<string, number>>(new Map())
   const engineContextRef = React.useRef<TourEngineContext | null>(null)
 
   const navigateToStep = React.useCallback((stepIndex: number): Promise<boolean> => {
@@ -769,11 +786,7 @@ export function TourProvider({
   // Wrapper delegates through the engine context ref so async branches read
   // fresh state across awaits.
   const handleBranchTarget = React.useCallback(
-    (
-      target: import('../types').BranchTarget,
-      branchContext: BranchContext,
-      actionId?: string
-    ): Promise<void> => {
+    (target: BranchTarget, branchContext: BranchContext, actionId?: string): Promise<void> => {
       const ctx = engineContextRef.current
       if (!ctx) return Promise.resolve()
       return handleBranchTargetImpl(ctx, target, branchContext, actionId)
@@ -781,15 +794,20 @@ export function TourProvider({
     []
   )
 
-  // Refresh engine context on every render so getters close over the latest
-  // state / data / callbacks. Refs may be mutated during render; doing this
-  // synchronously avoids a one-render lag where engine functions would read
-  // a stale snapshot.
+  // Refresh the live refs synchronously each render so engine getters always
+  // resolve to the latest committed state, even when called through a `ctx`
+  // captured during an earlier render (e.g. a BranchWait recursion that
+  // resumes after a state-changing dispatch).
+  stateRef.current = state
+  currentTourLiveRef.current = currentTour
+  dataRef.current = data
+  stepIdMapRef.current = stepIdMap
+
   engineContextRef.current = {
-    getState: () => state,
-    getCurrentTour: () => currentTour,
-    getData: () => data,
-    getStepIdMap: () => stepIdMap,
+    getState: () => stateRef.current,
+    getCurrentTour: () => currentTourLiveRef.current,
+    getData: () => dataRef.current,
+    getStepIdMap: () => stepIdMapRef.current,
     dispatch,
     abortControllerRef,
     completedTourIdRef,

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -5,172 +5,38 @@ import { useFlowSession } from '../hooks/use-flow-session'
 import { usePersistence } from '../hooks/use-persistence'
 import { useRoutePersistence } from '../hooks/use-route-persistence'
 import { explainTour } from '../lib/diagnostic'
-import { TourValidationError, validateTour } from '../lib/validate-tour'
-import { TourRouteError, waitForStepTarget } from '../lib/wait-for-step-target'
+import type { TourEngineAnalytics, TourEngineContext } from '../lib/tour-engine/context'
+import { handleBranchTargetImpl } from '../lib/tour-engine/handle-branch-target'
+import {
+  buildCallbackContext,
+  evaluateStepWhen,
+  findNearestVisibleStepIndex,
+  findNextVisibleStepIndex,
+} from '../lib/tour-engine/helpers'
+import { navigateToStepImpl } from '../lib/tour-engine/navigate-to-step'
+import { validateTour } from '../lib/validate-tour'
+import { waitForStepTarget } from '../lib/wait-for-step-target'
+import type { TourRouteError } from '../lib/wait-for-step-target'
 import { tourRegistry } from '../registry/tour-registry'
 import type {
   BranchContext,
-  BranchTarget,
   Tour,
   TourCallbackContext,
   TourContextValue,
-  TourState,
-  TourStep,
 } from '../types'
 import { defaultPersistenceConfig } from '../types/config'
 import type { DiagnosticContext, DiagnosticGate, EligibilityReport } from '../types/diagnostic'
 import type { MultiPagePersistenceConfig, RouterAdapter } from '../types/router'
 import { isVisibleStep } from '../types/step'
 import type { TestBridge } from '../types/test-bridge'
-import {
-  isBranchToTour,
-  isBranchWait,
-  isLoopDetected,
-  isSpecialTarget,
-  resolveBranch,
-  resolveTargetToIndex,
-} from '../utils/branch'
+import type { TourAction, TourReducerState } from '../types/tour-reducer'
+import { resolveBranch } from '../utils/branch'
 import { logger } from '../utils/logger'
 import { TourContext } from './tour-context'
 import { TourKitContext } from './tourkit-context'
 
 /** Maximum hidden-step chain length before throwing HIDDEN_STEP_LOOP. */
 const MAX_HIDDEN_CHAIN = 50
-
-/**
- * Check if navigation is needed for a step
- */
-function isNavigationNeeded(
-  step: TourStep | undefined,
-  router: RouterAdapter | undefined
-): { needed: boolean; isOnRoute: boolean } {
-  if (!step?.route || !router) {
-    return { needed: false, isOnRoute: true }
-  }
-
-  const matchMode = step.routeMatch ?? 'exact'
-  const isOnRoute = router.matchRoute(step.route, matchMode)
-  return { needed: !isOnRoute, isOnRoute }
-}
-
-/**
- * Build TourCallbackContext for when/lifecycle callbacks
- */
-function buildCallbackContext(
-  state: TourState,
-  tour: Tour | null,
-  data: Record<string, unknown>
-): TourCallbackContext {
-  return {
-    tourId: state.tourId,
-    isActive: state.isActive,
-    currentStepIndex: state.currentStepIndex,
-    currentStep: state.currentStep,
-    totalSteps: state.totalSteps,
-    isLoading: state.isLoading,
-    isTransitioning: state.isTransitioning,
-    completedTours: state.completedTours,
-    skippedTours: state.skippedTours,
-    visitedSteps: state.visitedSteps,
-    stepVisitCount: state.stepVisitCount,
-    previousStepId: state.previousStepId,
-    tour,
-    data,
-  }
-}
-
-/**
- * Evaluate step's when condition
- * @returns true if step should be shown, false if it should be skipped
- */
-async function evaluateStepWhen(step: TourStep, context: TourCallbackContext): Promise<boolean> {
-  if (!step.when) return true
-
-  try {
-    return await step.when(context)
-  } catch (error) {
-    logger.warn(`Error evaluating when condition for step "${step.id}":`, error)
-    return false // Skip step on error
-  }
-}
-
-/**
- * Find the next visible step index starting from a given index
- * @param startIndex - Index to start searching from (inclusive)
- * @param direction - 1 for forward, -1 for backward
- * @param steps - Array of tour steps
- * @param context - Callback context for when evaluation
- * @returns Index of next visible step, or -1 if none found
- */
-async function findNextVisibleStepIndex(
-  startIndex: number,
-  direction: 1 | -1,
-  steps: TourStep[],
-  context: TourCallbackContext
-): Promise<number> {
-  let index = startIndex
-
-  while (index >= 0 && index < steps.length) {
-    const step = steps[index]
-    if (!step) break
-
-    // Update context with the potential new index for accurate evaluation
-    const stepContext: TourCallbackContext = {
-      ...context,
-      currentStepIndex: index,
-      currentStep: step,
-    }
-    const shouldShow = await evaluateStepWhen(step, stepContext)
-
-    if (shouldShow) {
-      return index
-    }
-
-    index += direction
-  }
-
-  return -1 // No visible step found
-}
-
-/**
- * Find the nearest visible step from a starting index
- * Tries forward first, then backward
- * @returns Index of nearest visible step, or -1 if none found
- */
-async function findNearestVisibleStepIndex(
-  startIndex: number,
-  steps: TourStep[],
-  context: TourCallbackContext
-): Promise<number> {
-  // Try forward first
-  const forwardIndex = await findNextVisibleStepIndex(startIndex, 1, steps, context)
-  if (forwardIndex !== -1) return forwardIndex
-
-  // Try backward
-  return findNextVisibleStepIndex(startIndex - 1, -1, steps, context)
-}
-
-// Action types for reducer
-type TourAction =
-  | { type: 'START_TOUR'; tourId: string; stepIndex?: number }
-  | { type: 'NEXT_STEP' }
-  | { type: 'PREV_STEP' }
-  | { type: 'GO_TO_STEP'; stepIndex: number }
-  | { type: 'SKIP_TOUR' }
-  | { type: 'COMPLETE_TOUR' }
-  | { type: 'STOP_TOUR' }
-  | { type: 'SET_LOADING'; isLoading: boolean }
-  | { type: 'SET_TRANSITIONING'; isTransitioning: boolean }
-  | { type: 'ADD_COMPLETED'; tourId: string }
-  | { type: 'ADD_SKIPPED'; tourId: string }
-  | { type: 'RESET'; tourId?: string }
-  | { type: 'UPDATE_TOURS'; tours: Tour[] }
-  | { type: 'TRACK_STEP_VISIT'; stepId: string; previousStepId: string | null }
-  | { type: 'CLEAR_VISIT_TRACKING' }
-
-interface TourReducerState extends TourState {
-  tours: Map<string, Tour>
-}
 
 function createStoppedState(state: TourReducerState): TourReducerState {
   return {
@@ -838,164 +704,20 @@ export function TourProvider({
     setDataState((prev) => ({ ...prev, [key]: value }))
   }, [])
 
-  // Run a hidden step's lifecycle and compute the next cursor. Returns
-  // either the next step index, or 'terminate' (caller should stop the
-  // chain by walking past end of steps array).
-  const advancePastHiddenStep = React.useCallback(
-    async (
-      step: TourStep,
-      cursor: number,
-      tour: Tour,
-      stepIdLookup: Map<string, number>
-    ): Promise<number | 'terminate'> => {
-      const baseCtx = buildCallbackContext(state, tour, data)
-      const stepCtx: TourCallbackContext = {
-        ...baseCtx,
-        currentStepIndex: cursor,
-        currentStep: step,
-      }
-      // Hidden-step lifecycle: onEnter pre-mount, then legacy onShow.
-      await step.onEnter?.(stepCtx)
-      await step.onShow?.(stepCtx)
+  // ─── Engine context wiring ───────────────────────────────────────────────
+  // `navigateToStep` and `handleBranchTarget` live in `../lib/tour-engine/`.
+  // The provider holds `engineContextRef` whose `current` is refreshed every
+  // render so the engine impls read fresh state / data / callbacks across
+  // async navigation. Wrappers below are stable (empty-deps `useCallback`).
+  const engineContextRef = React.useRef<TourEngineContext | null>(null)
 
-      if (step.onNext === undefined || step.onNext === null) {
-        return cursor + 1
-      }
-
-      const branchCtx: BranchContext = { ...stepCtx, setData }
-      const target = await resolveBranch(step.onNext, branchCtx)
-
-      if (target === 'complete' || target === 'skip') {
-        return 'terminate'
-      }
-
-      const idx = resolveTargetToIndex(target, cursor, stepIdLookup, tour.steps.length)
-      // Unmappable target (BranchToTour, BranchWait, etc.) — fall back to +1.
-      return idx ?? cursor + 1
-    },
-    [state, data, setData]
-  )
-
-  // Route-aware step navigation. Walks past hidden steps (firing their
-  // `onEnter`/`onShow` lifecycle) until a mountable step is reached, then
-  // dispatches GO_TO_STEP. Throws TourValidationError on hidden-step loops.
-  //
-  // Per-step `routeChangeStrategy` (Phase 1.3):
-  // - 'auto'   (default): navigate, await target via `waitForStepTarget`,
-  //   dispatch. On `TourRouteError`: fire `onStepError`, STOP_TOUR.
-  // - 'prompt': fire `onNavigationRequired(route, stepId)`, do NOT dispatch.
-  // - 'manual': do nothing — consumer drives navigation explicitly.
   const navigateToStep = React.useCallback(
-    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: hidden-traversal + route navigation in one orchestrator
-    async (stepIndex: number): Promise<boolean> => {
-      if (!currentTour) {
-        dispatch({ type: 'GO_TO_STEP', stepIndex })
-        return true
-      }
-
-      const localStepIdMap = new Map<string, number>()
-      currentTour.steps.forEach((s, i) => localStepIdMap.set(s.id, i))
-
-      let cursor = stepIndex
-      for (let chain = 0; chain <= MAX_HIDDEN_CHAIN; chain++) {
-        const step = currentTour.steps[cursor]
-        if (!step) {
-          dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
-          return false
-        }
-
-        if (step.kind !== 'hidden') {
-          const { needed } = isNavigationNeeded(step, router)
-          if (!needed || !step.route || !router) {
-            dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
-            return true
-          }
-
-          // `autoNavigate: false` (legacy) is equivalent to per-step 'prompt'
-          // and still surfaces via `onNavigationRequired`.
-          if (!autoNavigate) {
-            onNavigationRequired?.(step.route, step.id)
-            return false
-          }
-
-          const strategy = step.routeChangeStrategy ?? 'auto'
-
-          if (strategy === 'manual') {
-            // Consumer drives navigation. Do not dispatch — `useTourRoute()`
-            // handles `goToStepRoute()` and the next provider tick will
-            // re-enter once the route matches.
-            return false
-          }
-
-          if (strategy === 'prompt') {
-            onNavigationRequired?.(step.route, step.id)
-            return false
-          }
-
-          // strategy === 'auto'
-          try {
-            // RouterAdapter.navigate returns:
-            //   App Router / React Router → undefined (sync)
-            //   Pages Router               → Promise<boolean>
-            //
-            // A literal `false` from Pages Router means the navigation was
-            // cancelled (e.g. another `push()` raced ahead, beforeunload, a
-            // route guard rejected). Surface as a typed reject instead of
-            // silently waiting 3 seconds for a target that will never mount.
-            const navResult = await router.navigate(step.route)
-            if (navResult === false) {
-              throw new TourRouteError({
-                code: 'NAVIGATION_REJECTED',
-                route: step.route,
-                message: `Router rejected navigation to "${step.route}".`,
-              })
-            }
-
-            // Honor the legacy `routeDelay` knob before observing — gives
-            // route-bound suspense / data-fetch a beat to flush so the
-            // MutationObserver doesn't burn its 3s budget on hydration.
-            if (step.routeDelay && step.routeDelay > 0) {
-              await new Promise((resolve) => setTimeout(resolve, step.routeDelay))
-            }
-
-            await waitForStepTarget(step, {
-              route: step.route,
-              timeoutMs: step.waitTimeout ?? 3000,
-              signal: abortControllerRef.current?.signal,
-            })
-          } catch (err) {
-            // Cooperative cancellation (STOP_TOUR / unmount) — silent.
-            if (abortControllerRef.current?.signal.aborted) return false
-            if (err instanceof TourRouteError) {
-              onStepError?.(err)
-              dispatch({ type: 'STOP_TOUR' })
-              return false
-            }
-            throw err
-          }
-
-          dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
-          return true
-        }
-
-        const next = await advancePastHiddenStep(step, cursor, currentTour, localStepIdMap)
-        if (next === 'terminate') {
-          // Walk past end so caller's outer flow can handle complete/skip.
-          dispatch({ type: 'GO_TO_STEP', stepIndex: currentTour.steps.length })
-          return false
-        }
-        cursor = next
-      }
-
-      // Loop guard: hidden chain exceeded the maximum.
-      const stuckStep = currentTour.steps[cursor]
-      throw new TourValidationError({
-        code: 'HIDDEN_STEP_LOOP',
-        stepId: stuckStep?.id ?? '?',
-        message: `Hidden-step chain exceeded ${MAX_HIDDEN_CHAIN} iterations${stuckStep ? ` at step "${stuckStep.id}"` : ''}. Likely an infinite loop.`,
-      })
+    (stepIndex: number): Promise<boolean> => {
+      const ctx = engineContextRef.current
+      if (!ctx) return Promise.resolve(false)
+      return navigateToStepImpl(ctx, stepIndex)
     },
-    [currentTour, router, autoNavigate, onNavigationRequired, onStepError, advancePastHiddenStep]
+    []
   )
 
   // Step ID to index map for branch resolution
@@ -1051,199 +773,46 @@ export function TourProvider({
     currentTour.onSkip?.({ ...state, tour: currentTour, data })
   }, [currentTour, state, data, tourKitContext, clear, persistTerminalTours, markSkipped])
 
-  // Handle branch target resolution and navigation
+  // Branch-target orchestration extracted to ../lib/tour-engine/handle-branch-target.
+  // Wrapper delegates through the engine context ref so async branches read
+  // fresh state across awaits.
   const handleBranchTarget = React.useCallback(
-    async (
-      target: BranchTarget,
+    (
+      target: import('../types').BranchTarget,
       branchContext: BranchContext,
       actionId?: string
-      // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: branch navigation with multiple target types
     ): Promise<void> => {
-      if (!currentTour || !state.currentStep) return
-
-      const currentStepId = state.currentStep.id
-
-      // null - stay on current step
-      if (target === null) {
-        dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
-        return
-      }
-
-      // Special targets
-      if (isSpecialTarget(target)) {
-        switch (target) {
-          case 'complete':
-            completeTour()
-            return
-
-          case 'skip':
-            skipTour()
-            return
-
-          case 'restart': {
-            dispatch({ type: 'CLEAR_VISIT_TRACKING' })
-            dispatch({ type: 'GO_TO_STEP', stepIndex: 0 })
-            const firstStep = currentTour.steps[0]
-            if (firstStep) {
-              dispatch({
-                type: 'TRACK_STEP_VISIT',
-                stepId: firstStep.id,
-                previousStepId: currentStepId,
-              })
-              tourKitContext?.onStepView?.(currentTour.id, firstStep.id, 0)
-            }
-            return
-          }
-
-          case 'next':
-          case 'prev':
-            // Resolve to index and continue
-            break
-        }
-      }
-
-      // BranchToTour - cross-tour navigation
-      if (isBranchToTour(target)) {
-        const toTour = state.tours.get(target.tour)
-        if (!toTour) {
-          logger.warn(`Branch target tour "${target.tour}" not found`)
-          dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
-          return
-        }
-
-        // Fire analytics callbacks
-        tourKitContext?.onTourBranch?.(currentTour.id, target.tour, currentStepId)
-        currentTour.onTourBranch?.(target.tour, currentStepId)
-
-        // Stop current tour and start new one
-        dispatch({ type: 'STOP_TOUR' })
-
-        // Resolve step in new tour
-        let newStepIndex = 0
-        if (target.step !== undefined) {
-          if (typeof target.step === 'number') {
-            newStepIndex = target.step
-          } else {
-            const newTourStepMap = new Map<string, number>()
-            toTour.steps.forEach((s, i) => newTourStepMap.set(s.id, i))
-            newStepIndex = newTourStepMap.get(target.step) ?? 0
-          }
-        }
-
-        // Re-arm terminal-callback guards for the new tour
-        completedTourIdRef.current = null
-        skippedTourIdRef.current = null
-
-        dispatch({ type: 'START_TOUR', tourId: target.tour, stepIndex: newStepIndex })
-        tourKitContext?.onTourStart?.(target.tour)
-        toTour.onStart?.({ ...state, tour: toTour, data })
-        return
-      }
-
-      // BranchWait - delay before proceeding
-      if (isBranchWait(target)) {
-        await new Promise((resolve) => setTimeout(resolve, target.wait))
-        if (target.then) {
-          await handleBranchTarget(target.then, branchContext, actionId)
-        }
-        return
-      }
-
-      // Resolve target to index
-      const targetIndex = resolveTargetToIndex(
-        target,
-        state.currentStepIndex,
-        stepIdMap,
-        currentTour.steps.length
-      )
-
-      if (targetIndex === null || targetIndex === state.currentStepIndex) {
-        dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
-        return
-      }
-
-      // Check for loop detection
-      const targetStep = currentTour.steps[targetIndex]
-      if (targetStep && isLoopDetected(targetStep.id, state.stepVisitCount)) {
-        logger.warn(
-          `Loop detected: step "${targetStep.id}" visited too many times. Stopping navigation.`
-        )
-        dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
-        return
-      }
-
-      // Apply when filter to the target step
-      const context = buildCallbackContext(state, currentTour, data)
-      const stepContext: TourCallbackContext = {
-        ...context,
-        currentStepIndex: targetIndex,
-        currentStep: targetStep ?? null,
-      }
-
-      if (targetStep) {
-        const shouldShow = await evaluateStepWhen(targetStep, stepContext)
-        if (!shouldShow) {
-          // Find next visible step in the appropriate direction
-          const direction = targetIndex > state.currentStepIndex ? 1 : -1
-          const visibleIndex = await findNextVisibleStepIndex(
-            targetIndex + direction,
-            direction as 1 | -1,
-            currentTour.steps,
-            context
-          )
-
-          if (visibleIndex === -1) {
-            // No visible steps, complete the tour
-            completeTour()
-            return
-          }
-
-          // Navigate to the visible step instead
-          const navigated = await navigateToStep(visibleIndex)
-          if (!navigated) {
-            dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
-            return
-          }
-          const step = currentTour.steps[visibleIndex]
-          if (step) {
-            dispatch({
-              type: 'TRACK_STEP_VISIT',
-              stepId: step.id,
-              previousStepId: currentStepId,
-            })
-            tourKitContext?.onStepView?.(currentTour.id, step.id, visibleIndex)
-            currentTour.onStepChange?.(step, visibleIndex, {
-              ...state,
-              tour: currentTour,
-              data,
-            })
-          }
-          return
-        }
-      }
-
-      // Navigate to target step
-      const navigated = await navigateToStep(targetIndex)
-      if (!navigated) {
-        dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
-        return
-      }
-      if (targetStep) {
-        dispatch({
-          type: 'TRACK_STEP_VISIT',
-          stepId: targetStep.id,
-          previousStepId: currentStepId,
-        })
-        tourKitContext?.onStepView?.(currentTour.id, targetStep.id, targetIndex)
-        currentTour.onStepChange?.(targetStep, targetIndex, {
-          ...state,
-          tour: currentTour,
-          data,
-        })
-      }
+      const ctx = engineContextRef.current
+      if (!ctx) return Promise.resolve()
+      return handleBranchTargetImpl(ctx, target, branchContext, actionId)
     },
-    [currentTour, state, data, stepIdMap, tourKitContext, navigateToStep, completeTour, skipTour]
+    []
   )
+
+  // Refresh engine context on every render so getters close over the latest
+  // state / data / callbacks. Refs may be mutated during render; doing this
+  // synchronously avoids a one-render lag where engine functions would read
+  // a stale snapshot.
+  engineContextRef.current = {
+    getState: () => state,
+    getCurrentTour: () => currentTour,
+    getData: () => data,
+    getStepIdMap: () => stepIdMap,
+    dispatch,
+    abortControllerRef,
+    completedTourIdRef,
+    skippedTourIdRef,
+    router,
+    autoNavigate,
+    maxHiddenChain: MAX_HIDDEN_CHAIN,
+    onNavigationRequired,
+    onStepError,
+    completeTour,
+    skipTour,
+    setData,
+    navigateToStep,
+    tourKitContext: tourKitContext satisfies TourEngineAnalytics | null,
+  }
 
   // Actions
   const start = React.useCallback(

--- a/packages/core/src/lib/tour-engine/__tests__/_helpers/fake-engine-context.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/_helpers/fake-engine-context.ts
@@ -1,0 +1,159 @@
+import { type Mock, vi } from 'vitest'
+import type { RouterAdapter } from '../../../../types/router'
+import type { Tour } from '../../../../types/tour'
+import type { TourReducerState } from '../../../../types/tour-reducer'
+import type { TourEngineAnalytics, TourEngineContext } from '../../context'
+
+export interface FakeEngineOverrides {
+  state?: Partial<TourReducerState>
+  currentTour?: Tour | null
+  data?: Record<string, unknown>
+  stepIdMap?: Map<string, number>
+  router?: Partial<RouterAdapter>
+  autoNavigate?: boolean
+  maxHiddenChain?: number
+  tourKitContext?: TourEngineAnalytics | null
+  onNavigationRequired?: TourEngineContext['onNavigationRequired']
+  onStepError?: TourEngineContext['onStepError']
+  abortSignal?: AbortSignal | null
+  preAborted?: boolean
+  navigateToStep?: (stepIndex: number) => Promise<boolean>
+}
+
+export interface FakeRouterMock {
+  navigate: Mock<RouterAdapter['navigate']>
+  getCurrentRoute: Mock<RouterAdapter['getCurrentRoute']>
+  matchRoute: Mock<RouterAdapter['matchRoute']>
+  subscribe: Mock<NonNullable<RouterAdapter['onRouteChange']>>
+}
+
+export interface FakeEngineHandle {
+  ctx: TourEngineContext
+  mocks: {
+    dispatch: ReturnType<typeof vi.fn>
+    completeTour: ReturnType<typeof vi.fn>
+    skipTour: ReturnType<typeof vi.fn>
+    setData: ReturnType<typeof vi.fn>
+    navigateToStep: ReturnType<typeof vi.fn>
+    router: FakeRouterMock
+    onNavigationRequired: ReturnType<typeof vi.fn>
+    onStepError: ReturnType<typeof vi.fn>
+  }
+  setState: (next: Partial<TourReducerState>) => void
+  setCurrentTour: (tour: Tour | null) => void
+  abortController: AbortController
+}
+
+const baseState: TourReducerState = {
+  tourId: 't1',
+  isActive: true,
+  currentStepIndex: 0,
+  currentStep: null,
+  totalSteps: 0,
+  isLoading: false,
+  isTransitioning: false,
+  completedTours: [],
+  skippedTours: [],
+  visitedSteps: [],
+  stepVisitCount: new Map<string, number>(),
+  previousStepId: null,
+  tours: new Map<string, Tour>(),
+}
+
+function buildFakeRouter(overrides?: Partial<RouterAdapter>): FakeRouterMock {
+  return {
+    navigate: vi.fn(overrides?.navigate ?? (() => Promise.resolve(undefined))) as Mock<
+      RouterAdapter['navigate']
+    >,
+    getCurrentRoute: vi.fn(overrides?.getCurrentRoute ?? (() => '/')) as Mock<
+      RouterAdapter['getCurrentRoute']
+    >,
+    matchRoute: vi.fn(overrides?.matchRoute ?? (() => false)) as Mock<RouterAdapter['matchRoute']>,
+    subscribe: vi.fn(overrides?.onRouteChange ?? (() => () => {})) as Mock<
+      NonNullable<RouterAdapter['onRouteChange']>
+    >,
+  }
+}
+
+export function createFakeEngineContext(overrides: FakeEngineOverrides = {}): FakeEngineHandle {
+  let state: TourReducerState = { ...baseState, ...overrides.state }
+  let currentTour = overrides.currentTour ?? null
+  let data = overrides.data ?? {}
+  let stepIdMap = overrides.stepIdMap ?? new Map<string, number>()
+
+  // Keep tour map in sync with currentTour for cross-tour reads. The engine
+  // reads `state.tours` for BranchToTour resolution.
+  if (currentTour && !state.tours.has(currentTour.id)) {
+    state = { ...state, tours: new Map(state.tours).set(currentTour.id, currentTour) }
+  }
+
+  const dispatch = vi.fn()
+  const completeTour = vi.fn()
+  const skipTour = vi.fn()
+  const setData = vi.fn((k: string, v: unknown) => {
+    data = { ...data, [k]: v }
+  })
+
+  const router = buildFakeRouter(overrides.router)
+
+  const onNavigationRequired = vi.fn(overrides.onNavigationRequired ?? (() => {}))
+  const onStepError = vi.fn(overrides.onStepError ?? (() => {}))
+
+  const abortController = new AbortController()
+  if (overrides.preAborted) abortController.abort()
+  const abortControllerRef = { current: abortController }
+
+  const completedTourIdRef = { current: null as string | null }
+  const skippedTourIdRef = { current: null as string | null }
+
+  const navigateToStep = vi.fn(
+    overrides.navigateToStep ?? ((_idx: number) => Promise.resolve(true))
+  )
+
+  const ctx: TourEngineContext = {
+    getState: () => state,
+    getCurrentTour: () => currentTour,
+    getData: () => data,
+    getStepIdMap: () => stepIdMap,
+    dispatch,
+    abortControllerRef,
+    completedTourIdRef,
+    skippedTourIdRef,
+    router: router as unknown as RouterAdapter,
+    autoNavigate: overrides.autoNavigate ?? true,
+    maxHiddenChain: overrides.maxHiddenChain ?? 50,
+    onNavigationRequired,
+    onStepError,
+    completeTour,
+    skipTour,
+    setData,
+    navigateToStep,
+    tourKitContext: overrides.tourKitContext ?? null,
+  }
+
+  return {
+    ctx,
+    mocks: {
+      dispatch,
+      completeTour,
+      skipTour,
+      setData,
+      navigateToStep,
+      router,
+      onNavigationRequired,
+      onStepError,
+    },
+    setState(next) {
+      state = { ...state, ...next }
+    },
+    setCurrentTour(tour) {
+      currentTour = tour
+      if (tour) {
+        state = { ...state, tours: new Map(state.tours).set(tour.id, tour) }
+      }
+      stepIdMap = new Map()
+      tour?.steps.forEach((s, i) => stepIdMap.set(s.id, i))
+    },
+    abortController,
+  }
+}

--- a/packages/core/src/lib/tour-engine/__tests__/_helpers/fake-engine-context.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/_helpers/fake-engine-context.ts
@@ -24,7 +24,7 @@ export interface FakeRouterMock {
   navigate: Mock<RouterAdapter['navigate']>
   getCurrentRoute: Mock<RouterAdapter['getCurrentRoute']>
   matchRoute: Mock<RouterAdapter['matchRoute']>
-  subscribe: Mock<NonNullable<RouterAdapter['onRouteChange']>>
+  onRouteChange: Mock<NonNullable<RouterAdapter['onRouteChange']>>
 }
 
 export interface FakeEngineHandle {
@@ -69,7 +69,7 @@ function buildFakeRouter(overrides?: Partial<RouterAdapter>): FakeRouterMock {
       RouterAdapter['getCurrentRoute']
     >,
     matchRoute: vi.fn(overrides?.matchRoute ?? (() => false)) as Mock<RouterAdapter['matchRoute']>,
-    subscribe: vi.fn(overrides?.onRouteChange ?? (() => () => {})) as Mock<
+    onRouteChange: vi.fn(overrides?.onRouteChange ?? (() => () => {})) as Mock<
       NonNullable<RouterAdapter['onRouteChange']>
     >,
   }
@@ -119,7 +119,7 @@ export function createFakeEngineContext(overrides: FakeEngineOverrides = {}): Fa
     abortControllerRef,
     completedTourIdRef,
     skippedTourIdRef,
-    router: router as unknown as RouterAdapter,
+    router: router satisfies RouterAdapter,
     autoNavigate: overrides.autoNavigate ?? true,
     maxHiddenChain: overrides.maxHiddenChain ?? 50,
     onNavigationRequired,

--- a/packages/core/src/lib/tour-engine/__tests__/_helpers/make-tour.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/_helpers/make-tour.ts
@@ -1,0 +1,23 @@
+import type { HiddenTourStep, TourStep, VisibleTourStep } from '../../../../types/step'
+import type { Tour } from '../../../../types/tour'
+
+export const visibleStep = (id: string, extras: Partial<VisibleTourStep> = {}): VisibleTourStep =>
+  ({
+    id,
+    target: '#x',
+    content: 'hi',
+    ...extras,
+  }) as VisibleTourStep
+
+export const hiddenStep = (id: string, extras: Partial<HiddenTourStep> = {}): HiddenTourStep =>
+  ({
+    id,
+    kind: 'hidden',
+    ...extras,
+  }) as HiddenTourStep
+
+export const makeTour = (id: string, steps: TourStep[], extras: Partial<Tour> = {}): Tour => ({
+  id,
+  steps,
+  ...extras,
+})

--- a/packages/core/src/lib/tour-engine/__tests__/handle-branch-target.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/handle-branch-target.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { BranchContext } from '../../../types'
+import { handleBranchTargetImpl } from '../handle-branch-target'
+import { createFakeEngineContext } from './_helpers/fake-engine-context'
+import { makeTour, visibleStep } from './_helpers/make-tour'
+
+const noopBranchCtx = {} as BranchContext
+
+describe('handleBranchTargetImpl', () => {
+  describe('null target', () => {
+    it('clears the transitioning flag and returns', async () => {
+      const tour = makeTour('t1', [visibleStep('a'), visibleStep('b')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, isTransitioning: true },
+      })
+
+      await handleBranchTargetImpl(handle.ctx, null, noopBranchCtx)
+
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'SET_TRANSITIONING',
+        isTransitioning: false,
+      })
+    })
+
+    it('no-ops when there is no current tour', async () => {
+      const handle = createFakeEngineContext({ currentTour: null })
+      await handleBranchTargetImpl(handle.ctx, null, noopBranchCtx)
+      expect(handle.mocks.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('no-ops when there is no current step', async () => {
+      const tour = makeTour('t1', [visibleStep('a')])
+      const handle = createFakeEngineContext({ currentTour: tour, state: { currentStep: null } })
+      await handleBranchTargetImpl(handle.ctx, null, noopBranchCtx)
+      expect(handle.mocks.dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('terminal targets', () => {
+    it('"complete" calls completeTour exactly once', async () => {
+      const tour = makeTour('t1', [visibleStep('a')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null },
+      })
+      await handleBranchTargetImpl(handle.ctx, 'complete', noopBranchCtx)
+      expect(handle.mocks.completeTour).toHaveBeenCalledTimes(1)
+      expect(handle.mocks.skipTour).not.toHaveBeenCalled()
+    })
+
+    it('"skip" calls skipTour exactly once', async () => {
+      const tour = makeTour('t1', [visibleStep('a')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null },
+      })
+      await handleBranchTargetImpl(handle.ctx, 'skip', noopBranchCtx)
+      expect(handle.mocks.skipTour).toHaveBeenCalledTimes(1)
+      expect(handle.mocks.completeTour).not.toHaveBeenCalled()
+    })
+
+    it('"restart" dispatches GO_TO_STEP 0 and tracks step visit', async () => {
+      const tour = makeTour('t1', [visibleStep('first'), visibleStep('second')])
+      const onStepView = vi.fn()
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[1] ?? null, currentStepIndex: 1 },
+        tourKitContext: { onStepView },
+      })
+
+      await handleBranchTargetImpl(handle.ctx, 'restart', noopBranchCtx)
+
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'CLEAR_VISIT_TRACKING' })
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 0 })
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'TRACK_STEP_VISIT', stepId: 'first' })
+      )
+      expect(onStepView).toHaveBeenCalledWith('t1', 'first', 0)
+    })
+  })
+
+  describe('cross-tour branch', () => {
+    it('missing target tour — warns via dispatch and clears transitioning', async () => {
+      const tour = makeTour('t1', [visibleStep('a')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null },
+      })
+
+      await handleBranchTargetImpl(handle.ctx, { tour: 'does-not-exist' }, noopBranchCtx)
+
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'SET_TRANSITIONING',
+        isTransitioning: false,
+      })
+      expect(handle.mocks.dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'START_TOUR' })
+      )
+    })
+
+    it('named step in target tour — STOP_TOUR then START_TOUR with resolved index', async () => {
+      const target = makeTour('t2', [visibleStep('step-x'), visibleStep('step-y')])
+      const source = makeTour('t1', [visibleStep('a')])
+      const onTourBranch = vi.fn()
+      const onTourStart = vi.fn()
+      const handle = createFakeEngineContext({
+        currentTour: source,
+        state: {
+          currentStep: source.steps[0] ?? null,
+          tours: new Map([
+            ['t1', source],
+            ['t2', target],
+          ]),
+        },
+        tourKitContext: { onTourBranch, onTourStart },
+      })
+
+      await handleBranchTargetImpl(handle.ctx, { tour: 't2', step: 'step-y' }, noopBranchCtx)
+
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'STOP_TOUR' })
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'START_TOUR',
+        tourId: 't2',
+        stepIndex: 1,
+      })
+      expect(onTourBranch).toHaveBeenCalledWith('t1', 't2', 'a')
+      expect(onTourStart).toHaveBeenCalledWith('t2')
+      // Terminal-guards re-armed
+      expect(handle.ctx.completedTourIdRef.current).toBeNull()
+      expect(handle.ctx.skippedTourIdRef.current).toBeNull()
+    })
+
+    it('numeric step in target tour — resolves directly', async () => {
+      const target = makeTour('t2', [visibleStep('x'), visibleStep('y'), visibleStep('z')])
+      const source = makeTour('t1', [visibleStep('a')])
+      const handle = createFakeEngineContext({
+        currentTour: source,
+        state: {
+          currentStep: source.steps[0] ?? null,
+          tours: new Map([
+            ['t1', source],
+            ['t2', target],
+          ]),
+        },
+      })
+
+      await handleBranchTargetImpl(handle.ctx, { tour: 't2', step: 2 }, noopBranchCtx)
+
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'START_TOUR',
+        tourId: 't2',
+        stepIndex: 2,
+      })
+    })
+  })
+
+  describe('BranchWait', () => {
+    it('waits then chains the `then` target', async () => {
+      const tour = makeTour('t1', [visibleStep('a')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null },
+      })
+
+      // biome-ignore lint/suspicious/noThenProperty: BranchWait's `then` is the public branching API
+      await handleBranchTargetImpl(handle.ctx, { wait: 1, then: 'complete' }, noopBranchCtx)
+
+      expect(handle.mocks.completeTour).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('current-index target', () => {
+    it('target resolves to current index → clears transitioning, no navigation', async () => {
+      const tour = makeTour('t1', [visibleStep('a'), visibleStep('b')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+        stepIdMap: new Map([
+          ['a', 0],
+          ['b', 1],
+        ]),
+      })
+
+      await handleBranchTargetImpl(handle.ctx, 'a', noopBranchCtx)
+
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'SET_TRANSITIONING',
+        isTransitioning: false,
+      })
+      expect(handle.mocks.navigateToStep).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('loop detection', () => {
+    it('targeting a step that exceeds maxVisits → clears transitioning, no nav', async () => {
+      const tour = makeTour('t1', [visibleStep('a'), visibleStep('b')])
+      const stepVisitCount = new Map<string, number>([['b', 10]])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0, stepVisitCount },
+        stepIdMap: new Map([
+          ['a', 0],
+          ['b', 1],
+        ]),
+      })
+
+      await handleBranchTargetImpl(handle.ctx, 'b', noopBranchCtx)
+
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'SET_TRANSITIONING',
+        isTransitioning: false,
+      })
+      expect(handle.mocks.navigateToStep).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when-condition false', () => {
+    it('target.when returns false AND next visible step exists → navigates to next visible', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('current'),
+        visibleStep('target', { when: () => false }),
+        visibleStep('next-visible'),
+      ])
+      const onStepView = vi.fn()
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+        stepIdMap: new Map([
+          ['current', 0],
+          ['target', 1],
+          ['next-visible', 2],
+        ]),
+        tourKitContext: { onStepView },
+      })
+
+      await handleBranchTargetImpl(handle.ctx, 'target', noopBranchCtx)
+
+      expect(handle.mocks.navigateToStep).toHaveBeenCalledWith(2)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'TRACK_STEP_VISIT', stepId: 'next-visible' })
+      )
+      expect(onStepView).toHaveBeenCalledWith('t1', 'next-visible', 2)
+    })
+
+    it('target.when returns false AND no visible step exists → completeTour', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('current'),
+        visibleStep('target', { when: () => false }),
+        visibleStep('tail', { when: () => false }),
+      ])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+        stepIdMap: new Map([
+          ['current', 0],
+          ['target', 1],
+          ['tail', 2],
+        ]),
+      })
+
+      await handleBranchTargetImpl(handle.ctx, 'target', noopBranchCtx)
+
+      expect(handle.mocks.completeTour).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('successful target navigation', () => {
+    it('tracks step view and calls onStepChange', async () => {
+      const onStepChange = vi.fn()
+      const tour = makeTour('t1', [visibleStep('a'), visibleStep('b', { onShow: undefined })], {
+        onStepChange,
+      })
+      const onStepView = vi.fn()
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+        stepIdMap: new Map([
+          ['a', 0],
+          ['b', 1],
+        ]),
+        tourKitContext: { onStepView },
+      })
+
+      await handleBranchTargetImpl(handle.ctx, 'b', noopBranchCtx)
+
+      expect(handle.mocks.navigateToStep).toHaveBeenCalledWith(1)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'TRACK_STEP_VISIT',
+          stepId: 'b',
+          previousStepId: 'a',
+        })
+      )
+      expect(onStepView).toHaveBeenCalledWith('t1', 'b', 1)
+      expect(onStepChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('navigateToStep returns false → clear transitioning, no step-view tracking', async () => {
+      const tour = makeTour('t1', [visibleStep('a'), visibleStep('b')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+        stepIdMap: new Map([
+          ['a', 0],
+          ['b', 1],
+        ]),
+        navigateToStep: () => Promise.resolve(false),
+      })
+
+      await handleBranchTargetImpl(handle.ctx, 'b', noopBranchCtx)
+
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'SET_TRANSITIONING',
+        isTransitioning: false,
+      })
+      expect(handle.mocks.dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'TRACK_STEP_VISIT' })
+      )
+    })
+  })
+
+  describe('stale closure regression (US-5)', () => {
+    it('reads the latest state on each getState call', () => {
+      const tour = makeTour('t1', [visibleStep('a'), visibleStep('b')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+      })
+
+      expect(handle.ctx.getState().currentStepIndex).toBe(0)
+      handle.setState({ currentStepIndex: 1 })
+      expect(handle.ctx.getState().currentStepIndex).toBe(1)
+    })
+  })
+})

--- a/packages/core/src/lib/tour-engine/__tests__/handle-branch-target.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/handle-branch-target.test.ts
@@ -116,6 +116,12 @@ describe('handleBranchTargetImpl', () => {
         tourKitContext: { onTourBranch, onTourStart },
       })
 
+      // Pre-arm the terminal-callback guards as if the source tour had already
+      // completed once; the cross-tour branch MUST clear them so the new tour
+      // can fire its own onComplete / onSkip later.
+      handle.ctx.completedTourIdRef.current = 't1'
+      handle.ctx.skippedTourIdRef.current = 't1'
+
       await handleBranchTargetImpl(handle.ctx, { tour: 't2', step: 'step-y' }, noopBranchCtx)
 
       expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'STOP_TOUR' })
@@ -126,7 +132,7 @@ describe('handleBranchTargetImpl', () => {
       })
       expect(onTourBranch).toHaveBeenCalledWith('t1', 't2', 'a')
       expect(onTourStart).toHaveBeenCalledWith('t2')
-      // Terminal-guards re-armed
+      // Now meaningful: refs were 't1', should have been cleared to null.
       expect(handle.ctx.completedTourIdRef.current).toBeNull()
       expect(handle.ctx.skippedTourIdRef.current).toBeNull()
     })
@@ -321,16 +327,58 @@ describe('handleBranchTargetImpl', () => {
   })
 
   describe('stale closure regression (US-5)', () => {
-    it('reads the latest state on each getState call', () => {
+    it('BranchWait recursion sees state mutations applied during the wait', async () => {
+      // Outer call enters at currentStepIndex=0 with target=BranchWait→'b'.
+      // During the wait we mutate state so currentStepIndex moves to 1.
+      // When the recursion resolves 'b' to index 1 it MUST compare against
+      // the fresh currentStepIndex (1), triggering the current-index path
+      // (SET_TRANSITIONING false, no navigation). If state were stale, the
+      // recursion would see index 0 and instead dispatch navigation to 1.
+      const tour = makeTour('t1', [visibleStep('a'), visibleStep('b'), visibleStep('c')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+        stepIdMap: new Map([
+          ['a', 0],
+          ['b', 1],
+          ['c', 2],
+        ]),
+      })
+
+      const pending = handleBranchTargetImpl(
+        handle.ctx,
+        // biome-ignore lint/suspicious/noThenProperty: BranchWait's `then` is the public branching API
+        { wait: 20, then: 'b' },
+        noopBranchCtx
+      )
+
+      // Wait long enough for the outer setTimeout to be in flight, then
+      // mutate state mid-wait.
+      await new Promise((r) => setTimeout(r, 5))
+      handle.setState({ currentStep: tour.steps[1] ?? null, currentStepIndex: 1 })
+
+      await pending
+
+      // Recursion's target ('b' → index 1) equals fresh currentStepIndex (1),
+      // so the current-index short-circuit fires.
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'SET_TRANSITIONING',
+        isTransitioning: false,
+      })
+      expect(handle.mocks.navigateToStep).not.toHaveBeenCalled()
+    })
+
+    it('getter returns latest state when invoked from a captured ctx', () => {
+      // Sanity check on the engine-context contract itself: a ctx captured
+      // before a mutation MUST observe the mutation on the next getState().
       const tour = makeTour('t1', [visibleStep('a'), visibleStep('b')])
       const handle = createFakeEngineContext({
         currentTour: tour,
         state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
       })
-
-      expect(handle.ctx.getState().currentStepIndex).toBe(0)
+      const capturedCtx = handle.ctx
       handle.setState({ currentStepIndex: 1 })
-      expect(handle.ctx.getState().currentStepIndex).toBe(1)
+      expect(capturedCtx.getState().currentStepIndex).toBe(1)
     })
   })
 })

--- a/packages/core/src/lib/tour-engine/__tests__/navigate-to-step.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/navigate-to-step.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TourValidationError } from '../../validate-tour'
+import { TourRouteError } from '../../wait-for-step-target'
+import { navigateToStepImpl } from '../navigate-to-step'
+import { createFakeEngineContext } from './_helpers/fake-engine-context'
+import { hiddenStep, makeTour, visibleStep } from './_helpers/make-tour'
+
+describe('navigateToStepImpl', () => {
+  describe('no current tour', () => {
+    it('dispatches GO_TO_STEP and returns true', async () => {
+      const handle = createFakeEngineContext({ currentTour: null })
+      const result = await navigateToStepImpl(handle.ctx, 3)
+      expect(result).toBe(true)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 3 })
+    })
+  })
+
+  describe('visible step without route', () => {
+    it('dispatches GO_TO_STEP synchronously', async () => {
+      const tour = makeTour('t1', [visibleStep('a'), visibleStep('b')])
+      const handle = createFakeEngineContext({ currentTour: tour })
+      const result = await navigateToStepImpl(handle.ctx, 1)
+      expect(result).toBe(true)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 1 })
+    })
+  })
+
+  describe('autoNavigate: false', () => {
+    it('fires onNavigationRequired and does not dispatch', async () => {
+      const tour = makeTour('t1', [visibleStep('a', { route: '/about' })])
+      const handle = createFakeEngineContext({ currentTour: tour, autoNavigate: false })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+
+      const result = await navigateToStepImpl(handle.ctx, 0)
+
+      expect(result).toBe(false)
+      expect(handle.mocks.onNavigationRequired).toHaveBeenCalledWith('/about', 'a')
+      expect(handle.mocks.router.navigate).not.toHaveBeenCalled()
+      expect(handle.mocks.dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('routeChangeStrategy: "manual"', () => {
+    it('returns false without firing any side effects', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a', { route: '/about', routeChangeStrategy: 'manual' }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+
+      const result = await navigateToStepImpl(handle.ctx, 0)
+
+      expect(result).toBe(false)
+      expect(handle.mocks.onNavigationRequired).not.toHaveBeenCalled()
+      expect(handle.mocks.router.navigate).not.toHaveBeenCalled()
+      expect(handle.mocks.dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('routeChangeStrategy: "prompt"', () => {
+    it('fires onNavigationRequired', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a', { route: '/about', routeChangeStrategy: 'prompt' }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+
+      const result = await navigateToStepImpl(handle.ctx, 0)
+
+      expect(result).toBe(false)
+      expect(handle.mocks.onNavigationRequired).toHaveBeenCalledWith('/about', 'a')
+      expect(handle.mocks.router.navigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('routeChangeStrategy: "auto"', () => {
+    it('navigates, waits for target, then dispatches GO_TO_STEP', async () => {
+      // waitForStepTarget resolves immediately when the step has no target
+      // selector — pass a target/content but stub the document query via JSDOM
+      const tour = makeTour('t1', [visibleStep('a', { route: '/about', target: '#exists' })])
+      document.body.innerHTML = '<div id="exists"></div>'
+      const handle = createFakeEngineContext({ currentTour: tour })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+
+      const result = await navigateToStepImpl(handle.ctx, 0)
+
+      expect(result).toBe(true)
+      expect(handle.mocks.router.navigate).toHaveBeenCalledWith('/about')
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 0 })
+
+      document.body.innerHTML = ''
+    })
+
+    it('router returning false → throws NAVIGATION_REJECTED, onStepError, STOP_TOUR', async () => {
+      const tour = makeTour('t1', [visibleStep('a', { route: '/about', target: '#x' })])
+      const handle = createFakeEngineContext({ currentTour: tour })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+      handle.mocks.router.navigate.mockResolvedValue(false)
+
+      const result = await navigateToStepImpl(handle.ctx, 0)
+
+      expect(result).toBe(false)
+      expect(handle.mocks.onStepError).toHaveBeenCalledTimes(1)
+      const err = handle.mocks.onStepError.mock.calls[0]?.[0]
+      expect(err).toBeInstanceOf(TourRouteError)
+      expect((err as TourRouteError).code).toBe('NAVIGATION_REJECTED')
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'STOP_TOUR' })
+    })
+
+    it('waitForStepTarget times out → onStepError(TARGET_NOT_FOUND), STOP_TOUR', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a', { route: '/about', target: '#never', waitTimeout: 50 }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+
+      const result = await navigateToStepImpl(handle.ctx, 0)
+
+      expect(result).toBe(false)
+      expect(handle.mocks.onStepError).toHaveBeenCalledTimes(1)
+      const err = handle.mocks.onStepError.mock.calls[0]?.[0]
+      expect(err).toBeInstanceOf(TourRouteError)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'STOP_TOUR' })
+    })
+  })
+
+  describe('abort signal already aborted', () => {
+    it('returns false silently — no onStepError', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a', { route: '/about', target: '#never', waitTimeout: 100 }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour, preAborted: true })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+
+      const result = await navigateToStepImpl(handle.ctx, 0)
+
+      expect(result).toBe(false)
+      expect(handle.mocks.onStepError).not.toHaveBeenCalled()
+      expect(handle.mocks.dispatch).not.toHaveBeenCalledWith({ type: 'STOP_TOUR' })
+    })
+  })
+
+  describe('hidden step without branch', () => {
+    it('advances cursor past hidden step to the next visible step', async () => {
+      const onEnter = vi.fn()
+      const onShow = vi.fn()
+      const tour = makeTour('t1', [
+        visibleStep('start'),
+        hiddenStep('h1', { onEnter, onShow }),
+        visibleStep('after-hidden'),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      const result = await navigateToStepImpl(handle.ctx, 1)
+
+      expect(result).toBe(true)
+      expect(onEnter).toHaveBeenCalled()
+      expect(onShow).toHaveBeenCalled()
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 2 })
+    })
+
+    it('hidden step with onNext "complete" → walks past end of steps and returns false', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        hiddenStep('h1', { onNext: 'complete' }),
+        visibleStep('z'),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      const result = await navigateToStepImpl(handle.ctx, 1)
+
+      expect(result).toBe(false)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'GO_TO_STEP',
+        stepIndex: tour.steps.length,
+      })
+    })
+  })
+
+  describe('hidden chain enforcement', () => {
+    it('exceeding maxHiddenChain throws HIDDEN_STEP_LOOP', async () => {
+      // Build a tour of N+2 hidden steps with onNext: 'next' so the loop walks
+      // the whole chain. maxHiddenChain=3 → cursor visits 0,1,2,3 (4 iterations,
+      // chain index reaches 3 which is the loop tail) and throws.
+      const max = 3
+      const steps = Array.from({ length: max + 2 }, (_, i) =>
+        hiddenStep(`h${i}`, { onNext: 'next' })
+      )
+      const tour = makeTour('t1', steps)
+      const handle = createFakeEngineContext({ currentTour: tour, maxHiddenChain: max })
+
+      await expect(navigateToStepImpl(handle.ctx, 0)).rejects.toBeInstanceOf(TourValidationError)
+    })
+  })
+})

--- a/packages/core/src/lib/tour-engine/__tests__/tour-engine-context.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/tour-engine-context.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { createFakeEngineContext } from './_helpers/fake-engine-context'
+import { makeTour, visibleStep } from './_helpers/make-tour'
+
+describe('TourEngineContext — refs and getters, not snapshots (US-5)', () => {
+  it('getState reflects subsequent setState mutations', () => {
+    const handle = createFakeEngineContext({ state: { currentStepIndex: 0 } })
+
+    expect(handle.ctx.getState().currentStepIndex).toBe(0)
+    handle.setState({ currentStepIndex: 4 })
+    expect(handle.ctx.getState().currentStepIndex).toBe(4)
+  })
+
+  it('getCurrentTour returns the latest currentTour after setCurrentTour', () => {
+    const handle = createFakeEngineContext({ currentTour: null })
+    expect(handle.ctx.getCurrentTour()).toBeNull()
+
+    const next = makeTour('t1', [visibleStep('a')])
+    handle.setCurrentTour(next)
+    expect(handle.ctx.getCurrentTour()).toBe(next)
+  })
+
+  it('getStepIdMap reflects setCurrentTour updates', () => {
+    const handle = createFakeEngineContext({ currentTour: null })
+    expect(handle.ctx.getStepIdMap().size).toBe(0)
+
+    handle.setCurrentTour(makeTour('t1', [visibleStep('a'), visibleStep('b')]))
+    expect(handle.ctx.getStepIdMap().get('a')).toBe(0)
+    expect(handle.ctx.getStepIdMap().get('b')).toBe(1)
+  })
+
+  it('abortControllerRef.current.abort() flips signal.aborted on the same ref', () => {
+    const handle = createFakeEngineContext()
+    expect(handle.ctx.abortControllerRef.current?.signal.aborted).toBe(false)
+    handle.abortController.abort()
+    expect(handle.ctx.abortControllerRef.current?.signal.aborted).toBe(true)
+  })
+})

--- a/packages/core/src/lib/tour-engine/context.ts
+++ b/packages/core/src/lib/tour-engine/context.ts
@@ -18,10 +18,17 @@ export interface TourEngineAnalytics {
 /**
  * Engine-scoped context shared by `navigateToStep` and `handleBranchTarget`.
  *
- * Every read-back-mutable value is exposed as a getter or ref. This is
- * deliberate — the engine functions are `await`ed across microtask boundaries
- * and would otherwise capture stale state via closure. The provider builds a
- * stable `engineContextRef` once and updates its `current` on each render.
+ * Every read-back-mutable value is exposed as a getter or ref so the engine
+ * impls see fresh state across `await` boundaries. The provider holds a set
+ * of long-lived "live" refs (`stateRef`, `currentTourRef`, `dataRef`,
+ * `stepIdMapRef`) that are refreshed each render to mirror the latest
+ * committed values; the getters here close over those refs, NOT over a
+ * render-scoped `state` const. As a result, even if an engine impl captures
+ * `ctx` during render N, calling `ctx.getState()` after a state-changing
+ * dispatch reads the render-N+1 value through the shared ref.
+ *
+ * `engineContextRef` itself is rebuilt each render so non-getter fields
+ * (`router`, `autoNavigate`, consumer callbacks) stay current.
  */
 export interface TourEngineContext {
   // ─── State accessors (getters — read fresh on every call) ────────────────

--- a/packages/core/src/lib/tour-engine/context.ts
+++ b/packages/core/src/lib/tour-engine/context.ts
@@ -1,0 +1,58 @@
+import type * as React from 'react'
+import type { RouterAdapter } from '../../types/router'
+import type { Tour } from '../../types/tour'
+import type { TourAction, TourReducerState } from '../../types/tour-reducer'
+import type { TourRouteError } from '../wait-for-step-target'
+
+/**
+ * Minimal slice of `TourKitContextValue` consumed by engine functions for
+ * analytics fan-out. Declared locally so engine modules do not pull in the
+ * full provider type (which would re-introduce a circular import surface).
+ */
+export interface TourEngineAnalytics {
+  onStepView?: (tourId: string, stepId: string, stepIndex: number) => void
+  onTourStart?: (tourId: string) => void
+  onTourBranch?: (fromTourId: string, toTourId: string, stepId: string) => void
+}
+
+/**
+ * Engine-scoped context shared by `navigateToStep` and `handleBranchTarget`.
+ *
+ * Every read-back-mutable value is exposed as a getter or ref. This is
+ * deliberate — the engine functions are `await`ed across microtask boundaries
+ * and would otherwise capture stale state via closure. The provider builds a
+ * stable `engineContextRef` once and updates its `current` on each render.
+ */
+export interface TourEngineContext {
+  // ─── State accessors (getters — read fresh on every call) ────────────────
+  getState: () => TourReducerState
+  getCurrentTour: () => Tour | null
+  getData: () => Record<string, unknown>
+  getStepIdMap: () => Map<string, number>
+
+  // ─── Dispatch + refs ─────────────────────────────────────────────────────
+  dispatch: React.Dispatch<TourAction>
+  abortControllerRef: React.RefObject<AbortController | null>
+  completedTourIdRef: React.RefObject<string | null>
+  skippedTourIdRef: React.RefObject<string | null>
+
+  // ─── Config (static for the provider's lifetime) ─────────────────────────
+  router?: RouterAdapter
+  autoNavigate: boolean
+  maxHiddenChain: number
+
+  // ─── Consumer callbacks ──────────────────────────────────────────────────
+  onNavigationRequired?: (route: string, stepId: string) => void
+  onStepError?: (err: TourRouteError) => void
+
+  // ─── Provider-owned helpers ──────────────────────────────────────────────
+  completeTour: () => void
+  skipTour: () => void
+  setData: (key: string, value: unknown) => void
+
+  // ─── Cross-extraction call (handleBranchTarget → navigateToStep) ─────────
+  navigateToStep: (stepIndex: number) => Promise<boolean>
+
+  // ─── Analytics fan-out ───────────────────────────────────────────────────
+  tourKitContext: TourEngineAnalytics | null
+}

--- a/packages/core/src/lib/tour-engine/handle-branch-target.ts
+++ b/packages/core/src/lib/tour-engine/handle-branch-target.ts
@@ -1,0 +1,214 @@
+import type { BranchContext, BranchTarget, TourCallbackContext } from '../../types'
+import {
+  isBranchToTour,
+  isBranchWait,
+  isLoopDetected,
+  isSpecialTarget,
+  resolveTargetToIndex,
+} from '../../utils/branch'
+import { logger } from '../../utils/logger'
+import type { TourEngineContext } from './context'
+import { buildCallbackContext, evaluateStepWhen, findNextVisibleStepIndex } from './helpers'
+
+/**
+ * Resolve a `BranchTarget` to its effect on the active tour. Mirrors the
+ * branch-handling matrix documented in the provider — terminal targets
+ * (`'complete'` / `'skip'` / `'restart'`), cross-tour navigation, branch
+ * delays, loop detection, `when`-filtered targets, and the success path that
+ * tracks step view + fires `onStepChange`.
+ *
+ * Calls `ctx.navigateToStep` for actual route-aware navigation; never
+ * imports `navigate-to-step` directly so swap-points and circular surface
+ * stay clean.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: branch navigation with multiple target types
+export async function handleBranchTargetImpl(
+  ctx: TourEngineContext,
+  target: BranchTarget,
+  branchContext: BranchContext,
+  actionId?: string
+): Promise<void> {
+  void branchContext
+  void actionId
+
+  const state = ctx.getState()
+  const currentTour = ctx.getCurrentTour()
+  const data = ctx.getData()
+
+  if (!currentTour || !state.currentStep) return
+
+  const currentStepId = state.currentStep.id
+
+  // null - stay on current step
+  if (target === null) {
+    ctx.dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
+    return
+  }
+
+  // Special targets
+  if (isSpecialTarget(target)) {
+    switch (target) {
+      case 'complete':
+        ctx.completeTour()
+        return
+
+      case 'skip':
+        ctx.skipTour()
+        return
+
+      case 'restart': {
+        ctx.dispatch({ type: 'CLEAR_VISIT_TRACKING' })
+        ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: 0 })
+        const firstStep = currentTour.steps[0]
+        if (firstStep) {
+          ctx.dispatch({
+            type: 'TRACK_STEP_VISIT',
+            stepId: firstStep.id,
+            previousStepId: currentStepId,
+          })
+          ctx.tourKitContext?.onStepView?.(currentTour.id, firstStep.id, 0)
+        }
+        return
+      }
+
+      case 'next':
+      case 'prev':
+        // Resolve to index and fall through to the resolveTargetToIndex path
+        break
+    }
+  }
+
+  // BranchToTour - cross-tour navigation
+  if (isBranchToTour(target)) {
+    const toTour = state.tours.get(target.tour)
+    if (!toTour) {
+      logger.warn(`Branch target tour "${target.tour}" not found`)
+      ctx.dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
+      return
+    }
+
+    ctx.tourKitContext?.onTourBranch?.(currentTour.id, target.tour, currentStepId)
+    currentTour.onTourBranch?.(target.tour, currentStepId)
+
+    ctx.dispatch({ type: 'STOP_TOUR' })
+
+    let newStepIndex = 0
+    if (target.step !== undefined) {
+      if (typeof target.step === 'number') {
+        newStepIndex = target.step
+      } else {
+        const newTourStepMap = new Map<string, number>()
+        toTour.steps.forEach((s, i) => newTourStepMap.set(s.id, i))
+        newStepIndex = newTourStepMap.get(target.step) ?? 0
+      }
+    }
+
+    // Re-arm terminal-callback guards for the new tour
+    ctx.completedTourIdRef.current = null
+    ctx.skippedTourIdRef.current = null
+
+    ctx.dispatch({ type: 'START_TOUR', tourId: target.tour, stepIndex: newStepIndex })
+    ctx.tourKitContext?.onTourStart?.(target.tour)
+    toTour.onStart?.({ ...state, tour: toTour, data })
+    return
+  }
+
+  // BranchWait - delay before proceeding
+  if (isBranchWait(target)) {
+    await new Promise((resolve) => setTimeout(resolve, target.wait))
+    if (target.then) {
+      await handleBranchTargetImpl(ctx, target.then, branchContext, actionId)
+    }
+    return
+  }
+
+  // Resolve target to index
+  const targetIndex = resolveTargetToIndex(
+    target,
+    state.currentStepIndex,
+    ctx.getStepIdMap(),
+    currentTour.steps.length
+  )
+
+  if (targetIndex === null || targetIndex === state.currentStepIndex) {
+    ctx.dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
+    return
+  }
+
+  // Check for loop detection
+  const targetStep = currentTour.steps[targetIndex]
+  if (targetStep && isLoopDetected(targetStep.id, state.stepVisitCount)) {
+    logger.warn(
+      `Loop detected: step "${targetStep.id}" visited too many times. Stopping navigation.`
+    )
+    ctx.dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
+    return
+  }
+
+  // Apply `when` filter to the target step
+  const context = buildCallbackContext(state, currentTour, data)
+  const stepContext: TourCallbackContext = {
+    ...context,
+    currentStepIndex: targetIndex,
+    currentStep: targetStep ?? null,
+  }
+
+  if (targetStep) {
+    const shouldShow = await evaluateStepWhen(targetStep, stepContext)
+    if (!shouldShow) {
+      const direction = targetIndex > state.currentStepIndex ? 1 : -1
+      const visibleIndex = await findNextVisibleStepIndex(
+        targetIndex + direction,
+        direction as 1 | -1,
+        currentTour.steps,
+        context
+      )
+
+      if (visibleIndex === -1) {
+        ctx.completeTour()
+        return
+      }
+
+      const navigated = await ctx.navigateToStep(visibleIndex)
+      if (!navigated) {
+        ctx.dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
+        return
+      }
+      const step = currentTour.steps[visibleIndex]
+      if (step) {
+        ctx.dispatch({
+          type: 'TRACK_STEP_VISIT',
+          stepId: step.id,
+          previousStepId: currentStepId,
+        })
+        ctx.tourKitContext?.onStepView?.(currentTour.id, step.id, visibleIndex)
+        currentTour.onStepChange?.(step, visibleIndex, {
+          ...state,
+          tour: currentTour,
+          data,
+        })
+      }
+      return
+    }
+  }
+
+  // Navigate to target step
+  const navigated = await ctx.navigateToStep(targetIndex)
+  if (!navigated) {
+    ctx.dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
+    return
+  }
+  if (targetStep) {
+    ctx.dispatch({
+      type: 'TRACK_STEP_VISIT',
+      stepId: targetStep.id,
+      previousStepId: currentStepId,
+    })
+    ctx.tourKitContext?.onStepView?.(currentTour.id, targetStep.id, targetIndex)
+    currentTour.onStepChange?.(targetStep, targetIndex, {
+      ...state,
+      tour: currentTour,
+      data,
+    })
+  }
+}

--- a/packages/core/src/lib/tour-engine/handle-branch-target.ts
+++ b/packages/core/src/lib/tour-engine/handle-branch-target.ts
@@ -25,12 +25,12 @@ import { buildCallbackContext, evaluateStepWhen, findNextVisibleStepIndex } from
 export async function handleBranchTargetImpl(
   ctx: TourEngineContext,
   target: BranchTarget,
+  // `branchContext` and `actionId` are forwarded into the BranchWait recursion
+  // below; they're part of the public branching surface but are not consumed
+  // by this impl directly.
   branchContext: BranchContext,
   actionId?: string
 ): Promise<void> {
-  void branchContext
-  void actionId
-
   const state = ctx.getState()
   const currentTour = ctx.getCurrentTour()
   const data = ctx.getData()

--- a/packages/core/src/lib/tour-engine/helpers.ts
+++ b/packages/core/src/lib/tour-engine/helpers.ts
@@ -1,0 +1,107 @@
+import type { RouterAdapter } from '../../types/router'
+import type { TourCallbackContext, TourState } from '../../types/state'
+import type { TourStep } from '../../types/step'
+import type { Tour } from '../../types/tour'
+import { logger } from '../../utils/logger'
+
+/**
+ * Whether the step requires the router to navigate before mount.
+ */
+export function isNavigationNeeded(
+  step: TourStep | undefined,
+  router: RouterAdapter | undefined
+): { needed: boolean; isOnRoute: boolean } {
+  if (!step?.route || !router) {
+    return { needed: false, isOnRoute: true }
+  }
+  const matchMode = step.routeMatch ?? 'exact'
+  const isOnRoute = router.matchRoute(step.route, matchMode)
+  return { needed: !isOnRoute, isOnRoute }
+}
+
+/**
+ * Build a `TourCallbackContext` from the reducer state, current tour, and
+ * data slice. Shared by `navigateToStep` and `handleBranchTarget` for `when`
+ * evaluation and lifecycle callbacks.
+ */
+export function buildCallbackContext(
+  state: TourState,
+  tour: Tour | null,
+  data: Record<string, unknown>
+): TourCallbackContext {
+  return {
+    tourId: state.tourId,
+    isActive: state.isActive,
+    currentStepIndex: state.currentStepIndex,
+    currentStep: state.currentStep,
+    totalSteps: state.totalSteps,
+    isLoading: state.isLoading,
+    isTransitioning: state.isTransitioning,
+    completedTours: state.completedTours,
+    skippedTours: state.skippedTours,
+    visitedSteps: state.visitedSteps,
+    stepVisitCount: state.stepVisitCount,
+    previousStepId: state.previousStepId,
+    tour,
+    data,
+  }
+}
+
+/**
+ * Evaluate a step's `when` predicate. Defaults to true on undefined; any
+ * thrown error is logged and treated as `false` (skip the step) so a buggy
+ * predicate cannot brick the tour.
+ */
+export async function evaluateStepWhen(
+  step: TourStep,
+  context: TourCallbackContext
+): Promise<boolean> {
+  if (!step.when) return true
+  try {
+    return await step.when(context)
+  } catch (error) {
+    logger.warn(`Error evaluating when condition for step "${step.id}":`, error)
+    return false
+  }
+}
+
+/**
+ * Walk steps in `direction` from `startIndex` (inclusive) until a step's
+ * `when` predicate returns true or the array boundary is reached.
+ *
+ * @returns The matching index, or `-1` when no visible step exists.
+ */
+export async function findNextVisibleStepIndex(
+  startIndex: number,
+  direction: 1 | -1,
+  steps: TourStep[],
+  context: TourCallbackContext
+): Promise<number> {
+  let index = startIndex
+  while (index >= 0 && index < steps.length) {
+    const step = steps[index]
+    if (!step) break
+    const stepContext: TourCallbackContext = {
+      ...context,
+      currentStepIndex: index,
+      currentStep: step,
+    }
+    const shouldShow = await evaluateStepWhen(step, stepContext)
+    if (shouldShow) return index
+    index += direction
+  }
+  return -1
+}
+
+/**
+ * Nearest visible step from `startIndex` — tries forward, then backward.
+ */
+export async function findNearestVisibleStepIndex(
+  startIndex: number,
+  steps: TourStep[],
+  context: TourCallbackContext
+): Promise<number> {
+  const forwardIndex = await findNextVisibleStepIndex(startIndex, 1, steps, context)
+  if (forwardIndex !== -1) return forwardIndex
+  return findNextVisibleStepIndex(startIndex - 1, -1, steps, context)
+}

--- a/packages/core/src/lib/tour-engine/navigate-to-step.ts
+++ b/packages/core/src/lib/tour-engine/navigate-to-step.ts
@@ -1,0 +1,160 @@
+import type { BranchContext, TourCallbackContext } from '../../types'
+import type { TourStep } from '../../types/step'
+import type { Tour } from '../../types/tour'
+import { resolveBranch, resolveTargetToIndex } from '../../utils/branch'
+import { TourValidationError } from '../validate-tour'
+import { TourRouteError, waitForStepTarget } from '../wait-for-step-target'
+import type { TourEngineContext } from './context'
+import { buildCallbackContext, isNavigationNeeded } from './helpers'
+
+/**
+ * Run a hidden step's lifecycle and return either the next cursor or
+ * `'terminate'` if the step's `onNext` resolves to a terminal target.
+ */
+async function advancePastHiddenStep(
+  ctx: TourEngineContext,
+  step: TourStep,
+  cursor: number,
+  tour: Tour,
+  stepIdLookup: Map<string, number>
+): Promise<number | 'terminate'> {
+  const state = ctx.getState()
+  const data = ctx.getData()
+  const baseCtx = buildCallbackContext(state, tour, data)
+  const stepCtx: TourCallbackContext = {
+    ...baseCtx,
+    currentStepIndex: cursor,
+    currentStep: step,
+  }
+  await step.onEnter?.(stepCtx)
+  await step.onShow?.(stepCtx)
+
+  if (step.onNext === undefined || step.onNext === null) {
+    return cursor + 1
+  }
+
+  const branchCtx: BranchContext = { ...stepCtx, setData: ctx.setData }
+  const target = await resolveBranch(step.onNext, branchCtx)
+
+  if (target === 'complete' || target === 'skip') {
+    return 'terminate'
+  }
+
+  const idx = resolveTargetToIndex(target, cursor, stepIdLookup, tour.steps.length)
+  return idx ?? cursor + 1
+}
+
+/**
+ * Route-aware step navigation.
+ *
+ * Walks past hidden steps (firing their `onEnter` / `onShow` lifecycle) until
+ * a mountable step is reached, then dispatches `GO_TO_STEP`. Throws
+ * `TourValidationError({ code: 'HIDDEN_STEP_LOOP' })` when the hidden chain
+ * exceeds `ctx.maxHiddenChain`.
+ *
+ * Per-step `routeChangeStrategy`:
+ * - `'auto'` (default): navigate, await target via `waitForStepTarget`,
+ *   dispatch. On `TourRouteError`: fire `onStepError`, `STOP_TOUR`.
+ * - `'prompt'`: fire `onNavigationRequired(route, stepId)`, do not dispatch.
+ * - `'manual'`: do nothing — consumer drives navigation explicitly.
+ *
+ * `autoNavigate: false` (legacy) is equivalent to per-step `'prompt'`.
+ *
+ * @returns `true` on a successful synchronous-or-route-based dispatch, `false`
+ *   when navigation is deferred to the consumer or aborted, throws on a
+ *   hidden-step loop.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: hidden-traversal + route navigation in one orchestrator
+export async function navigateToStepImpl(
+  ctx: TourEngineContext,
+  stepIndex: number
+): Promise<boolean> {
+  const currentTour = ctx.getCurrentTour()
+  if (!currentTour) {
+    ctx.dispatch({ type: 'GO_TO_STEP', stepIndex })
+    return true
+  }
+
+  const localStepIdMap = new Map<string, number>()
+  currentTour.steps.forEach((s, i) => localStepIdMap.set(s.id, i))
+
+  let cursor = stepIndex
+  for (let chain = 0; chain <= ctx.maxHiddenChain; chain++) {
+    const step = currentTour.steps[cursor]
+    if (!step) {
+      ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
+      return false
+    }
+
+    if (step.kind !== 'hidden') {
+      const { needed } = isNavigationNeeded(step, ctx.router)
+      if (!needed || !step.route || !ctx.router) {
+        ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
+        return true
+      }
+
+      if (!ctx.autoNavigate) {
+        ctx.onNavigationRequired?.(step.route, step.id)
+        return false
+      }
+
+      const strategy = step.routeChangeStrategy ?? 'auto'
+
+      if (strategy === 'manual') {
+        return false
+      }
+
+      if (strategy === 'prompt') {
+        ctx.onNavigationRequired?.(step.route, step.id)
+        return false
+      }
+
+      // strategy === 'auto'
+      try {
+        const navResult = await ctx.router.navigate(step.route)
+        if (navResult === false) {
+          throw new TourRouteError({
+            code: 'NAVIGATION_REJECTED',
+            route: step.route,
+            message: `Router rejected navigation to "${step.route}".`,
+          })
+        }
+
+        if (step.routeDelay && step.routeDelay > 0) {
+          await new Promise((resolve) => setTimeout(resolve, step.routeDelay))
+        }
+
+        await waitForStepTarget(step, {
+          route: step.route,
+          timeoutMs: step.waitTimeout ?? 3000,
+          signal: ctx.abortControllerRef.current?.signal,
+        })
+      } catch (err) {
+        if (ctx.abortControllerRef.current?.signal.aborted) return false
+        if (err instanceof TourRouteError) {
+          ctx.onStepError?.(err)
+          ctx.dispatch({ type: 'STOP_TOUR' })
+          return false
+        }
+        throw err
+      }
+
+      ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
+      return true
+    }
+
+    const next = await advancePastHiddenStep(ctx, step, cursor, currentTour, localStepIdMap)
+    if (next === 'terminate') {
+      ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: currentTour.steps.length })
+      return false
+    }
+    cursor = next
+  }
+
+  const stuckStep = currentTour.steps[cursor]
+  throw new TourValidationError({
+    code: 'HIDDEN_STEP_LOOP',
+    stepId: stuckStep?.id ?? '?',
+    message: `Hidden-step chain exceeded ${ctx.maxHiddenChain} iterations${stuckStep ? ` at step "${stuckStep.id}"` : ''}. Likely an infinite loop.`,
+  })
+}

--- a/packages/core/src/types/tour-reducer.ts
+++ b/packages/core/src/types/tour-reducer.ts
@@ -1,0 +1,33 @@
+import type { TourState } from './state'
+import type { Tour } from './tour'
+
+/**
+ * Reducer-scoped tour state. Extends the public {@link TourState} with the
+ * `tours` Map the reducer keeps to resolve `tourId → Tour` synchronously
+ * inside action handlers. The public state surface (`TourContextValue`) does
+ * not expose this Map — consumers receive `tour: Tour | null` instead.
+ */
+export interface TourReducerState extends TourState {
+  tours: Map<string, Tour>
+}
+
+/**
+ * Discriminated-union of reducer actions. Lives in `types/` so engine modules
+ * (`lib/tour-engine/*`) can dispatch without importing the provider.
+ */
+export type TourAction =
+  | { type: 'START_TOUR'; tourId: string; stepIndex?: number }
+  | { type: 'NEXT_STEP' }
+  | { type: 'PREV_STEP' }
+  | { type: 'GO_TO_STEP'; stepIndex: number }
+  | { type: 'SKIP_TOUR' }
+  | { type: 'COMPLETE_TOUR' }
+  | { type: 'STOP_TOUR' }
+  | { type: 'SET_LOADING'; isLoading: boolean }
+  | { type: 'SET_TRANSITIONING'; isTransitioning: boolean }
+  | { type: 'ADD_COMPLETED'; tourId: string }
+  | { type: 'ADD_SKIPPED'; tourId: string }
+  | { type: 'RESET'; tourId?: string }
+  | { type: 'UPDATE_TOURS'; tours: Tour[] }
+  | { type: 'TRACK_STEP_VISIT'; stepId: string; previousStepId: string | null }
+  | { type: 'CLEAR_VISIT_TRACKING' }


### PR DESCRIPTION
## Phase 5 — TourProvider Navigation Extraction (Refactor Train)

Extracts `navigateToStep` and `handleBranchTarget` (the two largest navigation orchestrators) out of `packages/core/src/context/tour-provider.tsx` into pure module-level functions under `packages/core/src/lib/tour-engine/`.

### Changes
- **`types/tour-reducer.ts`** *(new)* — `TourAction` and `TourReducerState` hoisted so engine modules can dispatch without importing the provider.
- **`lib/tour-engine/context.ts`** *(new)* — `TourEngineContext` interface: getters back onto provider-owned "live" refs (`stateRef`, `currentTourRef`, `dataRef`, `stepIdMapRef`). A `ctx` captured by an impl during render N observes render N+1's state through the same long-lived ref. `TourEngineAnalytics` declared inline to avoid circular imports.
- **`lib/tour-engine/helpers.ts`** *(new)* — pure step-visibility utilities (`buildCallbackContext`, `evaluateStepWhen`, `findNextVisibleStepIndex`, `findNearestVisibleStepIndex`, `isNavigationNeeded`) shared by both engine impls and the surviving provider callbacks (`start`/`next`/`prev`/`goTo`).
- **`lib/tour-engine/navigate-to-step.ts`** *(new)* — `navigateToStepImpl` + the `advancePastHiddenStep` helper. Identical behavior: hidden-chain walking + `routeChangeStrategy` matrix + `waitForStepTarget` cancellation.
- **`lib/tour-engine/handle-branch-target.ts`** *(new)* — `handleBranchTargetImpl` covering all 11 branch cases (null / complete / skip / restart / cross-tour ± named-step / BranchWait+then / current-index / loop detection / when-false → next visible or completeTour / success path).
- **`tour-provider.tsx`** — drops to 1377 LOC (was 1803, −426). Three `noExcessiveCognitiveComplexity` ignores remain (reducer, flow-restore, `prev`). `navigateToStep` + `handleBranchTarget` become thin `useCallback` wrappers that dispatch through `engineContextRef.current`; the four live state refs are refreshed in-render so engine getters always read the latest committed values, even when an impl captured `ctx` during an earlier render.

### Cross-await fresh state — the design point
The engine impls are `await`ed across microtask boundaries. Naive useCallback-closure-style state capture (what the original code did, and what the first cut of this PR also did) means a BranchWait recursion or a `waitForStepTarget` resume reads stale state from before the await.

This PR routes every engine getter through a long-lived ref:

```ts
// tour-provider.tsx
const stateRef = React.useRef(state)
stateRef.current = state                          // refresh per render

engineContextRef.current = {
  getState: () => stateRef.current,               // reads live ref
  ...
}
```

`engineContextRef.current` is replaced each render so non-getter fields stay current, but the getters all close over the SAME refs across renders. A captured `ctx_N` and a fresh `ctx_N+1` therefore both resolve to the same live source.

### Tests
- **`tour-engine/__tests__/_helpers/`** — `FakeTourEngineContext` factory with mutable backing variables under getters that mirror the production ref-indirection semantics; `setState`/`setCurrentTour` mutators for cross-await regression coverage; tour/step factories.
- **`handle-branch-target.test.ts`** — 18 tests across all branch cases. Includes a **real** US-5 cross-await test that starts a BranchWait→`'b'`, mutates `currentStepIndex` to 1 mid-wait, and asserts the recursion sees the fresh index (current-index short-circuit fires, no navigation). Cross-tour test now pre-arms terminal-guard refs to `'t1'` so the post-call `null` assertion actually verifies the impl cleared them.
- **`navigate-to-step.test.ts`** — 12 tests across all navigation cases incl. abort short-circuit and `HIDDEN_STEP_LOOP` enforcement.
- **`tour-engine-context.test.ts`** — getters reflect mutations between calls; `abortControllerRef.abort()` flips signal on same ref.
- **`provider-complexity-ignores.test.ts`** — source-grep M5 gate asserting exactly 3 ignores in `tour-provider.tsx`.

Existing provider integration suites (`tour-provider.test.tsx`, `tour-provider-hidden.test.tsx`, `branching.test.tsx`, `tour-provider-flow-session.test.tsx`, `test-bridge.test.tsx`) are unchanged — they are the regression net. All 928 prior tests pass alongside the 35 new ones (963 total in @tour-kit/core).

### Validation
- `pnpm --filter @tour-kit/core test` — 963 passed, 3 skipped (was 928)
- `pnpm --filter @tour-kit/core typecheck` — clean
- `pnpm typecheck` (workspace) — clean
- `pnpm lint` (biome) — clean
- `pnpm build` — all 21 packages green
- `wc -l packages/core/src/context/tour-provider.tsx` — **1377** (was 1803)
- `rg "noExcessiveCognitiveComplexity" packages/core/src/context/tour-provider.tsx` — exactly **3** matches (reducer, flow-restore, `prev`)

### Trade-off vs phase plan
The plan's ideal end state is **zero** complexity ignores in the extracted engine files. This PR keeps the original two ignores on `navigateToStepImpl` and `handleBranchTargetImpl` because both functions are inherently branchy orchestrators and splitting them further raised the risk of behavior regression without test-equivalent payoff. The provider's 5→3 ignore reduction is the load-bearing target and is met. A follow-up can split the engine impls into smaller helpers once the surface has settled.

### Closure read catalog (PR review map)
**`navigateToStep`:** `currentTour` (getter), `dispatch`, `router`, `autoNavigate`, `onNavigationRequired`, `onStepError`, `abortControllerRef`; via `advancePastHiddenStep`: `state` (getter), `data` (getter), `setData`. Pure imports: `isNavigationNeeded`, `TourRouteError`, `waitForStepTarget`, `TourValidationError`, `resolveBranch`, `resolveTargetToIndex`.

**`handleBranchTarget`:** `currentTour` (getter), `state.{currentStep,tours,currentStepIndex,stepVisitCount}` (getter), `data` (getter), `stepIdMap` (getter), `tourKitContext`, `navigateToStep` (via ctx), `completeTour`, `skipTour`, `dispatch`, `completedTourIdRef`, `skippedTourIdRef`. Pure imports: `isSpecialTarget`, `isBranchToTour`, `isBranchWait`, `resolveTargetToIndex`, `isLoopDetected`, `logger`.

## Test plan
- [x] `pnpm --filter @tour-kit/core test` exits 0 (963 passed)
- [x] `pnpm --filter @tour-kit/core typecheck` exits 0
- [x] `pnpm --filter @tour-kit/react test` exits 0
- [x] `pnpm typecheck` exits 0
- [x] `pnpm build` exits 0
- [x] `pnpm lint` exits 0
- [x] `wc -l packages/core/src/context/tour-provider.tsx` < 1500
- [x] `rg "noExcessiveCognitiveComplexity" packages/core/src/context/tour-provider.tsx` returns exactly 3
- [x] The 5 listed provider integration test files are unchanged in this PR
- [x] Real cross-await US-5 test exercises BranchWait recursion against a mid-wait `setState` and asserts the recursion observes the fresh index
- [ ] Manual smoke in `dashboard-next` covering hidden-step, route-auto/manual, cross-tour branch, BranchWait+then, loop-detection paths

🤖 Generated with run-phase skill