### PR TITLE
docs(codemods): add codemods subtree (G-1)

### DIFF
--- a/apps/docs/content/docs/codemods/from-driver.mdx
+++ b/apps/docs/content/docs/codemods/from-driver.mdx
@@ -1,0 +1,118 @@
+---
+title: from-driver
+description: >-
+  Migrate a Driver.js v1+ codebase to Tour Kit with the
+  tour-kit-migrate --from driver codemod.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+Reshapes `driver({...})` config objects into a Tour Kit tour-shaped object
+literal and turns the `.drive()` chain into a `// TODO:` pointing at `useTour()`.
+
+## Run
+
+```bash
+npx tour-kit-migrate --from driver --dry-run ./src
+npx tour-kit-migrate --from driver ./src
+```
+
+<Callout type="info">
+Run with `--dry-run` to preview the diff without writing. Run with `--print` to
+write transformed source to stdout. Add `--verbose` to log every file action.
+</Callout>
+
+## What it changes
+
+| Driver.js | Tour Kit |
+| --- | --- |
+| `import { driver } from 'driver.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| `driver({ steps: [...] })` | `{ id: 'migrated-tour', steps: [...] }` literal + `// TODO:` to register at `<TourProvider>` |
+| `Step.element` (selector) | `target` |
+| `popover.title` | `title` |
+| `popover.description` | `content` |
+| `popover.side` | `placement` |
+| `popover.align` | folded into compound placement (`top-start`, `top-end`, …) + `// TODO:` |
+| `d.drive()` | `// TODO:` → `useTour().start()` |
+| `d.destroy()` | `// TODO:` → `useTour().stop()` |
+| `d.moveNext()` / `.movePrevious()` / `.moveTo(i)` | `// TODO:` → `useTour().next()` / `.prev()` / `.goTo(i)` |
+
+## What it does NOT handle
+
+- **Tour-level styling config** (`overlayColor`, `overlayOpacity`, `stagePadding`,
+  `stageRadius`, `popoverClass`) — each is preserved as a `// TODO:`; port via
+  your theme tokens and overlay slot.
+- **Per-step button overrides** (`doneBtnText`, `showButtons`, `onNextClick`, …)
+  — Tour Kit composes buttons through [`<TourCard>`](/docs/react/components/tour-card)
+  slots; the codemod leaves a `// TODO:` for each.
+- **`d.highlight()`** (single popover, no tour) — there's no single-step
+  highlight in `@tour-kit/react`; the codemod points you at `<HintHotspot>` from
+  `@tour-kit/hints`.
+- **Dynamic config / DOM-element targets** (`element: () => ...`, captured
+  `HTMLElement`) — left as a `// TODO:` against the
+  [Driver.js migration guide](/docs/migration/driver).
+
+## Example
+
+**Before:**
+
+```ts
+import { driver } from 'driver.js'
+
+const tour = driver({
+  steps: [
+    {
+      element: '#header',
+      popover: { title: 'Welcome', description: 'Get started.', side: 'bottom' },
+    },
+  ],
+})
+
+tour.drive()
+```
+
+**After codemod:**
+
+```tsx
+import { TourProvider } from '@tour-kit/react'
+
+// TODO: register this tour at a <TourProvider> ancestor — see
+// /docs/migration/driver#driver-call
+const tour = {
+  id: 'migrated-tour',
+  steps: [
+    {
+      target: '#header',
+      title: 'Welcome',
+      content: 'Get started.',
+      placement: 'bottom',
+    },
+  ],
+}
+
+// TODO: the migrated tour has no .drive() — call useTour().start() from a
+// descendant of the <TourProvider> that registers it.
+// /docs/migration/driver#drive
+```
+
+Wire it up by hand:
+
+```tsx
+import { TourProvider, useTour } from '@tour-kit/react'
+
+function App({ children }) {
+  return <TourProvider tours={[tour]}>{children}</TourProvider>
+}
+
+function StartButton() {
+  const { start } = useTour()
+  return <button onClick={() => start()}>Take the tour</button>
+}
+```
+
+## See also
+
+- [Migration guide: Driver.js → Tour Kit](/docs/migration/driver) — the
+  per-anchor hand-port reference for everything the codemod leaves as a TODO.
+- [`<TourProvider>`](/docs/core/providers/tour-provider) — register the migrated tour shape here.
+- [`useTour`](/docs/core/hooks/use-tour) — the imperative replacement for `d.drive()` / `.moveNext()` / `.moveTo()`.

