### PR TITLE
chore: add changesets for #68 and #69 ahead of release

### DIFF
--- a/.changeset/phase-5-tour-engine-extraction.md
+++ b/.changeset/phase-5-tour-engine-extraction.md
@@ -1,0 +1,22 @@
+---
+'@tour-kit/core': patch
+---
+
+Extract TourProvider navigation orchestrators into the new internal
+`tour-engine` module (refactor-train phase 5).
+
+`navigateToStep`, `handleBranchTarget`, and the related step-visibility
+helpers (`buildCallbackContext`, `evaluateStepWhen`, `findNextVisibleStepIndex`,
+`findNearestVisibleStepIndex`, `isNavigationNeeded`) move out of
+`tour-provider.tsx` into pure module-level functions under
+`packages/core/src/lib/tour-engine/`. The engine impls receive a
+`TourEngineContext` (refs/getters) so async navigation reads fresh state
+across await boundaries.
+
+Behavior is preserved: all 928 existing core tests pass, plus 34 new direct
+engine unit tests. Provider LOC drops from 1803 to 1372, and the
+`noExcessiveCognitiveComplexity` ignore count drops from 5 to 3 (reducer,
+flow-restore, prev — `navigateToStep` and `handleBranchTarget` no longer
+need provider-side ignores).
+
+No public API change.

--- a/.changeset/qa-banner-sticky-modal-a11y.md
+++ b/.changeset/qa-banner-sticky-modal-a11y.md
@@ -1,0 +1,18 @@
+---
+'@tour-kit/announcements': patch
+---
+
+QA fixes surfaced by the dashboard-next example.
+
+- `AnnouncementBanner` now defaults to `sticky: true`. Without an explicit
+  `sticky` value the banner was rendering as a flow-positioned flex sibling,
+  which in flex/grid layouts (like dashboard-next's `AnnouncementsHost`) ate
+  ~728px of horizontal space and squeezed `<main>` from 1171px to 442px.
+  Both the cva `defaultVariants` and the `effectiveSticky ?? true` fallback
+  now agree on `true`; opt out with `sticky={false}` or
+  `bannerOptions.sticky = false`.
+- `AnnouncementModal` adds an explicit `aria-modal="true"` on
+  `Dialog.Content` so screen readers can detect modality.
+- `ScheduledBanner` (example) wraps its diagnostic body in a mount guard so
+  the SSR/CSR diagnostic text no longer diverges (`not_registered` vs
+  `wrong_time`).


### PR DESCRIPTION
## Summary

- Adds a missing patch changeset for **#68** (refactor-train phase 5 — TourProvider navigation extraction into `tour-engine`) targeting `@tour-kit/core`.
- Adds a missing patch changeset for **#69** (QA: announcements banner sticky default + modal `aria-modal` + Tailwind `@source` coverage) targeting `@tour-kit/announcements`.
- No code changes — only `.changeset/*.md` files.

## Why

Both PRs landed on `main` after `chore: version packages (#63)` without attaching changesets, so their changes are not yet slated for any version bump. Adding the changesets retroactively lets the next Changesets cycle pick them up.

Side-effect (intentional): the `updateInternalDependencies: "patch"` setting in `.changeset/config.json` cascades the bump to every downstream package, so the resulting publish run will also cover the 15 versions already bumped at HEAD whose previous publish attempts on `main` failed with `E404 Not Found` from the npm registry.

The publish failures are a separate, infrastructure-level issue (likely an expired/rotated `NPM_TOKEN` secret on the Release workflow — last 4 release runs failed; last success was on commit `d075815b` 2026-05-22T07:21Z). Refreshing the token is a prerequisite for this release to actually publish.

## Test plan

- [ ] CI green on this PR (typecheck, lint, build).
- [ ] After merge, confirm the Release workflow opens a `chore: version packages` follow-up PR that includes patch bumps for `@tour-kit/core` and `@tour-kit/announcements` plus the cascaded internal-dep updates.
- [ ] After refreshing the `NPM_TOKEN` repo secret and merging the version-packages PR, confirm the Release workflow publishes all bumped packages and creates the corresponding git tags.