### PR TITLE
test(testing-library): guard documented recipes against rot

### DIFF
--- a/packages/testing-library/src/__tests__/_fixtures.tsx
+++ b/packages/testing-library/src/__tests__/_fixtures.tsx
@@ -62,3 +62,22 @@ export function ThreeStepFixture() {
     </>
   )
 }
+
+/**
+ * Two-step tour wired with an `onSkip` callback. Backs the recipe §3 guard —
+ * skipping mid-tour must invoke the tour's `onSkip`.
+ */
+export function SkipFixture({ onSkip }: { onSkip: Tour['onSkip'] }) {
+  const tour: Tour = { ...twoStepTour, id: 'skip-demo', onSkip }
+  return (
+    <>
+      <div data-test="welcome-target">welcome target</div>
+      <div data-test="pricing-target">pricing target</div>
+      <TourProvider tours={[tour]}>
+        <AutoStart tourId="skip-demo" />
+        <TourCard />
+        <HookProbe />
+      </TourProvider>
+    </>
+  )
+}

--- a/packages/testing-library/src/__tests__/floating-ui-integration.test.tsx
+++ b/packages/testing-library/src/__tests__/floating-ui-integration.test.tsx
@@ -1,5 +1,5 @@
 /// <reference types="vitest-axe/extend-expect" />
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { TourKitTestingError } from '../error'
@@ -7,10 +7,11 @@ import { advanceTour } from '../helpers/advance-tour'
 import { completeTour } from '../helpers/complete-tour'
 import { expectStepVisible } from '../helpers/expect-step-visible'
 import { goToStep } from '../helpers/go-to-step'
+import { getActiveTourHandle } from '../helpers/hook-probe'
 import { previousTour } from '../helpers/previous-tour'
 import { skipTour } from '../helpers/skip-tour'
 import { setupTourKitTesting } from '../setup'
-import { ThreeStepFixture, TwoStepFixture } from './_fixtures'
+import { SkipFixture, ThreeStepFixture, TwoStepFixture } from './_fixtures'
 
 // Spy on the dynamic `import('jsdom-testing-mocks')` inside setupTourKitTesting.
 // The factory body fires once per resolved import per vitest module cache slot.
@@ -124,5 +125,27 @@ describe('@tour-kit/testing-library — integration against real <TourCard>', ()
       rules: { region: { enabled: false } },
     })
     expect(results).toHaveNoViolations()
+  })
+
+  // --- Documentation recipe guards (apps/docs/.../testing-library/recipes.mdx) ---
+  // These mirror the recipes that the floating-ui cases above don't already
+  // cover, so the published sample code can't silently rot.
+
+  it('getActiveTourHandle exposes currentStep + totalSteps (recipe §6)', async () => {
+    render(<TwoStepFixture />)
+    // start() settles asynchronously, so wait for the handle to reflect it.
+    await waitFor(() => {
+      expect(getActiveTourHandle()?.currentStep?.id).toBe('welcome')
+    })
+    expect(getActiveTourHandle()?.totalSteps).toBe(2)
+  })
+
+  it('skipTour fires the tour onSkip callback (recipe §3)', async () => {
+    const onSkip = vi.fn()
+    render(<SkipFixture onSkip={onSkip} />)
+    // The card (and its Skip button) must mount before skipTour queries it.
+    await expectStepVisible('welcome')
+    await skipTour()
+    expect(onSkip).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
## Summary
Follow-up to the code review of #85. The `recipes.mdx` snippets are runnable sample code, but two recipe behaviors had **no test guard**, so a provider change could silently break the published examples:

- **§6** — `getActiveTourHandle()` returning `currentStep.id` + `totalSteps`.
- **§3** — `skipTour()` firing the tour's `onSkip` callback.

Both are now integration cases against the real `<TourCard>`. Adds a `SkipFixture` (two-step tour wired with `onSkip`) to `_fixtures.tsx`.

The §2 (advance/complete) and §4 (goToStep) recipes are **already** covered by existing cases in `floating-ui-integration.test.tsx`, so they are intentionally not duplicated.

## Why separate from #85
#85 is contractually docs-only (its US-7 gate asserts zero `packages/` changes). This is package test code, so it ships on its own branch off `main`.

## Test plan
- [x] `pnpm --filter @tour-kit/testing-library typecheck` — clean.
- [x] `pnpm --filter @tour-kit/testing-library test --run` — **32 passed** (30 + 2 new).
- [x] `biome check` on both changed files — clean.