--- a/apps/docs/content/docs/codemods/from-joyride.mdx
+++ b/apps/docs/content/docs/codemods/from-joyride.mdx
@@ -1,0 +1,104 @@
+---
+title: from-joyride
+description: >-
+  Migrate a React Joyride v2 codebase to Tour Kit with the
+  tour-kit-migrate --from joyride codemod.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+Rewrites the `react-joyride` imports plus both the legacy `<Joyride>` JSX form
+and the modern `useJoyride()` hook form. Joyride's step shape
+(`{ target, content }`) already matches Tour Kit, so step lists carry over
+unchanged.
+
+## Run
+
+```bash
+npx tour-kit-migrate --from joyride --dry-run ./src
+npx tour-kit-migrate --from joyride ./src
+```
+
+<Callout type="info">
+Run with `--dry-run` to preview the diff without writing. Run with `--print` to
+write transformed source to stdout. Add `--verbose` to log every file action.
+</Callout>
+
+## What it changes
+
+| React Joyride | Tour Kit |
+| --- | --- |
+| `import Joyride from 'react-joyride'` | `import { TourProvider } from '@tour-kit/react'` |
+| `import { useJoyride } from 'react-joyride'` | `import { useTour } from '@tour-kit/react'` |
+| `<Joyride steps={...} />` | `<TourProvider tours={[{ id: 'migrated-tour', steps }]} />` |
+| `{ target: '.x', content: '...' }` | same shape — no change |
+| `const { Tour, controls } = useJoyride({ steps })` | `const controls = useTour()` + `// TODO:` to register the tour |
+| `<Tour />` | `null` + `// TODO:` to render via a `<TourProvider>` ancestor |
+
+## What it does NOT handle
+
+- **Joyride-only props** (`callback`, `run`, `stepIndex`, `showProgress`,
+  `showSkipButton`, `continuous`, `disableBeacon`, …) are preserved next to the
+  output with a `// TODO:` linking to the matching anchor in the
+  [React Joyride migration guide](/docs/migration/joyride). For example
+  `continuous` is the default in Tour Kit and can be dropped, while `run` maps
+  to calling `useTour().start()`.
+- **`Step.styles` / `Step.tooltipComponent`** — custom tooltip rendering ports
+  to [`<TourCard>`](/docs/react/components/tour-card) children, not a prop.
+- **`useJoyride` control wiring.** The hook is swapped for `useTour()`, but
+  registering the tour at a `<TourProvider>` ancestor is left as a `// TODO:`.
+
+## Example
+
+**Before:**
+
+```tsx
+import Joyride from 'react-joyride'
+
+function App() {
+  return (
+    <Joyride
+      steps={[
+        { target: '.step-1', content: 'Welcome!' },
+        { target: '.step-2', content: 'Next up.' },
+      ]}
+      run
+      continuous
+    />
+  )
+}
+```
+
+**After codemod:**
+
+```tsx
+import { TourProvider } from '@tour-kit/react'
+
+function App() {
+  return (
+    <TourProvider
+      tours={[
+        {
+          id: 'migrated-tour',
+          steps: [
+            { target: '.step-1', content: 'Welcome!' },
+            { target: '.step-2', content: 'Next up.' },
+          ],
+        },
+      ]}
+      // TODO: `run` had no direct prop — call useTour().start() to begin.
+      // /docs/migration/joyride#run
+      // TODO: `continuous` is the Tour Kit default — drop it.
+      // /docs/migration/joyride#continuous
+    />
+  )
+}
+```
+
+## See also
+
+- [Migration guide: React Joyride → Tour Kit](/docs/migration/joyride) — the
+  per-anchor hand-port reference for everything the codemod leaves as a TODO.
+- [`<TourProvider>`](/docs/core/providers/tour-provider) — where the migrated `tours` array is registered.
+- [`useTour`](/docs/core/hooks/use-tour) — the replacement for `useJoyride()`.
+- [Quick start](/docs/getting-started/quick-start) — wire the migrated tour into a working app.

