### PR TITLE
docs: cover 100% of public exports + narrow @tour-kit/codemods surface

### DIFF
--- a/.changeset/codemods-narrow-public-surface.md
+++ b/.changeset/codemods-narrow-public-surface.md
@@ -1,0 +1,19 @@
+---
+'@tour-kit/codemods': minor
+---
+
+Narrow the public API surface to CLI-only.
+
+The previous JS-API re-exports (`fromJoyride`, `fromJoyrideParser`, `mapStepObject`,
+`emitTodo`, `todoToComment`, `runMigrate`) and their accompanying types
+(`StepMapping`, `Todo`, `CliOptions`) were intended as internal helpers but
+ended up in `packages/codemods/src/index.ts`. The package ships with a `bin`
+(`tour-kit-migrate`) and is consumed exclusively via `npx tour-kit-migrate`,
+so the JS API was undocumented and unused outside the package itself.
+
+**Breaking:** `import { ... } from '@tour-kit/codemods'` now returns nothing.
+If you were depending on the programmatic API, please open an issue describing
+your use case — we'd rather build a small, documented surface than leave the
+current accidental exports in place.
+
+The CLI behavior is unchanged.

--- a/apps/docs/content/docs/announcements/hooks/meta.json
+++ b/apps/docs/content/docs/announcements/hooks/meta.json
@@ -4,6 +4,8 @@
     "use-announcement",
     "use-announcements",
     "use-announcement-queue",
-    "use-announcements-context"
+    "use-announcements-context",
+    "use-filtered-announcements",
+    "use-resolved-text"
   ]
 }

--- a/apps/docs/content/docs/announcements/hooks/use-filtered-announcements.mdx
+++ b/apps/docs/content/docs/announcements/hooks/use-filtered-announcements.mdx
@@ -1,0 +1,57 @@
+---
+title: useFilteredAnnouncements
+description: >-
+  Filter a list of AnnouncementConfig by their `audience` prop. Bulk segment
+  evaluation that is safe under dynamic lists.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Filter a list of `AnnouncementConfig` objects by their `audience` prop. Returns a new array containing only the announcements whose audience passes the current segmentation context.
+
+## Usage
+
+```tsx
+import { useFilteredAnnouncements } from '@tour-kit/announcements';
+
+function ChangelogList({ announcements }: { announcements: AnnouncementConfig[] }) {
+  const visible = useFilteredAnnouncements(announcements);
+  return (
+    <ul>
+      {visible.map((a) => (
+        <li key={a.id}>{a.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+## Signature
+
+```ts
+function useFilteredAnnouncements(
+  announcements: AnnouncementConfig[]
+): AnnouncementConfig[]
+```
+
+## Audience evaluation rules
+
+| Audience shape | Behavior |
+|----------------|----------|
+| `undefined` | Let through (always visible). |
+| `AudienceCondition[]` | Let through — forwarded to the scheduler, which re-checks against the provider's `userContext` prop. |
+| `{ segment: string }` | Evaluated here via [`useSegments`](/docs/core/hooks/use-segments). Filtered out if the segment is `false`. |
+
+<Callout type="info">
+Only segment-shape audiences are filtered at this seam — array-shape audiences pass through because they require the provider's `userContext`, which the framework-agnostic scheduler owns. See the [segmentation guide](/docs/guides/segmentation) for the full evaluation pipeline.
+</Callout>
+
+## Why bulk?
+
+The hook reads all segments once at the top via `useSegments()` and reuses that map inside the filter callback. This is safe under dynamic announcement lists — never call `useSegment` (the single-segment hook) inside a `.filter()` body; that violates the rules of hooks.
+
+## Related
+
+- [evaluateAnnouncementAudience](/docs/announcements/types) — underlying single-item evaluator
+- [Audience targeting](/docs/announcements/configuration) — audience prop reference
+- [Segmentation guide](/docs/guides/segmentation)

--- a/apps/docs/content/docs/announcements/hooks/use-resolved-text.mdx
+++ b/apps/docs/content/docs/announcements/hooks/use-resolved-text.mdx
@@ -1,0 +1,23 @@
+---
+title: useResolvedText
+description: >-
+  Re-export of @tour-kit/core's useResolvedText for ergonomic in-package
+  access. Resolves LocalizedText | ReactNode into a ReactNode.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Re-exported from [`@tour-kit/core`](/docs/core/hooks/use-resolved-text) so consumers using `@tour-kit/announcements` can import it from the same package as the rest of the API.
+
+```tsx
+import { useResolvedText } from '@tour-kit/announcements';
+
+function AnnouncementBody({ body }: { body: LocalizedText | React.ReactNode }) {
+  const resolved = useResolvedText(body);
+  return <div>{resolved}</div>;
+}
+```
+
+<Callout type="info">
+The canonical implementation lives in `@tour-kit/core`. See the [core docs](/docs/core/hooks/use-resolved-text) for the full signature, resolution rules, and the relationship with [`useResolveLocalizedText`](/docs/core/hooks/use-resolve-localized-text).
+</Callout>

--- a/apps/docs/content/docs/api/adoption.mdx
+++ b/apps/docs/content/docs/api/adoption.mdx
@@ -309,3 +309,34 @@ interface FeatureUsage {
   adoptedAt: Date | null;
 }
 ```
+
+### AdoptionFunnelProps
+
+```tsx
+interface AdoptionFunnelProps
+  extends Omit<React.ComponentPropsWithoutRef<'div'>, 'role' | 'aria-label' | 'children' | 'title'> {
+  /** Pre-computed funnel data, in display order */
+  steps: readonly FunnelStep[];
+  /** Optional header rendered above the bars */
+  title?: React.ReactNode;
+  /** Click/keyboard activation handler. When omitted, steps are not focusable */
+  onStepClick?: (step: FunnelStep, index: number) => void;
+  /** Replaces the default "No funnel data yet." message when steps is empty */
+  emptyState?: React.ReactNode;
+  /** Override the auto-generated chart summary on the role="img" element */
+  ariaLabel?: string;
+}
+```
+
+### UseFunnelDataInput
+
+```tsx
+interface UseFunnelDataInput {
+  /** Feature IDs in funnel order */
+  featureIds: readonly string[];
+  /** Optional label overrides keyed by feature id */
+  labels?: Partial<Record<string, string>>;
+}
+```
+
+Used by `useFunnelData()` to derive a current-state funnel from `useAdoptionStats`. For aggregated, date-ranged funnels, pass pre-computed data directly to `<AdoptionFunnel steps={...}>`.

