### PR TITLE
fix(analytics): keep optional SDK imports out of build-time resolution

### DIFF
--- a/.changeset/analytics-optional-import-build-fix.md
+++ b/.changeset/analytics-optional-import-build-fix.md
@@ -1,0 +1,16 @@
+---
+"@tour-kit/analytics": patch
+---
+
+Fix `next build` / webpack `Module not found` when an optional analytics peer
+(`posthog-js`, `mixpanel-browser`, `@amplitude/analytics-browser`) isn't
+installed. The guarded dynamic `import()` for each optional SDK now carries a
+`/* webpackIgnore: true */ /* @vite-ignore */` magic comment, so bundlers leave
+the import for runtime instead of resolving it at build time. The plugins
+already degraded gracefully at runtime; this extends that to the build.
+
+tsup no longer uses the umbrella `minify: true` (esbuild's whitespace minifier
+strips the magic comments); it minifies identifiers + syntax only, which keeps
+the gzipped bundle size flat. Regression-guarded by a dist magic-comment check,
+a real webpack build smoke test, runtime-optionality tests for all three SDKs,
+and a `peerDependenciesMeta.optional` contract test.

--- a/packages/analytics/src/__tests__/build/optional-imports.bundler-guard.test.ts
+++ b/packages/analytics/src/__tests__/build/optional-imports.bundler-guard.test.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Regression guard for the "@tour-kit/analytics breaks `next build`" defect
+ * (utk-studio QA matrix, 2026-06-08).
+ *
+ * The optional analytics SDKs (`posthog-js`, `mixpanel-browser`,
+ * `@amplitude/analytics-browser`) are loaded via guarded dynamic `import()`.
+ * A bare `import('posthog-js')` is still *resolved at build time* by webpack
+ * (Next's bundler), so when the optional peer isn't installed the build fails
+ * with `Module not found`. The fix is the `/* webpackIgnore: true *​/`
+ * (and `/* @vite-ignore *​/` for Rollup/Vite) magic comment on each import.
+ *
+ * This test asserts the magic comments survive into the *built* output — which
+ * is exactly what breaks if someone removes the comment, or re-enables the
+ * umbrella `minify: true` in tsup.config.ts (esbuild's whitespace minifier
+ * strips these comments). It is the cheapest, most deterministic insurance and
+ * must never be skipped. See the end-to-end proof in
+ * `optional-imports.webpack-smoke.test.ts`.
+ */
+
+const OPTIONAL_SDKS = ['posthog-js', 'mixpanel-browser', '@amplitude/analytics-browser']
+
+// Files in `dist` that should contain each optional import with its magic
+// comment. `index.js`/`index.cjs` inline the plugin bodies (splitting: false),
+// so all three appear there; the subpath bundles carry one each.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../../')
+const DIST_FILES = [
+  { file: 'dist/index.js', sdks: OPTIONAL_SDKS },
+  { file: 'dist/index.cjs', sdks: OPTIONAL_SDKS },
+  { file: 'dist/plugins/posthog.js', sdks: ['posthog-js'] },
+  { file: 'dist/plugins/mixpanel.js', sdks: ['mixpanel-browser'] },
+  { file: 'dist/plugins/amplitude.js', sdks: ['@amplitude/analytics-browser'] },
+]
+
+function read(rel: string): string {
+  const path = join(ROOT, rel)
+  if (!existsSync(path)) {
+    throw new Error(
+      `${rel} not found — build the package before running this guard (\`pnpm --filter @tour-kit/analytics build\`). Turbo runs \`build\` before \`test\`, so this only fails on a standalone \`vitest run\`.`
+    )
+  }
+  return readFileSync(path, 'utf8')
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[/\\^$*+?.()|[\]{}]/g, '\\$&')
+}
+
+describe('optional analytics SDKs are bundler-ignored in dist', () => {
+  for (const { file, sdks } of DIST_FILES) {
+    for (const sdk of sdks) {
+      it(`${file}: import('${sdk}') carries webpackIgnore + @vite-ignore`, () => {
+        const code = read(file)
+
+        // Locate every `import(... 'sdk' ...)` call, tolerating the multi-line
+        // formatting that survives when whitespace minification is disabled.
+        // The tempered `(?!import\()` token keeps each match anchored to the
+        // `import(` that directly precedes the specifier (never spanning across
+        // a sibling import to a different SDK).
+        const re = new RegExp(
+          `import\\(((?:(?!import\\()[\\s\\S])*?)['"\`]${escapeRe(sdk)}['"\`]`,
+          'g'
+        )
+        const calls = [...code.matchAll(re)]
+
+        expect(calls.length, `no import('${sdk}') found in ${file}`).toBeGreaterThan(0)
+
+        for (const [, head] of calls) {
+          // The captured span between `import(` and the specifier must not jump
+          // over another import() (which would mean we matched the wrong call).
+          expect(head, `matched across another import() for '${sdk}'`).not.toContain('import(')
+          expect(head, `import('${sdk}') in ${file} is missing /* webpackIgnore: true */`).toMatch(
+            /webpackIgnore:\s*true/
+          )
+          expect(head, `import('${sdk}') in ${file} is missing /* @vite-ignore */`).toMatch(
+            /@vite-ignore/
+          )
+        }
+      })
+    }
+  }
+})