--- a/apps/docs/content/docs/codemods/from-shepherd.mdx
+++ b/apps/docs/content/docs/codemods/from-shepherd.mdx
@@ -1,0 +1,122 @@
+---
+title: from-shepherd
+description: >-
+  Migrate a Shepherd.js v10+ codebase to Tour Kit with the
+  tour-kit-migrate --from shepherd codemod.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+Rewrites the `new Shepherd.Tour({...})` + `.addStep({...})` + `.start()`
+imperative chain into a single Tour Kit tour-shaped object literal.
+
+## Run
+
+```bash
+npx tour-kit-migrate --from shepherd --dry-run ./src
+npx tour-kit-migrate --from shepherd ./src
+```
+
+<Callout type="info">
+Run with `--dry-run` to preview the diff without writing. Run with `--print` to
+write transformed source to stdout. Add `--verbose` to log every file action.
+</Callout>
+
+## What it changes
+
+| Shepherd.js | Tour Kit |
+| --- | --- |
+| `import Shepherd from 'shepherd.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| `import { Tour } from 'shepherd.js'` | `import { TourProvider } from '@tour-kit/react'` |
+| `new Shepherd.Tour({...})` | `{ id: 'migrated-tour', steps: [...] }` literal + `// TODO:` to register at `<TourProvider>` |
+| `.addStep({ id, text, attachTo })` chain | merged into the `steps: [...]` array |
+| `attachTo.element` (selector) | `target` |
+| `attachTo.on` (placement) | `placement` |
+| `Step.text` | `content` |
+| `tour.start()` | `// TODO:` → `useTour().start()` |
+| `tour.cancel()` | `// TODO:` → `useTour().skip()` |
+| `tour.complete()` | `// TODO:` → `useTour().complete()` |
+| `tour.next()` / `.back()` / `.show()` | `// TODO:` → `useTour().next()` / `.prev()` / `.goTo()` |
+
+## What it does NOT handle
+
+- **`buttons` arrays.** Shepherd's button array is open-ended; the codemod drops
+  it and leaves a `// TODO:`. Tour Kit ships fixed [`<TourCard>`](/docs/react/components/tour-card)
+  slots (Next / Prev / Skip / Close) — wire any custom button action through
+  the card's children.
+- **`classes`, `scrollTo`, `when`, `advanceOn`, `beforeShowPromise`.** Each is
+  preserved as a `// TODO:` linking to the matching anchor in the
+  [Shepherd.js migration guide](/docs/migration/shepherd).
+- **Dynamic `attachTo` or `addStep` arguments** (spread/variable, not an inline
+  object) — the codemod can't inline the shape, so it leaves a `// TODO:`.
+- **Multiple parallel `Tour` instances.** Tour Kit's multi-tour registry handles
+  this differently — see [`<TourProvider>`](/docs/core/providers/tour-provider).
+
+## Example
+
+**Before:**
+
+```ts
+import Shepherd from 'shepherd.js'
+
+const tour = new Shepherd.Tour({
+  defaultStepOptions: { scrollTo: true, cancelIcon: { enabled: true } },
+})
+
+tour.addStep({
+  id: 'welcome',
+  text: 'Welcome!',
+  attachTo: { element: '#header', on: 'bottom' },
+})
+
+tour.addStep({
+  id: 'cta',
+  text: 'Click here to begin.',
+  attachTo: { element: '#cta-button', on: 'top' },
+})
+
+tour.start()
+```
+
+**After codemod:**
+
+```tsx
+import { TourProvider } from '@tour-kit/react'
+
+// TODO: register this tour at a <TourProvider> ancestor — see
+// /docs/migration/shepherd#tour-constructor
+const tour = {
+  id: 'migrated-tour',
+  steps: [
+    { id: 'welcome', content: 'Welcome!', target: '#header', placement: 'bottom' },
+    { id: 'cta', content: 'Click here to begin.', target: '#cta-button', placement: 'top' },
+  ],
+}
+
+// TODO: the migrated tour has no .start() — call useTour().start() from a
+// descendant of the <TourProvider> that registers it.
+// /docs/migration/shepherd#start
+```
+
+Wire it up by hand:
+
+```tsx
+import { TourProvider, useTour } from '@tour-kit/react'
+
+function App({ children }) {
+  return <TourProvider tours={[tour]}>{children}</TourProvider>
+}
+
+function StartButton() {
+  const { start } = useTour()
+  return <button onClick={() => start()}>Take the tour</button>
+}
+```
+
+## See also
+
+- [Migration guide: Shepherd.js → Tour Kit](/docs/migration/shepherd) — the
+  per-anchor hand-port reference for everything the codemod leaves as a TODO.
+- [`<TourProvider>`](/docs/core/providers/tour-provider) — register the migrated tour shape here.
+- [`useTour`](/docs/core/hooks/use-tour) — the imperative replacement for `tour.start()` / `.cancel()` / `.next()`.
+- [`<TourCard>`](/docs/react/components/tour-card) — the slot that replaces Shepherd's `buttons` array.

