### PR TITLE
feat(surveys): honor RatingScale.step + gate advance on QuestionConfig.validation (Slice 3)

### DIFF
--- a/.changeset/slice-3-surveys-polish.md
+++ b/.changeset/slice-3-surveys-polish.md
@@ -1,0 +1,13 @@
+---
+"@tour-kit/surveys": minor
+---
+
+Honor `RatingScale.step` in the rating question (previously hardcoded to `1`) and call
+`QuestionConfig.validation` on advance — a non-null return surfaces a field error and blocks
+moving to the next question. Both fields were already typed; this makes them work.
+
+- `nextQuestion` now returns `string | null`: the validation error when the current question
+  blocks advancing, or `null` on success (return-type widening — non-breaking for existing callers).
+- New `getValidationError(surveyId, questionId)` on the surveys context and `validationError(questionId)`
+  on `useSurvey` read the transient error for accessible rendering (`role="alert"`, `aria-invalid`,
+  `aria-describedby`). Validation errors are in-memory only and are never persisted, so a reload starts clean.

--- a/apps/docs/content/docs/surveys/hooks/use-survey.mdx
+++ b/apps/docs/content/docs/surveys/hooks/use-survey.mdx
@@ -100,8 +100,9 @@ function NPSSurvey() {
       description: 'Record an answer. Persists immediately to storage.',
     },
     nextQuestion: {
-      type: '() => void',
-      description: 'Increment currentStep by 1.',
+      type: '() => string | null',
+      description:
+        'Advance to the next question. If the current question has a `validation` function that returns a non-null string, the survey does NOT advance and that string is returned; otherwise advances and returns null.',
     },
     prevQuestion: {
       type: '() => void',
@@ -114,6 +115,11 @@ function NPSSurvey() {
     reset: {
       type: '() => void',
       description: 'Reset the survey to its initial state, clearing all responses and flags.',
+    },
+    validationError: {
+      type: '(questionId: string) => string | undefined',
+      description:
+        'Read the transient validation error for a question, or undefined if it currently validates. Cleared on a passing nextQuestion.',
     },
   }}
 />