--- a/packages/analytics/src/__tests__/build/optional-imports.webpack-smoke.test.ts
+++ b/packages/analytics/src/__tests__/build/optional-imports.webpack-smoke.test.ts
@@ -1,0 +1,136 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, describe, expect, it } from 'vitest'
+
+/**
+ * The TRUE end-to-end guard for the `next build` / `Module not found` defect.
+ *
+ * A unit test cannot reproduce webpack's build-time resolution error — so this
+ * drives a real webpack 5 compile of the *built* `dist/index.js` with the
+ * optional peers (`posthog-js`, `mixpanel-browser`,
+ * `@amplitude/analytics-browser`) deliberately NOT installed, and asserts the
+ * build surfaces no `Module not found` (webpack emits it as a warning for an
+ * unresolved `import()`; Next promotes that to a failing build).
+ *
+ * Isolation: the dist is copied into an OS temp dir (outside any node_modules),
+ * and react + workspace deps are externalized, so the optional-peer `import()`
+ * is the *only* variable under test. A stripped-comment control build is run
+ * alongside to prove the assertion is faithful (it must reproduce the failure).
+ *
+ * Gated: resolves a webpack (Next's bundled copy in this monorepo, or a real
+ * `webpack` devDep in CI). If neither is present the suite skips rather than
+ * failing — keeping the default `vitest run` green on a bare checkout.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(here, '../../../../../')
+const distIndex = join(here, '../../../dist/index.js')
+
+type WebpackFn = (config: unknown, cb: (err: unknown, stats: unknown) => void) => void
+
+function resolveWebpack(): WebpackFn | null {
+  // 1) Next's precompiled webpack 5 (present in this monorepo via apps/docs).
+  try {
+    const reqFromDocs = createRequire(join(repoRoot, 'apps/docs/package.json'))
+    const mod = reqFromDocs('next/dist/compiled/webpack/webpack')
+    if (typeof mod.webpack === 'function') return mod.webpack as WebpackFn
+  } catch {
+    /* fall through */
+  }
+  // 2) A real `webpack` dependency (e.g. added as a CI devDep).
+  try {
+    const reqLocal = createRequire(here)
+    const wp = reqLocal('webpack')
+    if (typeof wp === 'function') return wp as WebpackFn
+  } catch {
+    /* fall through */
+  }
+  return null
+}
+
+const webpack = resolveWebpack()
+const distBuilt = existsSync(distIndex)
+
+const EXTERNALS = {
+  react: 'module react',
+  'react-dom': 'module react-dom',
+  'react/jsx-runtime': 'module react/jsx-runtime',
+  '@tour-kit/core': 'module @tour-kit/core',
+  '@tour-kit/license': 'module @tour-kit/license',
+}
+
+const tmpDirs: string[] = []
+
+function compile(analyticsFile: string): Promise<number> {
+  const dir = mkdtempSync(join(tmpdir(), 'tk-analytics-wp-'))
+  tmpDirs.push(dir)
+  writeFileSync(
+    join(dir, 'entry.mjs'),
+    "import * as a from 'analytics-under-test'\nglobalThis.__a = a\n"
+  )
+  return new Promise((resolve, reject) => {
+    ;(webpack as WebpackFn)(
+      {
+        mode: 'development',
+        optimization: { minimize: false },
+        entry: join(dir, 'entry.mjs'),
+        output: {
+          path: join(dir, 'out'),
+          filename: 'bundle.js',
+          module: true,
+          chunkFormat: 'module',
+        },
+        experiments: { outputModule: true },
+        resolve: { alias: { 'analytics-under-test': analyticsFile } },
+        externals: EXTERNALS,
+        externalsType: 'module',
+      },
+      (err, stats) => {
+        if (err) return reject(err)
+        const s = stats as {
+          toJson: (o: unknown) => {
+            errors?: { message?: string }[]
+            warnings?: { message?: string }[]
+          }
+        }
+        const json = s.toJson({ errors: true, warnings: true })
+        const all = [...(json.errors ?? []), ...(json.warnings ?? [])]
+        resolve(all.filter((e) => /Module not found/.test(e.message ?? String(e))).length)
+      }
+    )
+  })
+}
+
+afterAll(() => {
+  for (const d of tmpDirs) rmSync(d, { recursive: true, force: true })
+})
+
+describe.skipIf(!webpack || !distBuilt)('webpack build with optional peers absent', () => {
+  it('built dist/index.js produces NO "Module not found" (optional peers ignored)', async () => {
+    const fixedDir = mkdtempSync(join(tmpdir(), 'tk-analytics-fixed-'))
+    tmpDirs.push(fixedDir)
+    const fixed = join(fixedDir, 'analytics.fixed.js')
+    writeFileSync(fixed, readFileSync(distIndex, 'utf8'))
+
+    const moduleNotFound = await compile(fixed)
+    expect(moduleNotFound).toBe(0)
+  }, 60_000)
+
+  it('control: stripping the magic comment reproduces the build failure', async () => {
+    const ctrlDir = mkdtempSync(join(tmpdir(), 'tk-analytics-ctrl-'))
+    tmpDirs.push(ctrlDir)
+    const stripped = readFileSync(distIndex, 'utf8')
+      .replace(/\/\* webpackIgnore: true \*\//g, '')
+      .replace(/\/\* @vite-ignore \*\//g, '')
+    const ctrl = join(ctrlDir, 'analytics.stripped.js')
+    writeFileSync(ctrl, stripped)
+
+    const moduleNotFound = await compile(ctrl)
+    // Without the magic comment webpack tries to resolve the optional peers
+    // and reports them missing — exactly the defect we are guarding against.
+    expect(moduleNotFound).toBeGreaterThan(0)
+  }, 60_000)
+})

--- a/packages/analytics/src/__tests__/build/optional-imports.webpack-smoke.test.ts
+++ b/packages/analytics/src/__tests__/build/optional-imports.webpack-smoke.test.ts
@@ -54,6 +54,17 @@ function resolveWebpack(): WebpackFn | null {
 const webpack = resolveWebpack()
 const distBuilt = existsSync(distIndex)
 
+// Make a skip loud: a silently-skipped guard reads as "verified" on a green
+// run. If the dist is built but no bundler could be resolved, the end-to-end
+// build guard did NOT run — surface that so a future CI image change (Next's
+// compiled-webpack path moving, apps/docs absent) can't hide zero coverage.
+// The always-on `optional-imports.bundler-guard.test.ts` remains the backstop.
+if (distBuilt && !webpack) {
+  console.warn(
+    '[optional-imports.webpack-smoke] No bundler resolved (Next compiled webpack / `webpack` devDep absent) — the end-to-end build guard was SKIPPED. Dist magic-comment guard still covers the regression.'
+  )
+}
+
 const EXTERNALS = {
   react: 'module react',
   'react-dom': 'module react-dom',

--- a/packages/analytics/src/__tests__/package-contract.test.ts
+++ b/packages/analytics/src/__tests__/package-contract.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guards the optional-peer design against a naive "fix" for the `next build`
+ * failure. The correct fix is the `/* webpackIgnore *​/` magic comment on each
+ * dynamic import (see `build/optional-imports.*`). A tempting but wrong fix is
+ * to promote the SDKs to hard `dependencies` — that re-bloats every consumer
+ * (posthog-js alone is ~1 MB) and reintroduces the original design mistake.
+ *
+ * So: assert the three analytics SDKs stay optional peers, and never appear in
+ * `dependencies`.
+ */
+
+const OPTIONAL_SDKS = ['posthog-js', 'mixpanel-browser', '@amplitude/analytics-browser'] as const
+
+const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '../../package.json')
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+  dependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>
+}
+
+describe('@tour-kit/analytics optional-peer contract', () => {
+  for (const sdk of OPTIONAL_SDKS) {
+    it(`${sdk} is declared as a peer dependency`, () => {
+      expect(pkg.peerDependencies?.[sdk]).toBeDefined()
+    })
+
+    it(`${sdk} is marked optional in peerDependenciesMeta`, () => {
+      expect(pkg.peerDependenciesMeta?.[sdk]?.optional).toBe(true)
+    })
+
+    it(`${sdk} is NOT a hard dependency`, () => {
+      expect(pkg.dependencies?.[sdk]).toBeUndefined()
+    })
+  }
+})

--- a/packages/analytics/src/__tests__/plugins/optional-imports.runtime.test.ts
+++ b/packages/analytics/src/__tests__/plugins/optional-imports.runtime.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TourEvent } from '../../types/events'
+
+/**
+ * Runtime half of the optional-peer contract (the build half lives in
+ * `../build/optional-imports.*`). The `/* webpackIgnore *​/` fix moves
+ * resolution from build time to runtime, so the runtime guard must hold:
+ *
+ *  1. The optional SDK is only touched once the plugin's `init()` runs —
+ *     `track`/`identify`/`destroy` before `init()` never reach the SDK and
+ *     never throw (so an unconfigured/never-initialised plugin is inert).
+ *  2. When the peer is genuinely absent, the dynamic `import()` rejects and the
+ *     plugin degrades gracefully: `init()` resolves, later calls are no-ops,
+ *     and a single warning is logged — the host app must not crash.
+ *
+ * Case (2) was previously only covered for amplitude
+ * (`amplitude-externalization.test.ts`); this adds posthog + mixpanel.
+ */
+
+function mockTourEvent(overrides: Partial<TourEvent> = {}): TourEvent {
+  return {
+    eventName: 'tour_started',
+    timestamp: 1_700_000_000_000,
+    sessionId: 'session-1',
+    tourId: 'demo',
+    ...overrides,
+  }
+}
+
+describe('optional analytics plugins — runtime optionality', () => {
+  let warn: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warn.mockRestore()
+    vi.resetModules()
+  })
+
+  describe('inert before init() — no SDK contact, no throw', () => {
+    it('posthog: track/identify/destroy before init() do nothing and do not throw', async () => {
+      const sdk = { init: vi.fn(), capture: vi.fn(), identify: vi.fn(), reset: vi.fn() }
+      vi.doMock('posthog-js', () => ({ default: sdk }))
+      const { posthogPlugin } = await import('../../plugins/posthog')
+
+      const plugin = posthogPlugin({ apiKey: 'phc_x' })
+      expect(() => plugin.track?.(mockTourEvent())).not.toThrow()
+      expect(() => plugin.identify?.('u1')).not.toThrow()
+      expect(() => plugin.destroy?.()).not.toThrow()
+
+      expect(sdk.init).not.toHaveBeenCalled()
+      expect(sdk.capture).not.toHaveBeenCalled()
+      expect(sdk.identify).not.toHaveBeenCalled()
+      expect(sdk.reset).not.toHaveBeenCalled()
+      vi.doUnmock('posthog-js')
+    })
+
+    it('mixpanel: track/identify before init() do nothing and do not throw', async () => {
+      const sdk = {
+        init: vi.fn(),
+        track: vi.fn(),
+        identify: vi.fn(),
+        people: { set: vi.fn() },
+        reset: vi.fn(),
+      }
+      vi.doMock('mixpanel-browser', () => ({ default: sdk }))
+      const { mixpanelPlugin } = await import('../../plugins/mixpanel')
+
+      const plugin = mixpanelPlugin({ token: 't' })
+      expect(() => plugin.track?.(mockTourEvent())).not.toThrow()
+      expect(() => plugin.identify?.('u1')).not.toThrow()
+
+      expect(sdk.init).not.toHaveBeenCalled()
+      expect(sdk.track).not.toHaveBeenCalled()
+      expect(sdk.identify).not.toHaveBeenCalled()
+      vi.doUnmock('mixpanel-browser')
+    })
+
+    it('amplitude: track before init() does nothing and does not throw', async () => {
+      const sdk = {
+        init: vi.fn(),
+        track: vi.fn(),
+        setUserId: vi.fn(),
+        Identify: vi.fn(),
+        identify: vi.fn(),
+        flush: vi.fn(),
+      }
+      vi.doMock('@amplitude/analytics-browser', () => sdk)
+      const { amplitudePlugin } = await import('../../plugins/amplitude')
+
+      const plugin = amplitudePlugin({ apiKey: 'k' })
+      expect(() => plugin.track?.(mockTourEvent())).not.toThrow()
+
+      expect(sdk.init).not.toHaveBeenCalled()
+      expect(sdk.track).not.toHaveBeenCalled()
+      vi.doUnmock('@amplitude/analytics-browser')
+    })
+  })
+
+  describe('peer absent — graceful degradation (import rejects)', () => {
+    it('posthog: init resolves, track is a no-op, a warning is logged', async () => {
+      vi.doMock('posthog-js', () => {
+        throw new Error("Cannot find module 'posthog-js'")
+      })
+      const { posthogPlugin } = await import('../../plugins/posthog')
+      const plugin = posthogPlugin({ apiKey: 'phc_x' })
+
+      await expect(plugin.init?.()).resolves.toBeUndefined()
+      expect(() => plugin.track?.(mockTourEvent())).not.toThrow()
+      expect(warn).toHaveBeenCalled()
+      vi.doUnmock('posthog-js')
+    })
+
+    it('mixpanel: init resolves, track is a no-op, a warning is logged', async () => {
+      vi.doMock('mixpanel-browser', () => {
+        throw new Error("Cannot find module 'mixpanel-browser'")
+      })
+      const { mixpanelPlugin } = await import('../../plugins/mixpanel')
+      const plugin = mixpanelPlugin({ token: 't' })
+
+      await expect(plugin.init?.()).resolves.toBeUndefined()
+      expect(() => plugin.track?.(mockTourEvent())).not.toThrow()
+      expect(warn).toHaveBeenCalled()
+      vi.doUnmock('mixpanel-browser')
+    })
+
+    it('amplitude: init resolves, track is a no-op, a warning is logged', async () => {
+      vi.doMock('@amplitude/analytics-browser', () => {
+        throw new Error("Cannot find module '@amplitude/analytics-browser'")
+      })
+      const { amplitudePlugin } = await import('../../plugins/amplitude')
+      const plugin = amplitudePlugin({ apiKey: 'k' })
+
+      await expect(plugin.init?.()).resolves.toBeUndefined()
+      expect(() => plugin.track?.(mockTourEvent())).not.toThrow()
+      expect(warn).toHaveBeenCalled()
+      vi.doUnmock('@amplitude/analytics-browser')
+    })
+  })
+})

