### PR TITLE
docs: add React lazy-loading page, regenerate LLM context exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ test-results/
 # Turbo
 .turbo/
 
+# Vercel CLI project link (local machine state)
+.vercel/
+
 # Package tarballs (from npm pack)
 *.tgz
 #tour kit plan

--- a/apps/docs/content/docs/media/components/lottie-player.mdx
+++ b/apps/docs/content/docs/media/components/lottie-player.mdx
@@ -20,6 +20,8 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 
 ## Installation
 
+`@lottiefiles/react-lottie-player` is an **optional** peer dependency. If it is not installed, `LottiePlayer` degrades gracefully — it renders a silent no-op placeholder rather than throwing a build or runtime error. Install it only when you actively use Lottie animations.
+
 LottiePlayer requires the `lottie-web` peer dependency:
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>

--- a/apps/docs/content/docs/react/lazy.mdx
+++ b/apps/docs/content/docs/react/lazy.mdx
@@ -1,0 +1,186 @@
+---
+title: Lazy Loading
+description: >-
+  Code-split tour UI out of your initial bundle with @tour-kit/react/lazy —
+  lazy components, TourSuspense, and preload functions
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+Most users never see a tour on their first page load. The standard `@tour-kit/react` import bundles the entire tour UI — card, overlay, Floating UI positioning — into your initial chunk regardless. The `/lazy` entry point splits that UI into a separate chunk that loads only when a tour actually runs.
+
+This is especially useful for apps with strict [bundle-size budgets](/docs/react) where the tour components would add noticeable weight to the initial paint.
+
+<Callout type="info">
+  The lazy components are **drop-in equivalents** of their eager counterparts. They accept identical props and behave identically — the only difference is that they suspend on first render until the chunk has loaded. You still need the providers (`TourKitProvider`, `TourProvider`) from the main `@tour-kit/react` entry point.
+</Callout>
+
+## Basic Usage
+
+Wrap lazy components in `<TourSuspense>` instead of a bare `<React.Suspense>`. The `fallback` prop is optional — omitting it renders nothing while the chunk loads, which is usually correct for tours that mount after interaction.
+
+```tsx title="app/onboarding.tsx"
+import { TourKitProvider } from '@tour-kit/react'
+import {
+  TourSuspense,
+  LazyTour,
+  LazyTourStep,
+  LazyTourCard,
+  LazyTourOverlay,
+  LazyTourNavigation,
+  LazyTourProgress,
+  LazyTourClose,
+} from '@tour-kit/react/lazy'
+
+export function OnboardingTour() {
+  return (
+    <TourKitProvider>
+      <TourSuspense>
+        <LazyTour id="onboarding">
+          <LazyTourStep target="#dashboard" title="Your dashboard" content="Everything starts here." />
+          <LazyTourStep target="#settings" title="Settings" content="Configure your workspace." />
+
+          <LazyTourOverlay />
+
+          <LazyTourCard>
+            <LazyTourClose />
+            <LazyTourNavigation />
+            <LazyTourProgress />
+          </LazyTourCard>
+        </LazyTour>
+      </TourSuspense>
+    </TourKitProvider>
+  )
+}
+```
+
+Compare this to the eager import — the only change is the import path and the `<TourSuspense>` wrapper:
+
+```tsx title="Before (eager)"
+import { Tour, TourStep, TourCard, TourOverlay, TourNavigation, TourProgress, TourClose } from '@tour-kit/react'
+```
+
+```tsx title="After (lazy)"
+import { TourSuspense, LazyTour, LazyTourStep, LazyTourCard, LazyTourOverlay, LazyTourNavigation, LazyTourProgress, LazyTourClose } from '@tour-kit/react/lazy'
+```
+
+## Preloading
+
+When you know a tour is coming — user hovers a "Start tour" button, a route is entered — call a preload function to warm the chunk ahead of time. The tour then mounts without any visible suspense fallback.
+
+### Preload on hover
+
+```tsx title="components/start-tour-button.tsx"
+import { preloadTour, preloadTourCard, preloadTourOverlay } from '@tour-kit/react/lazy'
+import { useTourActions } from '@tour-kit/react'
+
+export function StartTourButton() {
+  const { start } = useTourActions('onboarding')
+
+  return (
+    <button
+      onMouseEnter={() => {
+        // Warm the chunk while the user is still deciding to click
+        preloadTour()
+        preloadTourCard()
+        preloadTourOverlay()
+      }}
+      onClick={() => start()}
+    >
+      Take the tour
+    </button>
+  )
+}
+```
+
+### Preload everything at once
+
+If you want all tour components warmed in one call — for example during an idle callback after the page loads — use `preloadAllTourComponents`:
+
+```tsx title="app/layout.tsx"
+import { useEffect } from 'react'
+import { preloadAllTourComponents } from '@tour-kit/react/lazy'
+
+export function AppLayout({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    // Warm all tour chunks during idle time, before any tour is triggered
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(() => preloadAllTourComponents())
+    } else {
+      preloadAllTourComponents()
+    }
+  }, [])
+
+  return <>{children}</>
+}
+```
+
+### Preload on route enter
+
+With Next.js App Router, preload when a layout that contains a tour mounts:
+
+```tsx title="app/dashboard/layout.tsx"
+'use client'
+
+import { useEffect } from 'react'
+import { preloadAllTourComponents } from '@tour-kit/react/lazy'
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    preloadAllTourComponents()
+  }, [])
+
+  return <>{children}</>
+}
+```
+
+<Callout type="info">
+  Each preload function is idempotent — calling `preloadTour()` multiple times resolves the same cached promise. There is no cost to calling it more than once.
+</Callout>
+
+## TourSuspense Props
+
+<TypeTable
+  type={{
+    children: {
+      type: 'ReactNode',
+      required: true,
+      description: 'The lazy tour components to render inside the Suspense boundary.',
+    },
+    fallback: {
+      type: 'ReactNode',
+      required: false,
+      default: 'undefined',
+      description: 'UI to show while the tour chunk is loading. Omit to render nothing during load.',
+    },
+  }}
+/>
+
+## Exports Reference
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `TourSuspense` | Component | Convenience `React.Suspense` wrapper for lazy tour components. |
+| `TourSuspenseProps` | Type | Props type for `TourSuspense`. |
+| `LazyTour` | Lazy component | Lazy equivalent of `Tour`. |
+| `LazyTourStep` | Lazy component | Lazy equivalent of `TourStep`. |
+| `LazyTourCard` | Lazy component | Lazy equivalent of `TourCard`. |
+| `LazyTourOverlay` | Lazy component | Lazy equivalent of `TourOverlay`. |
+| `LazyTourNavigation` | Lazy component | Lazy equivalent of `TourNavigation`. |
+| `LazyTourProgress` | Lazy component | Lazy equivalent of `TourProgress`. |
+| `LazyTourClose` | Lazy component | Lazy equivalent of `TourClose`. |
+| `preloadTour` | Function | Preloads the `Tour` chunk. Returns a `Promise`. |
+| `preloadTourStep` | Function | Preloads the `TourStep` chunk. Returns a `Promise`. |
+| `preloadTourCard` | Function | Preloads the `TourCard` chunk. Returns a `Promise`. |
+| `preloadTourOverlay` | Function | Preloads the `TourOverlay` chunk. Returns a `Promise`. |
+| `preloadTourNavigation` | Function | Preloads the `TourNavigation` chunk. Returns a `Promise`. |
+| `preloadTourProgress` | Function | Preloads the `TourProgress` chunk. Returns a `Promise`. |
+| `preloadTourClose` | Function | Preloads the `TourClose` chunk. Returns a `Promise`. |
+| `preloadAllTourComponents` | Function | Preloads all of the above at once. Returns a `Promise` that resolves when all chunks are ready. |
+
+## Related
+
+- [Components](/docs/react/components/tour) — the eager component API these lazy wrappers mirror.
+- [`@tour-kit/react` overview](/docs/react) — providers and the main entry point you still need alongside `/lazy`.
+- [Styling](/docs/react/styling/tailwind) — lazy components accept the same `className` props as their eager equivalents.