--- a/apps/docs/content/docs/api/announcements.mdx
+++ b/apps/docs/content/docs/api/announcements.mdx
@@ -320,3 +320,102 @@ interface AnnouncementState {
   completedAt: Date | null;
 }
 ```
+
+### AudienceProp
+
+```tsx
+// Audience prop accepted by AnnouncementConfig.audience
+type AudienceProp = AudienceCondition[] | { segment: string };
+
+// Re-exported from @tour-kit/core
+import { isSegmentAudience } from '@tour-kit/announcements';
+isSegmentAudience(audience): audience is { segment: string };
+```
+
+### Audience Evaluator
+
+```tsx
+import { evaluateAnnouncementAudience } from '@tour-kit/announcements';
+
+// Single-item evaluator used by useFilteredAnnouncements. Returns `true` for
+// undefined and array-shape audiences (deferred to the scheduler); evaluates
+// the segment branch against the current segments map.
+evaluateAnnouncementAudience(
+  audience: AudienceProp | undefined,
+  segments: Record<string, boolean>
+): boolean;
+```
+
+### ForceShowBypassKey
+
+```tsx
+// Storage key used by useAnnouncement(id, { forceShow: true }) to bypass
+// frequency / schedule / persistence gates during development.
+const ForceShowBypassKey: string;
+```
+
+### Reactions
+
+```tsx
+type Reaction = '👍' | '👎' | '🎉' | '🚀' | '❤️' | '🤔';
+
+interface ReactionsProps {
+  announcementId: string;
+  available?: Reaction[];           // default: all
+  onReact?: (reaction: Reaction) => void;
+  className?: string;
+}
+```
+
+### Changelog Components
+
+```tsx
+interface ChangelogPageProps {
+  announcements: AnnouncementConfig[];
+  title?: string;
+  description?: string;
+  filters?: ChangelogFilterProps['filters'];
+  className?: string;
+}
+
+interface ChangelogFilterProps {
+  filters: Array<{ id: string; label: string; predicate: (a: AnnouncementConfig) => boolean }>;
+  value: string | null;
+  onChange: (next: string | null) => void;
+}
+
+interface ChangelogEntryProps {
+  announcement: AnnouncementConfig;
+  className?: string;
+}
+```
+
+See [Changelog page](/docs/announcements/changelog).
+
+### Toast Adapter
+
+Plug a host-app toast library (sonner, react-hot-toast, etc.) into `@tour-kit/announcements` instead of using the built-in toast variant.
+
+```tsx
+interface ToastAdapterRenderArgs {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  variant?: 'default' | 'success' | 'warning' | 'destructive';
+  duration?: number;
+  onDismiss?: () => void;
+  onAction?: () => void;
+}
+
+interface ToastAdapterHandle {
+  /** Dismiss the toast programmatically. */
+  dismiss: () => void;
+}
+
+interface ToastAdapter {
+  /** Show a toast and return a handle the provider can use to dismiss it. */
+  show: (args: ToastAdapterRenderArgs) => ToastAdapterHandle;
+}
+```
+
+Pass `<AnnouncementsProvider toastAdapter={...}>` to route toast-variant announcements through your adapter.

--- a/apps/docs/content/docs/api/checklists.mdx
+++ b/apps/docs/content/docs/api/checklists.mdx
@@ -372,7 +372,20 @@ type TaskAction =
 type TaskCompletionCondition =
   | { event: string }
   | { selector: string }
-  | { custom: (ctx: ChecklistContext) => boolean };
+  | { custom: (ctx: ChecklistContext) => boolean }
+  | UrlVisitCompletion;
+```
+
+### UrlVisitCompletion
+
+Marks a task as complete the first time the user visits a matching URL.
+
+```tsx
+type UrlVisitCompletion = {
+  type: 'urlVisit';
+  /** String compared via startsWith, or a RegExp matched against location.pathname */
+  urlPattern: string | RegExp;
+};
 ```
 
 ### ChecklistProgress

