### PR TITLE
docs(testing-library): add index + recipes (G-2)

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -24,6 +24,7 @@
     "examples",
     "migration",
     "codemods",
+    "testing-library",
     "api",
     "troubleshooting",
     "---AI---",

--- a/apps/docs/content/docs/testing-library/index.mdx
+++ b/apps/docs/content/docs/testing-library/index.mdx
@@ -1,0 +1,152 @@
+---
+title: Testing Library
+description: Tour Kit's test helpers for Vitest, Jest, and React Testing Library.
+---
+
+`@tour-kit/testing-library` is a thin layer of test helpers on top of
+[`@testing-library/react`](https://testing-library.com/docs/react-testing-library/intro/).
+It exists so you can assert against tour state without reaching into
+provider internals or scraping the DOM by hand.
+
+## Install
+
+```bash
+pnpm add -D @tour-kit/testing-library @testing-library/react vitest
+# or npm install --save-dev ...
+```
+
+## Setup
+
+Call `setupTourKitTesting()` once in your test setup file (e.g.
+`vitest.setup.ts`). It registers cleanup hooks and configures
+`@testing-library/react` for tour-kit's portal layout.
+
+```ts
+// vitest.setup.ts
+import { setupTourKitTesting } from '@tour-kit/testing-library/setup'
+
+setupTourKitTesting()
+```
+
+> Use the `/setup` subpath to keep your setup file free of the RTL
+> dependency graph until tests actually need it.
+
+In `vitest.config.ts`:
+
+```ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+  },
+})
+```
+
+## Quick example
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import {
+  render,
+  expectStepVisible,
+  advanceTour,
+  HookProbe,
+} from '@tour-kit/testing-library'
+import { TourProvider, TourCard, useTour } from '@tour-kit/react'
+import * as React from 'react'
+
+const tours = [
+  {
+    id: 'demo',
+    steps: [
+      { id: 's1', target: '#a', content: 'First' },
+      { id: 's2', target: '#b', content: 'Second' },
+    ],
+  },
+]
+
+function AutoStart({ tourId }: { tourId: string }) {
+  const { start } = useTour()
+  const started = React.useRef(false)
+  // Start exactly once. `useTour().start` changes identity as provider state
+  // updates, so guard against re-running the effect and restarting the tour.
+  React.useEffect(() => {
+    if (started.current) return
+    started.current = true
+    void start(tourId)
+  }, [start, tourId])
+  return null
+}
+
+describe('demo tour', () => {
+  it('walks step 1 → step 2', async () => {
+    render(
+      <>
+        <div id="a">A</div>
+        <div id="b">B</div>
+        <TourProvider tours={tours}>
+          <AutoStart tourId="demo" />
+          <TourCard />
+          <HookProbe />
+        </TourProvider>
+      </>,
+    )
+
+    await expectStepVisible('s1')
+    await advanceTour()
+    await expectStepVisible('s2')
+  })
+})
+```
+
+The key bits:
+
+- **`<TourCard />`** — renders the current visible step. `TourProvider`
+  owns state but does not render a card by itself.
+- **`<HookProbe />`** — mount this inside `<TourProvider>` so helpers like
+  `goToStep` can reach the active tour handle.
+- **`expectStepVisible(id)`** — waits for the step's card to render
+  (handles portal mount delay) and asserts visibility.
+- **`advanceTour()`** — synthetic equivalent of clicking "Next."
+  Drives the same actions hook your UI uses.
+
+## Available helpers
+
+| Helper                          | Purpose                                          |
+|---------------------------------|--------------------------------------------------|
+| `setupTourKitTesting(opts?)`    | Global setup (call once in test setup file)      |
+| `virtualTarget(rect?, contextElement?)` | Create a Floating UI virtual reference for low-level positioning tests |
+| `expectStepVisible(id, opts?)`  | Wait + assert the step's card is visible         |
+| `advanceTour(opts?)`            | Click-equivalent "Next"                          |
+| `previousTour(opts?)`           | Click-equivalent "Back"                          |
+| `skipTour(opts?)`               | Click-equivalent "Skip"                          |
+| `completeTour(tourId, opts?)`   | Click-equivalent flow through the named tour until done |
+| `goToStep(id)`                  | Jump to step `id` (requires `<HookProbe />`)     |
+| `HookProbe`                     | Bridge component — mount inside `<TourProvider>` |
+| `getActiveTourHandle()`         | Escape hatch — returns the live tour handle      |
+| `TourKitTestingError`           | Typed error thrown by all helpers                |
+
+Plus re-exported from `@testing-library/react` for convenience:
+`render`, `screen`, `fireEvent`, `waitFor`, `act`, `cleanup`.
+
+## Why these helpers?
+
+Without them, you'd be:
+
+- Polling for portal mount by reading from `document.body` directly.
+- Calling `userEvent.click` on a button whose selector depends on
+  Tour Kit's internal DOM (brittle).
+- Reaching into the provider context with `useContext()` from a test
+  helper component you wrote yourself.
+
+The helpers normalize against the provider's actual state — if Tour Kit
+changes how a step renders, the helpers update with it; your tests don't.
+
+## See also
+
+- [Recipes](/docs/testing-library/recipes) — copy-paste patterns for
+  common test scenarios.
+- [`@tour-kit/react` reference](/docs/react) — `TourProvider`, `TourCard`,
+  and the `useTour` hook used throughout these examples.

--- a/apps/docs/content/docs/testing-library/meta.json
+++ b/apps/docs/content/docs/testing-library/meta.json
@@ -1,7 +1,4 @@
 {
   "title": "Testing Library",
-  "pages": [
-    "index",
-    "recipes"
-  ]
+  "pages": ["index", "recipes"]
 }

--- a/apps/docs/content/docs/testing-library/meta.json
+++ b/apps/docs/content/docs/testing-library/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "Testing Library",
+  "pages": [
+    "index",
+    "recipes"
+  ]
+}

--- a/apps/docs/content/docs/testing-library/recipes.mdx
+++ b/apps/docs/content/docs/testing-library/recipes.mdx
@@ -1,0 +1,171 @@
+---
+title: Recipes
+description: Copy-paste test patterns for Tour Kit.
+---
+
+Patterns that come up over and over in tour testing. Copy, adapt, ship.
+
+The snippets below assume this tiny harness:
+
+```tsx
+import { HookProbe, render } from '@tour-kit/testing-library'
+import { TourProvider, TourCard, useTour, type TourConfig } from '@tour-kit/react'
+import * as React from 'react'
+
+function AutoStart({ tourId }: { tourId: string }) {
+  const { start } = useTour()
+  const started = React.useRef(false)
+  // Start exactly once. `useTour().start` changes identity as provider state
+  // updates, so guard against re-running the effect and restarting the tour.
+  React.useEffect(() => {
+    if (started.current) return
+    started.current = true
+    void start(tourId)
+  }, [start, tourId])
+  return null
+}
+
+function renderTour(tours: TourConfig[], tourId: string, targets: React.ReactNode = null) {
+  return render(
+    <>
+      {targets}
+      <TourProvider tours={tours}>
+        <AutoStart tourId={tourId} />
+        <TourCard />
+        <HookProbe />
+      </TourProvider>
+    </>,
+  )
+}
+```
+
+## 1. Asserting that a tour starts on mount
+
+```tsx
+import { expectStepVisible } from '@tour-kit/testing-library'
+
+it('autostarts the welcome tour', async () => {
+  renderTour(
+    [{ id: 'welcome', steps: [{ id: 'hi', target: '#hi', content: 'Hi' }] }],
+    'welcome',
+    <div id="hi" />,
+  )
+
+  await expectStepVisible('hi')
+})
+```
+
+## 2. Driving a tour through every step
+
+```tsx
+import { render, advanceTour, completeTour, expectStepVisible, HookProbe } from '@tour-kit/testing-library'
+
+it('walks step 1 → 2 → done', async () => {
+  renderTour(tours, 'demo', <>
+    <div id="a" />
+    <div id="b" />
+  </>)
+
+  await expectStepVisible('s1')
+  await advanceTour()
+  await expectStepVisible('s2')
+  await completeTour('demo')
+
+  // Tour is done — no step should be visible:
+  expect(document.querySelector('[data-tour-step]')).toBeNull()
+})
+```
+
+## 3. Skipping mid-tour
+
+```tsx
+import { skipTour } from '@tour-kit/testing-library'
+
+it('skip mid-tour invokes onSkip', async () => {
+  const onSkip = vi.fn()
+  renderTour([{ ...tours[0], onSkip }], 'demo')
+
+  await skipTour()
+  expect(onSkip).toHaveBeenCalledOnce()
+})
+```
+
+## 4. Jumping to a non-adjacent step
+
+`goToStep` requires the `<HookProbe />` because it needs direct access to
+the tour handle.
+
+```tsx
+import { goToStep, expectStepVisible } from '@tour-kit/testing-library'
+
+it('jumps from step 1 to step 5', async () => {
+  renderTour(tours, 'long')
+
+  await expectStepVisible('s1')
+  await goToStep('s5')
+  await expectStepVisible('s5')
+})
+```
+
+## 5. Testing target positioning helpers
+
+Use `virtualTarget` for low-level Floating UI positioning tests. It does not
+create a selector-backed DOM element for `TourStep.target`; for full TourCard
+tests, render a real DOM target or pass a ref/getter.
+
+```tsx
+import { virtualTarget } from '@tour-kit/testing-library'
+
+it('creates a stable virtual rect', () => {
+  const target = virtualTarget({ width: 320, height: 180 })
+  expect(target.getBoundingClientRect().width).toBe(320)
+})
+```
+
+## 6. Asserting against the active tour handle directly
+
+For complex assertions, drop to the handle:
+
+```tsx
+import { getActiveTourHandle, waitFor } from '@tour-kit/testing-library'
+
+it('exposes step metadata via the handle', async () => {
+  renderTour(tours, 'demo')
+
+  // `start()` settles asynchronously, so wait for the handle to reflect it
+  // before reading. (`waitFor` is re-exported from the testing library.)
+  await waitFor(() => {
+    expect(getActiveTourHandle()?.currentStep?.id).toBe('s1')
+  })
+  expect(getActiveTourHandle()?.totalSteps).toBe(2)
+})
+```
+
+## 7. Mocking storage between tests
+
+Tour Kit persists progress to localStorage by default. If your tests
+care about a fresh state per test, clear it in `beforeEach`:
+
+```ts
+import { beforeEach } from 'vitest'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+```
+
+Or pass an in-memory storage adapter to the provider — see the
+[persistence guide](/docs/guides/persistence).
+
+## 8. Testing portal-rendered cards
+
+Cards render into a portal mounted on `document.body`. The helpers handle
+this for you, but if you bypass them and use `screen.getByText`, scope
+your query to the portal root:
+
+```tsx
+import { within } from '@testing-library/react'
+
+const text = within(document.body).getByText(/welcome/i)
+expect(text).toBeVisible()
+```

--- a/apps/docs/content/docs/testing-library/recipes.mdx
+++ b/apps/docs/content/docs/testing-library/recipes.mdx
@@ -37,7 +37,32 @@ function renderTour(tours: TourConfig[], tourId: string, targets: React.ReactNod
     </>,
   )
 }
+
+// A two-step demo tour, reused by several recipes below.
+const tours: TourConfig[] = [
+  {
+    id: 'demo',
+    steps: [
+      { id: 's1', target: '#a', content: 'First' },
+      { id: 's2', target: '#b', content: 'Second' },
+    ],
+  },
+]
+
+// A five-step tour for the "jump to a non-adjacent step" recipe.
+const longTour: TourConfig = {
+  id: 'long',
+  steps: ['s1', 's2', 's3', 's4', 's5'].map((id) => ({
+    id,
+    target: `#${id}`,
+    content: id,
+  })),
+}
 ```
+
+Each recipe below renders DOM targets for the steps it drives — the `#a` /
+`#b` / `#s1`… `<div>`s you'll see passed to `renderTour` — so the card has a
+real element to anchor to.
 
 ## 1. Asserting that a tour starts on mount
 
