### PR TITLE
fix(codemods): tour-kit-migrate --help exits 0 (Phase 5 bin-smoke unblock)

### DIFF
--- a/.changeset/codemods-help-exit-code.md
+++ b/.changeset/codemods-help-exit-code.md
@@ -1,0 +1,12 @@
+---
+"@tour-kit/codemods": patch
+---
+
+Fix `tour-kit-migrate --help`/`-h` to exit 0 and print usage once to stdout.
+
+Previously an explicit help request threw an internal `UsageError`, so the CLI
+exited with code 2 (bad args) and printed the usage text twice — once to stdout
+and again to stderr prefixed with `usage error: help requested`. Help is a
+success: it now exits 0 and prints usage a single time to stdout, matching the
+convention of `git`, `npm`, and `node`. Bad-args and exit codes 1/2/3 are
+unchanged.

--- a/packages/codemods/src/__tests__/bin-smoke.test.ts
+++ b/packages/codemods/src/__tests__/bin-smoke.test.ts
@@ -38,4 +38,11 @@ describe('bin smoke (gated on dist/bin/tour-kit-migrate.cjs existing)', () => {
     const r = run(['--from', 'joyride'])
     expect(r.code).toBe(3)
   })
+
+  skipUnlessBuilt('exits 0 on --help and prints usage to stdout', () => {
+    const r = run(['--help'])
+    expect(r.code).toBe(0)
+    expect(r.stdout).toMatch(/Usage: tour-kit-migrate/)
+    expect(r.stderr).toBe('')
+  })
 })

--- a/packages/codemods/src/__tests__/cli.test.ts
+++ b/packages/codemods/src/__tests__/cli.test.ts
@@ -49,6 +49,60 @@ describe('CLI exit codes', () => {
   })
 })
 
+describe('CLI --help', () => {
+  function captureConsole() {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const join = (spy: typeof log) => spy.mock.calls.map((c) => c.map(String).join(' ')).join('\n')
+    return {
+      get stdout(): string {
+        return join(log)
+      },
+      get stderr(): string {
+        return join(error)
+      },
+      restore: () => {
+        log.mockRestore()
+        error.mockRestore()
+      },
+    }
+  }
+
+  it('exits 0 on --help (help is success, not a usage error)', async () => {
+    const c = captureConsole()
+    const code = await runMigrate(['--help'])
+    c.restore()
+    expect(code).toBe(0)
+  })
+
+  it('exits 0 on the -h alias', async () => {
+    const c = captureConsole()
+    const code = await runMigrate(['-h'])
+    c.restore()
+    expect(code).toBe(0)
+  })
+
+  it('short-circuits before --from is required', async () => {
+    // `--help` with no `--from` must still exit 0, not 2 (bad args).
+    const c = captureConsole()
+    const code = await runMigrate(['--help'])
+    c.restore()
+    expect(code).toBe(0)
+  })
+
+  it('prints usage once to stdout and nothing to stderr', async () => {
+    const c = captureConsole()
+    await runMigrate(['--help'])
+    const { stdout, stderr } = c
+    c.restore()
+    expect(stdout).toMatch(/Usage: tour-kit-migrate/)
+    // Regression guard: the old path threw UsageError and re-printed usage to
+    // stderr with a spurious "usage error: help requested" line.
+    expect(stderr).toBe('')
+    expect(stdout.match(/Usage: tour-kit-migrate/g)).toHaveLength(1)
+  })
+})
+
 describe('CLI --dry-run safety (SHA comparison)', () => {
   it('does not modify any file on disk', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'tk-dry-'))

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -70,12 +70,21 @@ const EXIT_NO_FILES = 3
 
 class UsageError extends Error {}
 
+// An explicit `--help` / `-h` request is a success, not a usage error. Carrying
+// it as a distinct signal lets runMigrate print usage once to stdout and return
+// EXIT_OK, matching every well-behaved CLI (git, npm, node).
+class HelpRequested extends Error {}
+
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: top-level CLI dispatch — one branch per flag/exit-code; splitting hides the contract
 export async function runMigrate(argv: readonly string[]): Promise<number> {
   let opts: CliOptions
   try {
     opts = parseArgs(argv)
   } catch (e) {
+    if (e instanceof HelpRequested) {
+      console.log(usageMessage())
+      return EXIT_OK
+    }
     if (e instanceof UsageError) {
       console.error(`usage error: ${e.message}`)
       console.error(usageMessage())
@@ -210,8 +219,7 @@ function parseArgs(argv: readonly string[]): CliOptions {
       continue
     }
     if (arg === '--help' || arg === '-h') {
-      console.log(usageMessage())
-      throw new UsageError('help requested')
+      throw new HelpRequested()
     }
     if (arg.startsWith('--')) {
       throw new UsageError(`unrecognized flag: ${arg}`)


### PR DESCRIPTION
## Summary

`tour-kit-migrate --help` / `-h` exited with code **2** (bad args) and printed
the usage text **twice** — once to stdout, then again to stderr prefixed with
`usage error: help requested`. The `--help` branch threw an internal
`UsageError`, which `runMigrate` treated like a bad-args failure.

Help is a success. This introduces a distinct `HelpRequested` signal so
`runMigrate` prints usage **once to stdout** and returns `EXIT_OK` (0),
matching `git` / `npm` / `node`. Bad-args handling and exit codes 1/2/3 are
unchanged.

## Why now

This is split out from **Sprint 1 / Phase 5** (codemods docs, audit G-1). The
Phase 5 test plan's US-3 gate asserts `node dist/bin/tour-kit-migrate.cjs --help`
exits 0 as a bin smoke test before publishing the docs. The bin failed that
gate, and Phase 5 is required to be docs-only (US-6: zero `packages/` diff), so
the fix lands here first. The docs PR then branches off this fix.

## Changes
- `packages/codemods/src/cli.ts` — `HelpRequested` signal; `--help`/`-h` → exit 0, single stdout print.
- `packages/codemods/src/__tests__/cli.test.ts` — `--help`/`-h` exit 0, short-circuit before `--from`, single stdout print, empty stderr.
- `packages/codemods/src/__tests__/bin-smoke.test.ts` — built-bin `--help` exits 0, prints usage to stdout.
- `.changeset/codemods-help-exit-code.md` — patch.

## Test plan
- [x] `pnpm --filter @tour-kit/codemods test` — 109 passing (5 new).
- [x] `pnpm --filter @tour-kit/codemods typecheck` — clean.
- [x] `node packages/codemods/dist/bin/tour-kit-migrate.cjs --help; echo $?` → `0`, usage printed once, empty stderr.

Refs: audit G-1.