### PR TITLE
fix(verify-phase-4): tighten US-2 drift filter; drop unused catalog version

### DIFF
--- a/tasks/sprint-1-stop-the-bleeding/_phase-4-peer-resolve.mjs
+++ b/tasks/sprint-1-stop-the-bleeding/_phase-4-peer-resolve.mjs
@@ -7,30 +7,29 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
-function parseCatalogBlock(yamlText) {
-  // Find the `catalog:` block and collect `  key: value` (one indent level).
-  const lines = yamlText.split(/\r?\n/)
-  const catalog = {}
+function parseCatalogKeys(yamlText) {
+  // Collect the set of package names listed under the `catalog:` block.
+  // We only care about presence — the resolved version is pnpm's job.
+  const keys = new Set()
   let inCatalog = false
-  for (const line of lines) {
+  for (const line of yamlText.split(/\r?\n/)) {
     if (/^catalog:\s*$/.test(line)) {
       inCatalog = true
       continue
     }
     if (!inCatalog) continue
     if (/^\S/.test(line)) {
-      // Top-level key — left the catalog block.
       inCatalog = false
       continue
     }
-    // Match `  "@scope/pkg": ^1.2.3` or `  pkg: ^1.2.3` (no nested objects in catalog).
-    const m = line.match(/^\s+"?([^"\s:]+)"?:\s*(.+?)\s*$/)
-    if (m) catalog[m[1]] = m[2].replace(/^["']|["']$/g, '')
+    // Match `  "@scope/pkg":` or `  pkg:` — the value side is ignored.
+    const m = line.match(/^\s+"?([^"\s:]+)"?:/)
+    if (m) keys.add(m[1])
   }
-  return catalog
+  return keys
 }
 
-const catalog = parseCatalogBlock(readFileSync('pnpm-workspace.yaml', 'utf8'))
+const catalogKeys = parseCatalogKeys(readFileSync('pnpm-workspace.yaml', 'utf8'))
 
 const pkgDirs = readdirSync('packages').filter(
   (d) =>
@@ -48,9 +47,10 @@ for (const dir of pkgDirs) {
       for (const [name, range] of Object.entries(block)) {
         if (range === 'catalog:') {
           checked++
-          if (!catalog[name]) {
+          if (!catalogKeys.has(name)) {
+            const known = [...catalogKeys].join(', ')
             process.stderr.write(
-              `FAIL ${pkgPath} ${section}.${name}: catalog: but no catalog entry in pnpm-workspace.yaml\n`
+              `FAIL ${pkgPath} ${section}.${name}: catalog: but no entry in pnpm-workspace.yaml (known: ${known})\n`
             )
             fails++
           }

--- a/tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh
+++ b/tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh
@@ -35,30 +35,61 @@ done
 # ─────────────────────────────────────────────────────────────────────────────
 # US-2: lockfile resolution unchanged vs baseline.
 #
-# "Resolution drift" = a library resolves to a different version. The catalog
-# move adds bookkeeping noise we must ignore:
-#   - the new `catalogs.default` block at top of lockfile
-#   - `specifier: ^x.y.z` → `specifier: 'catalog:'` rewrites (both halves)
-#   - fumadocs cache-key bumps (hash recomputed when specifier strings change)
+# "Resolution drift" = a library resolves to a different version. To detect
+# that and only that, we strip and filter three categories of noise the
+# catalog move legitimately introduces:
 #
-# What we keep: a *new* `version: x.y.z` for a package that already existed
-# (i.e. the version actually changed).
+#   1. The contiguous `catalogs:` block at top of the lockfile (new entries).
+#   2. `specifier: 'catalog:'` ↔ `specifier: ^x.y.z` rewrites for the 7 libs.
+#   3. Peer-hash churn: lines like `version: 14.2.11(2ixb…)` ↔
+#      `version: 14.2.11(28d3…)` where the version *number* is identical and
+#      only the parenthetical peer-resolution hash differs. pnpm recomputes
+#      these hashes when specifier strings change, even though the resolved
+#      version is unchanged. We use a paired-line awk filter so this CANNOT
+#      mask a real version regression (e.g. `14.2.11` → `14.3.0`).
 # ─────────────────────────────────────────────────────────────────────────────
 if [ -f "$BASELINE_LOCK" ]; then
-  CATALOG_LIBS_RE='@floating-ui/react|class-variance-authority|@radix-ui/react-slot|@radix-ui/react-dialog|@mui/base|clsx|tailwind-merge'
+  # Drop the contiguous `catalogs:` block (until the next top-level key).
+  strip_catalogs() {
+    awk '
+      /^catalogs:/ { skip=1; next }
+      skip && /^[a-z]/ { skip=0 }
+      !skip
+    ' "$1"
+  }
+  # Drop paired < / > version lines where only the parenthetical hash differs.
+  drop_peer_hash_churn() {
+    awk '
+      function ver_of(s,   t) {
+        t = s
+        sub(/^[<>][[:space:]]+version: /, "", t)
+        sub(/\(.*$/, "", t)
+        return t
+      }
+      /^<[[:space:]]+version: .+\(.+\)/ {
+        held = $0
+        held_ver = ver_of($0)
+        next
+      }
+      held != "" && /^>[[:space:]]+version: .+\(.+\)/ {
+        if (ver_of($0) == held_ver) { held = ""; next }
+        print held; print $0; held = ""; next
+      }
+      { if (held != "") { print held; held = "" } print }
+      END { if (held != "") print held }
+    '
+  }
   drift=$(
-    diff "$BASELINE_LOCK" pnpm-lock.yaml \
+    diff <(strip_catalogs "$BASELINE_LOCK") <(strip_catalogs pnpm-lock.yaml) \
       | grep -E '^[<>] ' \
-      | grep -v 'catalog' \
-      | grep -vE "^[<>][[:space:]]+specifier: \^" \
-      | grep -vE "^[<>][[:space:]]+'?(${CATALOG_LIBS_RE})'?:[[:space:]]*$" \
-      | grep -vE "^[<>][[:space:]]+version: [0-9]" \
+      | grep -vE "^[<>][[:space:]]+specifier: ('catalog:'|\^)" \
       | grep -vE "^[<>][[:space:]]+fumadocs-(mdx|ui)@" \
+      | drop_peer_hash_churn \
       | wc -l | tr -d ' '
   )
   gate "[ '$drift' -lt 20 ]" \
-    "US-2: lockfile resolution drift < 20 non-bookkeeping lines (got $drift)" \
-    "diff '$BASELINE_LOCK' pnpm-lock.yaml | grep -E '^[<>] ' | grep -v catalog | head -30"
+    "US-2: lockfile resolution drift < 20 lines outside catalog bookkeeping (got $drift)" \
+    "diff <(strip_catalogs '$BASELINE_LOCK') <(strip_catalogs pnpm-lock.yaml) | grep -E '^[<>] ' | head -30"
 else
   echo "✗ US-2: $BASELINE_LOCK missing — re-run Phase 0"
   fails=$((fails + 1))


### PR DESCRIPTION
## Summary

Follow-up to #78. Two code-review findings on the Phase 4 asserter scripts.

### 1. US-2 filter was too broad (MEDIUM, B-1)

`tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh` used `grep -vE 'version: [0-9]'` to ignore the new `catalogs.default` block's `version:` entries. That pattern masked **every** `version:` line in the lockfile diff — including the per-importer `version: x.y.z(peer-hash)` lines under `importers:`. If a non-catalog dependency silently resolved to a different version, the gate would not catch it.

**Fix:**
- Strip the contiguous `catalogs:` block from both files before diffing (it's bookkeeping the catalog move legitimately adds).
- Drop `<` / `>` `version:` line **pairs** where the version numbers match and only the parenthetical peer-resolution hash differs (peer-hash churn from changed specifier strings — same resolved version). A real `14.2.11` → `14.3.0` bump is no longer hidden.

Result on the merged Phase 4 lockfile: drift = **0**.

### 2. `parseCatalogBlock` parsed values it never read (LOW, B-2)

`_phase-4-peer-resolve.mjs` stored `catalog[name] = version` but the only consumer was `if (!catalog[name])` — presence check. The value was dead weight that suggests it's load-bearing.

**Fix:** Renamed to `parseCatalogKeys` returning a `Set<string>`; failure messages now list the known catalog keys for easier debugging.

## Test plan

- [x] `bash tasks/sprint-1-stop-the-bleeding/verify-phase-4.sh` — 9/10 gates green (same as #78; US-4 pre-existing parallel-test flakiness unrelated).
- [x] `node tasks/sprint-1-stop-the-bleeding/_phase-4-peer-resolve.mjs` — `OK 175 catalog: references resolve to a catalog entry.`
- [x] `pnpm lint` — clean.

## Notes

These are scripts under `tasks/`, not shipped code. No package version bump, no changeset.

Refs: code-review findings on #78.