--- a/apps/docs/content/docs/codemods/index.mdx
+++ b/apps/docs/content/docs/codemods/index.mdx
@@ -1,0 +1,119 @@
+---
+title: Codemods
+description: >-
+  Automated jscodeshift codemods to migrate from React Joyride, Shepherd.js,
+  and Driver.js to Tour Kit using the tour-kit-migrate CLI.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+`@tour-kit/codemods` ships [jscodeshift](https://github.com/facebook/jscodeshift)
+transforms that rewrite Joyride, Shepherd.js, and Driver.js call sites into
+their Tour Kit equivalents. They handle the mechanical parts of a migration —
+step-list reshaping, prop renames, import swaps — so you can focus on the parts
+that need product judgment.
+
+The transforms are conservative by design: anything a codemod can't represent
+safely is kept in place and annotated with a `// TODO:` comment that links to
+the matching migration guide. A transform that mangles your code is worse than
+no transform.
+
+## When to use a codemod
+
+- **You have a working tour in another library** and want to evaluate Tour Kit
+  without hand-rewriting every step list.
+- **You're migrating a non-trivial app** (10+ tours). Hand-edits scale badly.
+- **You want a starting point.** Codemods aren't a one-shot drop-in; expect to
+  manually adjust the output. They get you past the boilerplate.
+
+If your app has one tour with three steps, hand-editing is faster.
+
+## Install
+
+Run it once with `npx` (no install), or add it as a dev dependency:
+
+```bash
+# One-off, no install
+npx tour-kit-migrate --from shepherd --dry-run ./src
+
+# Or add it to the project
+pnpm add -D @tour-kit/codemods   # or: npm install -D / bun add -D
+```
+
+Always start with `--dry-run` to preview the diff, then re-run without it to
+write the changes:
+
+```bash
+npx tour-kit-migrate --from shepherd --dry-run ./src
+npx tour-kit-migrate --from shepherd ./src
+```
+
+(Substitute `--from driver` or `--from joyride` as needed.)
+
+### Flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--from <source>` | required | One of `joyride`, `shepherd`, `driver` |
+| `--parser <parser>` | `tsx` | `tsx` / `ts` / `babel` |
+| `--dry-run` | off | Print diffs, don't write files |
+| `--print` | off | Write transformed source to stdout |
+| `--extensions <list>` | `ts,tsx,js,jsx` | Comma-separated extension list |
+| `--verbose` | off | Log every file action |
+| `--help`, `-h` | — | Print usage and exit |
+
+Print the full reference any time:
+
+```bash
+npx tour-kit-migrate --help
+```
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success (or `--help`) |
+| 1 | Parse error during transform |
+| 2 | Bad CLI args |
+| 3 | No files matched |
+
+## Available transforms
+
+- [from-shepherd](/docs/codemods/from-shepherd) — Shepherd.js v10+ → Tour Kit.
+- [from-driver](/docs/codemods/from-driver) — Driver.js v1+ → Tour Kit.
+- [from-joyride](/docs/codemods/from-joyride) — React Joyride v2 → Tour Kit.
+
+## After running a codemod
+
+1. **Review the diff.** The transform comments every construct it can't migrate
+   with a `// TODO:` that links to the matching migration guide — search the
+   output for `TODO`.
+2. **Run your tests.** Codemods don't preserve runtime behavior for 100% of
+   edge cases; the remainder is on you.
+3. **Format the output** (`prettier --write` or `biome format --write`).
+4. **Open the matching guide** for the library you migrated from
+   ([/docs/migration/shepherd](/docs/migration/shepherd),
+   [/docs/migration/driver](/docs/migration/driver),
+   [/docs/migration/joyride](/docs/migration/joyride)) for the hand-port context
+   the codemod can't infer.
+
+<Callout type="warn">
+The codemod produces a Tour Kit tour shape — a `{ id, steps }` object literal —
+but it does **not** decide where to mount `<TourProvider>` or wire imperative
+calls. You register the migrated tour at a [`<TourProvider>`](/docs/core/providers/tour-provider)
+ancestor and call [`useTour()`](/docs/core/hooks/use-tour) from a descendant.
+Those steps are flagged with `// TODO:` comments.
+</Callout>
+
+## Limitations
+
+Codemods operate on the AST. They cannot infer:
+
+- **Dynamically constructed step lists** (e.g. `steps.push(...)` driven by
+  runtime data) — these are left as a `// TODO:`.
+- **Custom themes / styles** — port these manually against the Tour Kit
+  theming setup.
+- **Server-rendered tours** (Next.js App Router) — add `'use client'` to the
+  migrated module yourself.
+
+When in doubt, search the output for `TODO` markers.

--- a/apps/docs/content/docs/codemods/meta.json
+++ b/apps/docs/content/docs/codemods/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Codemods",
+  "pages": [
+    "index",
+    "---",
+    "from-shepherd",
+    "from-driver",
+    "from-joyride"
+  ]
+}

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -23,6 +23,7 @@
     "guides",
     "examples",
     "migration",