--- a/apps/docs/content/docs/api/core.mdx
+++ b/apps/docs/content/docs/api/core.mdx
@@ -522,6 +522,175 @@ interface MultiPagePersistenceConfig {
 }
 ```
 
+### Step Visibility & Targets
+
+```tsx
+// Discriminated union for filtered step lists. See useStep / useTour.
+type VisibleTourStep = TourStep & { __visible: true };
+type HiddenTourStep = TourStep & { __visible: false };
+
+function isVisibleStep(step: TourStep): step is VisibleTourStep;
+
+// Target resolution types
+type TourTargetRef = React.RefObject<HTMLElement | null>;
+type TourTargetGetter = () => HTMLElement | null;
+
+// Step media — image / video / lottie attached to a step
+interface TourStepMedia {
+  type: 'image' | 'video' | 'lottie';
+  src: string;
+  alt?: string;
+  poster?: string;
+}
+```
+
+### Target Waiting
+
+```tsx
+interface WaitForStepTargetOptions {
+  timeoutMs?: number;       // default: 5000
+  pollIntervalMs?: number;  // default: 50
+  signal?: AbortSignal;
+}
+
+// Resolves when a step's target appears in the DOM, rejects on timeout/abort.
+function waitForStepTarget(
+  step: TourStep,
+  options?: WaitForStepTargetOptions
+): Promise<HTMLElement>;
+```
+
+### i18n Types
+
+```tsx
+interface LocaleContextValue {
+  locale: string;
+  messages: Messages;
+  t?: TranslateFn;
+  direction?: 'ltr' | 'rtl';
+}
+
+interface LocaleProviderProps extends Partial<LocaleContextValue> {
+  children: React.ReactNode;
+}
+
+type TranslateFn = (key: string, vars?: Record<string, unknown>) => string;
+
+// Type guard for `LocalizedText`'s key-shape branch
+function isI18nKey(value: unknown): value is { key: string };
+```
+
+See [LocaleProvider](/docs/core/providers/locale-provider), [useLocale](/docs/core/hooks/use-locale), and the [i18n guide](/docs/guides/i18n).
+
+### Segmentation & Audience Types
+
+```tsx
+// Segments registered on <SegmentationProvider>
+type SegmentDefinition = AudienceCondition[];                    // AND-joined
+
+interface StaticSegment {
+  type: 'static';
+  userIds: ReadonlyArray<string>;
+}
+
+type SegmentSource = SegmentDefinition | StaticSegment;
+
+interface SegmentationContextValue {
+  segments: Record<string, SegmentSource>;
+  userContext?: Record<string, unknown>;
+  currentUserId?: string;
+}
+
+interface SegmentationProviderProps extends SegmentationContextValue {
+  children: React.ReactNode;
+}
+
+// Audience prop accepted on tours, hints, announcements
+type AudienceProp = AudienceCondition[] | { segment: string };
+
+// Type guard for the segment-shape branch
+function isSegmentAudience(audience: AudienceProp): audience is { segment: string };
+
+// Headless audience evaluator (re-exports in @tour-kit/react too)
+function evaluateAudience(
+  audience: AudienceProp | undefined,
+  segments: Record<string, boolean>,
+  userContext: Record<string, unknown> | undefined,
+  source?: string
+): boolean;
+
+// Returns a human-readable explanation of why an audience did/didn't match
+function explainAudience(
+  audience: AudienceProp,
+  segments: Record<string, boolean>,
+  userContext?: Record<string, unknown>
+): string;
+```
+
+See [Segmentation guide](/docs/guides/segmentation) and [useSegmentationContext](/docs/core/hooks/use-segmentation-context).
+
+### Diagnostic Types
+
+```tsx
+// All built-in gates evaluated by the can-show pipeline, in declared order
+const BUILTIN_GATE_ORDER: readonly GateName[];
+
+// Stable identifiers used by diagnostics and analytics events
+type GateName =
+  | 'audience' | 'segment' | 'frequency' | 'schedule'
+  | 'persistence' | 'capacity' | 'custom';
+
+type GateCode = 'pass' | 'fail' | 'skipped' | 'error';
+
+// Context passed to diagnostic listeners (eventbus, devtools)
+interface DiagnosticContext {
+  source: 'tour' | 'hint' | 'announcement' | 'checklist';
+  id: string;
+  gate: GateName;
+  code: GateCode;
+  reason?: string;
+}
+```
+
+See [Diagnostic guide](/docs/core/diagnostic).
+
+### Flow Session
+
+```tsx
+interface UseFlowSessionConfig {
+  flowId: string;
+  storage?: 'localStorage' | 'sessionStorage' | 'memory';
+  ttlMs?: number;
+}
+
+interface FlowSessionConfig extends UseFlowSessionConfig {
+  initialState?: Record<string, unknown>;
+}
+
+interface UseFlowSessionReturn<TState = Record<string, unknown>> {
+  state: TState;
+  setState: (next: Partial<TState>) => void;
+  clear: () => void;
+  isRestored: boolean;
+}
+```
+
+### Broadcast & Frequency
+
+```tsx
+interface UseBroadcastReturn {
+  broadcast: (event: string, payload?: unknown) => void;
+  subscribe: (event: string, handler: (payload: unknown) => void) => () => void;
+}
+
+interface FrequencyState {
+  lastShownAt?: number;
+  shownCount: number;
+  dismissedAt?: number;
+  completedAt?: number;
+}
+```
+
 ---
 
 ## Default Configurations

--- a/apps/docs/content/docs/api/hints.mdx
+++ b/apps/docs/content/docs/api/hints.mdx
@@ -392,6 +392,45 @@ type Placement =
   | 'right' | 'right-start' | 'right-end' | 'right-center';
 ```
 
+### Hotspot Variants & Props
+
+Three built-in hotspot variants ship with `@tour-kit/hints`. Select one via `<HintHotspot variant="badge" />` or render the variant components directly.
+
+```tsx
+// Variant name discriminator
+type HintHotspotVariantName = 'badge' | 'beacon-with-label' | 'what-s-new-pill';
+
+interface HintBadgeProps extends Omit<React.ComponentPropsWithoutRef<'button'>, 'color'> {
+  targetRect: DOMRect;
+  position: HotspotPosition;
+  /** Numeric badge value (clamps to "99+" above 99) */
+  count?: number;
+  isOpen?: boolean;
+  asChild?: boolean;
+}
+
+interface HintBeaconWithLabelProps extends Omit<React.ComponentPropsWithoutRef<'button'>, 'color'> {
+  targetRect: DOMRect;
+  position: HotspotPosition;
+  /** Visible label adjacent to the beacon — also surfaced via aria-label */
+  label: string;
+  /** Which side the label sits on; defaults to "right" */
+  side?: 'left' | 'right';
+  isOpen?: boolean;
+  asChild?: boolean;
+}
+
+interface HintWhatsNewPillProps extends Omit<React.ComponentPropsWithoutRef<'button'>, 'color'> {
+  targetRect: DOMRect;
+  position: HotspotPosition;
+  label: string;
+  isOpen?: boolean;
+  asChild?: boolean;
+}
+```
+
+See [Hint variants](/docs/hints/variants).
+
 ---
 
 ## Utilities

