### PR TITLE
chore(docs): regenerate LLM context files for the 1.0.6 release train

### DIFF
--- a/apps/docs/public/context/adoption.txt
+++ b/apps/docs/public/context/adoption.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/adoption Context File
-Version: 2.1.5 | Generated: 2026-05-26
+Version: 2.1.9 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/adoption.
 =========================================================================
 

--- a/apps/docs/public/context/analytics.txt
+++ b/apps/docs/public/context/analytics.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/analytics Context File
-Version: 0.11.5 | Generated: 2026-05-26
+Version: 0.11.9 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/analytics.
 =========================================================================
 

--- a/apps/docs/public/context/announcements.txt
+++ b/apps/docs/public/context/announcements.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/announcements Context File
-Version: 4.1.2 | Generated: 2026-05-26
+Version: 4.1.6 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/announcements.
 =========================================================================
 

--- a/apps/docs/public/context/checklists.txt
+++ b/apps/docs/public/context/checklists.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/checklists Context File
-Version: 0.13.5 | Generated: 2026-05-26
+Version: 0.13.9 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/checklists.
 =========================================================================
 

--- a/apps/docs/public/context/core.txt
+++ b/apps/docs/public/context/core.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/core Context File
-Version: 1.0.2 | Generated: 2026-05-26
+Version: 1.0.6 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/core.
 =========================================================================
 

--- a/apps/docs/public/context/hints.txt
+++ b/apps/docs/public/context/hints.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/hints Context File
-Version: 1.0.2 | Generated: 2026-05-26
+Version: 1.0.6 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/hints.
 =========================================================================
 

--- a/apps/docs/public/context/media.txt
+++ b/apps/docs/public/context/media.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/media Context File
-Version: 0.12.6 | Generated: 2026-05-26
+Version: 0.13.2 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/media.
 =========================================================================
 

--- a/apps/docs/public/context/react.txt
+++ b/apps/docs/public/context/react.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/react Context File
-Version: 1.0.2 | Generated: 2026-05-26
+Version: 1.0.6 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/react.
 =========================================================================
 
@@ -21,7 +21,7 @@ Peer dependencies:
     @tour-kit/analytics: workspace:*
     next: ^13.0.0 || ^14.0.0 || ^15.0.0
     react-router: ^6.0.0 || ^7.0.0
-    react-router-dom: ^6.0.0
+    react-router-dom: ^6.0.0 || ^7.0.0
 
 EXPORTS
 -------

--- a/apps/docs/public/context/scheduling.txt
+++ b/apps/docs/public/context/scheduling.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/scheduling Context File
-Version: 0.11.5 | Generated: 2026-05-26
+Version: 0.11.9 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/scheduling.
 =========================================================================
 

--- a/apps/docs/public/context/surveys.txt
+++ b/apps/docs/public/context/surveys.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/surveys Context File
-Version: 3.0.5 | Generated: 2026-05-26
+Version: 3.0.9 | Generated: 2026-06-10
 Paste this into your LLM to get accurate answers about @tour-kit/surveys.
 =========================================================================
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -1,4 +1,4 @@
-# userTourKit v1.0.2 — Generated 2026-05-26T08:56:46Z
+# userTourKit v1.0.3 — Generated 2026-06-10T05:35:11Z
 
 # Feature Adoption Tracking
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,4 +1,4 @@
-# userTourKit v1.0.2 — Generated 2026-05-26T08:56:46Z
+# userTourKit v1.0.3 — Generated 2026-06-10T05:35:11Z
 
 # userTourKit
 


### PR DESCRIPTION
Regenerated `apps/docs/public/context/*.txt` + `llms*.txt` via `pnpm generate:context` so the published context files reflect the 2026-06-10 release (PR #97 + version PR #98). Content-only.