### PR TITLE
fix(ci): unblock main CI — action-setup v4 + testing-library testTimeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10.26.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10.26.1
 

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10.26.1
 

--- a/.github/workflows/smoke-npm.yml
+++ b/.github/workflows/smoke-npm.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10.26.1
 

--- a/packages/testing-library/vitest.config.ts
+++ b/packages/testing-library/vitest.config.ts
@@ -19,5 +19,9 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/__tests__/**/*.test.{ts,tsx}'],
+    // The integration suite renders a real <TourCard> (Floating UI autoUpdate,
+    // focus trap, inert background, portal), which exceeds vitest's 5s default
+    // on slower CI runners. Match the @tour-kit/announcements precedent.
+    testTimeout: 20000,
   },
 })


### PR DESCRIPTION
Two fixes to get `main` CI green after #90 merged.

## 1. `pnpm/action-setup` v3 → v4
Modernization. v3 is upstream-deprecated; v4 takes the same `version: 10.26.1` input (matches root `packageManager`). (Note: the 12:27–12:40 `Set up job` failures were a transient `codeload.github.com` outage for the pnpm/action-setup repo — since recovered — not a version problem; this bump is hygiene.)

## 2. `@tour-kit/testing-library` testTimeout → 20s
The real blocker. `floating-ui-integration.test.tsx` renders a real `<TourCard>`, which #90 made heavier (focus-trap activation + inert background + keyboard nav on mount). `expectStepVisible resolves on the welcome step` took 5–6s on the CI runner, over vitest's 5s default → Test job failed. Raised to 20s, matching the `@tour-kit/announcements` precedent. Locally: 32/32 pass.