@@ -58,7 +83,7 @@ it('autostarts the welcome tour', async () => {
 ## 2. Driving a tour through every step
 
 ```tsx
-import { render, advanceTour, completeTour, expectStepVisible, HookProbe } from '@tour-kit/testing-library'
+import { advanceTour, completeTour, expectStepVisible } from '@tour-kit/testing-library'
 
 it('walks step 1 → 2 → done', async () => {
   renderTour(tours, 'demo', <>
@@ -79,12 +104,19 @@ it('walks step 1 → 2 → done', async () => {
 ## 3. Skipping mid-tour
 
 ```tsx
-import { skipTour } from '@tour-kit/testing-library'
+import { vi } from 'vitest'
+import { expectStepVisible, skipTour } from '@tour-kit/testing-library'
 
 it('skip mid-tour invokes onSkip', async () => {
   const onSkip = vi.fn()
-  renderTour([{ ...tours[0], onSkip }], 'demo')
+  renderTour([{ ...tours[0], onSkip }], 'demo', <>
+    <div id="a" />
+    <div id="b" />
+  </>)
 
+  // Wait for the card (and its Skip button) to mount before skipping —
+  // skipTour() queries synchronously and start() settles asynchronously.
+  await expectStepVisible('s1')
   await skipTour()
   expect(onSkip).toHaveBeenCalledOnce()
 })
@@ -99,7 +131,15 @@ the tour handle.
 import { goToStep, expectStepVisible } from '@tour-kit/testing-library'
 
 it('jumps from step 1 to step 5', async () => {
-  renderTour(tours, 'long')
+  renderTour(
+    [longTour],
+    'long',
+    <>
+      {['s1', 's2', 's3', 's4', 's5'].map((id) => (
+        <div key={id} id={id} />
+      ))}
+    </>,
+  )
 
   await expectStepVisible('s1')
   await goToStep('s5')

--- a/tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh
+++ b/tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh
+# Run before opening the Phase 6 PR.
+set -u
+fails=0
+gate() { if eval "$1"; then echo "✓ $2"; else echo "✗ $2 — $(eval "$3")"; fails=$((fails+1)); fi; }
+
+DOCS="apps/docs/content/docs"
+
+# US-2: index.mdx exists with key concepts
+gate "[ -f $DOCS/testing-library/index.mdx ]" 'US-2: testing-library/index.mdx exists' "echo missing"
+gate "grep -q 'setupTourKitTesting' $DOCS/testing-library/index.mdx" 'US-2: index mentions setupTourKitTesting' "echo missing"
+gate "grep -q 'HookProbe' $DOCS/testing-library/index.mdx" 'US-2: index mentions HookProbe' "echo missing"
+gate "grep -q 'TourCard' $DOCS/testing-library/index.mdx" 'US-2: index uses TourCard in example' "echo missing"
+
+# US-3: recipes.mdx with 8 numbered sections
+gate "[ -f $DOCS/testing-library/recipes.mdx ]" 'US-3: recipes.mdx exists' "echo missing"
+for n in 1 2 3 4 5 6 7 8; do
+  gate "grep -qE '^## $n\\. ' $DOCS/testing-library/recipes.mdx" "US-3: recipes.mdx has section $n" "echo missing"
+done
+
+# US-1: meta.json wiring
+gate "[ -f $DOCS/testing-library/meta.json ]" 'US-1: testing-library/meta.json exists' "echo missing"
+gate 'node -e "const m=require(\"./apps/docs/content/docs/testing-library/meta.json\"); process.exit(m.pages?.includes(\"index\") && m.pages?.includes(\"recipes\") ? 0 : 1)"' \
+     'US-1: meta.json lists index + recipes' "cat $DOCS/testing-library/meta.json"
+gate 'node -e "const m=require(\"./apps/docs/content/docs/meta.json\"); const idx=m.pages.indexOf(\"---Resources---\"); const end=m.pages.findIndex((p,i)=>i>idx && p.startsWith(\"---\")); const slice=m.pages.slice(idx, end>=0?end:undefined); process.exit(slice.includes(\"testing-library\") ? 0 : 1)"' \
+     'US-1: root meta.json lists testing-library under Resources' "cat $DOCS/meta.json | grep -A 12 Resources"
+
+# US-5: every documented helper exists in source.
+# NOTE: matches the identifier anywhere in the barrel rather than anchoring on
+# `export` — `expectStepVisible` is re-exported across multiple lines, and US-7
+# forbids reformatting the package to make a line-anchored grep happy.
+for helper in setupTourKitTesting virtualTarget expectStepVisible advanceTour previousTour skipTour completeTour goToStep HookProbe getActiveTourHandle TourKitTestingError; do
+  gate "grep -qE '\\b$helper\\b' packages/testing-library/src/index.ts" \
+       "US-5: $helper exported by package" "grep -n $helper packages/testing-library/src/index.ts"
+done
+
+# US-7: no package code touched
+n=$(git diff --name-only -- packages/ | wc -l | tr -d ' ')
+gate "[ $n -eq 0 ]" "US-7: zero files under packages/ changed" "git diff --name-only -- packages/"
+
+# US-8: internal link integrity (only /docs/... refs).
+# NOTE: a `/docs/X` URL maps to the filesystem path apps/docs/content/docs/X —
+# the docs live under apps/docs/content/, not directly under apps/.
+missing_links=0
+while read -r link; do
+  target=$(echo "$link" | sed 's|#.*||' | sed 's|^/||')
+  if [ -f "apps/docs/content/$target.mdx" ] || [ -f "apps/docs/content/$target/index.mdx" ]; then
+    :
+  else
+    echo "  ✗ broken link: $link"
+    missing_links=$((missing_links+1))
+  fi
+done < <(grep -hoE '\(/docs/[a-z0-9-]+(/[a-z0-9-]+)*\)' $DOCS/testing-library/*.mdx 2>/dev/null | tr -d '()' | sort -u)
+
+gate "[ $missing_links -eq 0 ]" "US-8: all internal /docs/ links resolve" "echo $missing_links broken"
+
+# US-6: docs build
+gate 'pnpm --filter @tour-kit/docs build >/tmp/phase-6-build.log 2>&1' \
+     'US-6: apps/docs builds' "tail -n10 /tmp/phase-6-build.log"
+
+[ "$fails" -eq 0 ] || { echo "Phase 6 FAILED gates: $fails"; exit 1; }
+echo "Phase 6 all gates green."


### PR DESCRIPTION
## Summary
- New `apps/docs/content/docs/testing-library/` subtree with `index.mdx` + `recipes.mdx`.
- Documents the package's 10 exported helpers, the `<HookProbe />` bridge, and `setupTourKitTesting`.
- 8 copy-paste recipes for common test scenarios.
- Nav wired in `apps/docs/content/docs/meta.json` (under Resources, after `codemods`).
- Adds `tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh` gate.

## US-4: recipes verified against the real package
Lifted recipes **§1 (tour autostart)** and **§6 (active tour handle introspection)**
into scratch tests under `packages/testing-library/src/__tests__/`. Both **failed first**,
catching two real bugs in the sample code:
- `AutoStart` used `[start, tourId]` deps with no mount-once guard; `start`'s changing
  identity restarted the tour in a loop → `expectStepVisible` timed out.
- §6 read `getActiveTourHandle()` synchronously, but `start()` settles asynchronously,
  so `currentStep` was `undefined`.

Both recipes were corrected (mount-once ref guard; `await waitFor` before reading the
handle), re-run **green (32/32)**, and the scratch files **deleted** before commit.

## Asserter fixes (forced by US-7 — no package edits allowed)
- **US-5**: skeleton grep was line-anchored on `export`, but `expectStepVisible` is
  re-exported across multiple lines in `src/index.ts` → switched to a whole-file
  identifier match.
- **US-8**: skeleton resolved `/docs/X` to `apps/X`; docs live under
  `apps/docs/content/docs/X` → fixed the path prefix.

## Broken-link repoint
The phase template linked to `/docs/react/tour-provider`, which does not exist.
Repointed to `/docs/react` (index) and `/docs/guides/persistence` (storage).

## Test plan
- [x] `bash tasks/sprint-1-stop-the-bleeding/verify-phase-6.sh` — all gates green except US-6 (see below).
- [x] Both MDX pages render in `pnpm --filter @tour-kit/docs dev` (verified in browser at `/docs/testing-library` + `/recipes`; all 8 recipe sections present).
- [x] US-4: recipes §1 + §6 verified by running them as real tests (32/32), scratch files removed.
- [x] `git diff --stat -- packages/` empty.
- [ ] **US-6**: `pnpm --filter @tour-kit/docs build` compiles all routes (`✓ Compiled successfully`, 663 routes) but the static export crashes on the **pre-existing** `/blog` prerender bug (`Cannot read properties of null (reading 'useMemo')`) — a known WSL2-local-only failure unrelated to these pages; CI/Dokploy build `main` fine. `testing-library` appears in zero build errors.

Refs: audit G-2.