### PR TITLE
feat(ai): Slice 4 — @tour-kit/ai honest reposition (minor 0.13.0)

### DIFF
--- a/.changeset/slice-4-ai-honest-reposition.md
+++ b/.changeset/slice-4-ai-honest-reposition.md
@@ -1,0 +1,35 @@
+---
+"@tour-kit/ai": minor
+---
+
+Make every advertised AI knob either consumed or gone, and reframe the package's
+copy so nothing is falsifiable. The AI SDK is **not** upgraded — that is a
+separate gated track.
+
+**Wired (were typed but inert):**
+
+- `RAGConfig.minScore` now reaches retrieval. The RAG middleware hardcoded `-1`,
+  ignoring the configured threshold; it is now threaded through
+  `createRetriever` + `createRAGMiddleware`. The default stays `-1` (match-all)
+  when unset, so existing pipelines retrieve identically; a standalone
+  `createRetriever().search()` keeps its `0.7` default.
+- `AiChatConfig.rateLimit` — `AiChatProvider` now builds the
+  `SlidingWindowRateLimiter` and gates `sendMessage`; at the cap it emits a
+  rate-limited `error` event and does not hit the transport.
+- `AiChatConfig.strings` — resolved once and exposed on the context and
+  `useAiChat().strings`; `AiChatInput`/`AiChatHeader` read their labels from it
+  (explicit props still win). `DEFAULT_STRINGS` now mirrors the shipped UI text,
+  so an unset config renders exactly as before.
+- `AiChatConfig.errorMessage` — folded into `strings.errorMessage` (one error
+  string source).
+
+**Removed (genuinely unwireable / inert):**
+
+- `RAGConfig.rerank` / `RAGMiddlewareOptions.rerank` — was a score sort-and-slice
+  that never invoked the model string. Native `rerank()` is an AI SDK 6 export
+  this package cannot reach on the `ai@^5` pin.
+- `ChatRouteHandlerOptions.maxDuration` — a Next.js route-segment export, not a
+  handler param. Passing it did nothing; set `export const maxDuration` in your
+  route module instead (now documented).
+
+The server `options.rateLimit` (`createServerRateLimiter`) is unaffected.

--- a/apps/docs/components/landing/pricing.tsx
+++ b/apps/docs/components/landing/pricing.tsx
@@ -39,7 +39,7 @@ const PRO_FEATURES = [
   'Feature adoption tracking',
   'Media embedding (YouTube, Loom, Lottie)',
   'Business-hours scheduling (timezone-aware)',
-  'AI chat assistant',
+  'AI chat assistant (RAG + tour context)',
   'Priority GitHub issues',
 ]
 
@@ -55,7 +55,7 @@ const COMPARISON_ROWS = [
   { feature: 'Adoption tracking', free: false, pro: true },
   { feature: 'Media embedding', free: false, pro: true },
   { feature: 'Scheduling (business hours, timezones)', free: false, pro: true },
-  { feature: 'AI assistant', free: false, pro: true },
+  { feature: 'AI chat assistant (RAG + tour context)', free: false, pro: true },
   { feature: 'Sites', free: 'Unlimited', pro: '5 included' },
   { feature: 'License', free: 'MIT', pro: 'Commercial' },
 ]

