### PR TITLE
docs(sprint-1): test plans for phases 2, 4, 5–8

### DIFF
--- a/tasks/sprint-1-stop-the-bleeding/phase-2-tests.md
+++ b/tasks/sprint-1-stop-the-bleeding/phase-2-tests.md
@@ -1,0 +1,433 @@
+# Phase 2 — Testing: Remove Plugin Re-exports from Analytics Root (B-3)
+
+**Scope:** `packages/analytics/src/index.ts` (delete 5 `export { *Plugin }` lines),
+`packages/analytics/package.json` (add `./console` subpath), `packages/analytics/tsup.config.ts`
+(add `plugins/console` entry), `packages/analytics/MIGRATION.md` (new),
+internal call-sites that imported plugins from the root, and docs MDX.
+**Phase type:** **Breaking API contract.** This is a deliberate consumer-facing
+break. Tests fall into three buckets: (a) the dist no longer carries plugin
+code at the root, (b) every subpath still resolves and ships an identical
+plugin object, (c) every internal consumer was updated. No new runtime logic
+to mock — the plugin code is unchanged; only the public path changed.
+**Key Pattern:** Build-output grep gates + a subpath-equivalence vitest suite
+that imports the same plugin from old (root) and new (subpath) paths and
+asserts identity (after the source change, the root import must fail at
+type-check, which is itself part of the contract). No SDK mocks beyond what
+Phase 1 already established.
+**Dependencies:** `vitest`, `tsup`, `gzip`, `grep`, `node`, the Phase 1
+`fakeAmplitudeSdk` fake (reused as-is — do not duplicate).
+
+---
+
+## User Stories
+
+| #    | User Story                                                                                                                                       | Validation Check                                                                                                                  | Pass Condition                                                                              |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| US-1 | As a consumer who only uses PostHog, I want my bundle to NOT contain Mixpanel/Amplitude/GA/console plugin code.                                  | `grep -cE 'posthogPlugin\|mixpanelPlugin\|amplitudePlugin\|googleAnalyticsPlugin\|consolePlugin' packages/analytics/dist/index.js` | `== 0` after Phase 2; was 5 before                                                          |
+| US-2 | As any consumer, I want the analytics root entry to be tiny (just `createAnalytics` + `AnalyticsProvider` + types).                              | `gzip -c packages/analytics/dist/index.js \| wc -c`                                                                               | `< 4000 B` (was ~6 KB after Phase 1)                                                        |
+| US-3 | As a consumer migrating, I want every plugin reachable via its subpath — including `console`, which previously had no subpath.                   | Five dynamic imports from subpaths in a vitest run                                                                                | All 5 resolve and export a function whose return implements the `AnalyticsPlugin` shape    |
+| US-4 | As a documenter, I want a `MIGRATION.md` next to the package so consumers have an authoritative single page.                                     | `test -f packages/analytics/MIGRATION.md` + grep for each before/after row                                                        | File exists; all 5 mappings present                                                          |
+| US-5 | As a downstream package maintainer (8 packages import analytics), I want the externalization to not break my build.                              | `pnpm build --filter='./packages/*'`                                                                                              | exit 0                                                                                       |
+| US-6 | As an examples/docs/blog maintainer, I want every in-repo file to have been updated to subpath form — no stale root imports of plugin functions. | `rg "from ['\"]@tour-kit/analytics['\"]" packages apps examples \| rg "(posthog\|mixpanel\|amplitude\|googleAnalytics\|console)Plugin"` | `0` matches                                                                              |
+| US-7 | As a CI engineer, I want existing analytics unit tests (11+ Phase 1 additions) to remain green — this is a path change, not a behavior change.   | `pnpm --filter @tour-kit/analytics test --run`                                                                                    | All pre-existing + Phase 1 tests still pass; new subpath tests pass                          |
+
+---
+
+## Component Mock Strategy
+
+| Component                                  | Mock Strategy                                              | What to Assert                                                                            | User Story  |
+| ------------------------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| `src/index.ts` (root barrel)               | None — real build                                          | No plugin names in `dist/index.js`; root gz `< 4 KB`                                       | US-1, US-2  |
+| Per-plugin subpath builds                  | None — real build                                          | `dist/plugins/{console,posthog,mixpanel,amplitude,google-analytics}.js` all exist          | US-3        |
+| Subpath equivalence (vitest)               | Reuse `fakeAmplitudeSdk` from Phase 1; no other mocks       | Each `import { xPlugin } from '@tour-kit/analytics/x'` returns a function; calling it yields an object with `.init` + `.track` | US-3        |
+| `package.json` `exports` map               | None — JSON read                                           | `./console` block present with `import.types`, `import.default`, `require.types`, `require.default` | US-3        |
+| `MIGRATION.md`                              | None — file read                                           | 5 mapping rows present (one per plugin); call-out about types staying at root             | US-4        |
+| Monorepo consumers                          | None — real workspace build                                | `pnpm build --filter='./packages/*'` exits 0                                              | US-5        |
+| Internal call-site sweep                    | None — ripgrep                                             | Zero matches for plugin-name root imports                                                  | US-6        |
+| Existing 11 + Phase 1 analytics tests       | None — re-run                                              | Still green                                                                                | US-7        |
+
+---
+
+## Test Tier Table
+
+| Tier             | Dependencies                                              | Speed     | When to Run                              |
+| ---------------- | --------------------------------------------------------- | --------- | ---------------------------------------- |
+| Unit (vitest)    | `vi.mock` for `@amplitude/analytics-browser` (Phase 1 reuse) | < 5 s   | Every push                                |
+| Build assertion  | Real `tsup` build of analytics; `gzip` + `grep` on dist   | ~30 s     | Pre-PR, gated in `verify-phase-2.sh`     |
+| Workspace build  | All packages built once                                   | ~3 min    | Pre-PR, on CI                             |
+| Source-sweep grep| `rg` over `packages apps examples` MDX/TS files            | < 2 s    | Pre-PR + first CI step                    |
+
+There is no E2E tier for Phase 2 — the migration is mechanical and the
+behavior is unchanged. The Phase 8 smoke covers "real npm-installed
+consumer."
+
+---
+
+## Fake / Mock Implementations
+
+Phase 2 introduces **zero new fakes.** The Amplitude SDK fake from Phase 1
+(`packages/analytics/src/__tests__/__fakes__/fake-amplitude-sdk.ts`) covers
+the only third-party module touched here. If the Phase 2 subpath-equivalence
+test needs to invoke `amplitudePlugin(...)`, it imports the fake from the
+same path Phase 1 created.
+
+> **Do not write a `consolePlugin` fake.** `console.log` is the dependency.
+> Spy on it with `vi.spyOn(console, 'log')` in-test.
+
+```ts
+// Optional, only if the subpath-equivalence test invokes consolePlugin.
+// Co-locate inside the test file, do not add a new fake module.
+const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+afterEach(() => logSpy.mockClear())
+```
+
+---
+
+## Test File List
+
+```
+packages/analytics/
+├── src/__tests__/
+│   ├── subpath-imports.test.ts          # NEW: 5 imports from subpaths, identity + shape assertions
+│   ├── root-exports.test.ts             # NEW: ensures plugin names are NOT in root barrel
+│   ├── __fakes__/
+│   │   ├── fake-amplitude-sdk.ts        # EXISTING (Phase 1) — reused, not modified
+│   │   └── missing-peer.ts              # EXISTING (Phase 1) — reused
+│   └── (Phase 1 + pre-existing tests untouched)
+├── MIGRATION.md                          # NEW (also asserted by build asserter)
+├── package.json                          # MODIFIED — `./console` export block
+├── src/index.ts                          # MODIFIED — 5 lines deleted, comment added
+└── tsup.config.ts                        # MODIFIED — `plugins/console` entry
+
+tasks/sprint-1-stop-the-bleeding/
+└── verify-phase-2.sh                     # NEW: idempotent post-build gate runner
+
+# Out-of-package (touched by §2.3, validated by US-6 grep):
+apps/smoke/app/providers.tsx              # plugin import switched to subpath
+examples/vite-app/src/App.tsx             # same
+examples/next-app/src/app/providers.tsx   # same
+examples/dashboard-next/app/providers.tsx # same
+packages/analytics/README.md              # quick-start uses subpath imports
+apps/docs/content/docs/analytics/**/*.mdx # all plugin imports use subpath
+apps/docs/content/docs/migration/analytics-0-12-breaking-changes.mdx # NEW or extended
+```
+
+---
+
+## Vitest Setup Additions
+
+No global vitest setup changes. Phase 1's hoisted `vi.mock` of
+`@amplitude/analytics-browser` only applies to the test file that declares
+it; the new Phase 2 test files re-declare it locally.
+
+```ts
+// packages/analytics/src/__tests__/subpath-imports.test.ts (top)
+import { vi } from 'vitest'
+
+// Reuse Phase 1 fake — do not duplicate the surface.
+vi.mock('@amplitude/analytics-browser', async () => {
+  const { fakeAmplitudeSdk } = await import('./__fakes__/fake-amplitude-sdk')
+  return fakeAmplitudeSdk
+})
+```
+
+---
+
+## Key Testing Decisions
+
+| Decision                                                          | Approach                                                      | Rationale                                                                                                                |
+| ----------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Assert the *absence* of plugin names in `dist/index.js`           | `grep -cE 'posthogPlugin\|mixpanelPlugin\|...' \| == 0`       | A grep is the simplest gate that proves the re-exports were genuinely deleted and tsup didn't silently re-inline.        |
+| Use subpath imports in the new tests, not relative `../../plugins/...` | `await import('@tour-kit/analytics/posthog')`             | The whole point is the public path. Relative imports would pass even if the package's `exports` map was broken.          |
+| Don't test plugin *behavior* — just shape                         | `expect(plugin).toHaveProperty('init')`                       | Phase 1 already covered behavior (Amplitude). Re-testing PostHog/Mixpanel/GA here just bloats the suite and overlaps with the package's pre-existing tests. |
+| `root-exports.test.ts` runs against the *source*, not the dist     | `import * as root from '../index'` + `expect(root).not.toHaveProperty('posthogPlugin')` | Catches accidental re-introduction at PR review time, before a build runs.                                               |
+| Internal-callsite sweep is a bash grep, not a vitest test         | `rg` in `verify-phase-2.sh`                                   | Vitest can't easily enumerate the whole monorepo. A grep is faster and matches the §2.3 audit command verbatim.          |
+| MIGRATION.md is a file-shape gate, not a doc-test                 | `grep -c '@tour-kit/analytics/posthog' MIGRATION.md`          | We care that all 5 mappings are present and the new paths are quoted exactly. A renderer test would be ceremony.          |
+| No codemod tests                                                  | None — codemod explicitly out of scope per §2.5               | Phase 2 plan defers the codemod to a future sprint; testing a thing that doesn't exist is pointless.                      |
+
+---
+
+## Example Test Case
+
+```ts
+// packages/analytics/src/__tests__/subpath-imports.test.ts
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@amplitude/analytics-browser', async () => {
+  const { fakeAmplitudeSdk } = await import('./__fakes__/fake-amplitude-sdk')
+  return fakeAmplitudeSdk
+})
+
+describe('analytics subpath imports (post-B-3)', () => {
+  it('@tour-kit/analytics/console exports consolePlugin', async () => {
+    const mod = await import('@tour-kit/analytics/console')
+    expect(typeof mod.consolePlugin).toBe('function')
+    const plugin = mod.consolePlugin()
+    expect(plugin).toHaveProperty('init')
+    expect(plugin).toHaveProperty('track')
+  })
+
+  it('@tour-kit/analytics/posthog exports posthogPlugin', async () => {
+    const mod = await import('@tour-kit/analytics/posthog')
+    expect(typeof mod.posthogPlugin).toBe('function')
+    const plugin = mod.posthogPlugin({ apiKey: 'x' })
+    expect(plugin).toHaveProperty('init')
+  })
+
+  it('@tour-kit/analytics/mixpanel exports mixpanelPlugin', async () => {
+    const mod = await import('@tour-kit/analytics/mixpanel')
+    expect(typeof mod.mixpanelPlugin).toBe('function')
+  })
+
+  it('@tour-kit/analytics/amplitude exports amplitudePlugin', async () => {
+    const mod = await import('@tour-kit/analytics/amplitude')
+    expect(typeof mod.amplitudePlugin).toBe('function')
+  })
+
+  it('@tour-kit/analytics/google-analytics exports googleAnalyticsPlugin', async () => {
+    const mod = await import('@tour-kit/analytics/google-analytics')
+    expect(typeof mod.googleAnalyticsPlugin).toBe('function')
+  })
+})
+```
+
+```ts
+// packages/analytics/src/__tests__/root-exports.test.ts
+import { describe, expect, it } from 'vitest'
+import * as root from '../index'
+
+describe('analytics root barrel (post-B-3)', () => {
+  it('does NOT re-export plugin functions', () => {
+    expect(root).not.toHaveProperty('consolePlugin')
+    expect(root).not.toHaveProperty('posthogPlugin')
+    expect(root).not.toHaveProperty('mixpanelPlugin')
+    expect(root).not.toHaveProperty('amplitudePlugin')
+    expect(root).not.toHaveProperty('googleAnalyticsPlugin')
+  })
+
+  it('still exports the core surface', () => {
+    expect(root).toHaveProperty('createAnalytics')
+    expect(root).toHaveProperty('AnalyticsProvider')
+    expect(root).toHaveProperty('useAnalytics')
+    expect(root).toHaveProperty('useAnalyticsOptional')
+  })
+})
+```
+
+---
+
+## Build / Bundle Asserter
+
+```bash
+#!/usr/bin/env bash
+# tasks/sprint-1-stop-the-bleeding/verify-phase-2.sh
+# Run after `pnpm --filter @tour-kit/analytics build`.
+set -u
+fails=0
+gate() { if eval "$1"; then echo "✓ $2"; else echo "✗ $2 — $(eval "$3")"; fails=$((fails+1)); fi; }
+
+# US-1: root barrel has no plugin code
+plugin_strings=$(grep -cE 'posthogPlugin|mixpanelPlugin|amplitudePlugin|googleAnalyticsPlugin|consolePlugin' \
+  packages/analytics/dist/index.js)
+gate "[ $plugin_strings -eq 0 ]" "US-1: no plugin names in dist/index.js" "echo got $plugin_strings"
+
+# US-2: root entry under 4 KB gz
+gz_idx=$(gzip -c packages/analytics/dist/index.js | wc -c | tr -d ' ')
+gate "[ $gz_idx -lt 4000 ]" "US-2: dist/index.js gz < 4000 B" "echo got $gz_idx"
+
+# US-3: every plugin subpath built
+for p in console posthog mixpanel amplitude google-analytics; do
+  gate "[ -f packages/analytics/dist/plugins/$p.js ]" "US-3: dist/plugins/$p.js exists" "echo missing"
+done
+
+# US-3: console subpath in package.json exports
+gate 'node -e "const p=require(\"./packages/analytics/package.json\"); process.exit(p.exports?.[\"./console\"] ? 0 : 1)"' \
+     'US-3: package.json exports has ./console' "echo missing"
+
+# US-4: MIGRATION.md exists and lists all 5 mappings
+gate '[ -f packages/analytics/MIGRATION.md ]' "US-4: MIGRATION.md exists" "echo missing"
+for p in posthog mixpanel amplitude google-analytics console; do
+  gate "grep -q '@tour-kit/analytics/$p' packages/analytics/MIGRATION.md" \
+       "US-4: MIGRATION.md mentions /$p" "echo missing"
+done
+
+# US-5: downstream still builds
+gate 'pnpm build --filter=./packages/* >/tmp/phase-2-build.log 2>&1' \
+     'US-5: monorepo build green' "tail -n3 /tmp/phase-2-build.log"
+
+# US-6: no internal callers import plugins from root
+# (ripgrep returns exit 1 when no match; invert with || true and count)
+n=$(rg -n "from ['\"]@tour-kit/analytics['\"]" packages apps examples \
+      --glob '*.{ts,tsx,md,mdx}' 2>/dev/null \
+   | rg "(posthog|mixpanel|amplitude|googleAnalytics|console)Plugin" \
+   | wc -l | tr -d ' ')
+gate "[ $n -eq 0 ]" "US-6: no internal plugin-from-root imports" "echo got $n"
+
+# US-7: tests green
+gate 'pnpm --filter @tour-kit/analytics test --run >/tmp/phase-2-test.log 2>&1' \
+     'US-7: analytics vitest green' "tail -n5 /tmp/phase-2-test.log"
+
+[ "$fails" -eq 0 ] || { echo "Phase 2 FAILED gates: $fails"; exit 1; }
+echo "Phase 2 all gates green."
+```
+
+---
+
+## Execution Prompt
+
+Copy everything between the `---` lines into a new Claude session to write
+the Phase 2 tests:
+
+---
+You are writing the test additions for Phase 2 of Sprint 1 in the tour-kit
+monorepo — removing plugin re-exports from `@tour-kit/analytics` root entry,
+adding the `./console` subpath, and writing the migration documentation.
+
+### What This Project Is
+`@tour-kit/analytics` is a plugin-based analytics adapter. Before this PR,
+it re-exported five plugin functions from its root entry, which meant
+bundlers couldn't tree-shake unused providers — a consumer who only used
+PostHog still pulled in Mixpanel/Amplitude/GA/console plugin code. This PR
+deletes the re-exports, requiring subpath imports for plugins (e.g.
+`@tour-kit/analytics/posthog`).
+
+### Acceptance Criteria (from User Stories)
+| #    | User Story                                                            | Validation Check                                                            | Pass Condition                          |
+| ---- | --------------------------------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------- |
+| US-1 | Plugin code gone from root barrel                                     | `grep -cE '...Plugin' dist/index.js`                                        | `== 0`                                  |
+| US-2 | Root entry tiny                                                        | `gzip -c dist/index.js \| wc -c`                                            | `< 4000`                                |
+| US-3 | All 5 plugins reachable via subpath                                   | dynamic `import()` from each subpath in vitest                              | All 5 resolve + export function         |
+| US-4 | MIGRATION.md exists                                                    | `test -f packages/analytics/MIGRATION.md` + 5 grep checks                   | Present                                  |
+| US-5 | 8 downstream packages still build                                     | `pnpm build --filter='./packages/*'`                                        | exit 0                                  |
+| US-6 | No internal `plugin from root` imports                                | `rg ... \| rg 'PluginsName' \| wc -l`                                        | `== 0`                                  |
+| US-7 | Existing analytics tests + Phase 1 additions still green              | `pnpm --filter @tour-kit/analytics test`                                    | All pass                                |
+
+### Why Fakes Are Required
+The Amplitude SDK from Phase 1 is still mocked the same way — reuse the
+existing fake at `packages/analytics/src/__tests__/__fakes__/fake-amplitude-sdk.ts`.
+Do not duplicate it. PostHog, Mixpanel, and GA don't need fakes for Phase 2
+because we only assert plugin *shape*, not behavior.
+
+### What NOT to Test
+- Don't write behavior tests for `posthogPlugin`, `mixpanelPlugin`,
+  `googleAnalyticsPlugin`. They already have coverage in the package's
+  pre-existing suite; Phase 2 is a path change, not a behavior change.
+- Don't write a codemod test. The MIGRATION.md says no codemod ships in
+  Sprint 1.
+- Don't snapshot `MIGRATION.md` content. A snapshot of prose is brittle
+  and noise-generating. Grep for the 5 plugin path strings and call it done.
+- Don't try to install `@tour-kit/analytics@0.12.0` from npm — it's not
+  published yet. Use the in-tree workspace.
+- Don't add a "deprecation warning" test for old root imports — there is
+  no deprecation shim; the breaking change is hard.
+
+### Critical: Fake Implementations Reused from Phase 1
+
+```ts
+// EXISTING — do not redefine. Reuse from Phase 1.
+// packages/analytics/src/__tests__/__fakes__/fake-amplitude-sdk.ts
+import { vi } from 'vitest'
+
+export const fakeAmplitudeSdk = {
+  init: vi.fn((_apiKey: string, _userId?: string, _options?: unknown) => ({
+    promise: Promise.resolve(),
+  })),
+  track: vi.fn((_eventName: string, _properties?: Record<string, unknown>) => ({
+    promise: Promise.resolve(),
+  })),
+  identify: vi.fn(),
+  setUserId: vi.fn(),
+  reset: vi.fn(),
+  flush: vi.fn(() => ({ promise: Promise.resolve() })),
+}
+```
+
+### Files to Create
+
+```
+packages/analytics/src/__tests__/subpath-imports.test.ts
+packages/analytics/src/__tests__/root-exports.test.ts
+packages/analytics/MIGRATION.md
+tasks/sprint-1-stop-the-bleeding/verify-phase-2.sh
+```
+
+### Per-File Coverage Guidance
+
+#### `subpath-imports.test.ts`
+- One `it()` per plugin (5 total). Each does `await import('@tour-kit/analytics/<name>')`,
+  asserts the named export is a function, calls it with a minimal config, and
+  asserts the returned object has `.init` and `.track`.
+- Use the Amplitude mock at the top of the file (Phase 1 fake).
+- Don't assert behavior — just shape.
+
+#### `root-exports.test.ts`
+- Import `* as root from '../index'`.
+- 5 `expect(root).not.toHaveProperty('<plugin>Plugin')` assertions.
+- 4 `expect(root).toHaveProperty(...)` assertions for the preserved core
+  surface (`createAnalytics`, `AnalyticsProvider`, `useAnalytics`,
+  `useAnalyticsOptional`).
+
+#### `MIGRATION.md`
+- Markdown table with 5 rows: was → now for each plugin.
+- "Why" section: 2-3 sentences.
+- "How to migrate" section: pointer to find-and-replace.
+- Explicit note that no codemod ships in Sprint 1.
+
+#### `verify-phase-2.sh`
+- Bash gates as shown in the Build/Bundle Asserter section above.
+
+### Success Criteria
+- `pnpm --filter @tour-kit/analytics test --run` exits 0.
+- `bash tasks/sprint-1-stop-the-bleeding/verify-phase-2.sh` prints all ✓.
+- `grep -cE 'posthogPlugin|mixpanelPlugin|amplitudePlugin|googleAnalyticsPlugin|consolePlugin' packages/analytics/dist/index.js` == 0.
+- `gzip -c packages/analytics/dist/index.js | wc -c` < 4000.
+- `pnpm build --filter='./packages/*'` exits 0.
+
+### Expected End State
+
+```
+packages/analytics/
+├── src/__tests__/
+│   ├── subpath-imports.test.ts          # NEW
+│   ├── root-exports.test.ts             # NEW
+│   └── __fakes__/                        # UNCHANGED (Phase 1)
+├── MIGRATION.md                          # NEW
+├── package.json                          # ./console added to exports
+├── src/index.ts                          # 5 plugin re-exports deleted
+└── tsup.config.ts                        # plugins/console added to entry
+
+tasks/sprint-1-stop-the-bleeding/
+└── verify-phase-2.sh                     # NEW
+```
+---
+
+---
+
+## Run Commands
+
+```bash
+# Build + bundle gate
+pnpm --filter @tour-kit/analytics build
+bash tasks/sprint-1-stop-the-bleeding/verify-phase-2.sh
+
+# Unit tests
+pnpm --filter @tour-kit/analytics test --run
+
+# Targeted re-runs
+pnpm --filter @tour-kit/analytics test --run src/__tests__/subpath-imports.test.ts
+pnpm --filter @tour-kit/analytics test --run src/__tests__/root-exports.test.ts
+
+# Downstream guard (full monorepo)
+pnpm build --filter='./packages/*'
+pnpm typecheck
+
+# Internal callsite sweep (US-6, also runs inside verify-phase-2.sh)
+rg -n "from ['\"]@tour-kit/analytics['\"]" packages apps examples \
+  --glob '*.{ts,tsx,md,mdx}' \
+  | rg "(posthog|mixpanel|amplitude|googleAnalytics|console)Plugin"
+# Expected: zero output.
+```
+
+---
+
+**Next:** [phase-3-tests.md](phase-3-tests.md)