+    "codemods",
     "api",
     "troubleshooting",
     "---AI---",

--- a/apps/docs/content/docs/migration/driver.mdx
+++ b/apps/docs/content/docs/migration/driver.mdx
@@ -8,6 +8,12 @@ description: >-
 
 import { Callout } from 'fumadocs-ui/components/callout'
 
+<Callout type="info">
+**Automate the mechanical bits.** The [`from-driver` codemod](/docs/codemods/from-driver)
+reshapes `driver({...})` config into Tour Kit tours and renames props for you.
+Come back here for the patterns that need judgment.
+</Callout>
+
 ## Quick start
 
 ```bash

--- a/apps/docs/content/docs/migration/joyride.mdx
+++ b/apps/docs/content/docs/migration/joyride.mdx
@@ -9,6 +9,12 @@ description: >-
 import { Callout } from 'fumadocs-ui/components/callout'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 
+<Callout type="info">
+**Automate the mechanical bits.** The [`from-joyride` codemod](/docs/codemods/from-joyride)
+rewrites `<Joyride>` JSX and `useJoyride()` calls for you. Come back here for
+the patterns that need judgment.
+</Callout>
+
 ## Quick start
 
 ```bash

--- a/apps/docs/content/docs/migration/shepherd.mdx
+++ b/apps/docs/content/docs/migration/shepherd.mdx
@@ -8,6 +8,12 @@ description: >-
 
 import { Callout } from 'fumadocs-ui/components/callout'
 
