### PR TITLE
feat(scheduling): wire business-hours evaluation into the engine

### DIFF
--- a/.changeset/scheduling-business-hours.md
+++ b/.changeset/scheduling-business-hours.md
@@ -1,0 +1,9 @@
+---
+"@tour-kit/scheduling": minor
+---
+
+Wire business-hours evaluation into the schedule engine. `Schedule` now accepts
+an optional `businessHours` field; `isScheduleActive` evaluates it (timezone-aware,
+with `businessHours.timezone` taking precedence over the schedule timezone) and
+surfaces the `outside_business_hours` status reason. Additive, non-breaking.
+dist gz: 3546/4000.

--- a/apps/docs/app/pricing/page.tsx
+++ b/apps/docs/app/pricing/page.tsx
@@ -87,9 +87,9 @@ export default function PricingPage() {
               Tour Kit ships three MIT-licensed core packages — tours, React bindings, and hints —
               that are free forever for any project, commercial or otherwise. The Pro suite adds
               eight extended packages (analytics, checklists, adoption tracking, announcements,
-              media embeds, scheduling, surveys, and AI chat) for a single $99 purchase. No
-              subscriptions, no per-seat fees, no upgrade fees. Activation covers up to five
-              production domains; localhost and preview environments are unrestricted.
+              media embeds, business-hours scheduling, surveys, and AI chat) for a single $99
+              purchase. No subscriptions, no per-seat fees, no upgrade fees. Activation covers up to
+              five production domains; localhost and preview environments are unrestricted.
             </p>
           </div>
           <div

--- a/apps/docs/components/landing/pricing.tsx
+++ b/apps/docs/components/landing/pricing.tsx
@@ -38,7 +38,7 @@ const PRO_FEATURES = [
   'Onboarding checklists',
   'Feature adoption tracking',
   'Media embedding (YouTube, Loom, Lottie)',
-  'Time-based scheduling',
+  'Business-hours scheduling (timezone-aware)',
   'AI chat assistant',
   'Priority GitHub issues',
 ]