--- a/apps/docs/content/docs/api/license.mdx
+++ b/apps/docs/content/docs/api/license.mdx
@@ -382,6 +382,61 @@ type LicenseWarningProps = {
 };
 ```
 
+### Trial Types
+
+Trial mode lets gated packages run for a limited time before requiring activation.
+
+```tsx
+interface TrialConfig {
+  durationDays: number;
+  startsAt?: Date;             // defaults to first activation
+  /** Optional grace window after expiry before gating closes */
+  graceDays?: number;
+  /** Storage namespace; defaults to '@tour-kit/license:trial' */
+  storageKey?: string;
+}
+
+interface TrialContextValue {
+  isTrialing: boolean;
+  daysRemaining: number;
+  expiresAt: Date | null;
+  isExpired: boolean;
+  start: () => void;
+  end: () => void;
+}
+
+interface TrialBadgeRenderProps {
+  daysRemaining: number;
+  isExpired: boolean;
+  expiresAt: Date | null;
+}
+
+interface TrialBadgeProps {
+  className?: string;
+  pricingUrl?: string;
+  /** Render-prop override for custom badge UI */
+  children?: (state: TrialBadgeRenderProps) => React.ReactNode;
+}
+```
+
+See [Trial guide](/docs/licensing/trial).
+
+### Debug Components
+
+```tsx
+interface LicenseDebugPanelProps {
+  /** Position the floating panel; defaults to 'bottom-right' */
+  position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  className?: string;
+}
+
+interface LicenseTestModeProps {
+  /** Force a tier without making network calls (dev only) */
+  forceTier?: 'free' | 'pro';
+  children: React.ReactNode;
+}
+```
+
 ### Polar Response Types
 
 Raw Polar API response shapes (after camelCase transform). Subject to upstream Polar SDK changes.

--- a/apps/docs/content/docs/api/media.mdx
+++ b/apps/docs/content/docs/api/media.mdx
@@ -415,3 +415,30 @@ interface ResponsiveSource {
   type?: string;
 }
 ```
+
+### Media Slot Detection
+
+`<MediaSlot src="...">` auto-detects which player to render based on the URL. The detection layer is exported for advanced use (custom slots, URL validation).
+
+```tsx
+// All media slot types (`auto` is the unresolved discriminator)
+type MediaSlotType =
+  | 'auto'
+  | 'youtube'
+  | 'vimeo'
+  | 'loom'
+  | 'wistia'
+  | 'video'
+  | 'gif'
+  | 'lottie'
+  | 'image';
+
+// Concrete (post-detection) slot type
+type ResolvedMediaSlotType = Exclude<MediaSlotType, 'auto'>;
+
+// URL-pattern → slot-type pairs evaluated in declared order
+const MEDIA_SLOT_PATTERNS: ReadonlyArray<readonly [RegExp, ResolvedMediaSlotType]>;
+
+// Run the detection pipeline against a single URL
+function detectMediaSlotType(src: string): ResolvedMediaSlotType;
+```