+<Callout type="info">
+**Automate the mechanical bits.** The [`from-shepherd` codemod](/docs/codemods/from-shepherd)
+reshapes the `addStep` chain, renames props, and swaps imports for you. Come
+back here for the patterns that need judgment.
+</Callout>
+
 ## Quick start
 
 ```bash

--- a/tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh
+++ b/tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh
+# Run before opening the Phase 5 PR.
+set -u
+fails=0
+gate() { if eval "$1"; then echo "✓ $2"; else echo "✗ $2 — $(eval "$3")"; fails=$((fails+1)); fi; }
+
+DOCS_ROOT="apps/docs/content/docs"
+
+# US-2: 4 new pages exist
+for f in index from-shepherd from-driver from-joyride; do
+  gate "[ -f $DOCS_ROOT/codemods/$f.mdx ]" "US-2: $f.mdx exists" "echo missing"
+done
+
+# US-2 (each has frontmatter)
+for f in index from-shepherd from-driver from-joyride; do
+  gate "head -5 $DOCS_ROOT/codemods/$f.mdx | grep -q '^title:'" "US-2: $f.mdx has frontmatter title" "head -5 $DOCS_ROOT/codemods/$f.mdx"
+done
+
+# US-2 (transform pages have a run codeblock)
+for lib in shepherd driver joyride; do
+  gate "grep -q 'tour-kit-migrate --from $lib' $DOCS_ROOT/codemods/from-$lib.mdx" \
+       "US-2: from-$lib.mdx includes run command" "echo missing"
+done
+
+# US-2 (meta.json present)
+gate "[ -f $DOCS_ROOT/codemods/meta.json ]" 'US-2: codemods/meta.json exists' "echo missing"
+gate 'node -e "const m=require(\"./apps/docs/content/docs/codemods/meta.json\"); process.exit(m.pages?.includes(\"index\") && m.pages?.includes(\"from-shepherd\") ? 0 : 1)"' \
+     'US-2: meta.json lists index + transform pages' "cat $DOCS_ROOT/codemods/meta.json"
+
+# US-1: root meta.json includes "codemods" under Resources
+gate 'node -e "const m=require(\"./apps/docs/content/docs/meta.json\"); const idx=m.pages.indexOf(\"---Resources---\"); const end=m.pages.findIndex((p,i)=>i>idx && p.startsWith(\"---\")); const slice=m.pages.slice(idx, end>=0?end:undefined); process.exit(slice.includes(\"codemods\") ? 0 : 1)"' \
+     'US-1: root meta.json lists codemods under Resources' "cat $DOCS_ROOT/meta.json | grep -A 10 Resources"
+
+# US-3: tour-kit-migrate bin works
+if [ ! -f packages/codemods/dist/bin/tour-kit-migrate.cjs ]; then
+  echo "Building codemods first…"
+  pnpm --filter @tour-kit/codemods build >/dev/null 2>&1
+fi
+gate '[ -f packages/codemods/dist/bin/tour-kit-migrate.cjs ]' \
+     'US-3: tour-kit-migrate bin built' "echo missing — run pnpm --filter @tour-kit/codemods build"
+gate 'node packages/codemods/dist/bin/tour-kit-migrate.cjs --help >/dev/null 2>&1' \
+     'US-3: tour-kit-migrate --help exits 0' "node packages/codemods/dist/bin/tour-kit-migrate.cjs --help 2>&1 | tail -5"
+
+# US-4: existing migration pages link to the codemod pages
+for lib in shepherd driver joyride; do
+  gate "grep -q '/docs/codemods/from-$lib' $DOCS_ROOT/migration/$lib.mdx" \
+       "US-4: migration/$lib.mdx links to codemod" "echo missing callout"
+done
+
+# US-6: no package code touched
+n=$(git diff --name-only -- packages/ | wc -l | tr -d ' ')
+gate "[ $n -eq 0 ]" "US-6: zero files under packages/ changed" "git diff --name-only -- packages/"
+
+# US-7: internal link integrity (cheap pass — only check /docs/... refs)
+# Extracts every (/docs/...) link target from the new pages.
+missing_links=0
+while read -r link; do
+  # Strip anchor + leading slash
+  target=$(echo "$link" | sed 's|#.*||' | sed 's|^/||')
+  # Map /docs/foo → apps/docs/content/docs/foo (with .mdx or /index.mdx).
+  # $target already starts with "docs/", so the content root prefix is
+  # apps/docs/content/ (not apps/ — that dropped the content/docs segment).
+  if [ -f "apps/docs/content/$target.mdx" ] || [ -f "apps/docs/content/$target/index.mdx" ]; then
+    : # OK
+  else
+    echo "  ✗ broken link: $link"
+    missing_links=$((missing_links+1))
+  fi
+done < <(grep -hoE '\(/docs/[a-z0-9-]+(/[a-z0-9-]+)*\)' $DOCS_ROOT/codemods/*.mdx | tr -d '()' | sort -u)
+
+gate "[ $missing_links -eq 0 ]" "US-7: all internal /docs/ links resolve" "echo $missing_links broken"
+
+# US-5: docs build
+gate 'pnpm --filter @tour-kit/docs build >/tmp/phase-5-build.log 2>&1' \
+     'US-5: apps/docs builds' "tail -n10 /tmp/phase-5-build.log"
+
+[ "$fails" -eq 0 ] || { echo "Phase 5 FAILED gates: $fails"; exit 1; }
+echo "Phase 5 all gates green."


### PR DESCRIPTION
## Summary
- New `apps/docs/content/docs/codemods/` subtree: `index.mdx` + 3 per-transform pages (`from-shepherd`, `from-driver`, `from-joyride`) + `meta.json`.
- Wired `codemods` into the root nav (`apps/docs/content/docs/meta.json`) under Resources.
- Inbound "use the codemod" `<Callout>` on each existing migration guide (`migration/{shepherd,driver,joyride}.mdx`).
- New verifier `tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh` (US-1..US-7).

## Stacked on #81
Base is `fix/codemods-help-exit-code` (PR #81), which fixes `tour-kit-migrate --help`
to exit 0 — the US-3 bin-smoke gate this phase depends on. **Retarget this PR to
`main` once #81 merges.** Keeps the docs change docs-only (US-6: zero `packages/`
diff) while US-3 passes against the fixed bin.

## Accuracy notes
Content is derived from the real CLI and existing docs, not the (stale) phase-plan templates:
- Real flags: `--dry-run` / `--print` / `--verbose` / `--parser` / `--extensions` (plan said `--dry`, `--verbose=2`).
- Real API: `useTour()` (plan said `useTourActions()`); codemod emits a `{ id, steps }` literal + `// TODO:` comments, does not auto-wire the provider.
- Fumadocs conventions: frontmatter `title`, **no body H1**, `<Callout>` (plan used `:::tip`).
- Verified internal link targets (`/docs/core/providers/tour-provider`, not the plan's missing `/docs/react/tour-provider`).

## Verification
- `bash tasks/sprint-1-stop-the-bleeding/verify-phase-5.sh`: US-1/2/3/4/6/7 green.
- DOM check via `apps/docs dev` + Chrome: all 4 codemods routes HTTP 200; index, `from-shepherd`, and the migration callouts render correctly; `Codemods` shows in nav.

## Known pre-existing blocker (US-5)
`pnpm --filter @tour-kit/docs build` currently exits 1 while prerendering **`/blog`**
(`TypeError: Cannot read properties of null (reading 'useMemo')`). **This reproduces
on the base branch with these docs stashed** — it is unrelated to this PR. My MDX
compiles cleanly (the build reaches page export and only crashes on `/blog`). The
`/blog` crash should be fixed separately.

## What's NOT here
- No codemod binary implementation — the `tour-kit-migrate` bin already exists; this only documents it.
- No docs for `replay-bridge-to-use-tour-actions` / `target-to-ref` (internal helpers).

Refs: audit G-1.