@@ -54,7 +54,7 @@ const COMPARISON_ROWS = [
   { feature: 'Checklists', free: false, pro: true },
   { feature: 'Adoption tracking', free: false, pro: true },
   { feature: 'Media embedding', free: false, pro: true },
-  { feature: 'Scheduling', free: false, pro: true },
+  { feature: 'Scheduling (business hours, timezones)', free: false, pro: true },
   { feature: 'AI assistant', free: false, pro: true },
   { feature: 'Sites', free: 'Unlimited', pro: '5 included' },
   { feature: 'License', free: 'MIT', pro: 'Commercial' },

--- a/apps/docs/content/docs/scheduling/index.mdx
+++ b/apps/docs/content/docs/scheduling/index.mdx
@@ -73,6 +73,7 @@ interface Schedule {
   timezone?: string
   blackouts?: BlackoutPeriod[]
   recurring?: RecurringPattern
+  businessHours?: BusinessHours
   metadata?: Record<string, unknown>
 }
 ```
@@ -225,14 +226,24 @@ const schedule = {
 
 ### Business Hours
 
+Attach a `businessHours` window and the schedule is active only inside that
+window, evaluated in the schedule's timezone. The `standard` preset opens
+Monday–Friday 9:00–17:00 and is closed on weekends.
+
 ```tsx
 import { BUSINESS_HOURS_PRESETS } from '@tour-kit/scheduling'
 
 const schedule = {
-  timeOfDay: BUSINESS_HOURS_PRESETS.standard.days[1].hours[0],
-  // { start: '09:00', end: '17:00' }
+  businessHours: BUSINESS_HOURS_PRESETS.standard, // Mon–Fri 9:00–17:00
+  timezone: 'America/New_York',
 }
+// Active at 10:30 in New York; inactive at the same instant in Tokyo (23:30),
+// outside the window → reason: 'outside_business_hours'.
 ```
+
+`businessHours` is independent of `timeOfDay` — set both and a schedule must
+satisfy both to be active. To pin a store's hours regardless of the schedule's
+timezone, set `businessHours.timezone`; it takes precedence.
 
 ### Limited-Time Campaign
 

--- a/packages/scheduling/src/__tests__/utils/get-schedule-status.test.ts
+++ b/packages/scheduling/src/__tests__/utils/get-schedule-status.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import type { Schedule } from '../../types'
+import { BUSINESS_HOURS_PRESETS } from '../../types/business-hours'
+import { getScheduleStatus } from '../../utils/get-schedule-status'
+
+describe('getScheduleStatus — outside_business_hours', () => {
+  // 2025-06-16T14:30Z is Mon 23:30 in Tokyo → outside the standard 9-17 window.
+  const MON_1430Z = new Date('2025-06-16T14:30:00Z')
+
+  it('surfaces reason + message and leaves nextActiveAt undefined', () => {
+    const schedule: Schedule = {
+      businessHours: BUSINESS_HOURS_PRESETS.standard,
+      timezone: 'Asia/Tokyo',
+    }
+    const status = getScheduleStatus(schedule, { now: MON_1430Z })
+    expect(status.reason).toBe('outside_business_hours')
+    expect(status.message).toBe('Outside of business hours')
+    // Documented gap: next-open prediction is not computed for this reason.
+    expect(status.nextActiveAt).toBeUndefined()
+  })
+})

--- a/packages/scheduling/src/__tests__/utils/is-schedule-active.test.ts
+++ b/packages/scheduling/src/__tests__/utils/is-schedule-active.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { Schedule } from '../../types'
+import { BUSINESS_HOURS_PRESETS } from '../../types/business-hours'
 import { isScheduleActive } from '../../utils/is-schedule-active'
 
 describe('isScheduleActive', () => {
@@ -120,6 +121,71 @@ describe('isScheduleActive', () => {
       }
       const result = isScheduleActive(schedule, { now: fixedDate, userTimezone: 'UTC' })
       expect(result.isActive).toBe(true)
+    })
+  })
+
+  describe('business hours', () => {
+    // Same UTC instant, evaluated in two timezones, must yield opposite verdicts.
+    const MON_1430Z = new Date('2025-06-16T14:30:00Z') // Mon — NY 10:30 (in), Tokyo 23:30 (out)
+    const SUN_1430Z = new Date('2025-06-15T14:30:00Z') // Sun — closed under default { open: false }
+    const DST_MON = new Date('2025-03-10T14:30:00Z') // Mon after US spring-forward — NY 10:30 EDT
+
+    it('active in-window for New York', () => {
+      const schedule: Schedule = {
+        businessHours: BUSINESS_HOURS_PRESETS.standard,
+        timezone: 'America/New_York',
+      }
+      expect(isScheduleActive(schedule, { now: MON_1430Z }).isActive).toBe(true)
+    })
+
+    it('INACTIVE for the SAME instant in Tokyo → outside_business_hours', () => {
+      const schedule: Schedule = {
+        businessHours: BUSINESS_HOURS_PRESETS.standard,
+        timezone: 'Asia/Tokyo',
+      }
+      const result = isScheduleActive(schedule, { now: MON_1430Z })
+      expect(result.isActive).toBe(false)
+      expect(result.reason).toBe('outside_business_hours') // verdict flips vs NY
+    })
+
+    it('businessHours.timezone overrides schedule.timezone', () => {
+      const schedule: Schedule = {
+        timezone: 'Asia/Tokyo', // schedule says "out"…
+        businessHours: { ...BUSINESS_HOURS_PRESETS.standard, timezone: 'America/New_York' }, // …bh pins NY → "in"
+      }
+      expect(isScheduleActive(schedule, { now: MON_1430Z }).isActive).toBe(true)
+    })
+
+    it('closed day: Sunday under standard preset → outside_business_hours', () => {
+      const schedule: Schedule = {
+        businessHours: BUSINESS_HOURS_PRESETS.standard, // default { open: false }
+        timezone: 'UTC',
+      }
+      const result = isScheduleActive(schedule, { now: SUN_1430Z })
+      expect(result.isActive).toBe(false)
+      expect(result.reason).toBe('outside_business_hours')
+    })
+
+    it('businessHours and timeOfDay are independent (timeOfDay precedence: wrong_time first)', () => {
+      const schedule: Schedule = {
+        timezone: 'America/New_York',
+        timeOfDay: { start: '00:00', end: '01:00' }, // 10:30 NY is outside this
+        businessHours: BUSINESS_HOURS_PRESETS.standard,
+      }
+      // timeOfDay (step 5) is checked before business hours (step 5.5)
+      expect(isScheduleActive(schedule, { now: MON_1430Z }).reason).toBe('wrong_time')
+    })
+
+    it('DST edge: NY window holds across spring-forward', () => {
+      const schedule: Schedule = {
+        businessHours: BUSINESS_HOURS_PRESETS.standard,
+        timezone: 'America/New_York',
+      }
+      expect(isScheduleActive(schedule, { now: DST_MON }).isActive).toBe(true)
+    })
+
+    it('no businessHours field → behavior unchanged (active)', () => {
+      expect(isScheduleActive({}, { now: MON_1430Z }).isActive).toBe(true)
     })
   })
 

--- a/packages/scheduling/src/components/schedule-gate.tsx
+++ b/packages/scheduling/src/components/schedule-gate.tsx
@@ -5,6 +5,14 @@ interface ScheduleGateProps {
   children: React.ReactNode
 }
 
+/**
+ * Renders children only when the consumer holds a valid Pro license.
+ *
+ * This is a thin convenience wrapper over `<LicenseGate require="pro">` — it
+ * does NOT evaluate a schedule. To gate UI on schedule activity, evaluate
+ * `isScheduleActive(schedule)` (or `useScheduleStatus`) and branch in your own
+ * render. `ScheduleGate` only fences the scheduling feature behind the Pro tier.
+ */
 export function ScheduleGate({ children }: ScheduleGateProps) {
   return <LicenseGate require="pro">{children}</LicenseGate>
 }

--- a/packages/scheduling/src/types/schedule.ts
+++ b/packages/scheduling/src/types/schedule.ts
@@ -1,3 +1,5 @@
+import type { BusinessHours } from './business-hours'
+
 /**
  * Days of the week (0 = Sunday, 6 = Saturday)
  */
@@ -109,6 +111,14 @@ export interface Schedule {
 
   /** Recurring pattern for the schedule */
   recurring?: RecurringPattern
+
+  /**
+   * Business-hours window the schedule must fall within to be active.
+   * Independent of `timeOfDay` — both may be set and both must pass.
+   * Evaluated in the schedule's resolved timezone unless
+   * `businessHours.timezone` overrides it.
+   */
+  businessHours?: BusinessHours
 
   /** Custom metadata */
   metadata?: Record<string, unknown>

--- a/packages/scheduling/src/utils/get-schedule-status.ts
+++ b/packages/scheduling/src/utils/get-schedule-status.ts
@@ -184,6 +184,10 @@ function predictNextActiveTime(
       }
       return undefined
 
+    // outside_business_hours: next-open prediction is not computed (it requires a
+    // multi-day search across the business-hours window). The reason + message
+    // ('Outside of business hours') are surfaced; nextActiveAt is intentionally
+    // left undefined rather than faked.
     default:
       return undefined
   }

--- a/packages/scheduling/src/utils/is-schedule-active.ts
+++ b/packages/scheduling/src/utils/is-schedule-active.ts
@@ -1,5 +1,6 @@
 import type { Schedule, ScheduleEvaluationOptions, ScheduleResult } from '../types'
 import { isInAnyBlackout } from './blackout'
+import { isWithinBusinessHours } from './business-hours'
 import { isWithinDateRange } from './date-range'
 import { isAllowedDay } from './day-of-week'
 import { matchesRecurringPattern } from './recurring'
@@ -15,6 +16,7 @@ import { getUserTimezone } from './timezone'
  * 3. Check blackout periods
  * 4. Check day of week
  * 5. Check time of day
+ * 5.5. Check business hours (if defined; independent of time of day)
  * 6. Check recurring pattern
  *
  * @param schedule - The schedule configuration to evaluate
@@ -60,6 +62,15 @@ export function isScheduleActive(
   if (schedule.timeOfDay) {
     if (!isWithinTimeRange(now, schedule.timeOfDay, timezone)) {
       return { isActive: false, reason: 'wrong_time' }
+    }
+  }
+
+  // 5.5. Check business hours (independent of time of day; both must pass).
+  // businessHours.timezone takes precedence over the schedule-resolved tz.
+  if (schedule.businessHours) {
+    const bhTimezone = schedule.businessHours.timezone ?? timezone
+    if (!isWithinBusinessHours(now, schedule.businessHours, bhTimezone)) {
+      return { isActive: false, reason: 'outside_business_hours' }
     }
   }
 


### PR DESCRIPTION
## Slice 2 — Scheduling Business Hours

`@tour-kit/scheduling` **advertised** business hours (npm keyword `business-hours`, package description, `CLAUDE.md` eval step 5) and the barrel already exported `isWithinBusinessHours`, **but the engine never called it and `Schedule` had no field to configure it.** A buyer wiring `businessHours` onto a schedule got silently-ignored evaluation. This makes the claim true and names it on `/pricing`.

### Changes
- **`Schedule.businessHours?: BusinessHours`** — additive optional field, reuses the already-exported type (no new public symbol).
- **`is-schedule-active.ts`** — evaluates it as **step 5.5** (after `timeOfDay`, before `recurring`), timezone-aware. `businessHours.timezone` takes precedence over the schedule-resolved tz. Returns `{ isActive: false, reason: 'outside_business_hours' }` out of window. Doc-comment eval order updated to match the code.
- **`get-schedule-status.ts`** — the `outside_business_hours` message already existed and now propagates; added an intentional-gap comment that `nextActiveAt` is left `undefined` for this reason (next-open prediction needs a multi-day search — out of scope, not faked).
- **`schedule-gate.tsx`** — honest JSDoc: it's a thin `<LicenseGate require="pro">` wrapper, not a schedule evaluator.
- **`/pricing` + docs** — Pro list now "Business-hours scheduling (timezone-aware)", comparison row "Scheduling (business hours, timezones)", hero word-swap; scheduling docs gain a real `businessHours` example (and the documented `Schedule` interface gains the field).

### Tests (TDD)
RED first (3 out-of-window assertions failed against the un-wired engine), GREEN after wiring — **60/60 pass**. The load-bearing design is **timezone-paired**: the same `2025-06-16T14:30Z` instant is active in New York (10:30) and inactive in Tokyo (23:30). Also covers `bh.timezone` override, closed Sunday, `timeOfDay` precedence (`wrong_time` wins), DST spring-forward, and no-field-unchanged. Plus a `getScheduleStatus` surface test (reason + message + `nextActiveAt === undefined`).

### Gates
- `pnpm dist:size` → **scheduling gz=3546 / 4000** (baseline 3517 → +29 bytes; the tightest budget in the repo, 454 B headroom, no clawback needed)
- Typecheck clean; coverage above threshold (utils branch 48.5% > 39%)
- `/pricing` and `/docs/scheduling` render 200 with the new copy, no console errors

### Release
Minor changeset for `@tour-kit/scheduling` (0.11.9 → 0.12.0). Additive optional field → non-breaking.

### Studio / cross-repo
`businessHours` is **not** Studio-authored → SDK change is safe, no pin bump. No `utk-studio` / `tourkit-dash` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)