--- a/tasks/sprint-1-stop-the-bleeding/phase-4-tests.md
+++ b/tasks/sprint-1-stop-the-bleeding/phase-4-tests.md
@@ -1,0 +1,374 @@
+# Phase 4 — Testing: pnpm Catalog Hygiene (R-3)
+
+**Scope:** `pnpm-workspace.yaml` (add 7 catalog entries), 9 `packages/*/package.json`
+files (replace pinned `^x.y.z` with `catalog:` for the 7 libs), `pnpm-lock.yaml`
+(zero resolution diff vs baseline).
+**Phase type:** **Workspace metadata.** No runtime code touched, no behavior
+change intended. The risk surface is pnpm: does `catalog:` resolve to the
+same versions, including in `peerDependencies`? The test plan focuses
+exclusively on resolution drift and downstream build/test stability.
+**Key Pattern:** Lockfile-diff equality against the Phase 0 baseline +
+exhaustive grep for stale pinned versions + full monorepo build/test gate.
+No vitest changes anywhere. The "test" is "does pnpm + every package's
+existing test suite still pass?"
+**Dependencies:** `pnpm@10.26.1`, `git diff`, `git grep`, `node`, the
+Phase 0 baseline at `tasks/sprint-1-stop-the-bleeding/baselines/pnpm-lock.baseline.yaml`.
+
+---
+
+## User Stories
+
+| #    | User Story                                                                                                                          | Validation Check                                                                                                                | Pass Condition                                                                              |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| US-1 | As a maintainer, I want bumping `@floating-ui/react` (or any of the 7 libs) to be a one-line edit in `pnpm-workspace.yaml`, not a 9-file find-and-replace. | `grep -E '"(@floating-ui/react\|class-variance-authority\|@radix-ui/react-slot\|@radix-ui/react-dialog\|@mui/base\|clsx\|tailwind-merge)": "\^' packages/*/package.json` | `0` matches                                                                                  |
+| US-2 | As a CI engineer, I want `pnpm install` to produce the *same* resolved versions before and after — this is a refactor, not an upgrade. | `diff baselines/pnpm-lock.baseline.yaml pnpm-lock.yaml`                                                                          | Diff is empty or limited to a small catalog-metadata block (no `resolved:` URL changes)     |
+| US-3 | As a downstream maintainer, I want every package to still build after `catalog:` resolution.                                         | `pnpm build --filter='./packages/*'`                                                                                            | exit 0                                                                                       |
+| US-4 | As a CI engineer, I want every package's existing test suite to still pass.                                                          | `pnpm test --filter='./packages/*'`                                                                                             | exit 0                                                                                       |
+| US-5 | As a consumer who installs `@tour-kit/announcements` from npm, I want `peerDependencies: { "@mui/base": "catalog:" }` to publish a resolvable version range to my installer. | `node -e "..."` reads each `packages/*/package.json` and resolves `catalog:` against `pnpm-workspace.yaml`'s `catalog:` block | All 7 libs (where used) appear in the resolved peer table with an exact version range       |
+| US-6 | As a future debugger, I want the `pnpm-workspace.yaml` catalog block to be the single source of truth — no duplicate `workspaces.catalog` shadow in root `package.json`. | `grep -A 20 '"workspaces"' package.json` and confirm no `catalog` key is added there                                            | Root `package.json` `workspaces` has no new `catalog` sub-block                              |
+| US-7 | As a maintainer running Phase 7 next, I want `pnpm-lock.yaml` to remain consistent with `--frozen-lockfile`.                          | `pnpm install --frozen-lockfile`                                                                                                | exit 0                                                                                       |
+
+---
+
+## Component Mock Strategy
+
+| Component                              | Mock Strategy                                              | What to Assert                                                                            | User Story  |
+| -------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| `pnpm-workspace.yaml` catalog block    | None — real YAML read                                      | 7 new entries, exact version strings matching the pre-phase pinned values                  | US-1        |
+| Per-package `package.json` edits        | None — real JSON read in node                              | Every previously-pinned version is now `"catalog:"`; counts match the audit table         | US-1        |
+| pnpm install + lock resolution         | None — real `pnpm install`                                 | Lockfile diff vs Phase 0 baseline is empty (or catalog-only metadata)                      | US-2, US-7  |
+| Workspace build                        | None — real builds                                         | `pnpm build --filter='./packages/*'` exits 0                                              | US-3        |
+| Workspace tests                        | None — real test suites                                    | `pnpm test --filter='./packages/*'` exits 0                                               | US-4        |
+| Peer-dep resolution                    | None — JSON parse + manual catalog lookup                  | For each `peerDependencies: { "X": "catalog:" }`, the catalog has `X: <version>`           | US-5        |
+| Root `package.json` shadow check        | None — JSON read                                           | No `workspaces.catalog` shadow block introduced                                            | US-6        |
+
+---
+
+## Test Tier Table
+
+| Tier               | Dependencies                                              | Speed     | When to Run                              |
+| ------------------ | --------------------------------------------------------- | --------- | ---------------------------------------- |
+| Shape gate         | `git grep`, `node`                                        | < 5 s     | Pre-PR                                    |
+| Lockfile-diff gate | `pnpm install`, `diff` against baseline                   | ~1 min    | Pre-PR + on CI                            |
+| Workspace build    | All packages built once                                   | ~3 min    | Pre-PR + on CI                            |
+| Workspace tests    | All packages' vitest suites                               | ~2 min    | Pre-PR + on CI                            |
+| Peer-resolve gate  | `node` + JSON                                             | < 2 s     | Pre-PR                                    |
+
+No vitest changes. No new fakes. No new test files.
+
+---
+
+## No Fake Implementations (Workspace Metadata)
+
+Phase 4 has no behavior to mock. The only "third party" is pnpm itself,
+and we want to exercise its real resolution. Mocking pnpm would defeat
+the entire point of the lockfile-diff gate.
+
+The only file written for this phase outside the package metadata is
+the bash asserter (§Asserter Skeleton below).
+
+---
+
+## Test File List
+
+```
+pnpm-workspace.yaml                              # MODIFIED — 7 new catalog entries
+packages/hints/package.json                      # MODIFIED — 3 deps + 1 peer
+packages/announcements/package.json              # MODIFIED — 4 deps + 1 peer
+packages/checklists/package.json                 # MODIFIED — 3 deps + 1 peer
+packages/ai/package.json                         # MODIFIED — 1 dep
+packages/core/package.json                       # MODIFIED — 2 deps (clsx, tailwind-merge)
+packages/surveys/package.json                    # MODIFIED — 3 deps + 1 peer
+packages/adoption/package.json                   # MODIFIED — 2 deps + 1 peer
+packages/media/package.json                      # MODIFIED — 2 deps + 1 peer
+packages/react/package.json                      # MODIFIED — 3 deps + 1 peer
+pnpm-lock.yaml                                   # MODIFIED — catalog metadata only, no resolution drift
+
+tasks/sprint-1-stop-the-bleeding/
+└── verify-phase-4.sh                            # NEW: idempotent post-edit gate runner
+```
+
+---
+
+## Asserter Skeleton
+
+```bash
+#!/usr/bin/env bash
+# tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh
+# Run after editing package.json files and running `pnpm install`.
+set -u
+fails=0
+gate() { if eval "$1"; then echo "✓ $2"; else echo "✗ $2 — $(eval "$3")"; fails=$((fails+1)); fi; }
+
+BASELINE_LOCK="tasks/sprint-1-stop-the-bleeding/baselines/pnpm-lock.baseline.yaml"
+
+# US-1: no remaining pinned versions for the 7 catalog libs
+pinned=$(git grep -cE '"(@floating-ui/react|class-variance-authority|@radix-ui/react-slot|@radix-ui/react-dialog|@mui/base|clsx|tailwind-merge)": "\^' packages/ | wc -l | tr -d ' ')
+gate "[ $pinned -eq 0 ]" "US-1: no pinned catalog libs in packages/" "git grep -E '\"(@floating-ui/react|class-variance-authority|@radix-ui/react-slot|@radix-ui/react-dialog|@mui/base|clsx|tailwind-merge)\": \"\\^' packages/"
+
+# US-1 (positive): pnpm-workspace.yaml has the 7 new entries
+for lib in '@floating-ui/react' 'class-variance-authority' '@radix-ui/react-slot' '@radix-ui/react-dialog' '@mui/base' 'clsx' 'tailwind-merge'; do
+  gate "grep -qE '\"?${lib}\"?:' pnpm-workspace.yaml" "US-1: catalog has ${lib}" "echo missing in pnpm-workspace.yaml"
+done
+
+# US-2: lockfile resolution unchanged vs baseline
+if [ -f "$BASELINE_LOCK" ]; then
+  # Resolution-relevant lines: anything with `resolved:` or version pins.
+  # Catalog metadata is allowed to differ.
+  diff_count=$(diff "$BASELINE_LOCK" pnpm-lock.yaml | grep -E '^[<>] ' | grep -v 'catalog' | wc -l | tr -d ' ')
+  gate "[ $diff_count -lt 20 ]" "US-2: lockfile resolution drift < 20 non-catalog lines" "echo got $diff_count"
+else
+  echo "✗ US-2: baselines/pnpm-lock.baseline.yaml missing — re-run Phase 0"
+  fails=$((fails+1))
+fi
+
+# US-3: workspace builds
+gate 'pnpm build --filter=./packages/* >/tmp/phase-4-build.log 2>&1' \
+     'US-3: pnpm build --filter=./packages/* green' "tail -n5 /tmp/phase-4-build.log"
+
+# US-4: workspace tests
+gate 'pnpm test --filter=./packages/* --run >/tmp/phase-4-test.log 2>&1' \
+     'US-4: pnpm test --filter=./packages/* green' "tail -n10 /tmp/phase-4-test.log"
+
+# US-5: catalog: in peerDependencies resolves
+gate 'node tasks/sprint-1-stop-the-bleeding/_phase-4-peer-resolve.mjs' \
+     'US-5: every catalog: peer resolves to a real version' "node tasks/sprint-1-stop-the-bleeding/_phase-4-peer-resolve.mjs"
+
+# US-6: root package.json hasn't grown a shadow catalog
+gate 'node -e "const p=require(\"./package.json\"); process.exit(p.workspaces?.catalog ? 1 : 0)"' \
+     'US-6: no workspaces.catalog shadow in root package.json' "echo found shadow"
+
+# US-7: frozen lockfile install
+gate 'pnpm install --frozen-lockfile >/tmp/phase-4-frozen.log 2>&1' \
+     'US-7: pnpm install --frozen-lockfile green' "tail -n10 /tmp/phase-4-frozen.log"
+
+[ "$fails" -eq 0 ] || { echo "Phase 4 FAILED gates: $fails"; exit 1; }
+echo "Phase 4 all gates green."
+```
+
+### Helper: `_phase-4-peer-resolve.mjs`
+
+```js
+// tasks/sprint-1-stop-the-bleeding/_phase-4-peer-resolve.mjs
+// Exits 0 if every `peerDependencies: { ...: "catalog:" }` in packages/*/
+// resolves against the `catalog:` block in pnpm-workspace.yaml.
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { parse as parseYaml } from 'yaml'
+import { join } from 'node:path'
+
+const ws = parseYaml(readFileSync('pnpm-workspace.yaml', 'utf8'))
+const catalog = ws.catalog ?? {}
+
+const pkgDirs = readdirSync('packages').filter(d =>
+  statSync(join('packages', d)).isDirectory()
+)
+
+let fails = 0
+for (const dir of pkgDirs) {
+  const pkgPath = join('packages', dir, 'package.json')
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+    for (const section of ['dependencies', 'peerDependencies']) {
+      const block = pkg[section] ?? {}
+      for (const [name, range] of Object.entries(block)) {
+        if (range === 'catalog:') {
+          if (!catalog[name]) {
+            console.error(`✗ ${pkgPath} ${section}.${name}: catalog: but no catalog entry`)
+            fails++
+          }
+        }
+      }
+    }
+  } catch (e) {
+    console.error(`Cannot read ${pkgPath}: ${e.message}`)
+    fails++
+  }
+}
+
+process.exit(fails === 0 ? 0 : 1)
+```
+
+`yaml` is already in the workspace dependency graph (via the docs site).
+If your node setup can't find it from the repo root, replace with a small
+inline parser — or add `node -e "require('yaml')"` to the pre-conditions.
+
+---
+
+## Key Testing Decisions
+
+| Decision                                                          | Approach                                                      | Rationale                                                                                                                |
+| ----------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Use the Phase 0 baseline lockfile for the diff gate                | `diff baselines/pnpm-lock.baseline.yaml pnpm-lock.yaml`       | Phase 0 captured the lockfile *specifically* so this gate could be meaningful. Comparing against `main` would race with sibling merges. |
+| Allow catalog-metadata lines in the lockfile diff                  | `grep -v 'catalog'` before counting                           | pnpm legitimately writes a `catalog:` metadata block when catalog is used. Resolution drift is what we care about.        |
+| 20-line drift tolerance, not strict zero                           | `[ $diff_count -lt 20 ]`                                      | pnpm formatting can shift whitespace or section ordering. 20 is a sentry for "real drift," not formatting noise.          |
+| Catalog: in `peerDependencies` is verified via JSON parse, not grep | Helper Node script                                            | A grep would miss the case where pnpm "supports" catalog peers but the *consumer's* installer can't resolve them. Reading the value and confirming a catalog entry exists for it is the contract. |
+| Don't auto-detect drift in the catalog itself                      | Match exactly the versions from the audit table               | If a maintainer wants to upgrade `@floating-ui/react` *during* Phase 4, that's a different PR. Refactor first, upgrade later. |
+| Allow either "one workspace changeset" or "9 changesets"           | Phase plan §8 — pick one                                       | Test plan doesn't dictate; we only assert the *result* — patch versions bump for affected packages.                       |
+| Don't add vitest "import test" for catalog libs                    | Existing test suites + `pnpm test --filter='./packages/*'`    | Every package already exercises `@floating-ui/react`, `clsx`, etc. in its own tests. Bumping resolution would surface there. |
+
+---
+
+## Example "Test Case" — Reading the asserter output
+
+```bash
+$ bash tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh
+✓ US-1: no pinned catalog libs in packages/
+✓ US-1: catalog has @floating-ui/react
+✓ US-1: catalog has class-variance-authority
+✓ US-1: catalog has @radix-ui/react-slot
+✓ US-1: catalog has @radix-ui/react-dialog
+✓ US-1: catalog has @mui/base
+✓ US-1: catalog has clsx
+✓ US-1: catalog has tailwind-merge
+✓ US-2: lockfile resolution drift < 20 non-catalog lines
+✓ US-3: pnpm build --filter=./packages/* green
+✓ US-4: pnpm test --filter=./packages/* green
+✓ US-5: every catalog: peer resolves to a real version
+✓ US-6: no workspaces.catalog shadow in root package.json
+✓ US-7: pnpm install --frozen-lockfile green
+Phase 4 all gates green.
+```
+
+If `US-2` is red with a high drift count, one of:
+
+1. pnpm 9 → 10 was crossed mid-flight (corepack mismatch).
+2. A catalog version typo silently picked up a different resolved version.
+3. A sibling phase merged a dep bump during Phase 4 — re-baseline.
+
+If `US-5` is red on `@mui/base`, the §4.1 caveat applies: pnpm may not
+support `catalog:` in `peerDependencies` for your version. Revert the
+peer-dep lines only and keep the regular `dependencies` lines on
+`catalog:`. Document this in the PR.
+
+---
+
+## Execution Prompt
+
+Copy everything between the `---` lines into a new Claude session to write
+the Phase 4 asserter and verify the catalog migration:
+
+---
+You are completing Phase 4 of Sprint 1 in the tour-kit monorepo — moving
+7 runtime libraries into the pnpm catalog so future version bumps are a
+one-line edit instead of a 9-file find-and-replace.
+
+### What This Project Is
+tour-kit is a pnpm 10 monorepo. Seven runtime libs (`@floating-ui/react`,
+`class-variance-authority`, `@radix-ui/react-slot`, `@radix-ui/react-dialog`,
+`@mui/base`, `clsx`, `tailwind-merge`) are pinned identically across 9
+packages. Phase 4 moves them into `pnpm-workspace.yaml`'s `catalog:` block
+and replaces every pinned version with `"catalog:"`.
+
+### Acceptance Criteria (from User Stories)
+| #    | User Story                                                    | Validation Check                                              | Pass Condition                          |
+| ---- | ------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------- |
+| US-1 | One-line bumps after Phase 4                                  | `git grep -E '...: "\^' packages/`                            | `0` matches for the 7 libs              |
+| US-2 | Lockfile resolution unchanged                                  | `diff baselines/pnpm-lock.baseline.yaml pnpm-lock.yaml`       | < 20 non-catalog lines differ           |
+| US-3 | Every package still builds                                     | `pnpm build --filter='./packages/*'`                          | exit 0                                  |
+| US-4 | Every package's tests still pass                               | `pnpm test --filter='./packages/*'`                           | exit 0                                  |
+| US-5 | catalog: in peerDependencies resolves                          | Helper Node script                                            | All `catalog:` peers find a catalog entry |
+| US-6 | No shadow catalog in root `package.json`                      | `node -e "...!p.workspaces.catalog"`                          | True                                    |
+| US-7 | `--frozen-lockfile` install passes                             | `pnpm install --frozen-lockfile`                              | exit 0                                  |
+
+### Why Fakes Are Required
+None. Phase 4 exercises real pnpm resolution and real package builds —
+mocking pnpm would erase the entire risk surface we're checking.
+
+### What NOT to Test
+- Don't bump versions in the catalog beyond what's already pinned.
+  Refactor first, upgrade later.
+- Don't add `catalog:` entries for the test infra (vitest, tsup, etc.) —
+  those are already cataloged.
+- Don't write vitest tests that import the catalog libs to "prove
+  resolution worked" — the existing per-package suites already do that.
+- Don't manually edit `pnpm-lock.yaml`. Let `pnpm install` regenerate it.
+- Don't introduce a `package.json` `workspaces.catalog` block at the root.
+  pnpm-workspace.yaml is the canonical catalog (US-6).
+
+### Critical: The Asserter
+
+The body of `tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh` and
+`_phase-4-peer-resolve.mjs` are shown above. Drop them in, `chmod +x` the
+bash script, and run.
+
+### Files to Create / Modify
+
+```
+pnpm-workspace.yaml                              # +7 catalog entries
+packages/hints/package.json                      # 3 deps + 1 peer → "catalog:"
+packages/announcements/package.json              # 4 deps + 1 peer → "catalog:"
+packages/checklists/package.json                 # 3 deps + 1 peer → "catalog:"
+packages/ai/package.json                         # 1 dep → "catalog:"
+packages/core/package.json                       # 2 deps → "catalog:"
+packages/surveys/package.json                    # 3 deps + 1 peer → "catalog:"
+packages/adoption/package.json                   # 2 deps + 1 peer → "catalog:"
+packages/media/package.json                      # 2 deps + 1 peer → "catalog:"
+packages/react/package.json                      # 3 deps + 1 peer → "catalog:"
+pnpm-lock.yaml                                   # regenerated by pnpm install
+tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh           # NEW
+tasks/sprint-1-stop-the-bleeding/_phase-4-peer-resolve.mjs   # NEW
+```
+
+### Per-File Coverage Guidance
+
+#### Per-package `package.json` edits
+- For each row in the audit table (phase plan §2), find the matching line
+  in the named package.json and replace `"^x.y.z"` with `"catalog:"`.
+- Do NOT touch `version`, `name`, `peerDependenciesMeta`, or any other
+  field.
+- If pnpm errors on `catalog:` in `peerDependencies` after install (rare
+  on pnpm 10), revert that single line and leave the version pinned.
+  Document in the PR.
+
+#### `pnpm-workspace.yaml`
+- Add the 7 new entries under the existing `catalog:` block, after the
+  test-infra entries. Match the exact versions from the audit (§2 table
+  in the phase plan).
+
+#### `verify-phase-4.sh` + `_phase-4-peer-resolve.mjs`
+- Bodies shown above.
+
+### Success Criteria
+- `bash tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh` prints all ✓.
+- `git grep -E '"(@floating-ui/react|class-variance-authority|@radix-ui/react-slot|@radix-ui/react-dialog|@mui/base|clsx|tailwind-merge)": "\^' packages/` returns 0 hits.
+- `diff baselines/pnpm-lock.baseline.yaml pnpm-lock.yaml | grep -E '^[<>]' | grep -v catalog | wc -l` < 20.
+
+### Expected End State
+
+```
+pnpm-workspace.yaml                              # +7 catalog entries
+packages/{hints,announcements,checklists,ai,core,surveys,adoption,media,react}/package.json
+                                                 # catalog: replacements
+pnpm-lock.yaml                                   # catalog metadata, no resolution drift
+tasks/sprint-1-stop-the-bleeding/
+├── verify-phase-4.sh                            # NEW
+└── _phase-4-peer-resolve.mjs                    # NEW
+```
+---
+
+---
+
+## Run Commands
+
+```bash
+# Edit the files, then:
+pnpm install
+
+# Verify
+chmod +x tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh
+bash tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh
+
+# Inspect the lockfile diff (US-2)
+diff tasks/sprint-1-stop-the-bleeding/baselines/pnpm-lock.baseline.yaml \
+     pnpm-lock.yaml \
+  | grep -E '^[<>] ' | grep -v catalog | head -50
+
+# Quick smoke: install fresh and confirm peer warnings haven't grown
+rm -rf node_modules packages/*/node_modules
+pnpm install
+pnpm install --frozen-lockfile  # second pass to confirm idempotent
+```
+
+---
+
+**Next:** [phase-5-tests.md](phase-5-tests.md)

--- a/tasks/sprint-1-stop-the-bleeding/phase-5-tests.md
+++ b/tasks/sprint-1-stop-the-bleeding/phase-5-tests.md
@@ -1,0 +1,374 @@
+# Phase 5 — Testing: `@tour-kit/codemods` Docs (G-1)
+
+**Scope:** Four new MDX files under `apps/docs/content/docs/codemods/`
+(`index.mdx`, `from-shepherd.mdx`, `from-driver.mdx`, `from-joyride.mdx`),
+one new `meta.json` in that folder, one edit to the parent
+`apps/docs/content/docs/meta.json` (add `codemods` to nav), and three
+callout edits to the existing migration MDX pages.
+**Phase type:** **Docs only.** Zero package code touched. The "test" is
+"the docs build, the nav shows the new entry, every link resolves, and
+every command shown is the real published one." No vitest. No fakes.
+**Key Pattern:** Static-content asserter — file existence, frontmatter
+shape, link integrity, code-block-command validity (e.g. `pnpm exec
+tour-kit-migrate --help` actually runs), and a `pnpm --filter
+@tour-kit/docs build` gate.
+**Dependencies:** `pnpm`, `node`, the Fumadocs build (existing in
+`apps/docs`), the `tour-kit-migrate` binary from `packages/codemods/dist/`.
+
+---
+
+## User Stories
+
+| #    | User Story                                                                                                                          | Validation Check                                                                                                                | Pass Condition                                                                              |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| US-1 | As a consumer evaluating Tour Kit, I want to discover the migration codemods from the docs nav — not by `git grep`-ing the repo.    | `grep -A 20 '"---Resources---"' apps/docs/content/docs/meta.json` includes `"codemods"`                                          | `"codemods"` listed in nav under Resources                                                  |
+| US-2 | As a Shepherd/Driver/Joyride user, I want one page per source library that shows the exact `tour-kit-migrate` command for my case.  | `test -f apps/docs/content/docs/codemods/from-{shepherd,driver,joyride}.mdx`                                                    | All 3 files present, each has a `pnpm exec tour-kit-migrate --from <lib>` codeblock         |
+| US-3 | As a doc reader, I want every "Run" command in the codemod pages to actually work against the published bin.                        | Each `pnpm exec tour-kit-migrate --help` and `--from <lib> --dry-run` snippet is grep-extractable + runs without error          | Bin exists at `packages/codemods/dist/bin/tour-kit-migrate.cjs`; `--help` exits 0           |
+| US-4 | As a migrator scrolling the existing `migration/shepherd.mdx`, I want a "use the codemod" callout near the top.                      | `grep -l '/docs/codemods/from-' apps/docs/content/docs/migration/{shepherd,driver,joyride}.mdx`                                 | All 3 migration pages link to the matching codemod page                                     |
+| US-5 | As a docs reviewer, I want `pnpm --filter @tour-kit/docs build` to render every new page without an MDX parse error.                 | `pnpm --filter @tour-kit/docs build`                                                                                            | exit 0                                                                                       |
+| US-6 | As a repo owner, I want this PR to be docs-only — no risk of accidental package-code drift.                                          | `git diff --stat -- packages/`                                                                                                  | Empty (zero files under `packages/` changed)                                                 |
+| US-7 | As a doc reader, every internal link in the new pages must resolve to a real page (no 404s on `/docs/migration/...`, `/docs/react/...`). | `link-check.yml`-style scan: for each `[...]` link, confirm target file exists                                                | All internal links resolve                                                                   |
+
+---
+
+## Component Mock Strategy
+
+| Component                              | Mock Strategy                                              | What to Assert                                                                            | User Story  |
+| -------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| `apps/docs/content/docs/codemods/*.mdx`| None — real files                                          | Files exist; frontmatter has `title` + `description`; H1 present                          | US-2        |
+| `apps/docs/content/docs/codemods/meta.json` | None — JSON read                                       | Has `title: "Codemods"`, lists `index` + 3 transform pages + a separator                  | US-2        |
+| `apps/docs/content/docs/meta.json`      | None — JSON read                                          | `pages` array includes `"codemods"` exactly once, under `---Resources---`                  | US-1        |
+| `tour-kit-migrate` bin                  | None — run real bin                                       | `node packages/codemods/dist/bin/tour-kit-migrate.cjs --help` exits 0                     | US-3        |
+| Migration page callouts                 | None — grep                                                | `from-shepherd`, `from-driver`, `from-joyride` paths linked from matching migration pages  | US-4        |
+| Internal link integrity                 | None — grep + `test -f` per `/docs/...` path               | Every relative-path target file (or its `index.mdx`) exists                                 | US-7        |
+| Docs build                              | None — `pnpm --filter @tour-kit/docs build`                | exit 0                                                                                     | US-5        |
+| Package-code untouched                  | None — `git diff --stat -- packages/`                      | Empty                                                                                      | US-6        |
+
+---
+
+## Test Tier Table
+
+| Tier             | Dependencies                                              | Speed     | When to Run                              |
+| ---------------- | --------------------------------------------------------- | --------- | ---------------------------------------- |
+| Shape gate       | `node`, `grep`, `test`                                    | < 2 s     | Pre-PR, in `verify-phase-5.sh`           |
+| Bin smoke        | `packages/codemods/dist/bin/tour-kit-migrate.cjs`         | < 5 s     | Pre-PR (requires codemods build)         |
+| Internal-link gate | grep + `test -f` per target                              | < 5 s     | Pre-PR                                    |
+| Docs build       | `pnpm --filter @tour-kit/docs build`                      | ~1–2 min  | Pre-PR + on CI                            |
+| Manual eyeball   | `pnpm --filter @tour-kit/docs dev`, browser               | ~2 min    | Pre-PR (recommended, not blocking)        |
+
+No vitest. Recipes here are CLI examples, not testable code blocks.
+
+---
+
+## No Fake Implementations (Docs Only)
+
+Phase 5 ships zero new runtime code. There is nothing to mock. The
+`tour-kit-migrate` bin already exists in the package (Phase 5 only
+documents it); we exercise it via real `node` invocation in US-3.
+
+---
+
+## Test File List
+
+```
+apps/docs/content/docs/codemods/
+├── index.mdx                                # NEW
+├── from-shepherd.mdx                        # NEW
+├── from-driver.mdx                          # NEW
+├── from-joyride.mdx                         # NEW
+└── meta.json                                # NEW
+
+apps/docs/content/docs/meta.json             # MODIFIED — add "codemods" to Resources
+
+apps/docs/content/docs/migration/
+├── shepherd.mdx                             # MODIFIED — callout to /docs/codemods/from-shepherd
+├── driver.mdx                               # MODIFIED — callout to /docs/codemods/from-driver
+└── joyride.mdx                              # MODIFIED — callout to /docs/codemods/from-joyride
+
+tasks/sprint-1-stop-the-bleeding/
+└── verify-phase-5.sh                        # NEW: shape + bin + link gates
+
+# Out of scope (verify NOT touched):
+packages/codemods/**                         # MUST be empty in git diff
+```
+
+---
+
+## Asserter Skeleton
+
+```bash
+#!/usr/bin/env bash
+# tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh
+# Run before opening the Phase 5 PR.
+set -u
+fails=0
+gate() { if eval "$1"; then echo "✓ $2"; else echo "✗ $2 — $(eval "$3")"; fails=$((fails+1)); fi; }
+
+DOCS_ROOT="apps/docs/content/docs"
+
+# US-2: 4 new pages exist
+for f in index from-shepherd from-driver from-joyride; do
+  gate "[ -f $DOCS_ROOT/codemods/$f.mdx ]" "US-2: $f.mdx exists" "echo missing"
+done
+
+# US-2 (each has frontmatter)
+for f in index from-shepherd from-driver from-joyride; do
+  gate "head -5 $DOCS_ROOT/codemods/$f.mdx | grep -q '^title:'" "US-2: $f.mdx has frontmatter title" "head -5 $DOCS_ROOT/codemods/$f.mdx"
+done
+
+# US-2 (transform pages have a run codeblock)
+for lib in shepherd driver joyride; do
+  gate "grep -q 'tour-kit-migrate --from $lib' $DOCS_ROOT/codemods/from-$lib.mdx" \
+       "US-2: from-$lib.mdx includes run command" "echo missing"
+done
+
+# US-2 (meta.json present)
+gate "[ -f $DOCS_ROOT/codemods/meta.json ]" 'US-2: codemods/meta.json exists' "echo missing"
+gate 'node -e "const m=require(\"./apps/docs/content/docs/codemods/meta.json\"); process.exit(m.pages?.includes(\"index\") && m.pages?.includes(\"from-shepherd\") ? 0 : 1)"' \
+     'US-2: meta.json lists index + transform pages' "cat $DOCS_ROOT/codemods/meta.json"
+
+# US-1: root meta.json includes "codemods" under Resources
+gate 'node -e "const m=require(\"./apps/docs/content/docs/meta.json\"); const idx=m.pages.indexOf(\"---Resources---\"); const end=m.pages.findIndex((p,i)=>i>idx && p.startsWith(\"---\")); const slice=m.pages.slice(idx, end>=0?end:undefined); process.exit(slice.includes(\"codemods\") ? 0 : 1)"' \
+     'US-1: root meta.json lists codemods under Resources' "cat $DOCS_ROOT/meta.json | grep -A 10 Resources"
+
+# US-3: tour-kit-migrate bin works
+if [ ! -f packages/codemods/dist/bin/tour-kit-migrate.cjs ]; then
+  echo "Building codemods first…"
+  pnpm --filter @tour-kit/codemods build >/dev/null 2>&1
+fi
+gate '[ -f packages/codemods/dist/bin/tour-kit-migrate.cjs ]' \
+     'US-3: tour-kit-migrate bin built' "echo missing — run pnpm --filter @tour-kit/codemods build"
+gate 'node packages/codemods/dist/bin/tour-kit-migrate.cjs --help >/dev/null 2>&1' \
+     'US-3: tour-kit-migrate --help exits 0' "node packages/codemods/dist/bin/tour-kit-migrate.cjs --help 2>&1 | tail -5"
+
+# US-4: existing migration pages link to the codemod pages
+for lib in shepherd driver joyride; do
+  gate "grep -q '/docs/codemods/from-$lib' $DOCS_ROOT/migration/$lib.mdx" \
+       "US-4: migration/$lib.mdx links to codemod" "echo missing callout"
+done
+
+# US-6: no package code touched
+n=$(git diff --name-only -- packages/ | wc -l | tr -d ' ')
+gate "[ $n -eq 0 ]" "US-6: zero files under packages/ changed" "git diff --name-only -- packages/"
+
+# US-7: internal link integrity (cheap pass — only check /docs/... refs)
+# Extracts every (/docs/...) link target from the new pages.
+missing_links=0
+while read -r link; do
+  # Strip anchor + leading slash
+  target=$(echo "$link" | sed 's|#.*||' | sed 's|^/||')
+  # Map /docs/foo → apps/docs/content/docs/foo (with .mdx or /index.mdx)
+  if [ -f "apps/$target.mdx" ] || [ -f "apps/$target/index.mdx" ]; then
+    : # OK
+  else
+    echo "  ✗ broken link: $link"
+    missing_links=$((missing_links+1))
+  fi
+done < <(grep -hoE '\(/docs/[a-z0-9-]+(/[a-z0-9-]+)*\)' $DOCS_ROOT/codemods/*.mdx | tr -d '()' | sort -u)
+
+gate "[ $missing_links -eq 0 ]" "US-7: all internal /docs/ links resolve" "echo $missing_links broken"
+
+# US-5: docs build
+gate 'pnpm --filter @tour-kit/docs build >/tmp/phase-5-build.log 2>&1' \
+     'US-5: apps/docs builds' "tail -n10 /tmp/phase-5-build.log"
+
+[ "$fails" -eq 0 ] || { echo "Phase 5 FAILED gates: $fails"; exit 1; }
+echo "Phase 5 all gates green."
+```
+
+---
+
+## Key Testing Decisions
+
+| Decision                                                          | Approach                                                      | Rationale                                                                                                                |
+| ----------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Test the bin, not the codemod transforms                          | `node packages/codemods/dist/bin/tour-kit-migrate.cjs --help` | Phase 5 is *docs*. We assert the documented command resolves to a real bin. Transform behavior already has tests in `packages/codemods/src/__tests__/`. |
+| Internal-link scan is a grep, not a full link checker              | bash + `grep -hoE`                                            | The existing `link-check.yml` workflow handles full link checking on CI. Pre-PR, a cheap grep catches the 80 % cases.    |
+| Don't assert visual rendering (Playwright snapshot)                | Manual eyeball in `apps/docs dev`                             | Snapshotting 4 MDX pages is heavy ceremony for content that is changing daily during a docs sprint. Eyeball is honest.   |
+| Frontmatter check is "title field present", not full schema validation | `head -5 ... \| grep '^title:'`                           | Fumadocs already errors on missing required frontmatter at build time. Our shape gate is for "do the files exist" — not "are they perfect." |
+| Asserter requires codemods build                                  | `pnpm --filter @tour-kit/codemods build` if missing           | The bin smoke (US-3) won't run without it. We auto-build to avoid a brittle "skip if missing" path.                       |
+| Don't test `meta.json` ordering beyond "contains codemods"         | Set-membership only                                            | The exact position within `---Resources---` is taste, not contract. Asserting position would couple the gate to docs IA. |
+
+---
+
+## Example "Test Case" — Reading the asserter output
+
+```bash
+$ bash tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh
+✓ US-2: index.mdx exists
+✓ US-2: from-shepherd.mdx exists
+✓ US-2: from-driver.mdx exists
+✓ US-2: from-joyride.mdx exists
+✓ US-2: index.mdx has frontmatter title
+✓ US-2: from-shepherd.mdx has frontmatter title
+✓ US-2: from-driver.mdx has frontmatter title
+✓ US-2: from-joyride.mdx has frontmatter title
+✓ US-2: from-shepherd.mdx includes run command
+✓ US-2: from-driver.mdx includes run command
+✓ US-2: from-joyride.mdx includes run command
+✓ US-2: codemods/meta.json exists
+✓ US-2: meta.json lists index + transform pages
+✓ US-1: root meta.json lists codemods under Resources
+✓ US-3: tour-kit-migrate bin built
+✓ US-3: tour-kit-migrate --help exits 0
+✓ US-4: migration/shepherd.mdx links to codemod
+✓ US-4: migration/driver.mdx links to codemod
+✓ US-4: migration/joyride.mdx links to codemod
+✓ US-6: zero files under packages/ changed
+✓ US-7: all internal /docs/ links resolve
+✓ US-5: apps/docs builds
+Phase 5 all gates green.
+```
+
+If `US-3: tour-kit-migrate --help exits 0` is red, the bin smoke caught a
+regression in the published CLI. Stop and fix the codemods package first
+— shipping docs for a broken binary is a worse outcome than no docs.
+
+---
+
+## Execution Prompt
+
+Copy everything between the `---` lines into a new Claude session to write
+the Phase 5 docs and asserter:
+
+---
+You are completing Phase 5 of Sprint 1 in the tour-kit monorepo — adding
+docs for `@tour-kit/codemods` so the migration tooling is discoverable on
+the docs site.
+
+### What This Project Is
+`@tour-kit/codemods` v0.3.0 ships a `tour-kit-migrate` CLI plus jscodeshift
+transforms that automate migration from React Joyride, Shepherd.js, and
+Driver.js. The package exists, the CLI works, but there are zero docs
+pages — making the migration tooling effectively invisible.
+
+### Acceptance Criteria (from User Stories)
+| #    | User Story                                                    | Validation Check                                              | Pass Condition                          |
+| ---- | ------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------- |
+| US-1 | Discoverable from nav                                          | `meta.json` includes `"codemods"` under Resources             | Listed exactly once                     |
+| US-2 | Per-library pages exist                                        | `from-{shepherd,driver,joyride}.mdx` present + run commands   | All 3 + index, each has run codeblock   |
+| US-3 | Run commands actually work                                     | `node packages/codemods/dist/bin/tour-kit-migrate.cjs --help` | exit 0                                  |
+| US-4 | Existing migration pages cross-link                            | Grep for `/docs/codemods/from-` in migration MDX              | All 3 migration pages link out          |
+| US-5 | Docs build clean                                               | `pnpm --filter @tour-kit/docs build`                          | exit 0                                  |
+| US-6 | Docs-only PR                                                   | `git diff --stat -- packages/`                                | Empty                                   |
+| US-7 | No broken internal links                                       | Grep + `test -f` per `/docs/...` target                       | All resolve                             |
+
+### Why Fakes Are Required
+None. Phase 5 ships no runtime code. The "test" is "do the files exist,
+build clean, link out, and reference real commands." The CLI exists and
+runs; we exercise it for real.
+
+### What NOT to Test
+- Don't write codemod transform tests. The package already has them in
+  `packages/codemods/src/__tests__/`. Phase 5 is docs.
+- Don't document `replay-bridge-to-use-tour-actions` or `target-to-ref`.
+  Per the phase plan, those are internal helpers — Sprint 2 work.
+- Don't write a `npx -p @tour-kit/codemods` test. Network-dependent; the
+  bin smoke against `dist/bin/...` is enough.
+- Don't snapshot the rendered pages with Playwright. Manual eyeball in
+  `apps/docs dev` is honest for content that changes during a docs sprint.
+- Don't add per-transform vitest fixtures. The codemod's own test suite
+  is the authority.
+
+### Critical: The Asserter
+
+The body of `tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh` is shown
+above (the Asserter Skeleton section). Drop it in, `chmod +x`, and run.
+
+### Files to Create / Modify
+
+```
+apps/docs/content/docs/codemods/index.mdx              # NEW
+apps/docs/content/docs/codemods/from-shepherd.mdx      # NEW
+apps/docs/content/docs/codemods/from-driver.mdx        # NEW
+apps/docs/content/docs/codemods/from-joyride.mdx       # NEW
+apps/docs/content/docs/codemods/meta.json              # NEW
+apps/docs/content/docs/meta.json                       # MODIFIED — add "codemods" to Resources
+
+apps/docs/content/docs/migration/shepherd.mdx          # MODIFIED — callout
+apps/docs/content/docs/migration/driver.mdx            # MODIFIED — callout
+apps/docs/content/docs/migration/joyride.mdx          # MODIFIED — callout
+
+tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh     # NEW
+```
+
+### Per-File Coverage Guidance
+
+#### `codemods/index.mdx`
+- Frontmatter: `title: Codemods`, `description: ...`.
+- Sections: "When to use", "Install", "Available transforms", "After
+  running", "Limitations". Include the `pnpm exec tour-kit-migrate
+  --help` example.
+- Phase plan §3.1 has the full template — copy verbatim.
+
+#### `codemods/from-{shepherd,driver,joyride}.mdx`
+- Each: frontmatter + H1 + "Run" codeblock + "What it changes" table +
+  "What it does NOT handle" list + before/after example + "See also" link
+  to the matching `/docs/migration/<lib>` page.
+- Phase plan §3.2, §3.3, §3.4 have templates.
+
+#### `codemods/meta.json`
+- `{ "title": "Codemods", "pages": ["index", "---", "from-shepherd", "from-driver", "from-joyride"] }`
+
+#### `docs/meta.json`
+- Insert `"codemods"` in the existing `---Resources---` block, between
+  `"migration"` and `"api"`.
+
+#### Migration page callouts
+- Add a `:::tip` callout near the top of each `migration/<lib>.mdx`
+  linking to `/docs/codemods/from-<lib>`. Body shown in phase plan §4.
+
+#### `verify-phase-5.sh`
+- The body shown above (Asserter Skeleton).
+
+### Success Criteria
+- `bash tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh` prints all ✓.
+- `pnpm --filter @tour-kit/docs build` exits 0.
+- `git diff --stat -- packages/` is empty.
+- Manual: navigate to `http://localhost:3000/docs/codemods` in `apps/docs
+  dev` and click through all 4 pages — no MDX render errors visible.
+
+### Expected End State
+
+```
+apps/docs/content/docs/
+├── codemods/
+│   ├── index.mdx                            # NEW
+│   ├── from-shepherd.mdx                    # NEW
+│   ├── from-driver.mdx                      # NEW
+│   ├── from-joyride.mdx                     # NEW
+│   └── meta.json                            # NEW
+├── migration/
+│   ├── shepherd.mdx                         # +callout
+│   ├── driver.mdx                           # +callout
+│   └── joyride.mdx                          # +callout
+└── meta.json                                # +"codemods"
+
+tasks/sprint-1-stop-the-bleeding/
+└── verify-phase-5.sh                        # NEW
+```
+---
+
+---
+
+## Run Commands
+
+```bash
+# Build codemods (required for US-3 bin smoke)
+pnpm --filter @tour-kit/codemods build
+
+# Verify everything
+chmod +x tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh
+bash tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh
+
+# Manual eyeball
+pnpm --filter @tour-kit/docs dev
+# Open http://localhost:3000/docs/codemods in a browser.
+
+# Docs build (US-5)
+pnpm --filter @tour-kit/docs build
+```
+
+---
+
+**Next:** [phase-6-tests.md](phase-6-tests.md)

--- a/tasks/sprint-1-stop-the-bleeding/phase-6-tests.md
+++ b/tasks/sprint-1-stop-the-bleeding/phase-6-tests.md
@@ -1,0 +1,446 @@
+# Phase 6 — Testing: `@tour-kit/testing-library` Docs (G-2)
+
+**Scope:** Two new MDX pages under `apps/docs/content/docs/testing-library/`
+(`index.mdx`, `recipes.mdx`), one new `meta.json`, one edit to
+`apps/docs/content/docs/meta.json` (insert `testing-library` next to
+`codemods`).
+**Phase type:** **Docs only with code-block validation.** Like Phase 5, no
+package code touched. Unique twist: the `recipes.mdx` page contains 8
+copy-paste test snippets that are *meant* to be runnable test code. Phase
+plan §4.1 requires at least 2 recipes to be lifted into a real test file
+and verified before commit — making this the only Sprint-1 docs phase
+with a hard "show your work" code-verification step.
+**Key Pattern:** Static-content asserter + a manual "scratch test"
+verification step that proves at least 2 recipes compile and run against
+the actual `@tour-kit/testing-library` exports.
+**Dependencies:** `pnpm`, `node`, Fumadocs build,
+`packages/testing-library/src/__tests__/` for the scratch verification.
+
+---
+
+## User Stories
+
+| #    | User Story                                                                                                                          | Validation Check                                                                                                                | Pass Condition                                                                              |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| US-1 | As a consumer wanting to test their tours, I want to discover `@tour-kit/testing-library` from the docs nav.                         | `apps/docs/content/docs/meta.json` includes `"testing-library"` under Resources                                                  | Listed exactly once                                                                          |
+| US-2 | As a Vitest/Jest user, I want one page (`index.mdx`) that covers install + setup + a worked quick example I can copy.                | `test -f apps/docs/content/docs/testing-library/index.mdx`                                                                       | File exists; includes `setupTourKitTesting`, `<HookProbe />`, `<TourCard />`, and a `vi.fn` or `expect` call |
+| US-3 | As a test author, I want a recipes page with copy-pasteable patterns for the 8 most common scenarios.                                | `test -f apps/docs/content/docs/testing-library/recipes.mdx` + recipe count                                                      | File exists with `## 1. ` through `## 8. ` headers                                          |
+| US-4 | As a docs reviewer, I want at least 2 recipes verified against the real package — proof the docs don't ship broken sample code.      | A scratch test file under `packages/testing-library/src/__tests__/` was created, ran green, and was deleted before commit       | `git log -p` for the PR shows no `__tests__/scratch*.test.ts` remaining; PR description names the 2 recipes |
+| US-5 | As a docs reader, I want every helper referenced in `index.mdx` to actually exist in the package's public exports.                   | For each helper named in `index.mdx`'s "Available helpers" table, grep `packages/testing-library/src/index.ts`                  | All 10 helpers present in source                                                            |
+| US-6 | As a docs reviewer, I want the docs site to build clean with the new pages.                                                          | `pnpm --filter @tour-kit/docs build`                                                                                            | exit 0                                                                                       |
+| US-7 | As a repo owner, I want zero package code changed.                                                                                   | `git diff --stat -- packages/`                                                                                                  | Empty                                                                                       |
+| US-8 | As a doc reader, internal links in the new pages (e.g. `/docs/react/tour-provider`) must resolve.                                    | Grep + `test -f` per `/docs/...` target                                                                                          | All resolve                                                                                  |
+
+---
+
+## Component Mock Strategy
+
+| Component                              | Mock Strategy                                              | What to Assert                                                                            | User Story  |
+| -------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| `testing-library/index.mdx`            | None — real file                                           | Frontmatter, H1, mentions of `setupTourKitTesting`, `<HookProbe />`, `<TourCard />`        | US-2        |
+| `testing-library/recipes.mdx`          | None — real file                                           | `## 1.`–`## 8.` section headers                                                            | US-3        |
+| `testing-library/meta.json`            | None — JSON read                                           | `pages: ["index", "recipes"]`                                                              | US-1        |
+| Root `docs/meta.json`                  | None — JSON read                                           | `"testing-library"` under Resources                                                        | US-1        |
+| Helper-export cross-check               | None — grep `packages/testing-library/src/index.ts`        | All 10 documented helpers are real exports                                                  | US-5        |
+| Recipe scratch-test (manual)            | None — real package, real vitest                           | At least 2 recipes run green when lifted into `packages/testing-library/src/__tests__/`    | US-4        |
+| Docs build                              | None — `pnpm --filter @tour-kit/docs build`                | exit 0                                                                                     | US-6        |
+| Internal links                          | None — grep + `test -f`                                    | All resolve                                                                                | US-8        |
+
+---
+
+## Test Tier Table
+
+| Tier             | Dependencies                                              | Speed     | When to Run                              |
+| ---------------- | --------------------------------------------------------- | --------- | ---------------------------------------- |
+| Shape gate       | `node`, `grep`, `test`                                    | < 2 s     | Pre-PR, in `verify-phase-6.sh`           |
+| Export cross-check | `grep` over `packages/testing-library/src/index.ts`      | < 1 s     | Pre-PR                                    |
+| Recipe scratch run| `pnpm --filter @tour-kit/testing-library test --run`     | ~10 s     | Pre-PR (US-4, manual one-shot)            |
+| Internal-link gate| grep + `test -f` per target                              | < 5 s     | Pre-PR                                    |
+| Docs build       | `pnpm --filter @tour-kit/docs build`                      | ~1–2 min  | Pre-PR + on CI                            |
+
+---
+
+## No Fake Implementations (Docs Only)
+
+Phase 6 ships no runtime code. The recipes themselves *are* test code,
+but they're documentation; they're not run by CI. The US-4 scratch
+verification uses the real package's real exports.
+
+---
+
+## Test File List
+
+```
+apps/docs/content/docs/testing-library/
+├── index.mdx                                # NEW
+├── recipes.mdx                              # NEW
+└── meta.json                                # NEW
+
+apps/docs/content/docs/meta.json             # MODIFIED — add "testing-library" to Resources
+
+tasks/sprint-1-stop-the-bleeding/
+└── verify-phase-6.sh                        # NEW
+
+# Scratch tests (transient — created during US-4, deleted before commit):
+packages/testing-library/src/__tests__/scratch-recipe-1.test.ts   # TEMP
+packages/testing-library/src/__tests__/scratch-recipe-2.test.ts   # TEMP
+
+# Out of scope (verify NOT touched):
+packages/testing-library/**                  # MUST be empty in git diff
+```
+
+---
+
+## Asserter Skeleton
+
+```bash
+#!/usr/bin/env bash
+# tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh
+# Run before opening the Phase 6 PR.
+set -u
+fails=0
+gate() { if eval "$1"; then echo "✓ $2"; else echo "✗ $2 — $(eval "$3")"; fails=$((fails+1)); fi; }
+
+DOCS="apps/docs/content/docs"
+
+# US-2: index.mdx exists with key concepts
+gate "[ -f $DOCS/testing-library/index.mdx ]" 'US-2: testing-library/index.mdx exists' "echo missing"
+gate "grep -q 'setupTourKitTesting' $DOCS/testing-library/index.mdx" 'US-2: index mentions setupTourKitTesting' "echo missing"
+gate "grep -q 'HookProbe' $DOCS/testing-library/index.mdx" 'US-2: index mentions HookProbe' "echo missing"
+gate "grep -q 'TourCard' $DOCS/testing-library/index.mdx" 'US-2: index uses TourCard in example' "echo missing"
+
+# US-3: recipes.mdx with 8 numbered sections
+gate "[ -f $DOCS/testing-library/recipes.mdx ]" 'US-3: recipes.mdx exists' "echo missing"
+for n in 1 2 3 4 5 6 7 8; do
+  gate "grep -qE '^## $n\\. ' $DOCS/testing-library/recipes.mdx" "US-3: recipes.mdx has section $n" "echo missing"
+done
+
+# US-1: meta.json wiring
+gate "[ -f $DOCS/testing-library/meta.json ]" 'US-1: testing-library/meta.json exists' "echo missing"
+gate 'node -e "const m=require(\"./apps/docs/content/docs/testing-library/meta.json\"); process.exit(m.pages?.includes(\"index\") && m.pages?.includes(\"recipes\") ? 0 : 1)"' \
+     'US-1: meta.json lists index + recipes' "cat $DOCS/testing-library/meta.json"
+gate 'node -e "const m=require(\"./apps/docs/content/docs/meta.json\"); const idx=m.pages.indexOf(\"---Resources---\"); const end=m.pages.findIndex((p,i)=>i>idx && p.startsWith(\"---\")); const slice=m.pages.slice(idx, end>=0?end:undefined); process.exit(slice.includes(\"testing-library\") ? 0 : 1)"' \
+     'US-1: root meta.json lists testing-library under Resources' "cat $DOCS/meta.json | grep -A 12 Resources"
+
+# US-5: every documented helper exists in source
+for helper in setupTourKitTesting virtualTarget expectStepVisible advanceTour previousTour skipTour completeTour goToStep HookProbe getActiveTourHandle TourKitTestingError; do
+  gate "grep -qE '(export.*\\b$helper\\b|from.*$helper)' packages/testing-library/src/index.ts" \
+       "US-5: $helper exported by package" "grep -n $helper packages/testing-library/src/index.ts"
+done
+
+# US-7: no package code touched
+n=$(git diff --name-only -- packages/ | wc -l | tr -d ' ')
+gate "[ $n -eq 0 ]" "US-7: zero files under packages/ changed" "git diff --name-only -- packages/"
+
+# US-8: internal link integrity (only /docs/... refs)
+missing_links=0
+while read -r link; do
+  target=$(echo "$link" | sed 's|#.*||' | sed 's|^/||')
+  if [ -f "apps/$target.mdx" ] || [ -f "apps/$target/index.mdx" ]; then
+    :
+  else
+    echo "  ✗ broken link: $link"
+    missing_links=$((missing_links+1))
+  fi
+done < <(grep -hoE '\(/docs/[a-z0-9-]+(/[a-z0-9-]+)*\)' $DOCS/testing-library/*.mdx 2>/dev/null | tr -d '()' | sort -u)
+
+gate "[ $missing_links -eq 0 ]" "US-8: all internal /docs/ links resolve" "echo $missing_links broken"
+
+# US-6: docs build
+gate 'pnpm --filter @tour-kit/docs build >/tmp/phase-6-build.log 2>&1' \
+     'US-6: apps/docs builds' "tail -n10 /tmp/phase-6-build.log"
+
+[ "$fails" -eq 0 ] || { echo "Phase 6 FAILED gates: $fails"; exit 1; }
+echo "Phase 6 all gates green."
+```
+
+**US-4 is NOT in the bash asserter** — it's a one-shot human-driven gate.
+See the §Manual Verification section below.
+
+---
+
+## Manual Verification: US-4 (Recipe Scratch Test)
+
+Per the phase plan §4.1: **at least 2 recipes** must be lifted into a real
+test file under `packages/testing-library/src/__tests__/`, run green, and
+deleted before commit. The cost is ~5 minutes; the payoff is not shipping
+broken sample code.
+
+Recommended recipes (smallest first):
+
+```ts
+// packages/testing-library/src/__tests__/scratch-recipe-1.test.ts
+// Lifted from recipes.mdx §1 "Asserting that a tour starts on mount"
+// DELETE BEFORE COMMIT.
+import { describe, it } from 'vitest'
+import { render, expectStepVisible, HookProbe } from '@tour-kit/testing-library'
+import { TourProvider, TourCard, useTour } from '@tour-kit/react'
+import * as React from 'react'
+
+function AutoStart({ tourId }: { tourId: string }) {
+  const { start } = useTour()
+  React.useEffect(() => { void start(tourId) }, [start, tourId])
+  return null
+}
+
+describe('recipe 1: tour autostart', () => {
+  it('autostarts the welcome tour', async () => {
+    render(
+      <>
+        <div id="hi" />
+        <TourProvider tours={[{ id: 'welcome', steps: [{ id: 'hi', target: '#hi', content: 'Hi' }] }]}>
+          <AutoStart tourId="welcome" />
+          <TourCard />
+          <HookProbe />
+        </TourProvider>
+      </>,
+    )
+
+    await expectStepVisible('hi')
+  })
+})
+```
+
+```ts
+// packages/testing-library/src/__tests__/scratch-recipe-2.test.ts
+// Lifted from recipes.mdx §6 "Asserting against the active tour handle"
+// DELETE BEFORE COMMIT.
+import { describe, it, expect } from 'vitest'
+import { render, getActiveTourHandle, HookProbe } from '@tour-kit/testing-library'
+import { TourProvider, useTour } from '@tour-kit/react'
+import * as React from 'react'
+
+function AutoStart({ tourId }: { tourId: string }) {
+  const { start } = useTour()
+  React.useEffect(() => { void start(tourId) }, [start, tourId])
+  return null
+}
+
+describe('recipe 6: handle introspection', () => {
+  it('exposes step metadata via the handle', async () => {
+    const tours = [{ id: 'demo', steps: [{ id: 's1', target: '#a', content: 'A' }, { id: 's2', target: '#b', content: 'B' }] }]
+    render(
+      <TourProvider tours={tours}>
+        <AutoStart tourId="demo" />
+        <HookProbe />
+      </TourProvider>,
+    )
+
+    const handle = getActiveTourHandle()
+    expect(handle?.currentStep?.id).toBe('s1')
+    expect(handle?.totalSteps).toBe(2)
+  })
+})
+```
+
+Run:
+
+```bash
+pnpm --filter @tour-kit/testing-library test --run
+# Both scratch tests should pass. If either fails, the recipe has a bug —
+# fix the recipe in recipes.mdx before committing.
+```
+
+After both pass, delete the scratch files:
+
+```bash
+rm packages/testing-library/src/__tests__/scratch-recipe-{1,2}.test.ts
+```
+
+Mention in the PR description which 2 recipes were verified.
+
+---
+
+## Key Testing Decisions
+
+| Decision                                                          | Approach                                                      | Rationale                                                                                                                |
+| ----------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Verify at least 2 recipes via scratch tests, not all 8             | Manual one-shot                                               | All 8 verified would be 30 minutes of test scaffolding for an unchanging package. 2 catches the "I made up an API" failure mode at low cost. |
+| Don't keep the scratch tests in git                                | Delete after verification                                     | The recipes live in `.mdx`. Duplicating them as real tests adds maintenance burden and a second source of truth.          |
+| Cross-check helper names against `src/index.ts`, not behavior      | Grep                                                          | If the docs list a helper that doesn't exist, every reader's import breaks. Grep is enough; behavior tests already live in the package's suite. |
+| Recipe section count is 8                                         | `## 1.` through `## 8.`                                       | Phase plan §3.2 specifies 8 recipes. Asserting the count catches "someone deleted a recipe by accident."                  |
+| Don't enforce a specific recipe ORDER                              | Set-membership, not sequence                                  | Order is editorial taste, not contract.                                                                                  |
+| Internal-link scan is cheap grep, not full link checker           | bash + grep                                                   | Existing `link-check.yml` workflow is the authoritative pass. Pre-PR sanity is enough.                                    |
+| Don't snapshot the rendered pages                                  | Manual eyeball                                                | Same reasoning as Phase 5 — content is iterating; Playwright snapshots are heavier than they're worth.                    |
+
+---
+
+## Example "Test Case" — Reading the asserter output
+
+```bash
+$ bash tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh
+✓ US-2: testing-library/index.mdx exists
+✓ US-2: index mentions setupTourKitTesting
+✓ US-2: index mentions HookProbe
+✓ US-2: index uses TourCard in example
+✓ US-3: recipes.mdx exists
+✓ US-3: recipes.mdx has section 1
+✓ US-3: recipes.mdx has section 2
+✓ US-3: recipes.mdx has section 3
+✓ US-3: recipes.mdx has section 4
+✓ US-3: recipes.mdx has section 5
+✓ US-3: recipes.mdx has section 6
+✓ US-3: recipes.mdx has section 7
+✓ US-3: recipes.mdx has section 8
+✓ US-1: testing-library/meta.json exists
+✓ US-1: meta.json lists index + recipes
+✓ US-1: root meta.json lists testing-library under Resources
+✓ US-5: setupTourKitTesting exported by package
+✓ US-5: virtualTarget exported by package
+… (10 helpers total)
+✓ US-7: zero files under packages/ changed
+✓ US-8: all internal /docs/ links resolve
+✓ US-6: apps/docs builds
+Phase 6 all gates green.
+```
+
+Plus, in your PR description:
+
+> US-4 verified by lifting recipes §1 (autostart) and §6 (handle introspection)
+> into scratch tests at `packages/testing-library/src/__tests__/scratch-recipe-{1,2}.test.ts`.
+> Both passed; scratch files deleted in commit <sha>.
+
+---
+
+## Execution Prompt
+
+Copy everything between the `---` lines into a new Claude session to write
+the Phase 6 docs:
+
+---
+You are completing Phase 6 of Sprint 1 in the tour-kit monorepo — adding
+docs for `@tour-kit/testing-library` so the test helpers are discoverable.
+
+### What This Project Is
+`@tour-kit/testing-library` ships 10 test helpers, a `<HookProbe />`
+bridge component, and re-exports from `@testing-library/react`. The
+package has 12 source files and 6 test files but zero docs pages — making
+it effectively invisible to consumers.
+
+### Acceptance Criteria (from User Stories)
+| #    | User Story                                                    | Validation Check                                              | Pass Condition                          |
+| ---- | ------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------- |
+| US-1 | Discoverable from nav                                          | `meta.json` includes `"testing-library"` under Resources      | Listed exactly once                     |
+| US-2 | Quick-example page with setup                                  | `index.mdx` exists; mentions setup helpers                   | Present                                  |
+| US-3 | 8 numbered recipes                                             | `## 1.` through `## 8.` in `recipes.mdx`                      | All 8                                   |
+| US-4 | At least 2 recipes verified via scratch tests                  | Manual: lift recipe into `__tests__/scratch-*.test.ts`, run, delete | 2 recipes ran green                |
+| US-5 | All documented helpers are real exports                        | Grep `src/index.ts`                                           | 10/10 helpers found                     |
+| US-6 | Docs build clean                                               | `pnpm --filter @tour-kit/docs build`                          | exit 0                                  |
+| US-7 | Docs-only PR                                                   | `git diff --stat -- packages/`                                | Empty                                   |
+| US-8 | No broken internal links                                       | Grep + `test -f` per `/docs/...` target                       | All resolve                             |
+
+### Why Fakes Are Required
+None. Phase 6 ships no runtime code. The recipe scratch verification
+(US-4) uses the real package's real exports — that's the whole point.
+
+### What NOT to Test
+- Don't write per-helper API reference docs. Deferred to Sprint 2.
+  `index.mdx` covers the helper list informally, which is enough.
+- Don't keep the scratch tests in git. They're a one-shot verification,
+  not a permanent suite.
+- Don't snapshot the docs pages with Playwright. Manual eyeball in
+  `apps/docs dev`.
+- Don't document `TourProvider`'s `defaultActiveTour` prop — it doesn't
+  exist (per phase plan §1 validated API caveats).
+- Don't document `virtualTarget()` as a fake selector helper. It returns
+  a Floating UI virtual reference; the phase plan §1 calls this out.
+
+### Critical: The Asserter
+
+The body of `tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh` is shown
+above (Asserter Skeleton section). Drop it in, `chmod +x`, and run.
+
+### Files to Create / Modify
+
+```
+apps/docs/content/docs/testing-library/index.mdx       # NEW
+apps/docs/content/docs/testing-library/recipes.mdx     # NEW
+apps/docs/content/docs/testing-library/meta.json       # NEW
+apps/docs/content/docs/meta.json                       # MODIFIED — +"testing-library"
+
+tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh     # NEW
+
+# Transient (US-4):
+packages/testing-library/src/__tests__/scratch-recipe-1.test.ts   # CREATE then DELETE
+packages/testing-library/src/__tests__/scratch-recipe-2.test.ts   # CREATE then DELETE
+```
+
+### Per-File Coverage Guidance
+
+#### `testing-library/index.mdx`
+- Frontmatter: `title: Testing Library`, `description: ...`.
+- Sections: "Install", "Setup", "Quick example", "Available helpers",
+  "Why these helpers?". Phase plan §3.1 has the full template.
+- The quick example MUST use `<TourCard />` (not `defaultActiveTour`)
+  and `<HookProbe />`. See validated API caveats in phase plan §1.
+
+#### `testing-library/recipes.mdx`
+- 8 numbered recipes (`## 1.` through `## 8.`).
+- Phase plan §3.2 has the templates.
+
+#### `testing-library/meta.json`
+- `{ "title": "Testing Library", "pages": ["index", "recipes"] }`
+
+#### `docs/meta.json`
+- Insert `"testing-library"` immediately after `"codemods"` under
+  `---Resources---`. (Phase 5 added `"codemods"` in the same block.)
+
+#### `verify-phase-6.sh`
+- The body shown above (Asserter Skeleton).
+
+### US-4 Scratch Tests (Manual)
+- Pick 2 recipes (recommended: §1 and §6 — smallest + most distinct).
+- Lift them verbatim into `packages/testing-library/src/__tests__/scratch-recipe-{1,2}.test.ts`.
+- Run `pnpm --filter @tour-kit/testing-library test --run`.
+- Both must pass. If they don't, fix the recipe in `recipes.mdx` first.
+- Delete both scratch files before commit. Mention which 2 you verified
+  in the PR description.
+
+### Success Criteria
+- `bash tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh` prints all ✓.
+- `pnpm --filter @tour-kit/docs build` exits 0.
+- `git diff --stat -- packages/` is empty (after deleting scratch files).
+- PR description names the 2 verified recipes.
+
+### Expected End State
+
+```
+apps/docs/content/docs/testing-library/
+├── index.mdx                                # NEW
+├── recipes.mdx                              # NEW
+└── meta.json                                # NEW
+
+apps/docs/content/docs/
+└── meta.json                                # +"testing-library"
+
+tasks/sprint-1-stop-the-bleeding/
+└── verify-phase-6.sh                        # NEW
+```
+---
+
+---
+
+## Run Commands
+
+```bash
+# Pre-verify (US-4): scratch run a recipe
+# Create scratch-recipe-1.test.ts and scratch-recipe-2.test.ts (see §Manual Verification)
+pnpm --filter @tour-kit/testing-library test --run
+# Both must pass. Then DELETE the scratch files.
+rm packages/testing-library/src/__tests__/scratch-recipe-{1,2}.test.ts
+
+# Run the asserter
+chmod +x tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh
+bash tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh
+
+# Manual eyeball
+pnpm --filter @tour-kit/docs dev
+# Open http://localhost:3000/docs/testing-library and click through.
+
+# Docs build (US-6)
+pnpm --filter @tour-kit/docs build
+```
+
+---
+
+**Next:** [phase-7-tests.md](phase-7-tests.md)

--- a/tasks/sprint-1-stop-the-bleeding/phase-7-tests.md
+++ b/tasks/sprint-1-stop-the-bleeding/phase-7-tests.md
@@ -1,0 +1,488 @@
+# Phase 7 — Testing: Bundle-Size CI Gate (F-2)
+
+**Scope:** `/.size-limit.json` (replace with calibrated entries for all 12
+packages / 18 dist files), `tooling/bundle-check/check-dist-gzip.mjs` (new
+raw dist-gzip checker = the binding merge gate), `CLAUDE.md` Quality Gates
+section (extended budget table), `.github/workflows/{ci,size-limit,release,smoke-npm}.yml`
+(align pnpm version to 10.26.1), `turbo.json` (`bundlesize` task),
+root `package.json` (`bundlesize` + `dist:size` scripts).
+**Phase type:** **Infra / CI.** Two gates running in parallel: (a) the
+custom dist-gzip checker is the **load-bearing merge gate**, and (b)
+`size-limit` is the secondary smoke signal. The test plan exercises BOTH:
+green path + a deliberate failure injection (US-6) that proves the gate
+actually trips on a regression.
+**Key Pattern:** Positive gate (green on current builds) + negative gate
+(synthetic 5 KB padding makes the gate red, then reverts cleanly). No
+vitest changes. The "test" is "does CI fail when I break the budget."
+**Dependencies:** `pnpm`, `node`, `gzip`, the post-Phase-1+2+3 dist files,
+`size-limit` 11.x (already installed), the new `tooling/bundle-check`
+checker.
+
+---
+
+## User Stories
+
+| #    | User Story                                                                                                                          | Validation Check                                                                                                                | Pass Condition                                                                              |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| US-1 | As a CI engineer, I want a future B-2-class regression (someone adds a heavy import, forgets the external) to fail CI loudly within 5 minutes. | `tooling/bundle-check/check-dist-gzip.mjs` exits non-zero when any package's `dist/index.js` exceeds its budget                | Exit non-zero on synthetic overrun (US-6); exit 0 on current main                          |
+| US-2 | As a release engineer, I want every published package gated — not just `core/react/hints`.                                          | `.size-limit.json` has entries for all 12 published packages (excluding codemods/playwright/testing-library)                    | ≥ 18 entries; covers core, react, hints, analytics, adoption, checklists, announcements, surveys, media, ai, scheduling, license |
+| US-3 | As a maintainer, I want the dist-gzip checker to be the binding merge gate; size-limit is informational only.                       | `size-limit.yml` workflow runs `pnpm dist:size` (the binding gate) and `pnpm exec size-limit` (informational)                   | Workflow runs both; only `dist:size` non-zero exit fails the job                            |
+| US-4 | As a devops engineer, I want every GitHub workflow to use the same pnpm major as `package.json` so local and CI behavior match.     | `grep "version: 10" .github/workflows/*.yml` for every workflow that does `pnpm/action-setup`                                   | All 4 workflows pin pnpm `10.26.1` (was `9`)                                                |
+| US-5 | As a docs reader, I want `CLAUDE.md` to list the current budget per package — not just core/react/hints.                            | `grep -E "Bundle sizes \(gzipped\)" CLAUDE.md` shows the extended table                                                          | Table mentions analytics, adoption, checklists, announcements, surveys, media, ai, scheduling, license |
+| US-6 | As a CI engineer, I want proof the gate fires: I can deliberately exceed a budget and the gate goes red.                            | Inject 5 KB padding into `packages/media/src/index.ts`, rebuild, run gate                                                       | Gate exits non-zero with `media OVER` line; revert restores green                            |
+| US-7 | As a dev, I want `pnpm bundlesize` and `pnpm dist:size` to work locally so I can pre-check before pushing.                          | `pnpm bundlesize` and `pnpm dist:size` script entries exist in root `package.json`                                              | Both run end-to-end and exit 0 on current state                                              |
+| US-8 | As a maintainer reading `.github/workflows/ci.yml`, I don't want stale TODOs about disabled jobs.                                    | `grep "TODO: Re-enable when tooling/bundle-check" ci.yml` or its replacement comment                                            | Either deleted or replaced with a pointer to `size-limit.yml`                                |
+
+---
+
+## Component Mock Strategy
+
+| Component                              | Mock Strategy                                              | What to Assert                                                                            | User Story  |
+| -------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| `check-dist-gzip.mjs` (new)            | None — real `gzipSync` + real dist                         | Exits 0 on green; exits non-zero with a labeled OVER line on overrun                       | US-1, US-2, US-6 |
+| `/.size-limit.json`                    | None — JSON read                                           | ≥ 18 entries covering 12 packages; size-limit can run them                                 | US-2        |
+| `size-limit.yml` workflow              | None — YAML read                                           | Runs both `pnpm exec size-limit` and `pnpm dist:size` (or equivalent)                      | US-3        |
+| Workflow pnpm version                  | None — grep                                                | All 4 workflows pin `10.26.1`                                                              | US-4        |
+| `CLAUDE.md` budget table               | None — grep                                                | Table includes all production packages                                                     | US-5        |
+| Negative regression test (US-6)        | Synthetic 5 KB string appended to `packages/media/src/index.ts` | Gate exits non-zero; `media OVER` line in output; revert restores                       | US-6        |
+| Root `package.json` scripts            | None — JSON read                                           | `bundlesize` + `dist:size` scripts present                                                 | US-7        |
+
+---
+
+## Test Tier Table
+
+| Tier             | Dependencies                                              | Speed     | When to Run                              |
+| ---------------- | --------------------------------------------------------- | --------- | ---------------------------------------- |
+| Shape gate       | `node`, `grep`, `test`                                    | < 2 s     | Pre-PR, in `verify-phase-7.sh`           |
+| Positive gate    | All packages built; checker run                            | ~3 min    | Pre-PR + on CI                            |
+| Negative gate    | Synthetic 5 KB inject → rebuild → checker → revert         | ~1 min    | Pre-PR (US-6, one-shot)                  |
+| Workflow alignment| `grep` over `.github/workflows/*.yml`                     | < 1 s     | Pre-PR                                    |
+| CI smoke         | Push branch, watch `size-limit` workflow                  | ~5 min    | After Phase 7 PR pushed                  |
+
+No vitest. The "test" infrastructure itself is bash + node.
+
+---
+
+## No Fake Implementations (Infra Phase)
+
+The checker exercises real `gzipSync` against real dist files. Mocking
+either would erase the contract we want to gate. The "negative test"
+(US-6) is a real change-then-revert: we *want* the checker to fail
+against a real regression in real dist bytes, not against a stub.
+
+The only "test code" we write is the asserter (`verify-phase-7.sh`) and
+the `check-dist-gzip.mjs` checker itself.
+
+---
+
+## Test File List
+
+```
+/.size-limit.json                            # MODIFIED — calibrated 18-entry table
+
+tooling/bundle-check/
+└── check-dist-gzip.mjs                      # NEW — the binding gate
+
+CLAUDE.md                                    # MODIFIED — extended Quality Gates budget table
+
+.github/workflows/
+├── ci.yml                                   # MODIFIED — pnpm 10.26.1, stale TODO removed
+├── size-limit.yml                           # MODIFIED — pnpm 10.26.1, runs both gates
+├── release.yml                              # MODIFIED — pnpm 10.26.1
+└── smoke-npm.yml                            # MODIFIED — pnpm 10.26.1
+
+turbo.json                                   # MODIFIED — +bundlesize task
+package.json                                 # MODIFIED — +bundlesize + dist:size scripts
+
+tasks/sprint-1-stop-the-bleeding/
+└── verify-phase-7.sh                        # NEW — full gate runner
+
+# Out of scope (verify NOT created — Option A per §5.3 of phase plan):
+packages/core/.size-limit.json               # MUST NOT EXIST
+packages/react/.size-limit.json              # MUST NOT EXIST
+# ... (every per-package .size-limit.json except the existing packages/ai/.size-limit.json)
+```
+
+---
+
+## The Asserter Skeleton
+
+```bash
+#!/usr/bin/env bash
+# tasks/sprint-1-stop-the-bleeding/verify-phase-7.sh
+# Run after Phases 1–3 are merged + Phase 7 edits applied + build green.
+set -u
+fails=0
+gate() { if eval "$1"; then echo "✓ $2"; else echo "✗ $2 — $(eval "$3")"; fails=$((fails+1)); fi; }
+
+# US-2: root .size-limit.json exists, has ≥ 18 entries
+gate '[ -f .size-limit.json ]' 'US-2: /.size-limit.json exists' "echo missing"
+n=$(node -e "const a=require('./.size-limit.json'); console.log(Array.isArray(a) ? a.length : 0)")
+gate "[ $n -ge 18 ]" "US-2: .size-limit.json has ≥ 18 entries (got $n)" "echo $n"
+
+# US-2: critical packages covered
+for pkg in core react hints analytics adoption checklists announcements surveys media ai scheduling license; do
+  gate "node -e \"const a=require('./.size-limit.json'); process.exit(a.some(e=>(e.name||'').includes('$pkg') || (e.path||'').includes('packages/$pkg/')) ? 0 : 1)\"" \
+       "US-2: budget entry for $pkg" "echo missing"
+done
+
+# US-1, US-2: checker exists + runs green on current build
+gate '[ -f tooling/bundle-check/check-dist-gzip.mjs ]' \
+     'US-1: check-dist-gzip.mjs exists' "echo missing"
+gate 'node tooling/bundle-check/check-dist-gzip.mjs >/tmp/phase-7-dist-size.log 2>&1' \
+     'US-1: dist-gzip checker green on current build' "tail -n20 /tmp/phase-7-dist-size.log"
+
+# Side gate: size-limit also green (informational, but should pass)
+gate 'pnpm exec size-limit >/tmp/phase-7-size-limit.log 2>&1' \
+     'US-3: pnpm exec size-limit green' "tail -n20 /tmp/phase-7-size-limit.log"
+
+# US-3: workflow runs both metrics
+gate 'grep -q "pnpm dist:size\|node tooling/bundle-check" .github/workflows/size-limit.yml' \
+     'US-3: size-limit.yml runs dist-gzip checker' "grep -n run .github/workflows/size-limit.yml"
+gate 'grep -q "pnpm exec size-limit" .github/workflows/size-limit.yml' \
+     'US-3: size-limit.yml runs size-limit' "grep -n run .github/workflows/size-limit.yml"
+
+# US-4: all workflows pin pnpm 10.x
+for wf in ci size-limit release smoke-npm; do
+  gate "grep -E 'version: *10\\.' .github/workflows/$wf.yml >/dev/null 2>&1 || ! grep 'pnpm/action-setup' .github/workflows/$wf.yml >/dev/null 2>&1" \
+       "US-4: $wf.yml uses pnpm 10.x (or no pnpm setup)" "grep -B 1 -A 1 'pnpm/action-setup' .github/workflows/$wf.yml"
+done
+
+# US-5: CLAUDE.md budget table extended
+gate 'grep -qE "Bundle sizes \\(gzipped\\)" CLAUDE.md' \
+     'US-5: CLAUDE.md mentions extended budget table' "echo missing"
+gate 'grep -q "analytics <" CLAUDE.md && grep -q "adoption" CLAUDE.md' \
+     'US-5: CLAUDE.md table lists more than core/react/hints' "grep -A 15 'Bundle sizes' CLAUDE.md"
+
+# US-7: scripts present
+gate 'node -e "const p=require(\"./package.json\"); process.exit(p.scripts?.bundlesize && p.scripts?.[\"dist:size\"] ? 0 : 1)"' \
+     'US-7: package.json has bundlesize + dist:size scripts' "echo missing"
+
+# US-8: stale TODO replaced
+gate '! grep -q "TODO: Re-enable when tooling/bundle-check" .github/workflows/ci.yml' \
+     'US-8: ci.yml has no stale "Re-enable" TODO' "grep -n 'Re-enable' .github/workflows/ci.yml"
+
+# Sanity: option A (single root config) — no per-package .size-limit.json except ai
+extra=$(ls packages/*/.size-limit.json 2>/dev/null | grep -v 'packages/ai/' | wc -l | tr -d ' ')
+gate "[ $extra -eq 0 ]" "Single source of truth: no extra per-package .size-limit.json (got $extra)" \
+     "ls packages/*/.size-limit.json | grep -v 'packages/ai/'"
+
+[ "$fails" -eq 0 ] || { echo "Phase 7 FAILED gates: $fails"; exit 1; }
+echo "Phase 7 all gates green."
+```
+
+---
+
+## US-6: Negative-Test Procedure
+
+The most important Phase 7 validation: prove the gate fires when budgets
+are exceeded. Run this **once**, manually, immediately before opening the PR.
+
+```bash
+# 1. Confirm gate is green right now
+node tooling/bundle-check/check-dist-gzip.mjs
+echo "Pre-injection exit: $?"   # Must be 0
+
+# 2. Inject 5 KB of padding into media
+python3 -c "print('export const __padding = \"' + ('A' * 5000) + '\";')" >> packages/media/src/index.ts
+
+# 3. Rebuild media
+pnpm --filter @tour-kit/media build
+
+# 4. Run the gate — MUST fail with `media` line
+node tooling/bundle-check/check-dist-gzip.mjs
+echo "Post-injection exit: $?"  # Must be non-zero
+
+# 5. Revert and rebuild
+git checkout packages/media/src/index.ts
+pnpm --filter @tour-kit/media build
+
+# 6. Confirm green again
+node tooling/bundle-check/check-dist-gzip.mjs
+echo "Post-revert exit: $?"      # Must be 0
+```
+
+In the PR description, paste the three exit codes (0, non-zero, 0) as
+proof.
+
+---
+
+## Key Testing Decisions
+
+| Decision                                                          | Approach                                                      | Rationale                                                                                                                |
+| ----------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Two gates running, one binding                                    | dist-gzip = merge gate; size-limit = smoke                    | The audit + Sprint-1 acceptance speak in raw dist-gzip bytes. size-limit's bundled-size metric is useful but ~2× the unit; running both with one binding avoids unit-conversion ceremony. (Phase plan §2.1 + §2's "Load-bearing gate decision".) |
+| Negative test is a real inject-revert, not a stub                  | Append 5 KB string, rebuild, run, revert, rebuild              | A stubbed "what if dist was 25 KB" test mocks the very thing the gate cares about. Inject-revert exercises the full real path. Cost: ~1 minute. |
+| US-6 is a one-shot, not part of CI                                | Run manually before PR; paste exit codes                      | Running the inject-revert on every CI run would slow CI and confuse the test report. The PR description IS the evidence. |
+| Core budget set to 20 KB, not 8 KB                                 | Document in the entry name + CLAUDE.md                         | core is currently 19 KB gz. Setting the gate to 8 KB blocks every PR until B-1 (Sprint 2) lands. The 20 KB ceiling preserves the audit number AND the historical 8 KB target. |
+| Don't create per-package `.size-limit.json` files                  | Single root config (Option A per phase plan §5.3)              | Two sources of truth invite drift. The root file is what CI actually reads.                                              |
+| Allow `packages/ai/.size-limit.json` to stay                       | Local package documentation only                              | It exists already, doesn't drive the gate (root config does). Removing it from this PR is out of scope.                  |
+| Test the workflow change by grep, not by triggering CI            | `grep -E 'version: *10\\.' .github/workflows/*.yml`            | Triggering CI from the test plan is impossible (test plan runs locally). Grep is the cheap proxy; the PR's CI run is the authoritative test. |
+| Don't test size-limit's *internal* metrics                         | `pnpm exec size-limit` exit code only                          | We don't control size-limit's calculation logic; we control whether OUR config makes it exit cleanly.                     |
+
+---
+
+## Example Test Case — Reading the asserter output
+
+```bash
+$ bash tasks/sprint-1-stop-the-bleeding/verify-phase-7.sh
+✓ US-2: /.size-limit.json exists
+✓ US-2: .size-limit.json has ≥ 18 entries (got 19)
+✓ US-2: budget entry for core
+✓ US-2: budget entry for react
+✓ US-2: budget entry for hints
+✓ US-2: budget entry for analytics
+✓ US-2: budget entry for adoption
+✓ US-2: budget entry for checklists
+✓ US-2: budget entry for announcements
+✓ US-2: budget entry for surveys
+✓ US-2: budget entry for media
+✓ US-2: budget entry for ai
+✓ US-2: budget entry for scheduling
+✓ US-2: budget entry for license
+✓ US-1: check-dist-gzip.mjs exists
+✓ US-1: dist-gzip checker green on current build
+✓ US-3: pnpm exec size-limit green
+✓ US-3: size-limit.yml runs dist-gzip checker
+✓ US-3: size-limit.yml runs size-limit
+✓ US-4: ci.yml uses pnpm 10.x (or no pnpm setup)
+✓ US-4: size-limit.yml uses pnpm 10.x (or no pnpm setup)
+✓ US-4: release.yml uses pnpm 10.x (or no pnpm setup)
+✓ US-4: smoke-npm.yml uses pnpm 10.x (or no pnpm setup)
+✓ US-5: CLAUDE.md mentions extended budget table
+✓ US-5: CLAUDE.md table lists more than core/react/hints
+✓ US-7: package.json has bundlesize + dist:size scripts
+✓ US-8: ci.yml has no stale "Re-enable" TODO
+✓ Single source of truth: no extra per-package .size-limit.json (got 0)
+Phase 7 all gates green.
+```
+
+Then your PR description includes:
+
+> **US-6 negative test results:**
+> - Pre-injection: `node tooling/bundle-check/check-dist-gzip.mjs` exit 0
+> - Post 5 KB inject into `packages/media/src/index.ts`: exit 1, output included `media OVER budget`
+> - Post-revert: exit 0
+> Gate confirmed to trip on regression.
+
+---
+
+## Execution Prompt
+
+Copy everything between the `---` lines into a new Claude session to write
+the Phase 7 gates:
+
+---
+You are completing Phase 7 of Sprint 1 in the tour-kit monorepo — wiring
+`size-limit` and a custom raw-dist-gzip checker into CI on every PR so a
+future B-2-class regression (heavy import + forgot external) fails CI
+within 5 minutes.
+
+### What This Project Is
+A pnpm 10 monorepo with 12 published runtime packages. Phase 1 fixed a
+64 KB analytics bundle regression that would have been caught by a CI
+size gate. Phase 7 makes sure the next one is.
+
+Two gates run in parallel:
+1. **`tooling/bundle-check/check-dist-gzip.mjs`** — raw `dist/index.js`
+   gzip bytes, hard budgets from the audit (1.2× current size). This is
+   the **binding merge gate**.
+2. **`size-limit`** with root `/.size-limit.json` — bundled-with-deps +
+   brotli, secondary smoke signal. Calibrated separately.
+
+### Acceptance Criteria (from User Stories)
+| #    | User Story                                                    | Validation Check                                              | Pass Condition                          |
+| ---- | ------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------- |
+| US-1 | Gate fires on regression                                       | Synthetic 5 KB pad in media → re-build → checker              | Exit non-zero with `media OVER`         |
+| US-2 | All 12 packages covered                                        | `.size-limit.json` + checker have entries                     | ≥ 18 entries                            |
+| US-3 | Workflow runs both gates                                       | `grep` in `size-limit.yml`                                    | Both `dist:size` and `pnpm exec size-limit` |
+| US-4 | Workflows on pnpm 10.x                                         | `grep "version: 10" .github/workflows/*.yml`                  | All 4 workflows                         |
+| US-5 | CLAUDE.md budget table extended                                | `grep` for `Bundle sizes (gzipped)`                           | Lists analytics/adoption/etc.           |
+| US-6 | Negative test passes                                           | Manual inject/revert procedure                                | Pre 0, mid non-zero, post 0             |
+| US-7 | Local scripts work                                             | `pnpm bundlesize`, `pnpm dist:size`                            | Both present in package.json            |
+| US-8 | Stale TODO removed from `ci.yml`                              | `grep -v "TODO: Re-enable when tooling/bundle-check"`         | Gone or replaced                        |
+
+### Why Fakes Are Required
+None. The checker exercises real `gzipSync` on real dist files. Mocking
+would erase the contract. The negative test (US-6) is a real inject-revert
+into `packages/media/src/index.ts`.
+
+### What NOT to Test
+- Don't write vitest cases for the checker. The checker is bash-and-node
+  glue; testing it via `verify-phase-7.sh` is enough.
+- Don't create per-package `.size-limit.json` files. Phase plan §5.3
+  picks Option A (single root). The existing
+  `packages/ai/.size-limit.json` stays as documentation only.
+- Don't set core's budget to 8 KB. core is 19 KB gz today; an 8 KB gate
+  blocks every PR. 20 KB ceiling + a `target <8 KB in B-1` note is the
+  compromise.
+- Don't trigger CI from this test plan. Push the branch, watch the
+  workflow there.
+- Don't run the negative test on every CI run. One-shot before PR; paste
+  exit codes into the PR description.
+- Don't add `andresz1/size-limit-action`. The existing workflow's comment
+  notes it's broken; plain `pnpm exec size-limit` is sufficient.
+
+### Critical: The Checker
+
+Create `tooling/bundle-check/check-dist-gzip.mjs`:
+
+```js
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
+
+const budgets = [
+  ['core', 'packages/core/dist/index.js', 20000],
+  ['react', 'packages/react/dist/index.js', 12000],
+  ['hints', 'packages/hints/dist/index.js', 5120],
+  ['analytics:main', 'packages/analytics/dist/index.js', 4000],
+  ['analytics:console', 'packages/analytics/dist/plugins/console.js', 1000],
+  ['analytics:posthog', 'packages/analytics/dist/plugins/posthog.js', 1500],
+  ['analytics:mixpanel', 'packages/analytics/dist/plugins/mixpanel.js', 1500],
+  ['analytics:amplitude', 'packages/analytics/dist/plugins/amplitude.js', 1000],
+  ['analytics:ga', 'packages/analytics/dist/plugins/google-analytics.js', 1000],
+  ['adoption', 'packages/adoption/dist/index.js', 10000],
+  ['checklists', 'packages/checklists/dist/index.js', 10000],
+  ['announcements', 'packages/announcements/dist/index.js', 8000],
+  ['surveys', 'packages/surveys/dist/index.js', 8000],
+  ['media', 'packages/media/dist/index.js', 6000],
+  ['ai:client', 'packages/ai/dist/index.js', 5000],
+  ['ai:server', 'packages/ai/dist/server/index.js', 8000],
+  ['scheduling', 'packages/scheduling/dist/index.js', 4000],
+  ['license', 'packages/license/dist/index.js', 8000],
+]
+
+let fails = 0
+for (const [name, path, budget] of budgets) {
+  try {
+    const raw = readFileSync(path)
+    const gz = gzipSync(raw).length
+    const status = gz <= budget ? '✓' : '✗ OVER'
+    if (gz > budget) fails++
+    console.log(`${status.padEnd(8)} ${name.padEnd(24)} gz=${gz}  budget=${budget}`)
+  } catch (e) {
+    console.log(`?        ${name.padEnd(24)} MISSING (${e.code ?? e.message})`)
+    fails++
+  }
+}
+process.exit(fails === 0 ? 0 : 1)
+```
+
+### Files to Create / Modify
+
+```
+/.size-limit.json                            # REPLACE (calibrated 18 entries)
+tooling/bundle-check/check-dist-gzip.mjs     # NEW
+CLAUDE.md                                    # MODIFIED — Quality Gates section
+.github/workflows/ci.yml                     # MODIFIED — pnpm 10, stale TODO out
+.github/workflows/size-limit.yml             # MODIFIED — pnpm 10, runs both gates
+.github/workflows/release.yml                # MODIFIED — pnpm 10
+.github/workflows/smoke-npm.yml              # MODIFIED — pnpm 10
+turbo.json                                   # MODIFIED — +bundlesize task
+package.json                                 # MODIFIED — +bundlesize + dist:size
+tasks/sprint-1-stop-the-bleeding/verify-phase-7.sh   # NEW
+```
+
+### Per-File Coverage Guidance
+
+#### `tooling/bundle-check/check-dist-gzip.mjs`
+- Body shown above. Hardcode the budgets; this is the merge gate.
+
+#### `/.size-limit.json`
+- Phase plan §5.1 has the full 19-entry table. Copy verbatim.
+- Includes preserved entries: `core (useTour-only consumer)`,
+  `core/schemas` with `ignore: ["zod"]`.
+
+#### `.github/workflows/size-limit.yml`
+- Bump `pnpm/action-setup` version field from `9` to `10.26.1`.
+- Change "Check size" step to:
+  ```yaml
+        - name: Check size
+          run: |
+            pnpm exec size-limit
+            pnpm dist:size
+  ```
+
+#### `.github/workflows/{ci,release,smoke-npm}.yml`
+- Bump `pnpm/action-setup` version from `9` to `10.26.1`.
+- `ci.yml`: delete the commented-out `# TODO: Re-enable when tooling/bundle-check…` block.
+
+#### `package.json`
+- Add scripts:
+  ```json
+  "bundlesize": "pnpm build --filter='./packages/*' && pnpm exec size-limit",
+  "dist:size":  "pnpm build --filter='./packages/*' && node tooling/bundle-check/check-dist-gzip.mjs"
+  ```
+
+#### `turbo.json`
+- Add a `bundlesize` task with `dependsOn: ["^build", "build"]`, `cache: false`, `outputs: []`.
+
+#### `CLAUDE.md` Quality Gates
+- Replace the single `Bundle sizes: core < 8KB, react < 12KB, hints < 5KB (gzipped)` bullet with the table from phase plan §6.
+
+#### `verify-phase-7.sh`
+- The body shown above (Asserter Skeleton).
+
+### US-6 Negative Test (Manual)
+- Run BEFORE opening the PR.
+- Sequence shown in §US-6: Negative-Test Procedure.
+- Paste the three exit codes into the PR description.
+
+### Success Criteria
+- `bash tasks/sprint-1-stop-the-bleeding/verify-phase-7.sh` prints all ✓.
+- US-6 negative test cycle: 0, non-zero, 0.
+- All 4 workflows pin pnpm 10.26.1.
+- `pnpm bundlesize` and `pnpm dist:size` run end-to-end and exit 0 on
+  current main + this branch.
+- After push, the `size-limit` workflow on the PR shows both gates ran
+  and both are green.
+
+### Expected End State
+
+```
+/.size-limit.json                            # CALIBRATED for 12 packages
+tooling/bundle-check/check-dist-gzip.mjs     # NEW
+CLAUDE.md                                    # extended budget table
+.github/workflows/*.yml                      # pnpm 10.26.1, stale TODO out
+turbo.json                                   # +bundlesize task
+package.json                                 # +bundlesize +dist:size scripts
+tasks/sprint-1-stop-the-bleeding/verify-phase-7.sh   # NEW
+```
+---
+
+---
+
+## Run Commands
+
+```bash
+# Build first
+pnpm build --filter='./packages/*'
+
+# Run the binding gate
+node tooling/bundle-check/check-dist-gzip.mjs
+
+# Run the secondary smoke gate
+pnpm exec size-limit
+
+# Run both via root scripts
+pnpm dist:size
+pnpm bundlesize
+
+# Full asserter
+chmod +x tasks/sprint-1-stop-the-bleeding/verify-phase-7.sh
+bash tasks/sprint-1-stop-the-bleeding/verify-phase-7.sh
+
+# US-6 negative test (one-shot, manual)
+node tooling/bundle-check/check-dist-gzip.mjs              # Pre: exit 0
+python3 -c "print('export const __pad = \"' + 'A'*5000 + '\";')" >> packages/media/src/index.ts
+pnpm --filter @tour-kit/media build
+node tooling/bundle-check/check-dist-gzip.mjs              # Mid: non-zero
+git checkout packages/media/src/index.ts
+pnpm --filter @tour-kit/media build
+node tooling/bundle-check/check-dist-gzip.mjs              # Post: exit 0
+```
+
+---
+
+**Next:** [phase-8-tests.md](phase-8-tests.md)

--- a/tasks/sprint-1-stop-the-bleeding/phase-8-tests.md
+++ b/tasks/sprint-1-stop-the-bleeding/phase-8-tests.md
@@ -1,0 +1,456 @@
+# Phase 8 — Testing: Release + Communications
+
+**Scope:** `pnpm version-packages` consumes changesets and bumps versions
+in `packages/*/package.json` + `CHANGELOG.md`; release PR is merged;
+`pnpm release` publishes to npm; GitHub release notes posted;
+README status updated. No source code changed in Phase 8 itself.
+**Phase type:** **Process + external integration.** The only Sprint-1 phase
+that interacts with systems we can't roll back (npm, GitHub releases).
+Tests fall into two buckets: (a) pre-flight verification that every
+Sprint-1 acceptance gate still holds against `main`, and (b) post-publish
+smoke that pulls the actually-published packages from npm and exercises
+their published shape.
+**Key Pattern:** Idempotent verification harness reused across phases
+(every Phase-N acceptance gate re-runs as a checkbox here) + a temp-dir
+post-publish smoke that proves the npm artifact, not just the workspace
+artifact, has the Phase 1+2 fixes baked in.
+**Dependencies:** `pnpm@10.26.1`, `node`, `gzip`, `npm view`, `gh`,
+`esbuild` (in the temp smoke project), `NPM_TOKEN` configured in CI for
+`pnpm release`.
+
+---
+
+## User Stories
+
+| #    | User Story                                                                                                                          | Validation Check                                                                                                                | Pass Condition                                                                              |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| US-1 | As a release engineer, I want a single command that re-runs every Sprint-1 phase's acceptance gate against `main` before publishing. | `bash tasks/sprint-1-stop-the-bleeding/verify-phase-8-preflight.sh` (composes Phase 0–7 asserters)                              | All asserters exit 0; any FAIL line blocks publish                                          |
+| US-2 | As a consumer, I want the versions on npm to match what the release PR bumped to — no half-published state.                          | `npm view @tour-kit/<pkg> version` for every bumped package                                                                     | Each matches the version in `packages/<pkg>/package.json` on `main`                          |
+| US-3 | As a consumer running `pnpm add @tour-kit/analytics @tour-kit/core`, I want the published bundle to NOT contain Amplitude SDK strings (proves Phase 1 made it to npm). | Temp project: `pnpm add @tour-kit/analytics@latest`, esbuild a probe, `grep -c '@amplitude/plugin-'`                            | `== 0` in the bundled probe                                                                 |
+| US-4 | As a consumer migrating from < 0.12, I want the GitHub release note for `@tour-kit/analytics@0.12.0` to spell out the breaking change. | `gh release view '@tour-kit/analytics@0.12.0' --json body \| jq -r '.body'` contains the before/after import block             | Release body has both `from '@tour-kit/analytics'` (old) and `from '@tour-kit/analytics/posthog'` (new) lines |
+| US-5 | As a release engineer, I want `pnpm release` to be re-runnable safely if it half-failed (publish retries are idempotent).            | Document the retry behavior, ad-hoc verify with `npm view <pkg> version` re-checks                                              | Re-running `pnpm release` after a partial publish republishes only the missing tags (changeset publish is idempotent) |
+| US-6 | As a consumer, I want `@tour-kit/analytics` root entry (post-Phase-1+2) to ship under 5 KB gz from npm.                              | Same temp project as US-3: `gzip -c probe.bundled.js \| wc -c`                                                                  | `< 5000` bytes                                                                              |
+| US-7 | As a maintainer reading `tasks/sprint-1-stop-the-bleeding/README.md` after the sprint, I want the status flipped to SHIPPED + a retrospective.| `grep 'Status:' README.md`                                                                                                      | Reads `Status: SHIPPED YYYY-MM-DD`                                                          |
+| US-8 | As a future Sprint-2 owner, I want the 6 follow-up issues filed and tagged `sprint-2`.                                                | `gh issue list --label sprint-2 --search "B-1 OR F-3 OR R-1 OR R-2 OR R-4 OR R-5 OR G-3 OR G-7"`                                | ≥ 6 issues with matching titles, all open                                                   |
+
+---
+
+## Component Mock Strategy
+
+| Component                              | Mock Strategy                                              | What to Assert                                                                            | User Story  |
+| -------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| Phase 0–7 asserter re-runs              | None — re-run the real bash scripts                        | All exit 0 against current `main`                                                          | US-1        |
+| `npm view <pkg> version`                | None — real network call to npm registry                   | Version on registry matches `packages/<pkg>/package.json` on `main`                        | US-2        |
+| Temp project install + esbuild         | None — real `pnpm add` from npm + real `esbuild` bundle    | No `@amplitude/plugin-` strings in bundled output; gz size < 5 KB                          | US-3, US-6  |
+| GitHub release body                    | None — real `gh release view`                              | Body contains both old and new import paths                                                | US-4        |
+| `pnpm release` re-runnability           | Document only (don't simulate a half-publish in production) | Documented "if it half-fails, re-run safely"                                              | US-5        |
+| Sprint README status                    | None — file read                                           | `Status: SHIPPED <date>` + retrospective section present                                  | US-7        |
+| Sprint-2 issues                         | None — `gh issue list`                                     | 6 expected issues exist with `sprint-2` label                                              | US-8        |
+
+---
+
+## Test Tier Table
+
+| Tier               | Dependencies                                              | Speed     | When to Run                              |
+| ------------------ | --------------------------------------------------------- | --------- | ---------------------------------------- |
+| Pre-flight (US-1)  | Phase 0–7 asserter scripts + working tree                 | ~5 min    | Immediately before `pnpm version-packages` |
+| Post-publish smoke | `pnpm add` from npm + esbuild + gzip                      | ~2 min    | After `pnpm release` returns success      |
+| Registry verification (US-2) | `npm view <pkg> version` × N                    | ~30 s     | After `pnpm release`                      |
+| Release-note content (US-4) | `gh release view`                                   | < 5 s     | After release notes posted                |
+| Documentation gates (US-7, US-8) | File read + `gh issue list`                      | < 5 s     | Last thing before closing sprint          |
+
+No vitest changes. No new fakes. The "test" is composed of existing
+asserters + cheap external probes.
+
+---
+
+## No Fake Implementations (Release Process)
+
+Phase 8 deliberately *avoids* mocking external systems:
+
+- **Don't mock npm.** The point of the smoke is to confirm the artifact
+  on npm has the fix. Mocking npm would erase that verification.
+- **Don't mock `gh`.** Same reason — verifying the GitHub release exists
+  is the contract.
+- **Don't simulate `pnpm release` failure modes.** If it half-fails in
+  production, the right answer is to re-run it (`changeset publish` is
+  idempotent). Simulating that locally would teach you nothing about real
+  failure modes (auth expiry, npm 5xx, etc.).
+
+The only "test artifact" Phase 8 ships is the pre-flight asserter that
+composes the previous phases' gates.
+
+---
+
+## Test File List
+
+```
+tasks/sprint-1-stop-the-bleeding/
+├── verify-phase-8-preflight.sh             # NEW — composes Phase 0–7 asserters
+├── verify-phase-8-postpublish.sh           # NEW — npm-side smoke (US-2/3/6)
+└── README.md                                # MODIFIED — Status: SHIPPED + retrospective
+
+# Transient (during US-3 smoke):
+/tmp/tk-smoke/                                # Scratch project, deleted after
+├── probe.ts
+├── probe.bundled.js
+└── package.json
+
+# No new files in packages/* or apps/*.
+```
+
+---
+
+## Asserter Skeletons
+
+### Pre-flight (`verify-phase-8-preflight.sh`)
+
+```bash
+#!/usr/bin/env bash
+# Run from clean `main` checkout, after `pnpm install --frozen-lockfile && pnpm build`.
+set -u
+fails=0
+gate() { if eval "$1"; then echo "✓ $2"; else echo "✗ $2"; fails=$((fails+1)); fi; }
+
+ROOT="tasks/sprint-1-stop-the-bleeding"
+
+# Re-run every phase's asserter
+for n in 0 1 2 3 4 5 6 7; do
+  case "$n" in
+    0) script="$ROOT/verify-baselines.sh" ;;
+    *) script="$ROOT/verify-phase-$n.sh" ;;
+  esac
+  if [ -f "$script" ]; then
+    if bash "$script" >/tmp/phase-8-preflight-$n.log 2>&1; then
+      echo "✓ Phase $n acceptance gate green"
+    else
+      echo "✗ Phase $n acceptance gate FAILED — see /tmp/phase-8-preflight-$n.log"
+      fails=$((fails+1))
+    fi
+  else
+    echo "? Phase $n asserter missing: $script (skipping)"
+  fi
+done
+
+# Sprint-level gates from Phase 8 §2
+gate '[ "$(gzip -c packages/analytics/dist/index.js | wc -c)" -lt 4000 ]' \
+     'analytics root < 4 KB gz (Phase 2)'
+gate '[ "$(gzip -c packages/analytics/dist/plugins/amplitude.js | wc -c)" -lt 1000 ]' \
+     'amplitude plugin < 1 KB gz (Phase 1)'
+gate '[ "$(grep -cE "posthogPlugin|mixpanelPlugin|amplitudePlugin|googleAnalyticsPlugin|consolePlugin" packages/analytics/dist/index.js)" -eq 0 ]' \
+     'no plugin re-exports in analytics root (Phase 2)'
+gate 'grep -q "\"sideEffects\": false" packages/adoption/package.json' \
+     'adoption has sideEffects false (Phase 3)'
+gate '[ "$(git grep -cE "\"(@floating-ui/react|class-variance-authority|@radix-ui/react-slot|@radix-ui/react-dialog|@mui/base|clsx|tailwind-merge)\": \"\\^" packages/ | wc -l | tr -d " ")" -eq 0 ]' \
+     'no pinned catalog libs in packages/ (Phase 4)'
+gate '[ -d apps/docs/content/docs/codemods ]' 'codemods docs subtree exists (Phase 5)'
+gate '[ -d apps/docs/content/docs/testing-library ]' 'testing-library docs subtree exists (Phase 6)'
+gate '[ -f .size-limit.json ] && [ -f tooling/bundle-check/check-dist-gzip.mjs ]' \
+     'size-limit config + dist-gzip checker present (Phase 7)'
+
+# Optional peers
+gate 'node -e "const p=require(\"./packages/analytics/package.json\"); process.exit(p.peerDependencies?.[\"@amplitude/analytics-browser\"] && p.peerDependenciesMeta?.[\"@amplitude/analytics-browser\"]?.optional ? 0 : 1)"' \
+     'analytics declares optional Amplitude peer'
+
+[ "$fails" -eq 0 ] || { echo "Phase 8 PREFLIGHT FAILED gates: $fails"; exit 1; }
+echo "Phase 8 preflight all gates green. Safe to publish."
+```
+
+### Post-publish (`verify-phase-8-postpublish.sh`)
+
+```bash
+#!/usr/bin/env bash
+# Run AFTER `pnpm release` succeeds. Verifies the artifact on npm.
+set -u
+fails=0
+gate() { if eval "$1"; then echo "✓ $2"; else echo "✗ $2"; fails=$((fails+1)); fi; }
+
+# US-2: every bumped package is on npm at the expected version
+for pkg in analytics adoption core react hints checklists announcements surveys media ai scheduling license; do
+  local_v=$(node -e "try { console.log(require('./packages/$pkg/package.json').version) } catch (e) { console.log('') }")
+  if [ -z "$local_v" ]; then continue; fi
+  remote_v=$(npm view "@tour-kit/$pkg" version 2>/dev/null || echo "")
+  if [ "$local_v" = "$remote_v" ]; then
+    echo "✓ US-2: @tour-kit/$pkg → npm has $remote_v"
+  else
+    echo "✗ US-2: @tour-kit/$pkg local=$local_v remote=$remote_v"
+    fails=$((fails+1))
+  fi
+done
+
+# US-3 + US-6: temp project tree-shake smoke
+SMOKE_DIR=$(mktemp -d /tmp/tk-smoke-XXXXXX)
+(
+  cd "$SMOKE_DIR"
+  pnpm init >/dev/null
+  pnpm add @tour-kit/analytics@latest @tour-kit/core@latest react@19 react-dom@19 >/dev/null 2>&1
+  cat > probe.ts <<'EOF'
+import { createAnalytics } from '@tour-kit/analytics'
+import { posthogPlugin } from '@tour-kit/analytics/posthog'
+const a = createAnalytics({ plugins: [posthogPlugin({ apiKey: 'x' })] })
+export { a }
+EOF
+  pnpm add -D esbuild >/dev/null 2>&1
+  pnpm exec esbuild probe.ts --bundle --minify --format=esm \
+    --external:react --external:react-dom > probe.bundled.js 2>/dev/null
+)
+
+amp_strings=$(grep -c '@amplitude/plugin-' "$SMOKE_DIR/probe.bundled.js" 2>/dev/null || echo 0)
+gate "[ $amp_strings -eq 0 ]" "US-3: no @amplitude/plugin- strings in published bundle"
+
+gz=$(gzip -c "$SMOKE_DIR/probe.bundled.js" 2>/dev/null | wc -c | tr -d ' ')
+gate "[ $gz -lt 5000 ]" "US-6: published analytics+core probe < 5 KB gz (got $gz)"
+
+rm -rf "$SMOKE_DIR"
+
+# US-4: release notes mention the migration
+body=$(gh release view '@tour-kit/analytics@0.12.0' --json body --jq '.body' 2>/dev/null || echo "")
+gate "echo \"\$body\" | grep -q '@tour-kit/analytics/posthog'" \
+     "US-4: release notes mention subpath import"
+gate "echo \"\$body\" | grep -qE 'BREAKING|breaking'" \
+     "US-4: release notes flag breaking change"
+
+# US-7: README status
+gate "grep -qE '^> .*Status:\\s*SHIPPED' tasks/sprint-1-stop-the-bleeding/README.md" \
+     "US-7: README marked SHIPPED"
+
+# US-8: 6 sprint-2 issues exist
+n=$(gh issue list --label sprint-2 --state open --json title --jq '. | length' 2>/dev/null || echo 0)
+gate "[ $n -ge 6 ]" "US-8: ≥ 6 sprint-2 follow-up issues open (got $n)"
+
+[ "$fails" -eq 0 ] || { echo "Phase 8 POSTPUBLISH FAILED gates: $fails"; exit 1; }
+echo "Phase 8 post-publish all gates green. Sprint shipped."
+```
+
+---
+
+## Key Testing Decisions
+
+| Decision                                                          | Approach                                                      | Rationale                                                                                                                |
+| ----------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Re-run every phase's asserter as pre-flight                        | Compose `verify-phase-{0..7}.sh` in one wrapper               | A bad release is more expensive than a 5-minute re-verification. The asserters are already idempotent.                   |
+| Smoke against the npm-published artifact, not the workspace        | Temp project + `pnpm add @latest`                              | The workspace artifact is what we control. The published artifact is what consumers get. They must match — and the only way to prove that is to install it. |
+| Test the release-note content via `gh release view`                | Real network call to GitHub API                                | Release notes are the breaking-change contract for the consumer. A typo there is a worse outcome than a typo in MIGRATION.md. |
+| Don't simulate a `pnpm release` half-failure                       | Document idempotency, verify by re-running if it happens       | Simulating the failure mode teaches nothing about real causes (auth, npm 5xx). Idempotent retry is the actual mitigation. |
+| Issue-existence is a `gh issue list` count, not content match     | Set-cardinality                                                | The 6 follow-up issues' titles/labels are spelled out in Phase 8 §7; verifying the *count* under the `sprint-2` label is enough proof they were filed. |
+| README status check is a regex, not a date check                  | `grep -E 'Status:\s*SHIPPED'`                                  | Hardcoding today's date in the asserter would break the next run. The string "SHIPPED" is the contract.                  |
+| Don't test `npm view <pkg> versions --json` history               | Only test current `version`                                    | We care that the just-released version landed. The full version history is npm's job, not ours.                          |
+| US-3 uses `esbuild`, not the consumer's actual bundler             | Single deterministic bundler                                   | We can't anticipate every consumer's webpack/vite/rspack config. esbuild gives us a deterministic, fast bundle that proves "the npm artifact is tree-shakable." |
+
+---
+
+## Example Test Case — Reading the post-publish asserter output
+
+```bash
+$ bash tasks/sprint-1-stop-the-bleeding/verify-phase-8-postpublish.sh
+✓ US-2: @tour-kit/analytics → npm has 0.12.0
+✓ US-2: @tour-kit/adoption → npm has 2.1.4
+✓ US-2: @tour-kit/core → npm has 1.0.1
+✓ US-2: @tour-kit/react → npm has 1.0.1
+✓ US-2: @tour-kit/hints → npm has 1.0.1
+✓ US-2: @tour-kit/checklists → npm has 0.4.6
+✓ US-2: @tour-kit/announcements → npm has 0.4.6
+✓ US-2: @tour-kit/surveys → npm has 0.4.6
+✓ US-2: @tour-kit/media → npm has 0.4.6
+✓ US-2: @tour-kit/ai → npm has 0.1.4
+✓ US-2: @tour-kit/scheduling → npm has 0.3.4
+✓ US-2: @tour-kit/license → npm has 0.2.4
+✓ US-3: no @amplitude/plugin- strings in published bundle
+✓ US-6: published analytics+core probe < 5 KB gz (got 4278)
+✓ US-4: release notes mention subpath import
+✓ US-4: release notes flag breaking change
+✓ US-7: README marked SHIPPED
+✓ US-8: ≥ 6 sprint-2 follow-up issues open (got 6)
+Phase 8 post-publish all gates green. Sprint shipped.
+```
+
+If `US-3` is red, **the published artifact has the bug.** Cut a patch
+release immediately (per Phase 8 §9 emergency rollback) — do not assume
+"oh, it was fine locally."
+
+---
+
+## Execution Prompt
+
+Copy everything between the `---` lines into a new Claude session to write
+the Phase 8 asserters:
+
+---
+You are completing Phase 8 of Sprint 1 in the tour-kit monorepo — cutting
+the release that bundles Phases 1–7, publishing to npm, and announcing
+the breaking analytics change. This is the only Sprint-1 phase that
+touches systems we can't roll back (npm, GitHub releases).
+
+### What This Project Is
+A pnpm 10 monorepo with 12 published packages. Phases 1–7 fixed a 64 KB
+analytics bundle regression, removed plugin re-exports, restored
+tree-shaking for `@tour-kit/adoption`, cataloged 7 runtime deps, added
+codemods + testing-library docs, and wired bundle-size CI. Phase 8
+publishes the bundle.
+
+### Acceptance Criteria (from User Stories)
+| #    | User Story                                                    | Validation Check                                              | Pass Condition                          |
+| ---- | ------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------- |
+| US-1 | Pre-flight composes Phase 0–7 asserters                       | `verify-phase-8-preflight.sh`                                 | All exit 0                              |
+| US-2 | npm versions match `main`                                      | `npm view @tour-kit/<pkg> version` × N                        | All match                               |
+| US-3 | Published bundle has no Amplitude SDK strings                  | Temp project esbuild + grep                                   | 0 matches                               |
+| US-4 | Release notes flag breaking change + new path                  | `gh release view '@tour-kit/analytics@0.12.0' --json body`    | Contains both old + new import          |
+| US-5 | `pnpm release` is safely re-runnable                          | Documented; verified ad-hoc if it half-fails                  | Re-run finishes the publish              |
+| US-6 | Published analytics+core probe < 5 KB gz                       | Same temp project, `gzip -c probe.bundled.js`                  | `< 5000`                                |
+| US-7 | README marked SHIPPED with retrospective                       | `grep 'Status:' tasks/sprint-1-stop-the-bleeding/README.md`   | `Status: SHIPPED <date>`                |
+| US-8 | 6 sprint-2 follow-up issues filed                              | `gh issue list --label sprint-2`                              | ≥ 6 open                                |
+
+### Why Fakes Are Required
+None. Phase 8 deliberately doesn't mock npm, GitHub, or `pnpm release`.
+The whole point is to verify the *real* publish made it through, not
+that the workspace artifact (which we always control) is correct.
+
+### What NOT to Test
+- Don't simulate `pnpm release` half-failure modes. The mitigation
+  (re-run, changeset publish is idempotent) is documented; testing it
+  would require breaking npm auth, which is hostile.
+- Don't `npm unpublish` anything during testing. Even within the 72h
+  window, unpublishing is hostile to anyone who already installed.
+- Don't run the post-publish smoke against the *workspace* artifact.
+  Use `pnpm add @tour-kit/analytics@latest` from npm in a fresh
+  `/tmp/tk-smoke-*/` directory.
+- Don't gate the post-publish asserter on a specific `version` string —
+  use the version recorded in `main`'s `packages/<pkg>/package.json` to
+  cross-check.
+- Don't try to verify *every* changeset entry — the unbiased gate is
+  "npm has the expected version." If the CHANGELOG is wrong, that's a
+  separate followup.
+- Don't auto-create the 6 sprint-2 issues from the asserter. Issue
+  creation is a human-driven step in §7; the asserter only verifies they
+  exist.
+
+### Critical: The Two Asserters
+
+The body of `tasks/sprint-1-stop-the-bleeding/verify-phase-8-preflight.sh`
+and `verify-phase-8-postpublish.sh` are shown above. Drop them in,
+`chmod +x`, and run.
+
+### Files to Create / Modify
+
+```
+tasks/sprint-1-stop-the-bleeding/verify-phase-8-preflight.sh    # NEW
+tasks/sprint-1-stop-the-bleeding/verify-phase-8-postpublish.sh  # NEW
+tasks/sprint-1-stop-the-bleeding/README.md                       # MODIFIED — Status SHIPPED + retrospective
+
+# Versioning + publishing — these are run, not committed:
+.changeset/*.md                                                  # CONSUMED by `pnpm version-packages`
+packages/*/package.json                                          # bumped by `pnpm version-packages`
+packages/*/CHANGELOG.md                                          # appended by `pnpm version-packages`
+
+# External, not file-system:
+# - npm packages published via `pnpm release`
+# - `@tour-kit/analytics@0.12.0` GitHub release via `gh release create`
+# - 6 sprint-2 issues via `gh issue create`
+```
+
+### Per-File Coverage Guidance
+
+#### `verify-phase-8-preflight.sh`
+- Body shown above. Composes Phase 0–7 asserters + checks the Sprint-level
+  acceptance gates.
+- Run from clean `main` immediately before `pnpm version-packages`.
+
+#### `verify-phase-8-postpublish.sh`
+- Body shown above. Runs after `pnpm release` returns success.
+- Requires network (`npm view`, `pnpm add`, `gh`).
+- Uses a `mktemp -d` smoke dir; cleans up after.
+
+#### `tasks/sprint-1-stop-the-bleeding/README.md`
+- Flip the `Status:` line from `PLANNED` to `SHIPPED YYYY-MM-DD`.
+- Append a `## Retrospective` section at the bottom (per phase plan §6.4).
+
+### Success Criteria
+- `verify-phase-8-preflight.sh` all green BEFORE `pnpm version-packages`.
+- `pnpm release` returns success.
+- `verify-phase-8-postpublish.sh` all green within 5 minutes of `pnpm release`.
+- 6 sprint-2 issues filed via `gh issue create`, tagged `sprint-2`.
+- README status flipped to SHIPPED with retrospective written.
+
+### Expected End State
+
+```
+tasks/sprint-1-stop-the-bleeding/
+├── README.md                                # Status: SHIPPED <date> + retrospective
+├── verify-phase-8-preflight.sh              # NEW
+├── verify-phase-8-postpublish.sh            # NEW
+└── (phase plans + test plans + per-phase asserters from 0-7)
+
+npm:
+├── @tour-kit/analytics@0.12.0               # PUBLISHED (breaking)
+├── @tour-kit/adoption@<patch>               # PUBLISHED
+├── @tour-kit/core,react,hints@<patch>       # PUBLISHED (linked)
+└── (every catalog-touched package, patch)
+
+GitHub:
+├── Release: @tour-kit/analytics@0.12.0      # NEW (with migration notes)
+├── Tags: per-package version tags           # NEW
+├── Discussion: pinned migration thread      # NEW
+└── 6 sprint-2 issues open                   # NEW
+```
+---
+
+---
+
+## Run Commands
+
+```bash
+# Pre-flight — BEFORE pnpm version-packages
+chmod +x tasks/sprint-1-stop-the-bleeding/verify-phase-8-preflight.sh
+bash tasks/sprint-1-stop-the-bleeding/verify-phase-8-preflight.sh
+
+# Cut the version PR (after preflight green)
+pnpm version-packages
+git diff --stat
+git checkout -b release/sprint-1
+git add packages/*/package.json packages/*/CHANGELOG.md .changeset/
+git commit -m "chore: version packages for sprint-1 release"
+git push -u origin release/sprint-1
+gh pr create --title "chore: version packages for sprint-1 release"
+
+# After version PR merges to main:
+git checkout main && git pull --ff-only
+pnpm release
+
+# Post-publish smoke (within 5 min of pnpm release returning)
+chmod +x tasks/sprint-1-stop-the-bleeding/verify-phase-8-postpublish.sh
+bash tasks/sprint-1-stop-the-bleeding/verify-phase-8-postpublish.sh
+
+# Manual: create the GitHub release with migration notes
+gh release create '@tour-kit/analytics@0.12.0' \
+  --title 'analytics@0.12.0 — plugins move to subpaths (BREAKING)' \
+  --notes-file - <<'EOF'
+[paste the release-notes body from phase-8-release.md §5]
+EOF
+
+# Manual: file 6 sprint-2 follow-up issues
+for ref in B-1 F-3 R-1 R-2 R-4 R-5 G-3 G-7; do
+  # Adjust title per audit context; example:
+  gh issue create --title "[sprint-2] Follow-up: audit $ref" --label sprint-2 \
+    --body "Follow-up from Sprint 1; see reports/package-audit-2026-05-23.md §$ref."
+done
+
+# Re-run preflight if anything is red
+bash tasks/sprint-1-stop-the-bleeding/verify-phase-8-preflight.sh
+
+# After all green: flip the README status
+sed -i 's/Status: PLANNED/Status: SHIPPED '"$(date -I)"'/' tasks/sprint-1-stop-the-bleeding/README.md
+# Then append the ## Retrospective section manually.
+```
+
+---
+
+## End of Sprint-1 test plan train
+
+After Phase 8 ships, archive the directory:
+
+```bash
+mkdir -p tasks/_archive
+mv tasks/sprint-1-stop-the-bleeding tasks/_archive/
+```
+
+Then start Sprint 2 with the 6 follow-up issues as the seed backlog.


### PR DESCRIPTION
## Summary
Drops in the test plans for the remaining Sprint 1 phases (2, 4, 5, 6, 7, 8). Each follows the same template as `phase-3-tests.md` (already merged via #74).

## Why a separate PR
These are reference documents only — they're consumed by `/run-phase` when each phase runs. Bundling them with any single phase PR would conflate scope. Each corresponding phase will commit its own `verify-phase-N.sh` asserter and source/test changes on its own `sprint-1/phase-N-*` branch.

## Files
- `tasks/sprint-1-stop-the-bleeding/phase-2-tests.md`
- `tasks/sprint-1-stop-the-bleeding/phase-4-tests.md`
- `tasks/sprint-1-stop-the-bleeding/phase-5-tests.md`
- `tasks/sprint-1-stop-the-bleeding/phase-6-tests.md`
- `tasks/sprint-1-stop-the-bleeding/phase-7-tests.md`
- `tasks/sprint-1-stop-the-bleeding/phase-8-tests.md`

## Test plan
- [x] No code touched — pure docs add.
- [ ] CI green.