--- a/apps/docs/content/docs/api/react.mdx
+++ b/apps/docs/content/docs/api/react.mdx
@@ -445,6 +445,78 @@ import { UILibraryProvider, useUILibrary } from '@tour-kit/react';
 const library = useUILibrary(); // 'radix' | 'base-ui'
 ```
 
+### Audience Utilities
+
+```tsx
+import { explainAudience, matchUrl } from '@tour-kit/react';
+
+// Human-readable explanation of an audience match (debug panels, devtools)
+explainAudience(audience, segments, userContext): string;
+
+// URL pattern matcher used by router-aware steps (segments, glob, exact)
+matchUrl(pattern: string, route: string, mode?: 'exact' | 'startsWith' | 'contains'): boolean;
+```
+
+### Tour Registry Hooks
+
+```tsx
+import {
+  useTourRegistryContext,
+  useTourRegistryContextOptional,
+} from '@tour-kit/react';
+```
+
+Low-level access to the registry inside `MultiTourKitProvider`. See [useTourRegistryContext](/docs/react/hooks/use-tour-registry-context). Prefer [useTours](/docs/react/hooks/use-tours) for the ergonomic surface.
+
+### Theme Variation Types
+
+```tsx
+interface ThemeTokens {
+  colors: Record<string, string>;
+  radius?: string;
+  shadow?: string;
+  font?: string;
+}
+
+interface ThemeContextValue {
+  theme: ThemeTokens;
+  resolve: (token: string) => string;
+}
+
+interface ThemeResolveContext {
+  variation?: string;
+  variables?: Record<string, string>;
+}
+
+interface ThemeProviderProps {
+  tokens: ThemeTokens;
+  variation?: string;
+  children: React.ReactNode;
+}
+
+interface UseThemeVariationReturn {
+  variation: string | undefined;
+  setVariation: (next: string | undefined) => void;
+  resolved: Record<string, string>;
+}
+```
+
+See [Theme variations guide](/docs/guides/theme-variations).
+
+### Diagnostic Re-exports
+
+```tsx
+// Re-exported from @tour-kit/core for ergonomic in-package access
+import {
+  BUILTIN_GATE_ORDER,
+  type DiagnosticContext,
+  type GateCode,
+  type GateName,
+} from '@tour-kit/react';
+```
+
+See [Diagnostic types](/docs/api/core#diagnostic-types) for the full reference.
+
 ---
 
 ## Re-exports from @tour-kit/core

--- a/apps/docs/content/docs/core/hooks/meta.json
+++ b/apps/docs/content/docs/core/hooks/meta.json
@@ -14,6 +14,10 @@
     "use-route-persistence",
     "use-media-query",
     "use-advance-on",
-    "use-direction"
+    "use-direction",
+    "use-locale",
+    "use-resolved-text",
+    "use-resolve-localized-text",
+    "use-segmentation-context"
   ]
 }

--- a/apps/docs/content/docs/core/hooks/use-locale.mdx
+++ b/apps/docs/content/docs/core/hooks/use-locale.mdx
@@ -1,0 +1,47 @@
+---
+title: useLocale
+description: >-
+  Read the current LocaleContextValue (locale, messages, direction, optional
+  host-side t override) from the nearest LocaleProvider.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Read the active locale, translation dictionary, and text direction inside any component tree wrapped with `<LocaleProvider>`. Drives the i18n pipeline shared by tour copy, hint labels, announcement bodies, and any consumer code that resolves [`LocalizedText`](/docs/core/types).
+
+## Usage
+
+```tsx
+import { useLocale } from '@tour-kit/core';
+
+function DirectionAwareCard() {
+  const { locale, direction } = useLocale();
+  return (
+    <article dir={direction} lang={locale}>
+      {/* ... */}
+    </article>
+  );
+}
+```
+
+`useLocale` never throws — when no `<LocaleProvider>` is mounted it returns the default context (`locale: 'en'`, `messages: {}`, no override `t`, derived `direction`).
+
+## Return Value
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `locale` | `string` | Active locale tag (e.g. `'en'`, `'pt-BR'`). |
+| `messages` | `Messages` | Flat key → string dictionary used by [`useT`](/docs/core/hooks/use-t). |
+| `t` | `TranslateFn \| undefined` | Optional host-app translate override; when set, [`useT`](/docs/core/hooks/use-t) delegates to it instead of looking up `messages`. |
+| `direction` | `'ltr' \| 'rtl'` | Derived from the locale's primary subtag (`ar`, `he`, `fa`, `ur` → `rtl`); override via the `direction` prop on `<LocaleProvider>`. |
+
+<Callout type="info">
+For resolving a single `LocalizedText` value, prefer [`useResolvedText`](/docs/core/hooks/use-resolved-text) (returns `ReactNode`) or [`useResolveLocalizedText`](/docs/core/hooks/use-resolve-localized-text) (returns `string`). See the [i18n guide](/docs/guides/i18n) for the full pipeline.
+</Callout>
+
+## Related
+
+- [LocaleProvider](/docs/core/providers/locale-provider) — wrap your tree
+- [useResolvedText](/docs/core/hooks/use-resolved-text) — resolve `LocalizedText` to `ReactNode`
+- [useResolveLocalizedText](/docs/core/hooks/use-resolve-localized-text) — resolve `LocalizedText` to `string`
+- [i18n guide](/docs/guides/i18n) — end-to-end internationalization

--- a/apps/docs/content/docs/core/hooks/use-resolve-localized-text.mdx
+++ b/apps/docs/content/docs/core/hooks/use-resolve-localized-text.mdx
@@ -1,0 +1,52 @@
+---
+title: useResolveLocalizedText
+description: >-
+  Returns a memoized (value) => string resolver. Use for consumer-authored copy
+  that must be a string — aria-label, title, Dialog.Title.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+String-only sibling of [`useResolvedText`](/docs/core/hooks/use-resolved-text). Returns a memoized resolver:
+
+```ts
+function useResolveLocalizedText(): (value: LocalizedText | undefined) => string
+```
+
+Use it whenever the surface you're handing copy to requires a `string` (not a `ReactNode`) — `aria-label`, `title` attributes, `Dialog.Title` text, `document.title` updates, etc.
+
+## Usage
+
+```tsx
+import { useResolveLocalizedText } from '@tour-kit/core';
+
+function TaskRow({ task }: { task: ChecklistTaskConfig }) {
+  const resolveText = useResolveLocalizedText();
+  return (
+    <li aria-label={resolveText(task.title)}>
+      {/* ... */}
+    </li>
+  );
+}
+```
+
+## Resolution rules
+
+| Input | Result |
+|-------|--------|
+| `undefined` / `null` | `''` |
+| `string` | `interpolate(value, userContext, { warnOnMissing: false })` |
+| `{ key }` | `useT()(value.key, userContext)` |
+| any other `ReactNode` | `''` (JSX cannot render to a string) |
+
+`vars` are sourced from `useSegmentationContext().userContext` — the same shape that drives audience targeting. Without a `<SegmentationProvider>`, `userContext` is `undefined` and templates fall back to `{{x | default}}` rules.
+
+<Callout type="info">
+For `ReactNode` outputs (tour body copy, hint titles), use [`useResolvedText`](/docs/core/hooks/use-resolved-text) — it accepts JSX and returns `ReactNode`. This hook is the narrower variant for string-only sinks.
+</Callout>
+
+## Related
+
+- [useResolvedText](/docs/core/hooks/use-resolved-text)
+- [useLocale](/docs/core/hooks/use-locale)
+- [i18n guide](/docs/guides/i18n)

--- a/apps/docs/content/docs/core/hooks/use-resolved-text.mdx
+++ b/apps/docs/content/docs/core/hooks/use-resolved-text.mdx
@@ -1,0 +1,56 @@
+---
+title: useResolvedText
+description: >-
+  Resolve a LocalizedText | ReactNode value into a ReactNode. Handles string
+  interpolation, i18n key lookup, and ReactNode pass-through with one call.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Unified text pipeline used across `@tour-kit/react`, `@tour-kit/hints`, and `@tour-kit/announcements`. Given a `LocalizedText | ReactNode`, returns a `ReactNode` ready to render:
+
+- `string` → interpolated against `vars` (`'Hi {{user.name}}'`)
+- `{ key }` → translated via [`useT`](/docs/core/hooks/use-t)
+- any other `ReactNode` → returned as-is (JSX pass-through)
+
+## Usage
+
+```tsx
+import { useResolvedText } from '@tour-kit/core';
+
+function StepBody({ body }: { body: LocalizedText | React.ReactNode }) {
+  const resolved = useResolvedText(body);
+  return <div>{resolved}</div>;
+}
+```
+
+By default `vars` falls back to `useSegmentationContext().userContext`, so any consumer that wires `userContext` for audience targeting gets interpolation against the same shape for free.
+
+```tsx
+const resolved = useResolvedText('Welcome back, {{user.name}}');
+// With userContext = { user: { name: 'Ada' } } → "Welcome back, Ada"
+```
+
+## Signature
+
+```ts
+function useResolvedText(
+  value: ReactNode | LocalizedText | undefined,
+  vars?: Record<string, unknown>
+): ReactNode
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `value` | `ReactNode \| LocalizedText \| undefined` | Source value. Returned as-is for non-string non-key inputs. |
+| `vars` | `Record<string, unknown>` | Optional override; defaults to `useSegmentationContext().userContext`. |
+
+<Callout type="warn">
+This is a hook — call it from a component body, never from an event handler or `.map()` callback. For string outputs (`aria-label`, `Dialog.Title`), use [`useResolveLocalizedText`](/docs/core/hooks/use-resolve-localized-text) — it returns a memoized `(value) => string` resolver you can call anywhere.
+</Callout>
+
+## Related
+
+- [useResolveLocalizedText](/docs/core/hooks/use-resolve-localized-text) — string-only variant for ARIA attributes
+- [useLocale](/docs/core/hooks/use-locale) — read raw locale context
+- [i18n guide](/docs/guides/i18n)