--- a/apps/docs/content/docs/react/meta.json
+++ b/apps/docs/content/docs/react/meta.json
@@ -9,6 +9,7 @@
     "providers",
     "hooks",
     "styling",
+    "lazy",
     "target-prop",
     "types"
   ]

--- a/apps/docs/public/context/adoption.txt
+++ b/apps/docs/public/context/adoption.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/adoption Context File
-Version: 2.1.5 | Generated: 2026-05-26
+Version: 2.1.9 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/adoption.
 =========================================================================
 
@@ -284,15 +284,6 @@ EXAMPLES
 
 Example 1: Feature
 
-    const feature = {
-      id: 'dark-mode',
-      name: 'Dark Mode',
-      trigger: '#dark-mode-toggle', // CSS selector
-      adoptionCriteria: { minUses: 3, recencyDays: 30 },
-    }
-
-Example 2: Feature
-
     interface Feature {
       id: string
       name: string
@@ -305,7 +296,7 @@ Example 2: Feature
       premium?: boolean
     }
 
-Example 3: FeatureTrigger
+Example 2: FeatureTrigger
 
     // CSS selector (click tracking)
     trigger: '#dark-mode-toggle'
@@ -317,3 +308,11 @@ Example 3: FeatureTrigger
     
     // Callback (polled every 1s)
     trigger: { callback: () => document.fullscreenElement !== null }
+
+Example 3: AdoptionCriteria
+
+    interface AdoptionCriteria {
+      minUses?: number // default: 3
+      recencyDays?: number // default: 30
+      custom?: (usage: FeatureUsage) => boolean
+    }

--- a/apps/docs/public/context/analytics.txt
+++ b/apps/docs/public/context/analytics.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/analytics Context File
-Version: 0.11.5 | Generated: 2026-05-26
+Version: 0.11.9 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/analytics.
 =========================================================================
 

--- a/apps/docs/public/context/announcements.txt
+++ b/apps/docs/public/context/announcements.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/announcements Context File
-Version: 4.1.2 | Generated: 2026-05-26
+Version: 4.1.6 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/announcements.
 =========================================================================
 

--- a/apps/docs/public/context/checklists.txt
+++ b/apps/docs/public/context/checklists.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/checklists Context File
-Version: 0.13.5 | Generated: 2026-05-26
+Version: 0.13.9 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/checklists.
 =========================================================================
 