--- a/packages/analytics/src/plugins/amplitude.ts
+++ b/packages/analytics/src/plugins/amplitude.ts
@@ -49,7 +49,9 @@ export function amplitudePlugin(options: AmplitudePluginOptions): AnalyticsPlugi
       if (typeof window === 'undefined') return
 
       try {
-        const amp = await import('@amplitude/analytics-browser')
+        const amp = await import(
+          /* webpackIgnore: true */ /* @vite-ignore */ '@amplitude/analytics-browser'
+        )
         // @amplitude/analytics-browser exports its namespace directly (no default);
         // at runtime the namespace matches our AmplitudeInstance shape.
         amplitude = amp as unknown as AmplitudeInstance

--- a/packages/analytics/src/plugins/mixpanel.ts
+++ b/packages/analytics/src/plugins/mixpanel.ts
@@ -46,7 +46,7 @@ export function mixpanelPlugin(options: MixpanelPluginOptions): AnalyticsPlugin 
       if (typeof window === 'undefined') return
 
       try {
-        const mp = await import('mixpanel-browser')
+        const mp = await import(/* webpackIgnore: true */ /* @vite-ignore */ 'mixpanel-browser')
         mixpanel = (mp.default || mp) as MixpanelInstance
 
         mixpanel.init(options.token, {

--- a/packages/analytics/src/plugins/posthog.ts
+++ b/packages/analytics/src/plugins/posthog.ts
@@ -45,7 +45,9 @@ export function posthogPlugin(options: PostHogPluginOptions): AnalyticsPlugin {
       if (typeof window === 'undefined') return
 
       try {
-        const { default: ph } = await import('posthog-js')
+        const { default: ph } = await import(
+          /* webpackIgnore: true */ /* @vite-ignore */ 'posthog-js'
+        )
         // posthog-js's default export is typed loosely by the vendor; at runtime
         // it matches our PostHogInstance shape (init/capture/identify/reset).
         posthog = ph as unknown as PostHogInstance

--- a/packages/analytics/tsup.config.ts
+++ b/packages/analytics/tsup.config.ts
@@ -22,11 +22,22 @@ export default defineConfig({
   ],
   treeshake: true,
   splitting: false,
-  minify: true,
+  // NOTE: do not use the umbrella `minify: true`. esbuild's whitespace
+  // minifier strips the `/* webpackIgnore */` / `/* @vite-ignore */` magic
+  // comments on the optional-SDK `import()` calls in the plugins, which
+  // reintroduces the `Module not found` build failure when an optional peer
+  // (posthog-js, mixpanel-browser, @amplitude/analytics-browser) isn't
+  // installed. We minify identifiers + syntax (keeps gzip size flat after
+  // compression) but leave whitespace so the magic comments survive into dist.
+  // Guarded by src/__tests__/build/optional-imports.bundler-guard.test.ts.
+  minify: false,
   sourcemap: true,
   target: 'es2020',
   outDir: 'dist',
   esbuildOptions(options) {
+    options.minifyIdentifiers = true
+    options.minifySyntax = true
+    options.minifyWhitespace = false
     options.banner = {
       js: '"use client";',
     }


### PR DESCRIPTION
## Summary

A fresh Next.js (App Router) app that installs any Tour Kit recipe fails `next build` with `Module not found: Can't resolve 'posthog-js'`. `@tour-kit/analytics` is pulled in transitively by `@tour-kit/react` (the base of every recipe), so this broke **all recipe kinds on Next** regardless of whether analytics was configured. Vite was unaffected (Rollup only warns), which is why it was invisible until utk-studio's QA matrix exercised the Next column (2026-06-08).

**Root cause:** the optional analytics SDKs are loaded with guarded `await import()`, but a bare specifier is still **resolved at build time** by webpack — so when the optional peer isn't installed, webpack raises `Module not found` and fails the build. The runtime guard protected runtime, not the build.

## Fix

- Add `/* webpackIgnore: true */ /* @vite-ignore */` to each optional dynamic import (`posthog-js`, `mixpanel-browser`, `@amplitude/analytics-browser`). Bundlers leave the import for runtime; the existing graceful-degradation guard still applies.
- **tsup:** drop the umbrella `minify: true` — esbuild's *whitespace* minifier strips these magic comments (this was the subtle trap the handoff warned about). Now minifies identifiers + syntax only. Gzip stays flat (**3646 B**, budget 4000).

## Tests (the 4 the handoff specified)

1. **`build/optional-imports.bundler-guard.test.ts`** — greps built dist; every optional `import()` must carry the magic comments. Cheap deterministic regression guard.
2. **`build/optional-imports.webpack-smoke.test.ts`** — real webpack 5 compile of the built dist with optional peers absent, asserts no `Module not found`, **plus a stripped-comment control proving the failure reproduces without the comment**.
3. **`plugins/optional-imports.runtime.test.ts`** — runtime optionality for all three plugins (inert before `init()`; graceful degrade when peer absent).
4. **`package-contract.test.ts`** — the SDKs stay optional peers, never hard `dependencies`.

## Verification

Isolated webpack build (optional peers absent, react + workspace deps externalized):
- **Fixed dist: 0 `Module not found`** ✅
- **Stripped control: 3 `Module not found`** ✅ (proves the comment is load-bearing)

Full suite: **16 files, 245 passed, 11 skipped** · typecheck clean · biome clean · bundle gate ✅

## Notes

- Ships as `@tour-kit/analytics@0.11.7` (changeset included). `@tour-kit/react` peer-depends on analytics and doesn't inline it, so no react bump needed.
- After publish, utk-studio still needs its recipe pin bumped + Next matrix re-run per the handoff's acceptance steps (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