--- a/apps/docs/content/docs/core/hooks/use-segmentation-context.mdx
+++ b/apps/docs/content/docs/core/hooks/use-segmentation-context.mdx
@@ -1,0 +1,52 @@
+---
+title: useSegmentationContext
+description: >-
+  Low-level hook returning the raw SegmentationContextValue — registered
+  segments, userContext, and currentUserId. Use useSegment / useSegments for
+  typical lookups.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Direct access to the raw `SegmentationContextValue`. Most consumers should reach for [`useSegment`](/docs/core/hooks/use-segment) (single segment) or `useSegments` (bulk read) — this hook is the escape hatch for custom integrations, headless filters, and debug panels.
+
+## Usage
+
+```tsx
+import { useSegmentationContext } from '@tour-kit/core';
+
+function SegmentDebugPanel() {
+  const { segments, userContext, currentUserId } = useSegmentationContext();
+  return (
+    <aside>
+      <p>User: {currentUserId ?? 'anonymous'}</p>
+      <p>Registered segments: {Object.keys(segments).join(', ')}</p>
+      <pre>{JSON.stringify(userContext, null, 2)}</pre>
+    </aside>
+  );
+}
+```
+
+`useSegmentationContext` never throws — when no `<SegmentationProvider>` is mounted it returns the default context (`segments: {}`, `userContext: undefined`, `currentUserId: undefined`). Anonymous-user code paths stay stable.
+
+## Return Value
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `segments` | `Record<string, SegmentSource>` | Registered segments. Each value is either a `SegmentDefinition` (condition array, AND-joined) or a `StaticSegment` (user-id roster). |
+| `userContext` | `Record<string, unknown> \| undefined` | Audience targeting context — same shape used by [`useResolvedText`](/docs/core/hooks/use-resolved-text) for interpolation. |
+| `currentUserId` | `string \| undefined` | Resolved against `StaticSegment.userIds`; required for static-cohort lookups. |
+
+## Internal use
+
+Tour Kit packages call `useSegmentationContext` to thread `userContext` into [`useResolvedText`](/docs/core/hooks/use-resolved-text) and [`useResolveLocalizedText`](/docs/core/hooks/use-resolve-localized-text), so consumer-authored `'Hi {{user.name}}'` templates interpolate against the same data driving audience matching.
+
+<Callout type="info">
+For typical segment membership checks, prefer [`useSegment`](/docs/core/hooks/use-segment) — it returns a boolean and tracks segment registration changes. Use `useSegmentationContext` only when you need the whole context (debug UIs, custom filters, headless integrations).
+</Callout>
+
+## Related
+
+- [SegmentationProvider](/docs/core/providers/segmentation-provider)
+- [Segmentation guide](/docs/guides/segmentation)
+- [useResolvedText](/docs/core/hooks/use-resolved-text)

--- a/apps/docs/content/docs/guides/playwright.mdx
+++ b/apps/docs/content/docs/guides/playwright.mdx
@@ -105,6 +105,25 @@ Every helper short-circuits with a clear error pointing at
 `enableTestBridge` if the bridge is missing — saving you ten minutes of
 confused debugging.
 
+#### TourHelpers type
+
+The full interface is exported for fixture typing and custom helpers:
+
+```ts
+import type { TourHelpers } from '@tour-kit/playwright';
+
+interface TourHelpers {
+  start: (tourId: string) => Promise<void>;
+  waitForStep: (stepId: string, opts?: { timeout?: number }) => Promise<void>;
+  next: () => Promise<void>;
+  previous: () => Promise<void>;
+  complete: () => Promise<void>;
+  skip: () => Promise<void>;
+  goToStep: (stepId: string) => Promise<void>;
+  getDiagnostic: (tourId: string) => Promise<EligibilityReport | null>;
+}
+```
+
 ## 3 — Diagnostic integration
 
 Mount the provider with both `diagnose` and `enableTestBridge` to surface

--- a/apps/docs/content/docs/guides/testing.mdx
+++ b/apps/docs/content/docs/guides/testing.mdx
@@ -171,6 +171,75 @@ try {
 | `goToStep(stepId)` | Jumps to a non-adjacent step. Requires `<HookProbe />` in the provider tree. |
 | `virtualTarget(rect?, contextElement?)` | Returns a Floating UI virtual element with a merged DOMRect. |
 | `setupTourKitTesting(opts?)` | One-shot orchestrator; default touches nothing, `positionShim: true` lazy-loads `jsdom-testing-mocks`. |
+| `getActiveTourHandle()` | Returns the active `useTour()` result from inside `<HookProbe />`, or `null` when no tour is running. Imperative escape hatch for assertions that step over the public DOM. |
+| `fireEvent`, `render`, `screen`, `waitFor`, `act`, `cleanup` | Re-exported from `@testing-library/react` so you can import everything from one place. |
+
+### Option types
+
+All helpers accept a typed options object. Import them when typing fixtures or shared test utilities:
+
+```ts
+import type {
+  AdvanceTourOptions,
+  CompleteTourOptions,
+  ExpectStepVisibleOptions,
+  PreviousTourOptions,
+  SetupOptions,
+  SkipTourOptions,
+  TourKitTestingErrorOptions,
+  VirtualTarget,
+} from '@tour-kit/testing-library';
+```
+
+```ts
+interface AdvanceTourOptions {
+  /** Number of times to click Next. Defaults to 1. */
+  steps?: number;
+  /** Reuse an existing userEvent instance (recommended for multi-helper tests). */
+  user?: UserEvent;
+}
+
+interface PreviousTourOptions {
+  steps?: number;
+  user?: UserEvent;
+}
+
+interface SkipTourOptions {
+  user?: UserEvent;
+}
+
+interface CompleteTourOptions {
+  /** Overall deadline. Defaults to 5000ms. */
+  timeout?: number;
+  /** Hard cap on click iterations. Defaults to 50. */
+  maxSteps?: number;
+  user?: UserEvent;
+}
+
+interface ExpectStepVisibleOptions {
+  /** Override the polling deadline. Defaults to 1000ms. */
+  timeout?: number;
+  /** Scope queries to a subtree. Defaults to document.body (the portal root). */
+  container?: HTMLElement;
+}
+
+interface SetupOptions {
+  /** Lazy-load jsdom-testing-mocks for getBoundingClientRect coverage. */
+  positionShim?: boolean;
+}
+
+interface TourKitTestingErrorOptions {
+  cause?: unknown;
+  stepId?: string;
+  tourId?: string;
+}
+
+interface VirtualTarget {
+  /** Floating UI virtual-element contract. */
+  getBoundingClientRect: () => DOMRect;
+  contextElement?: Element;
+}
+```
 
 ## Browser-positioning tests live elsewhere
 

--- a/apps/docs/content/docs/react/hooks/meta.json
+++ b/apps/docs/content/docs/react/hooks/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Hooks",
-  "pages": ["use-tours", "use-tour-route"]
+  "pages": ["use-tours", "use-tour-route", "use-tour-registry-context"]
 }