@@ -148,79 +148,45 @@ COMPONENTS
 EXAMPLES
 --------
 
-Example 1: Quick Start
+Example 1: ChecklistConfig
 
-    import { ChecklistProvider, Checklist, ChecklistTask } from '@tour-kit/checklists';
-    
-    const onboardingChecklist = {
-      id: 'onboarding',
-      title: 'Get Started',
-      description: 'Complete these steps to get the most out of our app',
-      tasks: [
-        {
-          id: 'create-account',
-          title: 'Create your account',
-          description: 'Sign up and verify your email',
-        },
-        {
-          id: 'add-profile',
-          title: 'Add profile details',
-          description: 'Tell us about yourself',
-          dependsOn: ['create-account'], // Locked until account created
-        },
-        {
-          id: 'first-project',
-          title: 'Create your first project',
-          description: 'Start building something amazing',
-          dependsOn: ['add-profile'],
-          action: { type: 'navigate', url: '/projects/new' },
-        },
-      ],
-    };
-    
-    function App() {
-      return (
-        <ChecklistProvider checklists={[onboardingChecklist]}>
-          <Checklist checklistId="onboarding">
-            <ChecklistTask taskId="create-account" />
-            <ChecklistTask taskId="add-profile" />
-            <ChecklistTask taskId="first-project" />
-          </Checklist>
-    
-          <YourAppContent />
-        </ChecklistProvider>
-      );
+    interface ChecklistConfig {
+      id: string;
+      title: string;
+      description?: string;
+      icon?: string | ReactNode;
+      tasks: ChecklistTaskConfig[];
+      onComplete?: () => void;
+      onDismiss?: () => void;
+      dismissible?: boolean;
+      hideOnComplete?: boolean;
+      meta?: Record<string, unknown>;
     }
 
-Example 2: Task Dependencies
+Example 2: ChecklistTaskConfig
 
-    const tasks = [
-      { id: 'step1', title: 'First step' },
-      { id: 'step2', title: 'Second step', dependsOn: ['step1'] },
-      { id: 'step3', title: 'Final step', dependsOn: ['step1', 'step2'] },
-    ];
+    interface ChecklistTaskConfig {
+      id: string;
+      title: string;
+      description?: string;
+      icon?: string | ReactNode;
+      action?: TaskAction;
+      dependsOn?: string[];
+      when?: (context: ChecklistContext) => boolean;
+      completedWhen?: TaskCompletionCondition;
+      manualComplete?: boolean;
+      meta?: Record<string, unknown>;
+    }
 
-Example 3: Action Triggers
+Example 3: ChecklistState
 
-    const tasks = [
-      {
-        id: 'navigate-task',
-        title: 'View dashboard',
-        action: { type: 'navigate', url: '/dashboard' },
-      },
-      {
-        id: 'tour-task',
-        title: 'Learn the basics',
-        action: { type: 'tour', tourId: 'intro-tour' },
-      },
-      {
-        id: 'callback-task',
-        title: 'Custom action',
-        action: {
-          type: 'callback',
-          handler: async () => {
-            await api.doSomething();
-          }
-        },
-      },
-    ];
+    interface ChecklistState {
+      config: ChecklistConfig;
+      tasks: ChecklistTaskState[];
+      progress: number;
+      completedCount: number;
+      totalCount: number;
+      isComplete: boolean;
+      isDismissed: boolean;
+      isExpanded: boolean;
+    }

--- a/apps/docs/public/context/core.txt
+++ b/apps/docs/public/context/core.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/core Context File
-Version: 1.0.2 | Generated: 2026-05-26
+Version: 1.0.6 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/core.
 =========================================================================
 

--- a/apps/docs/public/context/hints.txt
+++ b/apps/docs/public/context/hints.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/hints Context File
-Version: 1.0.2 | Generated: 2026-05-26
+Version: 1.0.6 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/hints.
 =========================================================================
 
@@ -250,48 +250,32 @@ COMPONENTS
 EXAMPLES
 --------
 
-Example 1: Basic Usage
+Example 1: badge
 
-    import { HintsProvider, Hint } from '@tour-kit/hints';
+    import { HintHotspot } from '@tour-kit/hints';
     
-    function App() {
-      return (
-        <HintsProvider>
-          <Hint
-            id="new-feature"
-            target="#export-button"
-            content="New! Export your data to CSV or PDF"
-          />
-    
-          <button id="export-button">Export</button>
-        </HintsProvider>
-      );
-    }
+    <HintHotspot
+      variant="badge"
+      count={3}
+      targetRect={anchor.getBoundingClientRect()}
+      position="top-right"
+    />
 
-Example 2: Styling Variants
+Example 2: beacon-with-label
 
-    // Small - subtle indicators
-    <Hint id="subtle" target="#element" content="..." size="sm" />
-    
-    // Default - standard size
-    <Hint id="normal" target="#element" content="..." size="default" />
-    
-    // Large - prominent indicators
-    <Hint id="prominent" target="#element" content="..." size="lg" />
+    <HintHotspot
+      variant="beacon-with-label"
+      label="New"
+      side="right"
+      targetRect={anchor.getBoundingClientRect()}
+      position="top-right"
+    />
 
-Example 3: Styling Variants
+Example 3: what-s-new-pill
 
-    // Primary (default)
-    <Hint id="primary" target="#element" content="..." color="default" />
-    
-    // Secondary
-    <Hint id="secondary" target="#element" content="..." color="secondary" />
-    
-    // Success - for positive features
-    <Hint id="success" target="#element" content="New!" color="success" />
-    
-    // Warning - for important features
-    <Hint id="warning" target="#element" content="Required" color="warning" />
-    
-    // Destructive - for dangerous actions
-    <Hint id="danger" target="#element" content="Caution" color="destructive" />
+    <HintHotspot
+      variant="what-s-new-pill"
+      label="What's new"
+      targetRect={anchor.getBoundingClientRect()}
+      position="top-right"
+    />

--- a/apps/docs/public/context/media.txt
+++ b/apps/docs/public/context/media.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/media Context File
-Version: 0.12.6 | Generated: 2026-05-26
+Version: 0.13.2 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/media.
 =========================================================================
 
@@ -195,34 +195,32 @@ COMPONENTS
 EXAMPLES
 --------
 
-Example 1: Quick Start
+Example 1: MediaType
 
-    import { TourMedia } from '@tour-kit/media'
-    
-    export function WelcomeTour() {
-      return (
-        <TourMedia
-          src="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-          alt="Product walkthrough"
-        />
-      )
-    }
+    type MediaType =
+      | 'youtube'
+      | 'vimeo'
+      | 'loom'
+      | 'wistia'
+      | 'video'
+      | 'gif'
+      | 'lottie'
+      | 'image'
 
-Example 2: Reduced Motion Support
+Example 2: AspectRatio
+
+    type AspectRatio =
+      | '16/9'   // Standard widescreen
+      | '4/3'    // Classic TV
+      | '1/1'    // Square
+      | '9/16'   // Vertical/mobile
+      | '21/9'   // Ultra-wide
+      | 'auto'   // Preserve original
+
+Example 3: AspectRatio
 
     <TourMedia
-      src="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-      alt="Product walkthrough"
-      reducedMotionFallback="/static/thumbnail.jpg"
-    />
-
-Example 3: Caption Support
-
-    <TourMedia
-      src="/videos/demo.mp4"
-      alt="Feature demonstration"
-      captions={[
-        { src: '/captions/en.vtt', srcLang: 'en', label: 'English' },
-        { src: '/captions/es.vtt', srcLang: 'es', label: 'Español' }
-      ]}
+      src="video.mp4"
+      alt="Demo"
+      aspectRatio="16/9"
     />

--- a/apps/docs/public/context/react.txt
+++ b/apps/docs/public/context/react.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/react Context File
-Version: 1.0.2 | Generated: 2026-05-26
+Version: 1.0.6 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/react.
 =========================================================================
 
@@ -21,7 +21,7 @@ Peer dependencies:
     @tour-kit/analytics: workspace:*
     next: ^13.0.0 || ^14.0.0 || ^15.0.0
     react-router: ^6.0.0 || ^7.0.0
-    react-router-dom: ^6.0.0
+    react-router-dom: ^6.0.0 || ^7.0.0
 
 EXPORTS
 -------
@@ -407,48 +407,63 @@ COMPONENTS
 EXAMPLES
 --------
 
-Example 1: Selector string (legacy)
+Example 1: TourProps
 
-    import { Tour, TourStep } from '@tour-kit/react'
-    
-    export function Demo() {
-      return (
-        <Tour id="legacy">
-          <TourStep id="welcome" target="#welcome" title="Welcome" content="…" />
-          <button id="welcome" type="button">Click me</button>
-        </Tour>
-      )
+    interface TourProps {
+      id: string
+      autoStart?: boolean
+      startAt?: number
+      config?: Omit<Tour, 'id' | 'steps'>
+      onStart?: () => void
+      onComplete?: () => void
+      onSkip?: () => void
+      onStepChange?: (step: TourStep, index: number) => void
+      children: React.ReactNode
     }
 
-Example 2: RefObject (recommended)
+Example 2: TourCardHeaderProps / TourCardContentProps / TourCardFooterProps
 
-    import { Tour, TourStep } from '@tour-kit/react'
-    import { useRef } from 'react'
+    interface TourCardHeaderProps
+      extends Omit<React.ComponentPropsWithoutRef<'div'>, 'title'>,
+        TourCardHeaderVariants {
+      title?: React.ReactNode
+      /** ID for accessibility (aria-labelledby) */
+      titleId: string
+      showClose?: boolean
+    }
     
-    export function Demo() {
-      const welcomeRef = useRef<HTMLButtonElement>(null)
+    interface TourCardContentProps
+      extends Omit<React.ComponentPropsWithoutRef<'div'>, 'content'>,
+        TourCardContentVariants {
+      content?: React.ReactNode
+    }
     
-      return (
-        <Tour id="ref-mode">
-          <TourStep id="welcome" target={welcomeRef} title="Welcome" content="…" />
-          <button ref={welcomeRef} type="button">Click me</button>
-        </Tour>
-      )
+    interface TourCardFooterProps
+      extends React.ComponentPropsWithoutRef<'div'>,
+        TourCardFooterVariants {
+      currentStep: number
+      totalSteps: number
+      showNavigation?: boolean
+      showProgress?: boolean
+      isFirstStep: boolean
+      isLastStep: boolean
+      onPrev: () => void
+      onNext: () => void
+      onSkip: () => void
     }
 
-Example 3: Getter function (escape hatch)
+Example 3: TourNavigationProps
 
-    import { Tour, TourStep } from '@tour-kit/react'
-    
-    export function Demo() {
-      return (
-        <Tour id="thunk-mode">
-          <TourStep
-            id="cta"
-            target={() => document.querySelector<HTMLElement>('[data-cy="cta"]')}
-            title="Call to action"
-            content="…"
-          />
-        </Tour>
-      )
+    interface TourNavigationProps extends React.ComponentPropsWithoutRef<'div'> {
+      isFirstStep: boolean
+      isLastStep: boolean
+      onPrev: () => void
+      onNext: () => void
+      onSkip?: () => void
+      prevLabel?: string
+      nextLabel?: string
+      finishLabel?: string
+      skipLabel?: string
+      prevVariant?: TourButtonVariants['variant']
+      nextVariant?: TourButtonVariants['variant']
     }

--- a/apps/docs/public/context/scheduling.txt
+++ b/apps/docs/public/context/scheduling.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/scheduling Context File
-Version: 0.11.5 | Generated: 2026-05-26
+Version: 0.11.9 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/scheduling.
 =========================================================================
 
@@ -103,57 +103,58 @@ COMPONENTS
 EXAMPLES
 --------
 
-Example 1: ScheduleGate
-
-    import { ScheduleGate, useSchedule } from '@tour-kit/scheduling'
-    
-    function ScheduledTour() {
-      const { isActive } = useSchedule({
-        startAt: '2026-01-15',
-        endAt: '2026-03-31',
-        timeOfDay: { start: '09:00', end: '17:00' },
-      })
-    
-      return (
-        <ScheduleGate>
-          {isActive ? <Tour tourId="weekly" /> : null}
-        </ScheduleGate>
-      )
-    }
-
-Example 2: Quick Start
-
-    import { useSchedule } from '@tour-kit/scheduling'
-    
-    function OnboardingTour() {
-      const schedule = {
-        startAt: '2024-01-15',
-        endAt: '2024-03-31',
-        daysOfWeek: [1, 2, 3, 4, 5], // Weekdays only
-        timeOfDay: { start: '09:00', end: '17:00' },
-        useUserTimezone: true,
-      }
-    
-      const { isActive, reason } = useSchedule(schedule)
-    
-      if (!isActive) {
-        return null
-      }
-    
-      return <Tour tourId="onboarding">...</Tour>
-    }
-
-Example 3: Schedule
+Example 1: Schedule
 
     interface Schedule {
+      /** Schedule is enabled (default: true) */
       enabled?: boolean
+    
+      /** Start date (inclusive) - content won't show before this */
       startAt?: DateString | Date
+    
+      /** End date (inclusive) - content won't show after this */
       endAt?: DateString | Date
+    
+      /** Days of the week when content can show (0=Sunday, 6=Saturday) */
       daysOfWeek?: DayOfWeek[]
+    
+      /** Time range during the day when content can show */
       timeOfDay?: TimeRange
+    
+      /** Use user's detected timezone (default: true) */
       useUserTimezone?: boolean
+    
+      /** Override timezone (IANA timezone name) */
       timezone?: string
+    
+      /** Blackout periods when content should not show */
       blackouts?: BlackoutPeriod[]
+    
+      /** Recurring pattern for the schedule */
       recurring?: RecurringPattern
+    
+      /** Custom metadata */
       metadata?: Record<string, unknown>
     }
+
+Example 2: Example
+
+    const schedule: Schedule = {
+      enabled: true,
+      startAt: '2024-01-15',
+      endAt: '2024-12-31',
+      daysOfWeek: [1, 2, 3, 4, 5],
+      timeOfDay: { start: '09:00', end: '17:00' },
+      useUserTimezone: true,
+    }
+
+Example 3: TimeRange
+
+    interface TimeRange {
+      /** Start time in HH:MM format (24-hour) */
+      start: TimeString
+      /** End time in HH:MM format (24-hour) */
+      end: TimeString
+    }
+    
+    type TimeString = `${string}:${string}`

--- a/apps/docs/public/context/surveys.txt
+++ b/apps/docs/public/context/surveys.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/surveys Context File
-Version: 3.0.5 | Generated: 2026-05-26
+Version: 3.0.9 | Generated: 2026-06-11
 Paste this into your LLM to get accurate answers about @tour-kit/surveys.
 =========================================================================
 
@@ -298,72 +298,60 @@ COMPONENTS
 EXAMPLES
 --------
 
-Example 1: Quick Start
+Example 1: Usage Example
 
-    import { SurveysProvider, SurveyModal, useSurvey } from '@tour-kit/surveys';
-    
-    const npsConfig = {
-      id: 'nps-q1',
-      type: 'nps',
-      displayMode: 'modal',
-      title: 'How likely are you to recommend us?',
-      questions: [
-        {
-          id: 'score',
-          type: 'rating',
-          text: 'On a scale of 0 to 10, how likely are you to recommend us to a friend or colleague?',
-          ratingScale: { min: 0, max: 10, labels: { min: 'Not at all likely', max: 'Extremely likely' } },
-        },
-      ],
-      onComplete: (responses) => {
-        console.log('NPS score:', responses.get('score'));
-      },
-    };
-    
-    function NPSTrigger() {
-      const survey = useSurvey('nps-q1');
-    
-      return (
-        <>
-          <SurveyModal surveyId="nps-q1" />
-          <button onClick={survey.show}>Give feedback</button>
-        </>
-      );
-    }
-    
-    export function App() {
-      return (
-        <SurveysProvider surveys={[npsConfig]}>
-          <NPSTrigger />
-        </SurveysProvider>
-      );
+    import type {
+      SurveyConfig,
+      QuestionConfig,
+      NPSResult,
+      SurveysProviderProps,
+    } from '@tour-kit/surveys';
+
+Example 2: SurveyConfig
+
+    interface SurveyConfig {
+      id: string;
+      type: SurveyType;
+      displayMode: DisplayMode;
+      priority?: SurveyPriority;
+      title?: string;
+      description?: string | ReactNode;
+      questions: QuestionConfig[];
+      frequency?: FrequencyRule;
+      schedule?: unknown;           // requires @tour-kit/scheduling
+      audience?: AudienceCondition[];
+      globalCooldownDays?: number;
+      samplingRate?: number;        // 0–1
+      maxSnoozeCount?: number;
+      snoozeDelayDays?: number;
+      maxPerSession?: number;
+      modalOptions?: ModalOptions;
+      slideoutOptions?: SlideoutOptions;
+      bannerOptions?: BannerOptions;
+      popoverOptions?: PopoverOptions;
+      metadata?: Record<string, unknown>;
+      onShow?: () => void;
+      onDismiss?: (reason: DismissalReason) => void;
+      onComplete?: (responses: Map<string, AnswerValue>) => void;
+      onAnswer?: (questionId: string, value: AnswerValue) => void;
     }
 
-Example 2: Frequency rules
+Example 3: SurveyState
 
-    frequency?: FrequencyRule
-    // 'once'                          — shows exactly once per user
-    // 'session'                       — once per session
-    // 'always'                        — every time show() is called (ignores cooldown)
-    // { type: 'times', count: 3 }     — show up to N times total
-    // { type: 'interval', days: 30 }  — show at most once every N days
-
-Example 3: Skip logic
-
-    {
-      id: 'reason',
-      type: 'single-select',
-      text: 'What is your main reason for leaving?',
-      options: [
-        { value: 'price', label: 'Price' },
-        { value: 'features', label: 'Missing features' },
-        { value: 'other', label: 'Other' },
-      ],
-      skipLogic: [
-        {
-          questionId: 'reason',
-          condition: (answer) => answer !== 'other',
-          skipTo: 'confirm',   // jump over the free-text follow-up
-        },
-      ],
+    interface SurveyState {
+      id: string;
+      isActive: boolean;
+      isVisible: boolean;
+      isDismissed: boolean;
+      isSnoozed: boolean;
+      isCompleted: boolean;
+      viewCount: number;
+      lastViewedAt: Date | null;
+      dismissedAt: Date | null;
+      dismissalReason: DismissalReason | null;
+      completedAt: Date | null;
+      snoozeCount: number;
+      snoozeUntil: Date | null;
+      currentStep: number;
+      responses: Map<string, AnswerValue>;
     }

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -1,4 +1,4 @@
-# userTourKit v1.0.2 — Generated 2026-05-26T08:56:46Z
+# userTourKit v1.0.6 — Generated 2026-06-11T07:31:35Z
 
 # Feature Adoption Tracking
 
@@ -11468,6 +11468,8 @@ const plugin: AnalyticsPlugin = {
 > Product announcements with modal, toast, banner, slideout, and spotlight variants — priority queuing and audience targeting
 
 {/* llm-context-callout */}
+
+[Why userTourKit for product announcements →](/product-announcements)
 
 A flexible library for displaying product announcements and updates to your users. Choose from 5 UI variants, manage announcement queues with priority ordering, and target specific user segments.
 
@@ -24292,6 +24294,8 @@ and usage examples — optimized to fit within a single paste.
 
 {/* llm-context-callout */}
 
+[Why userTourKit for onboarding checklists →](/onboarding-checklists)
+
 Interactive checklists with task dependencies, progress tracking, and action triggers. Perfect for onboarding flows, feature adoption, and guided user journeys.
 
 ## Why Checklists?
@@ -29370,6 +29374,8 @@ function StartButton() {
 > Framework-agnostic hooks and utilities for building product tours — state management, positioning, and accessibility
 
 {/* llm-context-callout */}
+
+[Why userTourKit for product tours →](/product-tours)
 
 The core package contains all the headless logic for userTourKit. The reasoning behind a
 logic-first, UI-later split — and why it matters for shadcn/ui, Radix, and Base UI integration —
@@ -44022,6 +44028,8 @@ function TourButton() {
 
 {/* llm-context-callout */}
 
+[Why userTourKit for feature hints →](/feature-hints)
+
 A lightweight library for adding contextual hints to your React application. Hints are persistent UI elements that guide users to features without interrupting their flow.
 
 ## Why Hints?
@@ -47956,6 +47964,8 @@ When to use Loom:
 - **Performant**: GPU-accelerated rendering
 
 ## Installation
+
+`@lottiefiles/react-lottie-player` is an **optional** peer dependency. If it is not installed, `LottiePlayer` degrades gracefully — it renders a silent no-op placeholder rather than throwing a build or runtime error. Install it only when you actively use Lottie animations.
 
 LottiePlayer requires the `lottie-web` peer dependency:
 
@@ -54911,6 +54921,8 @@ to write the changes.
 
 {/* llm-context-callout */}
 
+[Why userTourKit for product tours →](/product-tours)
+
 Pre-built, accessible components styled with Tailwind CSS. For hydration-safe patterns, conditional
 steps, and analytics integration specific to React, see our
 [React product tour best practices](/blog/product-tour-best-practices-react) pillar article.
@@ -58581,6 +58593,165 @@ function OnboardingComplete() {
 - [useTour](/docs/core/hooks/use-tour) - Control individual tour actions
 - [MultiTourKitProvider](/docs/react/providers/multi-tour-kit-provider) - Parent provider
 - [Tour](/docs/react/components/tour) - Tour component
+
+---
+
+# Lazy Loading
+
+> Code-split tour UI out of your initial bundle with @tour-kit/react/lazy — lazy components, TourSuspense, and preload functions
+
+Most users never see a tour on their first page load. The standard `@tour-kit/react` import bundles the entire tour UI — card, overlay, Floating UI positioning — into your initial chunk regardless. The `/lazy` entry point splits that UI into a separate chunk that loads only when a tour actually runs.
+
+This is especially useful for apps with strict [bundle-size budgets](/docs/react) where the tour components would add noticeable weight to the initial paint.
+
+## Basic Usage
+
+Wrap lazy components in `<TourSuspense>` instead of a bare `<React.Suspense>`. The `fallback` prop is optional — omitting it renders nothing while the chunk loads, which is usually correct for tours that mount after interaction.
+
+```tsx title="app/onboarding.tsx"
+import { TourKitProvider } from '@tour-kit/react'
+import {
+  TourSuspense,
+  LazyTour,
+  LazyTourStep,
+  LazyTourCard,
+  LazyTourOverlay,
+  LazyTourNavigation,
+  LazyTourProgress,
+  LazyTourClose,
+} from '@tour-kit/react/lazy'
+
+export function OnboardingTour() {
+  return (
+    <TourKitProvider>
+      <TourSuspense>
+        <LazyTour id="onboarding">
+          <LazyTourStep target="#dashboard" title="Your dashboard" content="Everything starts here." />
+          <LazyTourStep target="#settings" title="Settings" content="Configure your workspace." />
+
+          <LazyTourOverlay />
+
+          <LazyTourCard>
+            <LazyTourClose />
+            <LazyTourNavigation />
+            <LazyTourProgress />
+          </LazyTourCard>
+        </LazyTour>
+      </TourSuspense>
+    </TourKitProvider>
+  )
+}
+```
+
+Compare this to the eager import — the only change is the import path and the `<TourSuspense>` wrapper:
+
+```tsx title="Before (eager)"
+import { Tour, TourStep, TourCard, TourOverlay, TourNavigation, TourProgress, TourClose } from '@tour-kit/react'
+```
+
+```tsx title="After (lazy)"
+import { TourSuspense, LazyTour, LazyTourStep, LazyTourCard, LazyTourOverlay, LazyTourNavigation, LazyTourProgress, LazyTourClose } from '@tour-kit/react/lazy'
+```
+
+## Preloading
+
+When you know a tour is coming — user hovers a "Start tour" button, a route is entered — call a preload function to warm the chunk ahead of time. The tour then mounts without any visible suspense fallback.
+
+### Preload on hover
+
+```tsx title="components/start-tour-button.tsx"
+import { preloadTour, preloadTourCard, preloadTourOverlay } from '@tour-kit/react/lazy'
+import { useTourActions } from '@tour-kit/react'
+
+export function StartTourButton() {
+  const { start } = useTourActions('onboarding')
+
+  return (
+    <button
+      onMouseEnter={() => {
+        // Warm the chunk while the user is still deciding to click
+        preloadTour()
+        preloadTourCard()
+        preloadTourOverlay()
+      }}
+      onClick={() => start()}
+    >
+      Take the tour
+    </button>
+  )
+}
+```
+
+### Preload everything at once
+
+If you want all tour components warmed in one call — for example during an idle callback after the page loads — use `preloadAllTourComponents`:
+
+```tsx title="app/layout.tsx"
+import { useEffect } from 'react'
+import { preloadAllTourComponents } from '@tour-kit/react/lazy'
+
+export function AppLayout({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    // Warm all tour chunks during idle time, before any tour is triggered
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(() => preloadAllTourComponents())
+    } else {
+      preloadAllTourComponents()
+    }
+  }, [])
+
+  return <>{children}</>
+}
+```
+
+### Preload on route enter
+
+With Next.js App Router, preload when a layout that contains a tour mounts:
+
+```tsx title="app/dashboard/layout.tsx"
+'use client'
+
+import { useEffect } from 'react'
+import { preloadAllTourComponents } from '@tour-kit/react/lazy'
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    preloadAllTourComponents()
+  }, [])
+
+  return <>{children}</>
+}
+```
+
+## TourSuspense Props
+
+## Exports Reference
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `TourSuspense` | Component | Convenience `React.Suspense` wrapper for lazy tour components. |
+| `TourSuspenseProps` | Type | Props type for `TourSuspense`. |
+| `LazyTour` | Lazy component | Lazy equivalent of `Tour`. |
+| `LazyTourStep` | Lazy component | Lazy equivalent of `TourStep`. |
+| `LazyTourCard` | Lazy component | Lazy equivalent of `TourCard`. |
+| `LazyTourOverlay` | Lazy component | Lazy equivalent of `TourOverlay`. |
+| `LazyTourNavigation` | Lazy component | Lazy equivalent of `TourNavigation`. |
+| `LazyTourProgress` | Lazy component | Lazy equivalent of `TourProgress`. |
+| `LazyTourClose` | Lazy component | Lazy equivalent of `TourClose`. |
+| `preloadTour` | Function | Preloads the `Tour` chunk. Returns a `Promise`. |
+| `preloadTourStep` | Function | Preloads the `TourStep` chunk. Returns a `Promise`. |
+| `preloadTourCard` | Function | Preloads the `TourCard` chunk. Returns a `Promise`. |
+| `preloadTourOverlay` | Function | Preloads the `TourOverlay` chunk. Returns a `Promise`. |
+| `preloadTourNavigation` | Function | Preloads the `TourNavigation` chunk. Returns a `Promise`. |
+| `preloadTourProgress` | Function | Preloads the `TourProgress` chunk. Returns a `Promise`. |
+| `preloadTourClose` | Function | Preloads the `TourClose` chunk. Returns a `Promise`. |
+| `preloadAllTourComponents` | Function | Preloads all of the above at once. Returns a `Promise` that resolves when all chunks are ready. |
+
+## Related
+
+- [Components](/docs/react/components/tour) — the eager component API these lazy wrappers mirror.
+- [`@tour-kit/react` overview](/docs/react) — providers and the main entry point you still need alongside `/lazy`.
+- [Styling](/docs/react/styling/tailwind) — lazy components accept the same `className` props as their eager equivalents.
 
 ---
 
@@ -64078,6 +64249,8 @@ const summerNY = getDateInTimezone(summerDate, 'America/New_York')
 > In-app microsurveys: NPS, CSAT, CES, and custom question flows with fatigue prevention, skip logic, and five display modes for React apps
 
 {/* llm-context-callout */}
+
+[Why userTourKit for in-app surveys →](/in-app-surveys)
 
 In-app microsurveys that surface at the right moment without overwhelming your users. Three industry-standard survey types (NPS, CSAT, CES) plus fully custom question flows, all delivered through five display modes and protected by a multi-layer fatigue prevention system.
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,4 +1,4 @@
-# userTourKit v1.0.2 — Generated 2026-05-26T08:56:46Z
+# userTourKit v1.0.6 — Generated 2026-06-11T07:31:35Z
 
 # userTourKit
 
@@ -74,6 +74,7 @@
 - [useTourRegistryContext](https://usertourkit.com/docs/react/hooks/use-tour-registry-context): Low-level hooks for reading the registered tour list inside MultiTourKitProvider. Use useTours for ergonomic access.
 - [useTourRoute](https://usertourkit.com/docs/react/hooks/use-tour-route): useTourRoute hook: synchronize tour progress with router state for multi-page tours in Next.js and React Router
 - [useTours](https://usertourkit.com/docs/react/hooks/use-tours): useTours hook: access all registered tour instances, check active states, and manage multiple tours from one place
+- [Lazy Loading](https://usertourkit.com/docs/react/lazy): Code-split tour UI out of your initial bundle with @tour-kit/react/lazy — lazy components, TourSuspense, and preload functions
 - [MultiTourKitProvider](https://usertourkit.com/docs/react/providers/multi-tour-kit-provider): MultiTourKitProvider: manage multiple independent tours with shared configuration, analytics, and storage settings
 - [CSS Variables](https://usertourkit.com/docs/react/styling/css-variables): Customize userTourKit appearance with CSS custom properties for colors, spacing, border radius, and shadow values
 - [Custom Components](https://usertourkit.com/docs/react/styling/custom-components): Build fully custom tour card, overlay, and navigation components using Tour Kit hooks and headless primitives


### PR DESCRIPTION
## Summary
- New **Lazy Loading** docs page (`docs/react/lazy`) covering the `@tour-kit/react/lazy` entry point: `LazyTour*` components, `TourSuspense`, and preload functions; added to the React sidebar nav
- LottiePlayer page: note that `@lottiefiles/react-lottie-player` is an optional peer dependency that degrades to a silent no-op when absent
- Regenerated LLM context exports (`public/context/*.txt`, `llms.txt`, `llms-full.txt`) to v1.0.6 — supersedes the v1.0.3 regen from #99 (merge conflict resolved in favor of the newer run, which includes the lazy page)
- Ignore `.vercel/` (local Vercel CLI link state)