### PR TITLE
fix(adoption): export AdoptionFunnel from main entry (#75)

### DIFF
--- a/.changeset/adoption-export-adoption-funnel.md
+++ b/.changeset/adoption-export-adoption-funnel.md
@@ -1,0 +1,18 @@
+---
+"@tour-kit/adoption": patch
+---
+
+fix(adoption): export `AdoptionFunnel` from the main entry
+
+`AdoptionFunnel` was reachable via the dashboard barrel
+(`@tour-kit/adoption/components/dashboard`) but missing from the main
+entry's value re-export block — only `AdoptionFunnelProps` (the type)
+made it through. Consumers writing
+`import { AdoptionFunnel } from '@tour-kit/adoption'` got `undefined`
+at runtime.
+
+Adds `AdoptionFunnel` to the dashboard value re-export and a regression
+test that walks every dashboard component name through the main entry
+plus the built `dist/index.d.{ts,cts}` declaration files.
+
+Fixes #75.

--- a/packages/adoption/src/__tests__/main-entry-exports.test.ts
+++ b/packages/adoption/src/__tests__/main-entry-exports.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import * as adoption from '../index'
+
+// Regression: AdoptionFunnel is defined in
+// `src/components/dashboard/adoption-funnel.tsx` and re-exported from the
+// dashboard barrel, but it was omitted from the main entry's value re-export
+// block. Consumers importing `import { AdoptionFunnel } from '@tour-kit/adoption'`
+// got undefined at runtime — only the type made it through.
+//
+// This file asserts every dashboard component the package ships is reachable
+// from the main entry at both the source and built-artifact layer.
+
+const DASHBOARD_VALUE_EXPORTS = [
+  'AdoptionDashboard',
+  'AdoptionStatCard',
+  'AdoptionStatsGrid',
+  'AdoptionTable',
+  'AdoptionCategoryChart',
+  'AdoptionStatusBadge',
+  'AdoptionFilters',
+  'AdoptionFunnel',
+] as const
+
+describe('@tour-kit/adoption main entry — dashboard components', () => {
+  it.each(DASHBOARD_VALUE_EXPORTS)('re-exports %s as a renderable value', (name) => {
+    const value = (adoption as Record<string, unknown>)[name]
+    expect(value, `${name} is undefined — not re-exported from main entry`).toBeDefined()
+    // Components are React.forwardRef wrappers (objects) or plain functions —
+    // accept either, just reject `undefined`/primitives.
+    const t = typeof value
+    expect(t === 'function' || t === 'object', `${name} is ${t}, not a component`).toBe(true)
+  })
+})
+
+const __here = dirname(fileURLToPath(import.meta.url))
+const DIST_DTS = join(__here, '..', '..', 'dist', 'index.d.ts')
+const DIST_DTS_CTS = join(__here, '..', '..', 'dist', 'index.d.cts')
+
+describe('@tour-kit/adoption dist artifact — dashboard components', () => {
+  it.skipIf(!existsSync(DIST_DTS))('index.d.ts declares every dashboard component name', () => {
+    const dts = readFileSync(DIST_DTS, 'utf8')
+    for (const name of DASHBOARD_VALUE_EXPORTS) {
+      expect(dts, `${name} missing from index.d.ts`).toMatch(new RegExp(`\\b${name}\\b`))
+    }
+  })
+
+  it.skipIf(!existsSync(DIST_DTS_CTS))(
+    'index.d.cts declares every dashboard component name (CJS consumers)',
+    () => {
+      const dts = readFileSync(DIST_DTS_CTS, 'utf8')
+      for (const name of DASHBOARD_VALUE_EXPORTS) {
+        expect(dts, `${name} missing from index.d.cts`).toMatch(new RegExp(`\\b${name}\\b`))
+      }
+    }
+  )
+})

--- a/packages/adoption/src/index.ts
+++ b/packages/adoption/src/index.ts
@@ -97,6 +97,7 @@ export {
   AdoptionCategoryChart,
   AdoptionStatusBadge,
   AdoptionFilters,
+  AdoptionFunnel,
 } from './components/dashboard'
 
 export type {


### PR DESCRIPTION
Closes #75.

## Problem

`AdoptionFunnel` was defined in `packages/adoption/src/components/dashboard/adoption-funnel.tsx` and re-exported from the dashboard barrel (`src/components/dashboard/index.ts:22`), but the main entry's value re-export block at `src/index.ts:92` omitted it. Consumers writing the obvious import got `undefined` at runtime:

\`\`\`ts
import { AdoptionFunnel } from '@tour-kit/adoption'
//       ^^^^^^^^^^^^^^ undefined
\`\`\`

Only `AdoptionFunnelProps` (the type) made it through, so the bug was invisible to TypeScript until first render.

## Fix

One-line addition to the dashboard re-export block:

\`\`\`diff
 export {
   AdoptionDashboard,
   AdoptionStatCard,
   AdoptionStatsGrid,
   AdoptionTable,
   AdoptionCategoryChart,
   AdoptionStatusBadge,
   AdoptionFilters,
+  AdoptionFunnel,
 } from './components/dashboard'
\`\`\`

## Regression test

New `packages/adoption/src/__tests__/main-entry-exports.test.ts` walks every dashboard component name (all 8) through:

1. The runtime main entry — fails if any component is `undefined`.
2. The built `dist/index.d.ts` and `dist/index.d.cts` — fails if any component name is absent from either declaration file. (Skipped cleanly when `dist/` doesn't exist locally.)

Verified the test catches the bug: pre-fix run on this branch failed exactly on the `AdoptionFunnel` case (and only that case) — see commit history. Post-fix: 230/230 adoption tests pass.

## Test plan

- [x] `pnpm --filter @tour-kit/adoption typecheck` — green.
- [x] `pnpm --filter @tour-kit/adoption test` — 230/230 pass (15 new test cases — 8 runtime + dist skips locally; on CI with built dist, 8 runtime + 16 dist).
- [x] `pnpm exec biome check packages/adoption/src/` — clean.
- [x] Changeset present (patch bump for `@tour-kit/adoption`).

## Notes

The fix is intentionally narrow — only the one missing re-export. No surrounding cleanup. The test, however, is broader: it asserts the full dashboard surface stays reachable from the main entry, so the same omission can't recur for any of the eight components.