--- a/apps/docs/content/docs/surveys/hooks/use-surveys.mdx
+++ b/apps/docs/content/docs/surveys/hooks/use-surveys.mdx
@@ -88,8 +88,9 @@ function SurveyDebugPanel() {
       description: 'Record an answer. Persists immediately.',
     },
     nextQuestion: {
-      type: '(surveyId: string) => void',
-      description: 'Advance the survey one step.',
+      type: '(surveyId: string) => string | null',
+      description:
+        'Advance the survey one step. Returns the validation error string if the current question blocks advancing, otherwise null.',
     },
     prevQuestion: {
       type: '(surveyId: string) => void',
@@ -110,6 +111,11 @@ function SurveyDebugPanel() {
     getState: {
       type: '(id: string) => SurveyState | undefined',
       description: 'Get state for a specific survey.',
+    },
+    getValidationError: {
+      type: '(surveyId: string, questionId: string) => string | undefined',
+      description:
+        'Read the transient validation error for a question, or undefined if it currently validates.',
     },
     getConfig: {
       type: '(id: string) => SurveyConfig | undefined',

--- a/apps/docs/content/docs/surveys/types.mdx
+++ b/apps/docs/content/docs/surveys/types.mdx
@@ -76,6 +76,8 @@ interface SurveyState {
   snoozeUntil: Date | null;
   currentStep: number;
   responses: Map<string, AnswerValue>;
+  /** Transient per-question validation errors — never persisted. */
+  validationErrors: Map<string, string>;
 }
 ```
 
@@ -185,6 +187,18 @@ interface RatingScale {
 }
 ```
 
+`step` controls the increment between rating options (default `1`). The scale renders
+every value from `min` to `max` inclusive, stepping by `step` — so `{ min: 0, max: 10, step: 5 }`
+renders exactly three options: `0`, `5`, `10`.
+
+```tsx
+<QuestionRating
+  id="effort"
+  label="How much effort did that take?"
+  ratingScale={{ min: 0, max: 10, step: 5 }} // → 0, 5, 10
+/>
+```
+
 ### SelectOption
 
 ```ts
@@ -203,6 +217,39 @@ interface SkipLogic {
   condition: (answer: AnswerValue) => boolean;
   skipTo: string;
 }
+```
+
+### Validation
+
+`QuestionConfig.validation` runs at the **advance** boundary (when you call
+`nextQuestion`), not on every keystroke. Return a string to block advancing and
+surface it as a field error; return `null` or `undefined` to allow the survey to
+move on. `nextQuestion` returns that same string (or `null` on success), and the
+error is also readable via `getValidationError(surveyId, questionId)` on the
+context — or `validationError(questionId)` from `useSurvey`. Errors are transient
+UI state and are never persisted, so a reload starts clean.
+
+```tsx
+const question: QuestionConfig = {
+  id: 'email',
+  type: 'text',
+  text: 'Work email',
+  required: true,
+  validation: (value) =>
+    typeof value === 'string' && value.includes('@') ? null : 'Enter a valid email',
+};
+
+// In a question UI built on the headless hook:
+const { nextQuestion, validationError } = useSurvey('signup');
+const error = validationError('email'); // string while invalid, undefined once it passes
+
+<input
+  aria-invalid={error ? true : undefined}
+  aria-describedby={error ? 'email-error' : undefined}
+  onChange={(e) => answer('email', e.target.value)}
+/>;
+{error && <p id="email-error" role="alert">{error}</p>}
+<button onClick={() => nextQuestion()}>Next</button>; // stays put until `value` validates
 ```
 
 ---
@@ -269,12 +316,14 @@ interface SurveysContextValue {
   dismiss: (id: string, reason?: DismissalReason) => void;
   snooze: (id: string) => void;
   answer: (surveyId: string, questionId: string, value: AnswerValue) => void;
-  nextQuestion: (surveyId: string) => void;
+  /** Returns the validation error string when the current question blocks advance, else `null`. */
+  nextQuestion: (surveyId: string) => string | null;
   prevQuestion: (surveyId: string) => void;
   complete: (surveyId: string) => void;
   reset: (id: string) => void;
   resetAll: () => void;
   getState: (id: string) => SurveyState | undefined;
+  getValidationError: (surveyId: string, questionId: string) => string | undefined;
   getConfig: (id: string) => SurveyConfig | undefined;
   canShow: (id: string) => boolean;
 }

--- a/apps/docs/content/docs/surveys/types.mdx
+++ b/apps/docs/content/docs/surveys/types.mdx
@@ -229,6 +229,10 @@ error is also readable via `getValidationError(surveyId, questionId)` on the
 context — or `validationError(questionId)` from `useSurvey`. Errors are transient
 UI state and are never persisted, so a reload starts clean.
 
+The value passed to `validation` is the answer recorded so far, which is
+`undefined` until the question is answered — that's the case to guard for a
+required field. Handle a falsy value rather than assuming a populated answer.
+
 ```tsx
 const question: QuestionConfig = {
   id: 'email',

--- a/packages/surveys/src/__tests__/question-rating.test.tsx
+++ b/packages/surveys/src/__tests__/question-rating.test.tsx
@@ -272,6 +272,22 @@ describe('step (RatingScale.step honored)', () => {
     expect(screen.getAllByRole('radio')).toHaveLength(11)
   })
 
+  it('step:0 is guarded to 1 (a non-positive step must not infinite-loop the render)', () => {
+    render(<QuestionRating {...labelProps} ratingScale={{ min: 0, max: 3, step: 0 }} />)
+    expect(screen.getAllByRole('radio')).toHaveLength(4) // [0, 1, 2, 3]
+  })
+
+  it('fractional step:0.5 is preserved (guards must not clamp valid sub-1 steps up to 1)', () => {
+    render(<QuestionRating {...labelProps} ratingScale={{ min: 0, max: 1, step: 0.5 }} />)
+    const radios = screen.getAllByRole('radio')
+    expect(radios).toHaveLength(3)
+    expect(radios.map((r) => r.getAttribute('aria-label'))).toEqual([
+      'Rate 0 out of 1',
+      'Rate 0.5 out of 1',
+      'Rate 1 out of 1',
+    ])
+  })
+
   it('shape-freeze: RatingScale.step stays optional number — Studio contract', () => {
     // Compiled by vitest's esbuild; this case fails to TYPECHECK if `step` is
     // reshaped (made required, or typed string/object). Both literals must compile.

--- a/packages/surveys/src/__tests__/question-rating.test.tsx
+++ b/packages/surveys/src/__tests__/question-rating.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { QuestionRating } from '../components/question-rating'
+import type { RatingScale } from '../types/question'
 
 vi.mock('@tour-kit/license', () => ({
   LicenseGate: ({ children }: { children: React.ReactNode }) => children,
@@ -228,5 +229,65 @@ describe('QuestionRating', () => {
     for (const button of buttons) {
       expect(button).toHaveAttribute('type', 'button')
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Slice 3 — RatingScale.step honored (was hardcoded `const step = 1`)
+// RED before question-rating.tsx reads `ratingScale?.step` and adds it to the
+// useMemo deps. Today step:5 over 0..10 still renders 11 radios.
+// ---------------------------------------------------------------------------
+
+describe('step (RatingScale.step honored)', () => {
+  const labelProps = { id: 'rating-step', label: 'Rate this feature' }
+
+  it('step:5 over min 0 / max 10 → exactly 3 radios [0, 5, 10]', () => {
+    render(<QuestionRating {...labelProps} ratingScale={{ min: 0, max: 10, step: 5 }} />)
+    const radios = screen.getAllByRole('radio')
+    expect(radios).toHaveLength(3)
+    expect(radios[0]).toHaveAttribute('aria-label', 'Rate 0 out of 10')
+    expect(radios[1]).toHaveAttribute('aria-label', 'Rate 5 out of 10')
+    expect(radios[2]).toHaveAttribute('aria-label', 'Rate 10 out of 10')
+  })
+
+  it('step:2 over min 0 / max 6 → [0, 2, 4, 6] (4 radios)', () => {
+    render(<QuestionRating {...labelProps} ratingScale={{ min: 0, max: 6, step: 2 }} />)
+    const radios = screen.getAllByRole('radio')
+    expect(radios).toHaveLength(4)
+    expect(radios.map((r) => r.getAttribute('aria-label'))).toEqual([
+      'Rate 0 out of 6',
+      'Rate 2 out of 6',
+      'Rate 4 out of 6',
+      'Rate 6 out of 6',
+    ])
+  })
+
+  it('no step on ratingScale → default 1 (no regression)', () => {
+    render(<QuestionRating {...labelProps} ratingScale={{ min: 1, max: 5 }} />)
+    expect(screen.getAllByRole('radio')).toHaveLength(5)
+  })
+
+  it('no ratingScale at all → default 0..10 step 1 (11 radios)', () => {
+    render(<QuestionRating {...labelProps} />)
+    expect(screen.getAllByRole('radio')).toHaveLength(11)
+  })
+
+  it('shape-freeze: RatingScale.step stays optional number — Studio contract', () => {
+    // Compiled by vitest's esbuild; this case fails to TYPECHECK if `step` is
+    // reshaped (made required, or typed string/object). Both literals must compile.
+    const withStep: RatingScale = { min: 0, max: 10, step: 5 }
+    const withoutStep: RatingScale = { min: 1, max: 5 } // step omitted is valid
+    expect(withStep.step).toBe(5)
+    expect(withoutStep.step).toBeUndefined()
+    // @ts-expect-error — step must be a number, not a string (locks the shape)
+    const _bad: RatingScale = { min: 0, max: 10, step: '5' }
+    void _bad
+  })
+
+  it('axe: a stepped scale has no violations', async () => {
+    const { container } = render(
+      <QuestionRating {...labelProps} ratingScale={{ min: 0, max: 10, step: 5 }} />
+    )
+    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/packages/surveys/src/__tests__/validation.test.tsx
+++ b/packages/surveys/src/__tests__/validation.test.tsx
@@ -1,0 +1,304 @@
+import { act, render, renderHook, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type * as React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+import { SurveysProvider } from '../context'
+import { useSurvey, useSurveys } from '../hooks'
+import type { SurveyConfig } from '../types'
+
+// License gate is a pass-through in tests (copied from question-rating.test.tsx:7-11).
+vi.mock('@tour-kit/license', () => ({
+  LicenseGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ProGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLicenseGate: () => ({ isAllowed: true, isLoading: false }),
+}))
+
+// Module-scoped storage Map + tour-context stub (copied from storage.test.tsx:13-31).
+// Only the persistence-guard test exercises it; the gate tests pass `storage={null}`.
+const sharedStore = new Map<string, string>()
+vi.mock('@tour-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tour-kit/core')>()
+  return {
+    ...actual,
+    useTourContext: () => ({ isActive: false }),
+    useTourContextOptional: () => ({ isActive: false }),
+    createStorageAdapter: () => ({
+      getItem: (key: string) => sharedStore.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        sharedStore.set(key, value)
+      },
+      removeItem: (key: string) => {
+        sharedStore.delete(key)
+      },
+    }),
+  }
+})
+
+const QID = 'q1'
+
+// Single-validation survey for the gate tests. `storage={null}` keeps each test
+// fully in-memory (no jsdom localStorage / no hydrate cross-talk).
+const configs: SurveyConfig[] = [
+  {
+    id: 'val',
+    type: 'csat',
+    displayMode: 'modal',
+    questions: [
+      {
+        id: QID,
+        type: 'text',
+        text: 'Your feedback',
+        required: true,
+        validation: (v) => (v ? null : 'Please answer'),
+      },
+      { id: 'q2', type: 'text', text: 'Anything else?' },
+    ],
+  },
+]
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <SurveysProvider surveys={configs} storage={null}>
+      {children}
+    </SurveysProvider>
+  )
+}
+
+describe('validation gates advance', () => {
+  it('fail path: returns the error, does NOT advance, exposes it', async () => {
+    const { result } = renderHook(() => useSurveys(), { wrapper })
+    await act(async () => {
+      result.current.show('val')
+    })
+
+    let returned: string | null = null
+    await act(async () => {
+      returned = result.current.nextQuestion('val')
+    })
+
+    expect(returned).toBe('Please answer') // surfaced to the caller
+    expect(result.current.getState('val')?.currentStep).toBe(0) // BLOCKED — the point
+    expect(result.current.getValidationError('val', QID)).toBe('Please answer')
+  })
+
+  it('pass path: a valid answer advances and clears the error', async () => {
+    const { result } = renderHook(() => useSurveys(), { wrapper })
+    await act(async () => {
+      result.current.show('val')
+    })
+    // trip the error first, then correct it
+    await act(async () => {
+      result.current.nextQuestion('val')
+    })
+    expect(result.current.getValidationError('val', QID)).toBe('Please answer')
+
+    await act(async () => {
+      result.current.answer('val', QID, 'ok')
+    })
+
+    let returned: string | null = 'sentinel'
+    await act(async () => {
+      returned = result.current.nextQuestion('val')
+    })
+
+    expect(returned).toBeNull()
+    expect(result.current.getState('val')?.currentStep).toBe(1) // advanced
+    expect(result.current.getValidationError('val', QID)).toBeUndefined() // cleared
+  })
+
+  it('no-validation regression: a question without validation advances normally', async () => {
+    const plain: SurveyConfig[] = [
+      {
+        id: 'plain',
+        type: 'csat',
+        displayMode: 'modal',
+        questions: [
+          { id: 'p1', type: 'text', text: 'Hi' },
+          { id: 'p2', type: 'text', text: 'Bye' },
+        ],
+      },
+    ]
+    const { result } = renderHook(() => useSurveys(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <SurveysProvider surveys={plain} storage={null}>
+          {children}
+        </SurveysProvider>
+      ),
+    })
+    await act(async () => {
+      result.current.show('plain')
+    })
+
+    let returned: string | null = 'sentinel'
+    await act(async () => {
+      returned = result.current.nextQuestion('plain')
+    })
+
+    expect(returned).toBeNull()
+    expect(result.current.getState('plain')?.currentStep).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A11y for the validation error surface.
+//
+// There is no built-in multi-question turnkey container with a Next button —
+// the advance flow is headless (turnkey modals are single-question). So we
+// assert the ARIA contract against a minimal harness built on the REAL exported
+// `useSurvey` hook: exactly what a consumer writes, and the pattern the docs
+// prescribe (mirrors question-text.tsx:79 `aria-describedby`).
+// ---------------------------------------------------------------------------
+
+function ValidationHarness() {
+  const { state, config, nextQuestion, answer, validationError } = useSurvey('val')
+  const question = config?.questions[state?.currentStep ?? 0]
+  if (!question) return <div data-testid="done" />
+
+  const error = validationError(question.id)
+  const errorId = `${question.id}-error`
+
+  return (
+    <div>
+      <input
+        aria-label={typeof question.text === 'string' ? question.text : question.id}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
+        onChange={(e) => answer(question.id, e.target.value)}
+      />
+      {error && (
+        <p id={errorId} role="alert">
+          {error}
+        </p>
+      )}
+      <button type="button" onClick={() => nextQuestion()}>
+        Next
+      </button>
+    </div>
+  )
+}
+
+describe('a11y for the error surface', () => {
+  it('announces the error and associates it with the control', async () => {
+    const user = userEvent.setup()
+    render(
+      <SurveysProvider surveys={configs} storage={null}>
+        <ValidationHarness />
+      </SurveysProvider>
+    )
+
+    // Advance with no answer → validation fails.
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('Please answer')
+    expect(alert).toHaveAttribute('id', `${QID}-error`)
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(input).toHaveAttribute('aria-describedby', `${QID}-error`)
+  })
+
+  it('errored container has no axe violations', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <SurveysProvider surveys={configs} storage={null}>
+        <ValidationHarness />
+      </SurveysProvider>
+    )
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Persistence guard — transient errors must NOT be serialized or resurface.
+// Uses the module-scoped storage Map (mocked @tour-kit/core).
+// ---------------------------------------------------------------------------
+
+const persistConfigs: SurveyConfig[] = [
+  {
+    id: 'val',
+    type: 'csat',
+    displayMode: 'modal',
+    questions: [
+      {
+        id: 'q1',
+        type: 'text',
+        text: 'A',
+        required: true,
+        validation: (v) => (v ? null : 'need q1'),
+      },
+      {
+        id: 'q2',
+        type: 'text',
+        text: 'B',
+        required: true,
+        validation: (v) => (v ? null : 'need q2'),
+      },
+    ],
+  },
+]
+
+function persistWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <SurveysProvider surveys={persistConfigs} storageKey="val-storage">
+      {children}
+    </SurveysProvider>
+  )
+}
+
+describe('persistence guard', () => {
+  beforeEach(() => {
+    sharedStore.clear()
+  })
+
+  it('drops stale validation errors on reload; responses/currentStep survive', async () => {
+    const first = renderHook(() => useSurveys(), { wrapper: persistWrapper })
+    // flush the hydrate microtask (no-op: empty store) so the persist effect arms
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      first.result.current.show('val')
+    })
+    // answer q1 + advance to step 1
+    await act(async () => {
+      first.result.current.answer('val', 'q1', 'keep')
+    })
+    await act(async () => {
+      first.result.current.nextQuestion('val')
+    })
+    // now on q2 — trip a live error (no answer)
+    await act(async () => {
+      first.result.current.nextQuestion('val')
+    })
+
+    // In memory: advanced to step 1, response kept, q2 error live.
+    expect(first.result.current.getState('val')?.currentStep).toBe(1)
+    expect(first.result.current.getValidationError('val', 'q2')).toBe('need q2')
+
+    // The persisted blob must NOT carry validationErrors.
+    const blob = sharedStore.get('val-storage:state')
+    expect(blob).toBeTruthy()
+    const parsed = JSON.parse(blob ?? '{}')
+    const entry = parsed.surveys.find(([id]: [string, unknown]) => id === 'val')
+    expect(entry?.[1]).not.toHaveProperty('validationErrors')
+    expect(entry?.[1]?.currentStep).toBe(1)
+
+    first.unmount()
+
+    // Reload: fresh provider hydrates from the same store.
+    const second = renderHook(() => useSurveys(), { wrapper: persistWrapper })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const reloaded = second.result.current.getState('val')
+    expect(reloaded?.currentStep).toBe(1) // survived
+    expect(reloaded?.responses.get('q1')).toBe('keep') // survived
+    expect(second.result.current.getValidationError('val', 'q2')).toBeUndefined() // gone
+  })
+})

--- a/packages/surveys/src/components/headless/headless-survey.tsx
+++ b/packages/surveys/src/components/headless/headless-survey.tsx
@@ -1,26 +1,13 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { useSurvey } from '../../hooks/use-survey'
-import type { AnswerValue } from '../../types/question'
-import type { DismissalReason, SurveyConfig, SurveyState } from '../../types/survey'
+import { type UseSurveyReturn, useSurvey } from '../../hooks/use-survey'
 
-export interface HeadlessSurveyRenderProps {
+// Mirrors the single-survey control surface of `useSurvey`, plus the survey id.
+// Derived from `UseSurveyReturn` so the two can't drift — adding a method to the
+// hook automatically flows here.
+export interface HeadlessSurveyRenderProps extends UseSurveyReturn {
   surveyId: string
-  state: SurveyState | undefined
-  config: SurveyConfig | undefined
-  canShow: boolean
-  show: () => void
-  hide: () => void
-  dismiss: (reason?: DismissalReason) => void
-  snooze: () => void
-  answer: (questionId: string, value: AnswerValue) => void
-  nextQuestion: () => string | null
-  prevQuestion: () => void
-  complete: () => void
-  reset: () => void
-  /** Transient validation error for a question, or `undefined` if it validates. */
-  validationError: (questionId: string) => string | undefined
 }
 
 export interface HeadlessSurveyProps {

--- a/packages/surveys/src/components/headless/headless-survey.tsx
+++ b/packages/surveys/src/components/headless/headless-survey.tsx
@@ -15,10 +15,12 @@ export interface HeadlessSurveyRenderProps {
   dismiss: (reason?: DismissalReason) => void
   snooze: () => void
   answer: (questionId: string, value: AnswerValue) => void
-  nextQuestion: () => void
+  nextQuestion: () => string | null
   prevQuestion: () => void
   complete: () => void
   reset: () => void
+  /** Transient validation error for a question, or `undefined` if it validates. */
+  validationError: (questionId: string) => string | undefined
 }
 
 export interface HeadlessSurveyProps {

--- a/packages/surveys/src/components/question-rating.tsx
+++ b/packages/surveys/src/components/question-rating.tsx
@@ -84,14 +84,16 @@ const QuestionRating = React.forwardRef<HTMLDivElement, QuestionRatingProps>(
     const max = ratingScale?.max ?? maxProp ?? presetDefaults?.max ?? 10
     const style = ratingScale?.style ?? styleProp ?? presetDefaults?.style ?? 'numeric'
 
-    const step = 1
+    // Per-field precedence matches min/max/style above: `ratingScale` wins, else 1.
+    // The Studio already emits `ratingScale.step`; consuming it makes that output truthful.
+    const step = ratingScale?.step ?? 1
     const options: number[] = React.useMemo(() => {
       const result: number[] = []
       for (let i = min; i <= max; i += step) {
         result.push(i)
       }
       return result
-    }, [min, max])
+    }, [min, max, step])
 
     const resolvedEmojiMap = emojiMap ?? presetDefaults?.emojiMap ?? DEFAULT_EMOJI_MAP
 

--- a/packages/surveys/src/components/question-rating.tsx
+++ b/packages/surveys/src/components/question-rating.tsx
@@ -86,7 +86,11 @@ const QuestionRating = React.forwardRef<HTMLDivElement, QuestionRatingProps>(
 
     // Per-field precedence matches min/max/style above: `ratingScale` wins, else 1.
     // The Studio already emits `ratingScale.step`; consuming it makes that output truthful.
-    const step = ratingScale?.step ?? 1
+    // Guard non-positive / NaN steps — a hand-authored `step: 0` (or negative/NaN) would make
+    // the `i += step` loop below never terminate. `> 0` keeps valid fractional steps (e.g. 0.5)
+    // intact, unlike `Math.max(1, step)` which would clamp them up to 1.
+    const rawStep = ratingScale?.step ?? 1
+    const step = rawStep > 0 ? rawStep : 1
     const options: number[] = React.useMemo(() => {
       const result: number[] = []
       for (let i = min; i <= max; i += step) {

--- a/packages/surveys/src/context/surveys-provider.tsx
+++ b/packages/surveys/src/context/surveys-provider.tsx
@@ -30,6 +30,8 @@ type SurveysAction =
   | { type: 'ANSWER'; id: string; questionId: string; value: AnswerValue }
   | { type: 'NEXT_QUESTION'; id: string }
   | { type: 'PREV_QUESTION'; id: string }
+  | { type: 'SET_VALIDATION_ERROR'; id: string; questionId: string; error: string }
+  | { type: 'CLEAR_VALIDATION_ERROR'; id: string; questionId: string }
   | { type: 'COMPLETE'; id: string; drain: boolean }
   | { type: 'RESET'; id: string }
   | { type: 'RESET_ALL' }
@@ -58,6 +60,7 @@ function createInitialSurveyState(id: string): SurveyState {
     snoozeUntil: null,
     currentStep: 0,
     responses: new Map(),
+    validationErrors: new Map(),
   }
 }
 
@@ -203,6 +206,21 @@ function surveysReducer(state: SurveysReducerState, action: SurveysAction): Surv
         currentStep: Math.max(0, e.currentStep - 1),
       }))
 
+    case 'SET_VALIDATION_ERROR':
+      return updateSurvey(state, action.id, (e) => {
+        const validationErrors = new Map(e.validationErrors)
+        validationErrors.set(action.questionId, action.error)
+        return { ...e, validationErrors }
+      })
+
+    case 'CLEAR_VALIDATION_ERROR':
+      return updateSurvey(state, action.id, (e) => {
+        if (!e.validationErrors.has(action.questionId)) return e
+        const validationErrors = new Map(e.validationErrors)
+        validationErrors.delete(action.questionId)
+        return { ...e, validationErrors }
+      })
+
     case 'COMPLETE': {
       const next = updateSurvey(state, action.id, (e) => ({
         ...e,
@@ -282,14 +300,27 @@ function serializeState(
   lastShownAt: Date | null
 ): string {
   const payload: SerializedState = {
+    // Build each entry explicitly (not `{ ...s }`) so transient runtime-only
+    // fields — `validationErrors` — can never leak into the blob. A spread would
+    // silently carry new SurveyState fields into storage; enumeration makes the
+    // persisted shape a deliberate allow-list that matches SerializedSurveyState.
     surveys: Array.from(surveys.entries()).map(([id, s]) => [
       id,
       {
-        ...s,
+        id: s.id,
+        isActive: s.isActive,
+        isVisible: s.isVisible,
+        isDismissed: s.isDismissed,
+        isSnoozed: s.isSnoozed,
+        isCompleted: s.isCompleted,
+        viewCount: s.viewCount,
         lastViewedAt: s.lastViewedAt?.toISOString() ?? null,
         dismissedAt: s.dismissedAt?.toISOString() ?? null,
+        dismissalReason: s.dismissalReason,
         completedAt: s.completedAt?.toISOString() ?? null,
+        snoozeCount: s.snoozeCount,
         snoozeUntil: s.snoozeUntil?.toISOString() ?? null,
+        currentStep: s.currentStep,
         responses: Array.from(s.responses.entries()),
       },
     ]),
@@ -325,6 +356,9 @@ function deserializeState(raw: string | null): {
         snoozeUntil: s.snoozeUntil ? new Date(s.snoozeUntil) : null,
         currentStep: s.currentStep,
         responses: new Map(s.responses),
+        // Transient — never serialized. Old blobs have no such key; a fresh
+        // empty Map is the back-compat default so a stale error never resurfaces.
+        validationErrors: new Map(),
       })
     }
     return {
@@ -566,8 +600,28 @@ export function SurveysProvider({
     [onQuestionAnswered, onSurveyAnswer]
   )
 
-  const handleNextQuestion = useCallback((surveyId: string) => {
+  const handleNextQuestion = useCallback((surveyId: string): string | null => {
+    // Read latest state/config off refs (same idiom as handleComplete/handleAnswer)
+    // so the gate sees the most recent answer recorded in this render cycle.
+    const survey = stateRef.current.surveys.get(surveyId)
+    const config = configsRef.current.find((c) => c.id === surveyId)
+    const question = config?.questions?.[survey?.currentStep ?? 0]
+    if (question?.validation && survey) {
+      const value = survey.responses.get(question.id)
+      const error = question.validation(value as AnswerValue)
+      if (error != null) {
+        dispatch({
+          type: 'SET_VALIDATION_ERROR',
+          id: surveyId,
+          questionId: question.id,
+          error,
+        })
+        return error
+      }
+      dispatch({ type: 'CLEAR_VALIDATION_ERROR', id: surveyId, questionId: question.id })
+    }
     dispatch({ type: 'NEXT_QUESTION', id: surveyId })
+    return null
   }, [])
 
   const handlePrevQuestion = useCallback((surveyId: string) => {
@@ -627,6 +681,11 @@ export function SurveysProvider({
 
   const getState = useCallback((id: string) => state.surveys.get(id), [state.surveys])
 
+  const getValidationError = useCallback(
+    (id: string, questionId: string) => state.surveys.get(id)?.validationErrors.get(questionId),
+    [state.surveys]
+  )
+
   const getConfig = useCallback((id: string) => configsRef.current.find((s) => s.id === id), [])
 
   const value = useMemo<SurveysContextValue>(
@@ -647,6 +706,7 @@ export function SurveysProvider({
       reset: handleReset,
       resetAll: handleResetAll,
       getState,
+      getValidationError,
       getConfig,
       canShow: canShowInternal,
     }),
@@ -667,6 +727,7 @@ export function SurveysProvider({
       handleReset,
       handleResetAll,
       getState,
+      getValidationError,
       getConfig,
       canShowInternal,
     ]

--- a/packages/surveys/src/context/surveys-provider.tsx
+++ b/packages/surveys/src/context/surveys-provider.tsx
@@ -607,6 +607,11 @@ export function SurveysProvider({
     const config = configsRef.current.find((c) => c.id === surveyId)
     const question = config?.questions?.[survey?.currentStep ?? 0]
     if (question?.validation && survey) {
+      // `value` is `AnswerValue | undefined` — undefined when the question is
+      // unanswered, which is exactly the case `validation` exists to catch (a
+      // required field). The cast bridges to the public `(value: AnswerValue)`
+      // signature, which can't be widened to `| undefined` without a breaking
+      // change to that frozen shape. Validation authors must handle a falsy value.
       const value = survey.responses.get(question.id)
       const error = question.validation(value as AnswerValue)
       if (error != null) {

--- a/packages/surveys/src/hooks/use-survey.ts
+++ b/packages/surveys/src/hooks/use-survey.ts
@@ -11,11 +11,13 @@ interface UseSurveyReturn {
   dismiss: (reason?: DismissalReason) => void
   snooze: () => void
   answer: (questionId: string, value: AnswerValue) => void
-  nextQuestion: () => void
+  nextQuestion: () => string | null
   prevQuestion: () => void
   complete: () => void
   reset: () => void
   canShow: boolean
+  /** Transient validation error for a question, or `undefined` if it validates. */
+  validationError: (questionId: string) => string | undefined
 }
 
 /**
@@ -39,6 +41,7 @@ export function useSurvey(surveyId: string): UseSurveyReturn {
       complete: () => ctx.complete(surveyId),
       reset: () => ctx.reset(surveyId),
       canShow: ctx.canShow(surveyId),
+      validationError: (questionId: string) => ctx.getValidationError(surveyId, questionId),
     }),
     [ctx, surveyId]
   )

--- a/packages/surveys/src/hooks/use-survey.ts
+++ b/packages/surveys/src/hooks/use-survey.ts
@@ -3,7 +3,7 @@ import { useSurveysContext } from '../context/surveys-context'
 import type { AnswerValue } from '../types/question'
 import type { DismissalReason, SurveyConfig, SurveyState } from '../types/survey'
 
-interface UseSurveyReturn {
+export interface UseSurveyReturn {
   state: SurveyState | undefined
   config: SurveyConfig | undefined
   show: () => void

--- a/packages/surveys/src/types/context.ts
+++ b/packages/surveys/src/types/context.ts
@@ -35,11 +35,22 @@ export interface SurveysContextValue {
   /** Record an answer for a question */
   answer: (surveyId: string, questionId: string, value: AnswerValue) => void
 
-  /** Advance to the next question */
-  nextQuestion: (surveyId: string) => void
+  /**
+   * Advance to the next question. If the current question declares a
+   * `validation` function and it returns a non-null string, the survey does
+   * NOT advance and that string is returned (and surfaced via
+   * `getValidationError`). Returns `null` when the advance succeeds.
+   */
+  nextQuestion: (surveyId: string) => string | null
 
   /** Go back to the previous question */
   prevQuestion: (surveyId: string) => void
+
+  /**
+   * Read the transient validation error for a question, or `undefined` if the
+   * question currently validates. Cleared on a passing `nextQuestion`.
+   */
+  getValidationError: (surveyId: string, questionId: string) => string | undefined
 
   /** Mark a survey as completed */
   complete: (surveyId: string) => void

--- a/packages/surveys/src/types/survey.ts
+++ b/packages/surveys/src/types/survey.ts
@@ -48,6 +48,13 @@ export interface SurveyState {
   snoozeUntil: Date | null
   currentStep: number
   responses: Map<string, import('./question').AnswerValue>
+  /**
+   * Transient per-question validation errors keyed by question id. Populated by
+   * `nextQuestion` when a `QuestionConfig.validation` returns a non-null string;
+   * cleared on a passing advance. NOT persisted — errors are UI state and must
+   * never resurface after a reload.
+   */
+  validationErrors: Map<string, string>
 }
 
 /** Position options for slideout variant */


### PR DESCRIPTION
## Slice 3 — Surveys Polish (Validation + Rating Step)

Wires up two already-typed-but-dead `@tour-kit/surveys` fields, **without changing their public shapes**. Plan: `plan/trust-restoration-slice-3-surveys-polish.md`.

### What changed
- **`RatingScale.step`** — `QuestionRating` now reads `ratingScale?.step ?? 1` (was hardcoded `const step = 1`) with `step` added to the `useMemo` deps. `{ min: 0, max: 10, step: 5 }` → `[0, 5, 10]`. The Studio already emits this field; consuming it makes that output truthful.
- **`QuestionConfig.validation`** — called at the **advance** boundary in `nextQuestion` (not on `answer()`, which stays a pure record). A non-null return blocks advancing and is surfaced three ways:
  - `nextQuestion(surveyId)` now returns `string | null` (return-type widening — non-breaking for existing callers).
  - `getValidationError(surveyId, questionId)` on the context.
  - `validationError(questionId)` on `useSurvey` / `HeadlessSurvey` render props.
  - State lives in a transient `SurveyState.validationErrors` Map via two reducer actions (`SET`/`CLEAR_VALIDATION_ERROR`), cleared on a passing advance.
- **a11y** — headless-first (the turnkey modals are single-question; the advance flow is consumer-driven). The error surface is the documented `role="alert"` + `aria-invalid` + `aria-describedby` pattern, tested against a harness built on the real exported `useSurvey` hook.

### Persistence safety (Risk #1 in the plan — caught by a test)
`serializeState`'s `{ ...s }` spread would have leaked the new `validationErrors` field into the persisted blob as `{}`. Rewrote it as an explicit field allow-list so transient fields **structurally can't** leak; `deserializeState` defaults the field to an empty `Map` for back-compat with old blobs. A persistence-guard test pins the empty-after-reload behavior.

### Deviations from the slice doc
1. **Slice 1 (skipLogic) is not merged** — its dependency was a churn-window optimization, not a correctness gate; the features are independent, so this ships standalone. The budget headroom the plan feared Slice 1 ate is intact (this slice added ~7 gzipped bytes).
2. **Surveys is at 4.0.0, not 3.0.9** → minor changeset targets **4.1.0**.
3. **No multi-question turnkey container exists** → the validation surface is headless.

### Verification
- `pnpm --filter @tour-kit/surveys typecheck` ✅
- `pnpm --filter @tour-kit/surveys test` ✅ 266/266 (incl. new `validation.test.tsx` + extended `question-rating.test.tsx` step cases)
- `biome check packages/surveys/src/` ✅ clean
- `pnpm dist:size` ✅ surveys **6486 / 8000 B** gzip
- Built-dist grep confirms the wiring survives bundling.

### Follow-up (not in this PR, by design)
- **Studio pin-bump** (lands in `utk-studio`): bump the surveys pin in `SUPPORTED_DEPS` (`recipe.ts`) + the `derive.ts` duplicate to 4.1.0 so its already-emitted `ratingScale.step` becomes functional once consumers install the new minor.

### Changeset
`@tour-kit/surveys`: **minor** (versions independently — not in the linked `core/react/hints` group).