--- a/apps/docs/content/docs/react/hooks/use-tour-registry-context.mdx
+++ b/apps/docs/content/docs/react/hooks/use-tour-registry-context.mdx
@@ -1,0 +1,57 @@
+---
+title: useTourRegistryContext
+description: >-
+  Low-level hooks for reading the registered tour list inside MultiTourKitProvider.
+  Use useTours for ergonomic access.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Low-level access to the tour registry exposed by [`MultiTourKitProvider`](/docs/react/providers/multi-tour-kit-provider). Most consumers should use [`useTours`](/docs/react/hooks/use-tours) — `useTourRegistryContext` is the escape hatch for custom registry integrations (declarative `<Tour>` mounting, tour deduplication, debug panels).
+
+## Usage
+
+```tsx
+import { useTourRegistryContext } from '@tour-kit/react';
+
+function RegistrySize() {
+  const { tours } = useTourRegistryContext();
+  return <span>Registered tours: {tours.length}</span>;
+}
+```
+
+`useTourRegistryContext` throws if no `<MultiTourKitProvider>` is mounted above. Use `useTourRegistryContextOptional` if rendering inside a tree that may or may not have a provider.
+
+## Return Value
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tours` | `Tour[]` | All currently registered tours. |
+| `registerTour` | `(tour: Tour) => void` | Add a tour to the registry. Called internally by `<Tour>` on mount. |
+| `unregisterTour` | `(tourId: string) => void` | Remove a tour from the registry. Called internally by `<Tour>` on unmount. |
+
+## useTourRegistryContextOptional
+
+Same as `useTourRegistryContext` but returns `null` instead of throwing when no provider is present. Useful for components that may render outside a `MultiTourKitProvider`.
+
+```tsx
+import { useTourRegistryContextOptional } from '@tour-kit/react';
+
+function ContextAwareLauncher() {
+  const ctx = useTourRegistryContextOptional();
+  if (!ctx) return <button>Help</button>; // standalone mode
+  return <TourSelector tours={ctx.tours} />;
+}
+```
+
+Returns `TourRegistryContextValue | null`.
+
+<Callout type="info">
+For tour listing, completion checks, and active-tour state, prefer [`useTours`](/docs/react/hooks/use-tours) — it wraps `useTourRegistryContext` and exposes a flatter API (`tours`, `activeTourId`, `isTourCompleted`, etc.).
+</Callout>
+
+## Related
+
+- [useTours](/docs/react/hooks/use-tours)
+- [MultiTourKitProvider](/docs/react/providers/multi-tour-kit-provider)
+- [Tour](/docs/react/components/tour)

--- a/apps/docs/content/docs/surveys/components/meta.json
+++ b/apps/docs/content/docs/surveys/components/meta.json
@@ -12,6 +12,7 @@
     "question-text",
     "question-select",
     "question-boolean",
+    "question-media",
     "survey-progress"
   ]
 }

--- a/apps/docs/content/docs/surveys/components/question-media.mdx
+++ b/apps/docs/content/docs/surveys/components/question-media.mdx
@@ -1,0 +1,40 @@
+---
+title: QuestionMedia
+description: >-
+  Render <MediaSlot> above a question when the question has a `media?` field.
+  No-op for questions without media, so consumers can mount it unconditionally.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Renders a `<MediaSlot>` from `@tour-kit/media` above a question prompt when the question config carries a `media?` field. Returns `null` when no media is configured — mount it unconditionally above your `Question*` component and it stays out of the way for plain text questions.
+
+## Usage
+
+```tsx
+import { QuestionMedia, QuestionRating } from '@tour-kit/surveys';
+
+function CurrentQuestion({ question }: { question: QuestionConfig }) {
+  return (
+    <>
+      <QuestionMedia question={question} />
+      <QuestionRating question={question} />
+    </>
+  );
+}
+```
+
+## Props
+
+```tsx
+interface QuestionMediaProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** The question whose `media?` should render. No-op when absent. */
+  question: Pick<QuestionConfig, 'media'>;
+}
+```
+
+Forwards refs (`React.forwardRef<HTMLDivElement>`) and accepts arbitrary `<div>` attributes. Rendered with `data-slot="question-media"` for styling hooks.
+
+<Callout type="info">
+Configure `question.media` once on your survey config; this component handles detection and rendering. See the [Media package](/docs/media) for supported URL formats (YouTube, Vimeo, Loom, Wistia, raw video, GIF, Lottie, image).
+</Callout>

--- a/apps/docs/content/docs/surveys/components/turnkey-modals.mdx
+++ b/apps/docs/content/docs/surveys/components/turnkey-modals.mdx
@@ -117,6 +117,42 @@ The category is computed by the pure helper `computeCesCategory(score)`:
 - Reduced motion is inherited from `SurveyModal` via the `motion-safe:` Tailwind prefix — no extra setup required.
 - Each modal is tree-shakeable: importing only `CsatModal` does not pull `NpsModal` or `CesModal`.
 
+## Props
+
+All three share the same base — they extend `SurveyModalProps` (excluding `surveyId`, `children`, `onSubmit`, `onSelect`) and add their own submit signature.
+
+```tsx
+interface CsatModalProps extends Omit<SurveyModalProps, 'surveyId' | 'children' | 'onSubmit' | 'onSelect'> {
+  surveyId?: string;        // defaults to React.useId()
+  question: string;
+  ratingScale?: RatingScale;  // default: 1–5 numeric
+  lowLabel?: string;
+  highLabel?: string;
+  onSubmit: (rating: number) => void;
+  onSkip?: () => void;
+}
+
+interface NpsModalProps extends Omit<SurveyModalProps, 'surveyId' | 'children' | 'onSubmit' | 'onSelect'> {
+  surveyId?: string;
+  question: string;
+  ratingScale?: RatingScale;  // default: 0–10
+  lowLabel?: string;
+  highLabel?: string;
+  onSubmit: (score: number, category: NpsCategory) => void;
+  onSkip?: () => void;
+}
+
+interface CesModalProps extends Omit<SurveyModalProps, 'surveyId' | 'children' | 'onSubmit' | 'onSelect'> {
+  surveyId?: string;
+  question: string;
+  ratingScale?: RatingScale;  // default: 1–7
+  lowLabel?: string;
+  highLabel?: string;
+  onSubmit: (score: number, category: CesCategory) => void;
+  onSkip?: () => void;
+}
+```
+
 ## Related
 
 - [SurveyModal](/docs/surveys/components/survey-modal) — the underlying primitive each turnkey wraps.

--- a/packages/codemods/src/index.ts
+++ b/packages/codemods/src/index.ts
@@ -1,4 +1,4 @@
-export { default as fromJoyride, parser as fromJoyrideParser } from './transforms/from-joyride'
-export { mapStepObject, type StepMapping } from './lib/step-mapper'
-export { emitTodo, todoToComment, type Todo } from './lib/todo-emitter'
-export { runMigrate, type CliOptions } from './cli'
+// `@tour-kit/codemods` is CLI-only. Run the migrator with:
+//   npx tour-kit-migrate <transform> <paths...>
+// Programmatic imports of internal helpers were removed in v0.4.
+export {}


### PR DESCRIPTION
## Summary

Closed the 102 export gaps surfaced by `tk-docs-audit` (90% → **100%** coverage across 15 packages, 1045 exports).

### Phase 1 — 8 BLOCKING hooks (new MDX pages)

Hooks that had no docs page at all:

- `apps/docs/content/docs/core/hooks/use-locale.mdx`
- `apps/docs/content/docs/core/hooks/use-resolved-text.mdx`
- `apps/docs/content/docs/core/hooks/use-resolve-localized-text.mdx`
- `apps/docs/content/docs/core/hooks/use-segmentation-context.mdx`
- `apps/docs/content/docs/announcements/hooks/use-filtered-announcements.mdx`
- `apps/docs/content/docs/announcements/hooks/use-resolved-text.mdx`
- `apps/docs/content/docs/react/hooks/use-tour-registry-context.mdx` (also covers `useTourRegistryContextOptional`)
- `meta.json` nav updates in all three hooks dirs

### Phase 2 — 93 WARN type/utility items

Sections appended to existing `api/<package>.mdx`, component pages, and guides:

- `api/core.mdx` — i18n, segmentation, audience eval, diagnostic types, flow-session, broadcast, frequency, step visibility, target waiting (25 items)
- `api/react.mdx` — audience utilities, registry hooks, theme variation types, diagnostic re-exports (13)
- `api/announcements.mdx` — AudienceProp, evaluator, reactions, changelog props, toast adapter (14)
- `api/license.mdx` — trial types, debug component props (6)
- `api/hints.mdx` — variant props + variant-name discriminator (4)
- `api/media.mdx` — media slot detection types (4)
- `api/adoption.mdx` — funnel props/input (2)
- `api/checklists.mdx` — `UrlVisitCompletion` (1)
- `guides/playwright.mdx` — `TourHelpers` interface (1)
- `guides/testing.mdx` — option types + `getActiveTourHandle` + `fireEvent` (10)
- `surveys/components/turnkey-modals.mdx` — modal props (3)
- New: `surveys/components/question-media.mdx` for `QuestionMedia` + `QuestionMediaProps` (2)

### Phase 3 — @tour-kit/codemods narrowed (breaking, minor bump)

`packages/codemods/src/index.ts` reduced to `export {}` with a CLI-only comment. The 9 accidental programmatic re-exports (`fromJoyride`, `fromJoyrideParser`, `mapStepObject`, `emitTodo`, `todoToComment`, `runMigrate`, `StepMapping`, `Todo`, `CliOptions`) were undocumented and unused outside the package itself — every consumer uses `npx tour-kit-migrate`.

- CLI bin (`tour-kit-migrate`) is **unchanged**
- Changeset: `.changeset/codemods-narrow-public-surface.md` (minor bump)
- Build verified: `dist/index.js` is now a 68B empty chunk

## Validation

- Re-ran the export audit after changes: **1045 total / 0 missing**
- `pnpm typecheck` clean across all 29 packages
- `pnpm --filter=@tour-kit/codemods build` succeeds; CLI bundle unchanged at ~56KB

## Test plan

- [ ] Skim a few new hook pages render correctly under `pnpm --filter docs dev`
- [ ] Confirm the new entries appear in nav (core/hooks, announcements/hooks, react/hooks, surveys/components)
- [ ] Sanity-check that `import { runMigrate } from '@tour-kit/codemods'` is OK to remove — search any downstream