--- a/apps/docs/content/docs/api/ai.mdx
+++ b/apps/docs/content/docs/api/ai.mdx
@@ -375,10 +375,15 @@ interface ChatRouteHandlerOptions {
   rateLimit?: ServerRateLimitConfig
   beforeSend?(message): Promise<UIMessage | null> | UIMessage | null
   beforeResponse?(response): Promise<string> | string
-  maxDuration?: number // default 30
   onEvent?(event: AiChatEvent): void | Promise<void>
 }
 ```
+
+<Callout type="info">
+  Request timeout is a Next.js route-segment export, not a handler option. Set
+  `export const maxDuration = 30` in your route module — it is read by the
+  platform, not by `createChatRouteHandler`.
+</Callout>
 
 ### ContextConfig
 
@@ -396,10 +401,9 @@ interface RAGConfig {
   embedding: EmbeddingAdapter
   vectorStore?: VectorStoreAdapter
   topK?: number
-  minScore?: number
+  minScore?: number // retrieval threshold (default: -1, match-all)
   chunkSize?: number
   chunkOverlap?: number
-  rerank?: { model: string; topN?: number }
 }
 ```
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -19619,10 +19619,13 @@ interface ChatRouteHandlerOptions {
   rateLimit?: ServerRateLimitConfig
   beforeSend?(message): Promise<UIMessage | null> | UIMessage | null
   beforeResponse?(response): Promise<string> | string
-  maxDuration?: number // default 30
   onEvent?(event: AiChatEvent): void | Promise<void>
 }
 ```
+
+Request timeout is a Next.js route-segment export, not a handler option. Set
+`export const maxDuration = 30` in your route module — it is read by the
+platform, not by `createChatRouteHandler`.
 
 ### ContextConfig
 
@@ -19640,10 +19643,9 @@ interface RAGConfig {
   embedding: EmbeddingAdapter
   vectorStore?: VectorStoreAdapter
   topK?: number
-  minScore?: number
+  minScore?: number // retrieval threshold (default: -1, match-all)
   chunkSize?: number
   chunkOverlap?: number
-  rerank?: { model: string; topN?: number }
 }
 ```
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -7,7 +7,7 @@
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@tour-kit/ai?label=gzip)](https://bundlephobia.com/package/@tour-kit/ai)
 [![types](https://img.shields.io/npm/types/@tour-kit/ai.svg)](https://www.npmjs.com/package/@tour-kit/ai)
 
-Drop-in **AI chat assistant** for React onboarding flows — adds a conversational layer that understands your tour structure, guides users through setup, and answers product questions. Powered by [Vercel AI SDK](https://sdk.vercel.ai/) with built-in **RAG**, **CAG**, vector search, suggestion chips, and rate limiting.
+Drop-in **AI chat assistant** for React onboarding flows — a **UI + orchestration layer** over the [Vercel AI SDK](https://sdk.vercel.ai/). This package owns the chat UI, document chunking, prompt assembly, and the RAG/CAG wiring; embeddings (`embedMany`), similarity (`cosineSimilarity`), and generation (`streamText`) are delegated to the SDK. RAG runs over an **in-memory vector store** (a linear cosine scan — no index, no persistence); bring your own persistent backend via a custom `VectorStoreAdapter` for production scale.
 
 > **Pro tier** — requires a license key. See [Licensing](https://usertourkit.com/docs/licensing).
 
@@ -17,9 +17,10 @@ Drop-in **AI chat assistant** for React onboarding flows — adds a conversation
 
 - **Tour-aware** — `useTourAssistant()` injects current tour step into the system prompt
 - **CAG** (Context-Augmented Generation) — stuff tour context directly into the prompt
-- **RAG** (Retrieval-Augmented Generation) — vector search over your docs with `createInMemoryVectorStore` or a custom adapter
+- **RAG** (Retrieval-Augmented Generation) — retrieval over an in-memory vector store (linear cosine search) via `createInMemoryVectorStore`; swap in a persistent backend with a custom `VectorStoreAdapter`
 - **Suggestion chips** — AI-generated follow-up prompts
-- **Rate limiting** — both client and server-side, sliding window
+- **Rate limiting** — sliding window on both the client (`AiChatConfig.rateLimit`, UX protection) and the server (`options.rateLimit`, cost protection)
+- **Configurable UI strings** — override any label via `AiChatConfig.strings` (English defaults otherwise)
 - **Strict client/server split** — server entry never imports React or browser APIs
 - **Vercel AI SDK** — works with OpenAI, Anthropic, Google, Mistral, and any AI SDK provider
 - **TypeScript-first**, supports React 18 & 19
@@ -101,27 +102,34 @@ export const { POST } = createChatRouteHandler({
 })
 ```
 
-For RAG with vector search:
+> **Request timeout** is a Next.js route-segment export, not a handler option.
+> Set it in your own route module:
+>
+> ```ts
+> // app/api/chat/route.ts
+> export const maxDuration = 30 // seconds — read by the platform, not by this handler
+> export const { POST } = createChatRouteHandler({ /* … */ })
+> ```
+
+For RAG, pass a `strategy: 'rag'` context — the handler chunks, embeds, and indexes your documents into an in-memory vector store on the first request, then retrieves per query:
 
 ```ts
 // app/api/chat/route.ts
-import {
-  createChatRouteHandler,
-  createInMemoryVectorStore,
-  createAiSdkEmbedding,
-  createRAGMiddleware,
-} from '@tour-kit/ai/server'
+import { createChatRouteHandler, createAiSdkEmbedding } from '@tour-kit/ai/server'
 import { openai } from '@ai-sdk/openai'
 
 const embedding = createAiSdkEmbedding({ model: openai.embedding('text-embedding-3-small') })
-const vectorStore = createInMemoryVectorStore({ embedding })
-await vectorStore.addDocuments(myDocuments)
 
 export const { POST } = createChatRouteHandler({
+  // RAG requires a model instance, not a string ID.
   model: openai('gpt-4o-mini'),
   context: {
     strategy: 'rag',
-    middleware: createRAGMiddleware({ vectorStore, topK: 4 }),
+    documents: myDocuments,
+    embedding,
+    topK: 4,
+    minScore: 0.5, // optional retrieval threshold (default: -1 = match-all)
+    // vectorStore: myAdapter, // optional — supply a persistent VectorStoreAdapter
   },
 })
 ```

--- a/packages/ai/src/__tests__/context/ai-chat-provider.test.tsx
+++ b/packages/ai/src/__tests__/context/ai-chat-provider.test.tsx
@@ -53,3 +53,67 @@ describe('AiChatProvider — US-1, US-3', () => {
     )
   })
 })
+
+// US-4 (WIRE path): the client trio config.strings / config.errorMessage /
+// config.rateLimit are now CONSUMED by the provider — not inert type-surface.
+// These tests would be false on the DEPRECATE path (the behavior wouldn't exist).
+describe('AiChatProvider — client trio WIRE (US-4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseChatReturn.messages = []
+    mockUseChatReturn.status = 'ready'
+    mockUseChatReturn.error = undefined
+  })
+
+  it('resolves config.strings and exposes them via useAiChat', () => {
+    const wrapper = createTestWrapper({
+      strings: { title: 'Helpdesk', placeholder: 'Ask away' },
+    })
+    const { result } = renderHook(() => useAiChat(), { wrapper })
+
+    // configured keys win…
+    expect(result.current.strings.title).toBe('Helpdesk')
+    expect(result.current.strings.placeholder).toBe('Ask away')
+    // …unset keys fall back to DEFAULT_STRINGS (today's shipped text)
+    expect(result.current.strings.send).toBe('Send')
+    expect(result.current.strings.closeLabel).toBe('Close chat')
+  })
+
+  it('folds config.errorMessage into strings.errorMessage (single source)', () => {
+    const wrapper = createTestWrapper({ errorMessage: 'Our bots are napping.' })
+    const { result } = renderHook(() => useAiChat(), { wrapper })
+
+    expect(result.current.strings.errorMessage).toBe('Our bots are napping.')
+  })
+
+  it('blocks sendMessage when the rate limiter is at cap', () => {
+    const onEvent = vi.fn()
+    const wrapper = createTestWrapper({ rateLimit: { maxMessages: 1 }, onEvent })
+    const { result } = renderHook(() => useAiChat(), { wrapper })
+
+    result.current.sendMessage({ text: 'first' }) // allowed (records 1/1)
+    result.current.sendMessage({ text: 'second' }) // at cap → blocked
+
+    // Only the first reached the transport.
+    expect(mockUseChatReturn.sendMessage).toHaveBeenCalledTimes(1)
+    expect(mockUseChatReturn.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'first' })
+    )
+    // The blocked send emitted a rate-limited error event instead.
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({ reason: 'rate_limited' }),
+      })
+    )
+  })
+
+  it('does not construct a limiter when config.rateLimit is unset (no blocking)', () => {
+    const wrapper = createTestWrapper()
+    const { result } = renderHook(() => useAiChat(), { wrapper })
+
+    for (let i = 0; i < 25; i++) result.current.sendMessage({ text: `m${i}` })
+
+    expect(mockUseChatReturn.sendMessage).toHaveBeenCalledTimes(25)
+  })
+})

--- a/packages/ai/src/__tests__/core/rate-limiter.test.ts
+++ b/packages/ai/src/__tests__/core/rate-limiter.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SlidingWindowRateLimiter, createRateLimiter } from '../../core/rate-limiter'
 
+// This is the CLIENT-side limiter (UX/cost protection in the browser), wired
+// into AiChatProvider in Slice 4 — distinct from the server-side
+// createServerRateLimiter (cost protection at the route). Different
+// implementations; never share an instance.
 describe('SlidingWindowRateLimiter', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/packages/ai/src/__tests__/core/strings.test.ts
+++ b/packages/ai/src/__tests__/core/strings.test.ts
@@ -29,12 +29,12 @@ describe('DEFAULT_STRINGS', () => {
     }
   })
 
-  it('has English defaults', () => {
-    expect(DEFAULT_STRINGS.placeholder).toBe('Ask a question...')
+  it('has English defaults that mirror the shipped UI literals', () => {
+    expect(DEFAULT_STRINGS.placeholder).toBe('Type a message...')
     expect(DEFAULT_STRINGS.send).toBe('Send')
     expect(DEFAULT_STRINGS.errorMessage).toBe('Something went wrong. Please try again.')
     expect(DEFAULT_STRINGS.emptyState).toBe('How can I help you?')
-    expect(DEFAULT_STRINGS.title).toBe('Chat')
+    expect(DEFAULT_STRINGS.title).toBe('AI Assistant')
   })
 })
 
@@ -62,7 +62,7 @@ describe('resolveStrings', () => {
     expect(strings.emptyState).toBe('How can I help you?')
     expect(strings.stopGenerating).toBe('Stop generating')
     expect(strings.retry).toBe('Retry')
-    expect(strings.title).toBe('Chat')
+    expect(strings.title).toBe('AI Assistant')
     expect(strings.closeLabel).toBe('Close chat')
     expect(strings.ratePositiveLabel).toBe('Helpful')
     expect(strings.rateNegativeLabel).toBe('Not helpful')

--- a/packages/ai/src/__tests__/coverage-gaps/components-coverage.test.tsx
+++ b/packages/ai/src/__tests__/coverage-gaps/components-coverage.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_STRINGS } from '../../core/strings'
 import type { UseAiChatReturn } from '../../hooks/use-ai-chat'
 
 // Mock the context module so AiChatSuggestions can render outside a provider
@@ -33,6 +34,7 @@ function buildChatState(overrides: Partial<UseAiChatReturn> = {}): UseAiChatRetu
     open: vi.fn(),
     close: vi.fn(),
     toggle: vi.fn(),
+    strings: DEFAULT_STRINGS,
     ...overrides,
   }
 }

--- a/packages/ai/src/__tests__/helpers/mock-use-ai-chat.ts
+++ b/packages/ai/src/__tests__/helpers/mock-use-ai-chat.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import { DEFAULT_STRINGS } from '../../core/strings'
 import type { UseAiChatReturn } from '../../hooks/use-ai-chat'
 
 export function createMockUseAiChatReturn(
@@ -16,6 +17,7 @@ export function createMockUseAiChatReturn(
     toggle: vi.fn(),
     error: null,
     status: 'ready',
+    strings: DEFAULT_STRINGS,
     ...overrides,
   }
 }

--- a/packages/ai/src/__tests__/server/cag-strategy.test.ts
+++ b/packages/ai/src/__tests__/server/cag-strategy.test.ts
@@ -7,6 +7,8 @@ const mockStreamResult = createMockStreamResult()
 vi.mock('ai', () => ({
   streamText: vi.fn(() => mockStreamResult),
   convertToModelMessages: vi.fn((msgs: unknown[]) => msgs),
+  // Only the RAG branch wraps the model; CAG must never touch it.
+  wrapLanguageModel: vi.fn((opts: { model: unknown }) => opts.model),
 }))
 
 describe('CAG Strategy — US-4', () => {
@@ -45,6 +47,33 @@ describe('CAG Strategy — US-4', () => {
     expect(systemPrompt).toContain('Tour Kit supports React 18 and 19.')
     expect(systemPrompt).toContain('Install with pnpm add @tour-kit/core.')
     expect(systemPrompt).toContain('WCAG 2.1 AA compliance is built-in.')
+  })
+
+  it('runs no retrieval pipeline under context-stuffing (no model wrapping)', async () => {
+    const { createChatRouteHandler } = await import('../../server/route-handler')
+    const { wrapLanguageModel } = await import('ai')
+
+    const handler = createChatRouteHandler({
+      model: 'openai/gpt-4o-mini',
+      context: {
+        strategy: 'context-stuffing',
+        documents: [createTestDocument({ content: 'Stuffed, not retrieved.' })],
+      },
+    })
+
+    await handler.POST(
+      new Request('http://localhost/api/chat', {
+        method: 'POST',
+        body: JSON.stringify({
+          messages: [{ id: '1', role: 'user', parts: [{ type: 'text', text: 'Hi' }] }],
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    // CAG stuffs documents straight into the system prompt — no retriever,
+    // no embedding, no RAG middleware wrapping the model.
+    expect(wrapLanguageModel).not.toHaveBeenCalled()
   })
 
   it('handles empty documents array gracefully', async () => {

--- a/packages/ai/src/__tests__/server/rag-integration.test.ts
+++ b/packages/ai/src/__tests__/server/rag-integration.test.ts
@@ -173,14 +173,22 @@ describe('RAG Pipeline Integration', () => {
     ]
 
     // Retriever carries the option; middleware also passes it explicitly to search().
-    const retriever = createRetriever({ documents: docs, embedding, vectorStore: store, minScore: 0.42 })
+    const retriever = createRetriever({
+      documents: docs,
+      embedding,
+      vectorStore: store,
+      minScore: 0.42,
+    })
     const middleware = createRAGMiddleware({ retriever, topK: 2, minScore: 0.42 })
 
     await middleware.transformParams?.({
       type: 'generate' as const,
       params: {
         prompt: [
-          { role: 'user' as const, content: [{ type: 'text' as const, text: 'How do tours work?' }] },
+          {
+            role: 'user' as const,
+            content: [{ type: 'text' as const, text: 'How do tours work?' }],
+          },
         ],
       },
       model: {} as never,

--- a/packages/ai/src/__tests__/server/rag-integration.test.ts
+++ b/packages/ai/src/__tests__/server/rag-integration.test.ts
@@ -20,6 +20,7 @@ import { createRetriever } from '../../server/retriever'
 import type { Document, VectorStoreAdapter } from '../../types'
 import { createTestDocuments } from '../helpers/factories'
 import { createMockEmbedding } from '../helpers/mock-embedding'
+import { createMockVectorStore } from '../helpers/mock-vector-store'
 
 describe('RAG Pipeline Integration', () => {
   it('indexes documents and retrieves relevant results for a query', async () => {
@@ -159,39 +160,34 @@ describe('RAG Pipeline Integration', () => {
     expect(results.length).toBeGreaterThan(0)
   })
 
-  it('handles rerank option in middleware', async () => {
+  it('threads a configured minScore end-to-end to the vector store (US-1)', async () => {
+    // Replaces the old "handles rerank option" test. rerank was an AI-SDK-6-only
+    // knob that never ran on the ai@5 pin — removed in 0.13.0. minScore is the
+    // real retrieval lever, so prove the WHOLE chain delivers it:
+    //   RAGConfig.minScore → createRetriever option → search() default → store.search()
     const embedding = createMockEmbedding()
+    const store = createMockVectorStore()
     const docs: Document[] = [
       { id: 'doc-1', content: 'First document about tours.', metadata: { title: 'Tours' } },
       { id: 'doc-2', content: 'Second document about hooks.', metadata: { title: 'Hooks' } },
-      { id: 'doc-3', content: 'Third document about state.', metadata: { title: 'State' } },
     ]
 
-    const retriever = createRetriever({ documents: docs, embedding })
+    // Retriever carries the option; middleware also passes it explicitly to search().
+    const retriever = createRetriever({ documents: docs, embedding, vectorStore: store, minScore: 0.42 })
+    const middleware = createRAGMiddleware({ retriever, topK: 2, minScore: 0.42 })
 
-    const middleware = createRAGMiddleware({
-      retriever,
-      topK: 2,
-      rerank: { model: 'rerank-model', topN: 1 },
-    })
-
-    const params = {
+    await middleware.transformParams?.({
       type: 'generate' as const,
       params: {
         prompt: [
-          {
-            role: 'user' as const,
-            content: [{ type: 'text' as const, text: 'How do tours work?' }],
-          },
+          { role: 'user' as const, content: [{ type: 'text' as const, text: 'How do tours work?' }] },
         ],
       },
       model: {} as never,
-    }
+    })
 
-    const result = await middleware.transformParams?.(params)
-
-    // Should have injected context
-    expect(result?.prompt[0].role).toBe('system')
+    expect(store.searchCalls).toHaveLength(1)
+    expect(store.searchCalls[0].minScore).toBe(0.42)
   })
 
   it('lazy indexes on first search — no upfront blocking', async () => {

--- a/packages/ai/src/__tests__/server/rag-middleware.test.ts
+++ b/packages/ai/src/__tests__/server/rag-middleware.test.ts
@@ -158,7 +158,12 @@ describe('createRAGMiddleware', () => {
 // so an unset minScore keeps today's retrieval behavior.
 describe('createRAGMiddleware — minScore (US-1)', () => {
   const HITS: RetrievedDocument[] = [
-    { id: 'd1', content: 'Tour Kit supports branching.', score: 0.95, metadata: { title: 'Branching' } },
+    {
+      id: 'd1',
+      content: 'Tour Kit supports branching.',
+      score: 0.95,
+      metadata: { title: 'Branching' },
+    },
     { id: 'd2', content: 'Use useTour for state.', score: 0.4, metadata: { source: 'hooks' } },
   ]
 

--- a/packages/ai/src/__tests__/server/rag-middleware.test.ts
+++ b/packages/ai/src/__tests__/server/rag-middleware.test.ts
@@ -149,26 +149,67 @@ describe('createRAGMiddleware', () => {
       expect(systemContent).toContain('[1] (Branching)')
       expect(systemContent).toContain('[2] (hooks-guide)')
     })
+  })
+})
 
-    it('retrieves topK * 2 results when rerank is configured', async () => {
-      let searchTopK = 0
-      const retriever = {
-        ...createMockRetriever(mockResults),
-        async search(_query: string, topK?: number) {
-          searchTopK = topK ?? 5
-          return mockResults
-        },
-      }
+// US-1 (guard + earned): the configured RAGConfig.minScore must reach the
+// retriever instead of the hardcoded -1 that rag-middleware.ts used to pass.
+// RED before Task 4.1; GREEN after the wire. The default stays -1 (match-all)
+// so an unset minScore keeps today's retrieval behavior.
+describe('createRAGMiddleware — minScore (US-1)', () => {
+  const HITS: RetrievedDocument[] = [
+    { id: 'd1', content: 'Tour Kit supports branching.', score: 0.95, metadata: { title: 'Branching' } },
+    { id: 'd2', content: 'Use useTour for state.', score: 0.4, metadata: { source: 'hooks' } },
+  ]
 
-      const middleware = createRAGMiddleware({
-        retriever,
-        topK: 3,
-        rerank: { model: 'rerank-model', topN: 2 },
-      })
+  it('threads the CONFIGURED minScore to retriever.search (not hardcoded -1)', async () => {
+    let received: number | undefined = Number.NaN
+    const retriever = {
+      ...createMockRetriever(HITS),
+      async search(_q: string, topK?: number, minScore?: number) {
+        received = minScore
+        return HITS.slice(0, topK ?? 5)
+      },
+    }
 
-      await middleware.transformParams?.(createMockParams('test'))
+    const middleware = createRAGMiddleware({ retriever, minScore: 0.5 })
+    await middleware.transformParams?.(createMockParams('How does branching work?'))
 
-      expect(searchTopK).toBe(6) // topK * 2 = 3 * 2
-    })
+    expect(received).toBe(0.5)
+  })
+
+  it("unset minScore keeps today's behavior (default -1, match-all)", async () => {
+    let received: number | undefined = Number.NaN
+    const retriever = {
+      ...createMockRetriever(HITS),
+      async search(_q: string, topK?: number, minScore?: number) {
+        received = minScore
+        return HITS.slice(0, topK ?? 5)
+      },
+    }
+
+    const middleware = createRAGMiddleware({ retriever })
+    await middleware.transformParams?.(createMockParams('test'))
+
+    expect(received).toBe(-1)
+  })
+
+  it('a minScore above every score ⇒ empty results ⇒ params returned unchanged', async () => {
+    const retriever = {
+      ...createMockRetriever(HITS),
+      async search(_q: string, _topK?: number, minScore?: number) {
+        return HITS.filter((h) => h.score >= (minScore ?? -1))
+      },
+    }
+
+    const middleware = createRAGMiddleware({ retriever, minScore: 0.99 })
+    const result = await middleware.transformParams?.(createMockParams('test'))
+
+    // No doc cleared the bar → no "Relevant context…" system message prepended.
+    expect(result?.prompt).toHaveLength(2)
+    expect(result?.prompt[0].role).toBe('system')
+    expect((result?.prompt[0] as { role: 'system'; content: string }).content).not.toContain(
+      'Relevant context from documentation'
+    )
   })
 })

--- a/packages/ai/src/__tests__/server/retriever.test.ts
+++ b/packages/ai/src/__tests__/server/retriever.test.ts
@@ -50,6 +50,22 @@ describe('chunkDocument', () => {
     })
   })
 
+  it('carries the trailing chunkOverlap chars into the start of the next chunk', () => {
+    // Two paragraphs that cannot share one 120-char chunk. The boundary is
+    // deterministic, so the last `overlap` chars of chunk 0 must reappear at the
+    // head of chunk 1 — this is the actual overlap behavior, not just chunk count.
+    const a = 'A'.repeat(100)
+    const b = 'B'.repeat(100)
+    const doc: Document = { id: 'doc-1', content: `${a}\n\n${b}` }
+
+    const chunks = chunkDocument(doc, 120, 20)
+
+    expect(chunks.length).toBe(2)
+    const overlap = chunks[0].content.slice(-20)
+    expect(overlap).toBe('A'.repeat(20))
+    expect(chunks[1].content.startsWith(overlap)).toBe(true)
+  })
+
   it('splits at paragraph boundaries (\\n\\n)', () => {
     const content =
       'Paragraph one about cats.\n\nParagraph two about dogs.\n\nParagraph three about birds.'
@@ -314,6 +330,38 @@ describe('createRetriever', () => {
 
       expect(mockVectorStore.searchCalls[0].topK).toBe(5)
       expect(mockVectorStore.searchCalls[0].minScore).toBe(0.7)
+    })
+
+    it('uses the configured RetrieverOptions.minScore as the search() default', async () => {
+      const docs: Document[] = [{ id: 'doc-1', content: 'Content.' }]
+
+      const retriever = createRetriever({
+        documents: docs,
+        embedding: mockEmbedding,
+        vectorStore: mockVectorStore,
+        minScore: 0.33,
+      })
+
+      await retriever.index()
+      await retriever.search('query') // no explicit per-call minScore
+
+      expect(mockVectorStore.searchCalls[0].minScore).toBe(0.33)
+    })
+
+    it('lets an explicit per-call minScore override the option default', async () => {
+      const docs: Document[] = [{ id: 'doc-1', content: 'Content.' }]
+
+      const retriever = createRetriever({
+        documents: docs,
+        embedding: mockEmbedding,
+        vectorStore: mockVectorStore,
+        minScore: 0.33,
+      })
+
+      await retriever.index()
+      await retriever.search('query', 5, 0.9)
+
+      expect(mockVectorStore.searchCalls[0].minScore).toBe(0.9)
     })
   })
 })

--- a/packages/ai/src/__tests__/server/route-handler-tour-context.test.ts
+++ b/packages/ai/src/__tests__/server/route-handler-tour-context.test.ts
@@ -110,3 +110,54 @@ describe('Route handler — tourContext parsing', () => {
     expect(prompt).not.toContain('Current User Context')
   })
 })
+
+// US-5: parseTourContext() is the untrusted-input boundary — its truncation
+// guards (title>500 / content>2000 → reject the whole context) are only
+// reachable THROUGH the handler, so assert them at the streamText system prompt.
+describe('Route handler — parseTourContext truncation guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  async function postWithTourContext(tourContext: unknown): Promise<string> {
+    const { streamText } = await import('ai')
+    const handler = createChatRouteHandler({
+      model: {} as Parameters<typeof createChatRouteHandler>[0]['model'],
+      context: { strategy: 'context-stuffing', documents: [] },
+    })
+    await handler.POST(
+      new Request('http://localhost/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [{ id: '1', role: 'user', parts: [{ type: 'text', text: 'Hi' }] }],
+          tourContext,
+        }),
+      })
+    )
+    const call = (streamText as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    return call.system as string
+  }
+
+  it('drops the whole tourContext when activeStep.title exceeds 500 chars', async () => {
+    const system = await postWithTourContext({
+      ...tourContextPayload,
+      activeStep: { id: 'step-connect', title: 'x'.repeat(501), content: 'ok' },
+    })
+    expect(system).not.toContain('Current User Context')
+  })
+
+  it('drops the whole tourContext when activeStep.content exceeds 2000 chars', async () => {
+    const system = await postWithTourContext({
+      ...tourContextPayload,
+      activeStep: { id: 'step-connect', title: 'Connect', content: 'y'.repeat(2001) },
+    })
+    expect(system).not.toContain('Current User Context')
+  })
+
+  it('keeps a tourContext whose fields are within the guards', async () => {
+    const system = await postWithTourContext(tourContextPayload)
+    expect(system).toContain('Current User Context')
+    expect(system).toContain('Onboarding Tour')
+  })
+})

--- a/packages/ai/src/__tests__/types/config-types.test.ts
+++ b/packages/ai/src/__tests__/types/config-types.test.ts
@@ -4,6 +4,9 @@ import type {
   ChatRouteHandlerOptions,
   ChatStatus,
   ContextStuffingConfig,
+  RAGConfig,
+  RAGMiddlewareOptions,
+  RetrieverOptions,
 } from '../../types/config'
 
 describe('Config Types — US-5', () => {
@@ -31,5 +34,37 @@ describe('Config Types — US-5', () => {
 
   it('ContextStuffingConfig has strategy "context-stuffing"', () => {
     expectTypeOf<ContextStuffingConfig['strategy']>().toEqualTypeOf<'context-stuffing'>()
+  })
+})
+
+// US-2 / US-3: Slice 4 removes two knobs that never did anything. These guards
+// fail (as "unused @ts-expect-error") if a future author re-introduces the
+// dead field — they lock the honesty claim at the type level. The matching
+// @deprecated/rg checks live in the slice exit criteria (TS erases @deprecated).
+describe('Removed AI knobs (US-2, US-3)', () => {
+  it('RAGConfig no longer carries a live `rerank` field', () => {
+    // `rerank()` is an AI SDK 6 export; this package pins ai@^5 → genuinely unwireable.
+    // @ts-expect-error — `rerank` is removed from RAGConfig in 0.13.0
+    const _r: RAGConfig['rerank'] = undefined
+    void _r
+  })
+
+  it('RAGMiddlewareOptions no longer carries a live `rerank` field', () => {
+    // @ts-expect-error — `rerank` is removed from RAGMiddlewareOptions in 0.13.0
+    const _r: RAGMiddlewareOptions['rerank'] = undefined
+    void _r
+  })
+
+  it('ChatRouteHandlerOptions no longer carries a live `maxDuration` field', () => {
+    // maxDuration is a Next.js route-segment export, not a handler param.
+    // @ts-expect-error — `maxDuration` is removed from ChatRouteHandlerOptions in 0.13.0
+    const _m: ChatRouteHandlerOptions['maxDuration'] = undefined
+    void _m
+  })
+
+  it('RetrieverOptions and RAGMiddlewareOptions expose the wired `minScore`', () => {
+    expectTypeOf<RetrieverOptions['minScore']>().toEqualTypeOf<number | undefined>()
+    expectTypeOf<RAGMiddlewareOptions['minScore']>().toEqualTypeOf<number | undefined>()
+    expectTypeOf<RAGConfig['minScore']>().toEqualTypeOf<number | undefined>()
   })
 })

--- a/packages/ai/src/components/ai-chat-header.tsx
+++ b/packages/ai/src/components/ai-chat-header.tsx
@@ -14,18 +14,20 @@ export interface AiChatHeaderProps {
 }
 
 export function AiChatHeader({
-  title = 'AI Assistant',
+  title,
   showClose = true,
   onClose,
   className,
   children,
 }: AiChatHeaderProps) {
-  const { close } = useAiChat()
+  const { close, strings } = useAiChat()
   const handleClose = onClose ?? close
+  // Explicit prop wins; otherwise fall back to the resolved config string.
+  const resolvedTitle = title ?? strings.title
 
   return (
     <div className={cn(aiChatHeaderVariants(), className)}>
-      <h3 className="text-sm font-semibold">{title}</h3>
+      <h3 className="text-sm font-semibold">{resolvedTitle}</h3>
       <div className="flex items-center gap-1">
         {children}
         {showClose && (
@@ -33,7 +35,7 @@ export function AiChatHeader({
             type="button"
             onClick={handleClose}
             className="rounded-sm p-0.5 opacity-70 transition-opacity hover:opacity-100"
-            aria-label="Close chat"
+            aria-label={strings.closeLabel}
           >
             <svg
               width="12"

--- a/packages/ai/src/components/ai-chat-input.tsx
+++ b/packages/ai/src/components/ai-chat-input.tsx
@@ -10,13 +10,11 @@ export interface AiChatInputProps {
   disabled?: boolean
 }
 
-export function AiChatInput({
-  className,
-  placeholder = 'Type a message...',
-  disabled,
-}: AiChatInputProps) {
-  const { sendMessage, stop, status } = useAiChat()
+export function AiChatInput({ className, placeholder, disabled }: AiChatInputProps) {
+  const { sendMessage, stop, status, strings } = useAiChat()
   const [value, setValue] = useState('')
+  // Explicit prop wins; otherwise fall back to the resolved config string.
+  const resolvedPlaceholder = placeholder ?? strings.placeholder
 
   const isStreaming = status === 'streaming'
   const isDisabled = disabled || status === 'submitted'
@@ -35,7 +33,7 @@ export function AiChatInput({
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        placeholder={placeholder}
+        placeholder={resolvedPlaceholder}
         disabled={isDisabled}
         className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:opacity-50"
         aria-label="Chat message"
@@ -45,7 +43,7 @@ export function AiChatInput({
           type="button"
           onClick={stop}
           className="shrink-0 rounded-md p-1 text-muted-foreground hover:text-foreground transition-colors"
-          aria-label="Stop generating"
+          aria-label={strings.stopGenerating}
         >
           <svg width="12" height="12" viewBox="0 0 14 14" fill="currentColor" aria-hidden="true">
             <rect x="2" y="2" width="10" height="10" rx="1" />

--- a/packages/ai/src/context/ai-chat-context.ts
+++ b/packages/ai/src/context/ai-chat-context.ts
@@ -1,6 +1,6 @@
 import type { UIMessage } from 'ai'
 import { createContext, useContext } from 'react'
-import type { AiChatConfig, ChatStatus } from '../types'
+import type { AiChatConfig, AiChatStrings, ChatStatus } from '../types'
 
 export interface AiChatContextValue {
   messages: UIMessage[]
@@ -18,6 +18,9 @@ export interface AiChatContextValue {
   toggle(): void
 
   config: AiChatConfig
+
+  /** Fully-resolved UI strings (config.strings merged over DEFAULT_STRINGS). */
+  strings: AiChatStrings
 
   /** Tour context value from @tour-kit/core (null when not available) */
   tourContextValue: unknown

--- a/packages/ai/src/context/ai-chat-provider.tsx
+++ b/packages/ai/src/context/ai-chat-provider.tsx
@@ -4,8 +4,10 @@ import { useChat } from '@ai-sdk/react'
 import { LicenseGate } from '@tour-kit/license'
 import { DefaultChatTransport } from 'ai'
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type SlidingWindowRateLimiter, createRateLimiter } from '../core/rate-limiter'
+import { resolveStrings } from '../core/strings'
 import { usePersistence } from '../hooks/use-persistence'
-import type { AiChatConfig, ChatStatus } from '../types'
+import type { AiChatConfig, AiChatStrings, ChatStatus } from '../types'
 import { AiChatContext, type AiChatContextValue } from './ai-chat-context'
 
 interface AiChatProviderProps {
@@ -95,12 +97,44 @@ export function AiChatProvider({ config, children, tourContextValue }: AiChatPro
   const status: ChatStatus = chatHelpers.status as ChatStatus
   const error: Error | null = chatHelpers.error ?? null
 
+  // Client-side rate limiter (UX/cost protection). Built once from config.rateLimit;
+  // null means unlimited. Lazy-init keeps it stable across renders.
+  const limiterRef = useRef<SlidingWindowRateLimiter | null>(null)
+  if (limiterRef.current === null && config.rateLimit) {
+    limiterRef.current = createRateLimiter(config.rateLimit)
+  }
+
+  // Resolve UI strings once. config.errorMessage is the shorthand for the single
+  // error-string source (strings.errorMessage), so fold it in when strings doesn't
+  // already set it. Unset config yields DEFAULT_STRINGS = today's rendered text.
+  const strings = useMemo<AiChatStrings>(() => {
+    const partial: Partial<AiChatStrings> = { ...config.strings }
+    if (config.errorMessage && partial.errorMessage === undefined) {
+      partial.errorMessage = config.errorMessage
+    }
+    return resolveStrings(partial)
+  }, [config.strings, config.errorMessage])
+
   // Resolve tour context: only use the explicit prop when tourContext config is enabled
   const resolvedTourContext = config.tourContext === true ? (tourContextValue ?? null) : null
 
   // Stable callbacks that always read the latest chatHelpers via ref
   const sendMessage = useCallback(
     (input: { text: string }) => {
+      // Client rate limit: when at cap, surface a rate-limited error and do not
+      // forward to the transport (protects the user's API spend / UX).
+      if (limiterRef.current && !limiterRef.current.recordMessage()) {
+        try {
+          config.onEvent?.({
+            type: 'error',
+            data: { reason: 'rate_limited', message: strings.errorMessage },
+            timestamp: new Date(),
+          })
+        } catch {
+          // onEvent errors must never break chat
+        }
+        return
+      }
       try {
         config.onEvent?.({
           type: 'message_sent',
@@ -112,7 +146,7 @@ export function AiChatProvider({ config, children, tourContextValue }: AiChatPro
       }
       helpersRef.current.sendMessage({ text: input.text })
     },
-    [config]
+    [config, strings]
   )
 
   const stop = useCallback(() => {
@@ -177,6 +211,7 @@ export function AiChatProvider({ config, children, tourContextValue }: AiChatPro
       close,
       toggle,
       config,
+      strings,
       tourContextValue: resolvedTourContext,
     }),
     [
@@ -192,6 +227,7 @@ export function AiChatProvider({ config, children, tourContextValue }: AiChatPro
       close,
       toggle,
       config,
+      strings,
       resolvedTourContext,
     ]
   )

--- a/packages/ai/src/core/strings.ts
+++ b/packages/ai/src/core/strings.ts
@@ -1,13 +1,16 @@
 import type { AiChatStrings } from '../types'
 
+// Single source of truth for the chat UI's English copy. Values mirror what the
+// components shipped as inline literals before Slice 4 wired this in, so an
+// unset `config.strings` renders exactly today's text.
 export const DEFAULT_STRINGS: AiChatStrings = {
-  placeholder: 'Ask a question...',
+  placeholder: 'Type a message...',
   send: 'Send',
   errorMessage: 'Something went wrong. Please try again.',
   emptyState: 'How can I help you?',
   stopGenerating: 'Stop generating',
   retry: 'Retry',
-  title: 'Chat',
+  title: 'AI Assistant',
   closeLabel: 'Close chat',
   ratePositiveLabel: 'Helpful',
   rateNegativeLabel: 'Not helpful',

--- a/packages/ai/src/hooks/use-ai-chat.ts
+++ b/packages/ai/src/hooks/use-ai-chat.ts
@@ -3,7 +3,7 @@
 import type { UIMessage } from 'ai'
 import { useContext } from 'react'
 import { AiChatContext } from '../context/ai-chat-context'
-import type { ChatStatus } from '../types'
+import type { AiChatStrings, ChatStatus } from '../types'
 
 export interface UseAiChatReturn {
   messages: UIMessage[]
@@ -17,6 +17,8 @@ export interface UseAiChatReturn {
   open(): void
   close(): void
   toggle(): void
+  /** Fully-resolved UI strings (config.strings merged over defaults). */
+  strings: AiChatStrings
 }
 
 export function useAiChat(): UseAiChatReturn {
@@ -41,5 +43,6 @@ export function useAiChat(): UseAiChatReturn {
     open: context.open,
     close: context.close,
     toggle: context.toggle,
+    strings: context.strings,
   }
 }

--- a/packages/ai/src/server/rag-middleware.ts
+++ b/packages/ai/src/server/rag-middleware.ts
@@ -11,7 +11,7 @@ function defaultFormatContext(docs: RetrievedDocument[]): string {
 }
 
 export function createRAGMiddleware(options: RAGMiddlewareOptions): LanguageModelMiddleware {
-  const { retriever, topK = 5, rerank, formatContext = defaultFormatContext } = options
+  const { retriever, topK = 5, minScore = -1, formatContext = defaultFormatContext } = options
 
   return {
     transformParams: async ({ params }) => {
@@ -27,22 +27,11 @@ export function createRAGMiddleware(options: RAGMiddlewareOptions): LanguageMode
 
       if (!text.trim()) return params
 
-      // Search with more results if reranking
-      const searchTopK = rerank ? topK * 2 : topK
-      const results = await retriever.search(text, searchTopK, -1)
+      const results = await retriever.search(text, topK, minScore)
 
       if (results.length === 0) return params
 
-      // Optional reranking — simple score-based re-ordering
-      let finalResults: RetrievedDocument[]
-      if (rerank) {
-        const topN = rerank.topN ?? topK
-        // Re-score by combining original score with position weight
-        finalResults = results.sort((a, b) => b.score - a.score).slice(0, topN)
-      } else {
-        finalResults = results.slice(0, topK)
-      }
-
+      const finalResults = results.slice(0, topK)
       const contextString = formatContext(finalResults)
 
       // Prepend a system message with the retrieved context

--- a/packages/ai/src/server/retriever.ts
+++ b/packages/ai/src/server/retriever.ts
@@ -128,6 +128,10 @@ export function createRetriever(options: RetrieverOptions): Retriever {
     vectorStore = createInMemoryVectorStore(),
     chunkSize = 512,
     chunkOverlap = 50,
+    // The option becomes the default threshold for search(). Stays 0.7 when
+    // unset so a standalone retriever keeps its existing match behavior; the
+    // RAG middleware passes its own value explicitly per request.
+    minScore: defaultMinScore = 0.7,
   } = options
 
   let indexed = false
@@ -152,7 +156,7 @@ export function createRetriever(options: RetrieverOptions): Retriever {
       await indexingPromise
     },
 
-    async search(query: string, topK = 5, minScore = 0.7) {
+    async search(query: string, topK = 5, minScore = defaultMinScore) {
       // Auto-index on first search
       if (!indexed) {
         if (!indexingPromise) {

--- a/packages/ai/src/server/route-handler.ts
+++ b/packages/ai/src/server/route-handler.ts
@@ -87,12 +87,13 @@ export function createChatRouteHandler(options: ChatRouteHandlerOptions): {
       vectorStore: ragConfig.vectorStore,
       chunkSize: ragConfig.chunkSize,
       chunkOverlap: ragConfig.chunkOverlap,
+      minScore: ragConfig.minScore,
     })
 
     const ragMiddleware = createRAGMiddleware({
       retriever,
       topK: ragConfig.topK,
-      rerank: ragConfig.rerank,
+      minScore: ragConfig.minScore,
     })
 
     resolvedModel = wrapLanguageModel({

--- a/packages/ai/src/types/config.ts
+++ b/packages/ai/src/types/config.ts
@@ -103,8 +103,6 @@ export interface ChatRouteHandlerOptions {
   beforeSend?(message: UIMessage): Promise<UIMessage | null> | UIMessage | null
   /** Hook: runs before response is returned (output filtering) */
   beforeResponse?(response: string): Promise<string> | string
-  /** Max request duration in seconds (default: 30) */
-  maxDuration?: number
   /** Server-side event callback */
   onEvent?(event: AiChatEvent): void | Promise<void>
 }
@@ -125,7 +123,6 @@ export interface RAGConfig {
   minScore?: number
   chunkSize?: number
   chunkOverlap?: number
-  rerank?: { model: string; topN?: number }
 }
 
 export interface InstructionsConfig {
@@ -181,6 +178,8 @@ export interface RetrieverOptions {
   vectorStore?: VectorStoreAdapter
   chunkSize?: number
   chunkOverlap?: number
+  /** Default retrieval threshold for `search()` when no per-call value is passed (default: 0.7). */
+  minScore?: number
 }
 
 export interface Retriever {
@@ -191,6 +190,7 @@ export interface Retriever {
 export interface RAGMiddlewareOptions {
   retriever: Retriever
   topK?: number
-  rerank?: { model: string; topN?: number }
+  /** Minimum similarity score for a chunk to be retrieved (default: -1, match-all). */
+  minScore?: number
   formatContext?(docs: RetrievedDocument[]): string
 }


### PR DESCRIPTION
## Slice 4 — @tour-kit/ai Honest Reposition

Makes every advertised AI knob **either consumed or gone**, and reframes the README / `/pricing` / API-reference copy so nothing is falsifiable. **The AI SDK is not upgraded** — that's a separate gated track. Ships as a `@tour-kit/ai` minor (0.12.3 → 0.13.0).

### Wired (were typed but inert)
- **`RAGConfig.minScore`** — the RAG middleware hardcoded `-1`, ignoring the configured threshold. Now threaded through `createRetriever` + `createRAGMiddleware`. Default stays `-1` (match-all) when unset, so existing pipelines retrieve identically; a standalone `createRetriever().search()` keeps its `0.7` default.
- **Client `rateLimit`** — `AiChatProvider` now builds the `SlidingWindowRateLimiter` and gates `sendMessage` (at the cap it emits a rate-limited `error` event and does not hit the transport).
- **Client `strings`** — resolved once and exposed on the context + `useAiChat().strings`; `AiChatInput`/`AiChatHeader` read their labels from it (explicit props still win). `DEFAULT_STRINGS` realigned to the shipped UI literals, so an unset config renders exactly as before.
- **Client `errorMessage`** — folded into `strings.errorMessage` (one error-string source).

### Removed (genuinely unwireable / inert)
- **`RAGConfig.rerank` / `RAGMiddlewareOptions.rerank`** — a score sort-and-slice that never invoked the model string. Native `rerank()` is an AI SDK 6 export this package can't reach on the `ai@^5` pin.
- **`ChatRouteHandlerOptions.maxDuration`** — a Next.js route-segment export, not a handler param. Documented the `export const maxDuration` form instead.

The server `options.rateLimit` (`createServerRateLimiter`) is untouched.

### Two principled deviations from the plan
- **Kept the standalone retriever `search()` default at `0.7`** (plan's literal `-1` would have silently changed retrieval for direct retriever consumers and broken `retriever.test.ts:303` — contradicting the slice's own "no silent change" principle). The middleware threads `?? -1`, so the pipeline is unchanged.
- **Chose WIRE over DEPRECATE** for the client trio — it fits the budget and makes the knobs *real* (the strongest trust outcome).

### Copy fixes beyond plan scope (surfaced by the honesty grep)
- The README RAG example was already broken (`vectorStore.addDocuments` / `middleware:` key never existed) → replaced with the real `strategy: 'rag'` context form.
- `api/ai.mdx` + `llms-full.txt` documented the now-removed `rerank` field and `maxDuration` option → removed.

## Verification
- `typecheck` green; **455 tests pass** (11 new), 3 spike skips.
- **TDD**: the 3 `minScore` tests were RED (`received === -1`) before the wire, green after; `config-types` guards lock `rerank`/`maxDuration` absence; the two rerank-doubling tests were deleted (not adapted).
- **dist-level smoke**: the shipped `dist/server` artifact threads `minScore=0.77`; the `dist` client limiter caps at the configured max.
- **Bundle** (`pnpm dist:size`): `ai:client` 4275 → **4573** gz (≤ 5000); `ai:server` 4752 → **4716** gz (≤ 8000); 0 packages over budget.
- **Honesty greps**: 0 `rerank` / false-`maxDuration` / `vector-database` claims across README, `/pricing`, `api/ai.mdx`, `llms-full.txt`.

## Not done
No live browser QA of the chat widget — it needs a Pro license + a real LLM endpoint, and this slice introduces **no visible UI change** (defaults preserve today's text). All behavioral changes are exercised through the real code paths by jsdom/node tests and confirmed against the built artifacts.