### PR TITLE
fix(ai): complete strings honesty (Finding-1) → 0.13.1

### DIFF
--- a/.changeset/ai-strings-honesty-completion.md
+++ b/.changeset/ai-strings-honesty-completion.md
@@ -1,0 +1,22 @@
+---
+"@tour-kit/ai": patch
+---
+
+Complete the `AiChatConfig.strings` honesty pass from 0.13.0 — every advertised
+label now maps to a control the package actually renders.
+
+- **Wired `send`** — the icon-only submit button in `AiChatInput` read a
+  hard-coded `aria-label="Send message"`; it now reads `strings.send` (default
+  unchanged), so `config.strings.send` finally applies.
+- **Wired `emptyState`** — `AiChatPanel` defaulted its empty state to a literal
+  that ignored `strings.emptyState`; the prop now falls back to
+  `strings.emptyState` (an explicit prop still wins), so configuring it works.
+- **Removed `retry`, `ratePositiveLabel`, `rateNegativeLabel`** from
+  `AiChatStrings` — they labelled a retry/rating UI the package does not ship
+  (no component, no `rate()` API, the `message_rated` event is never emitted).
+  They rendered nothing, so removing them changes no runtime behavior;
+  `AiChatStrings` is now exactly the seven labels the components render.
+
+Also drops the residual "vector search" superlative from the README tagline and
+funnels the provider's analytics events through one internal `emit()` helper (no
+public API change).

--- a/apps/docs/content/docs/api/ai.mdx
+++ b/apps/docs/content/docs/api/ai.mdx
@@ -206,16 +206,13 @@ interface AnalyticsBridgeConfig {
 
 ```tsx
 interface AiChatStrings {
-  placeholder: string
-  send: string
-  errorMessage: string
-  emptyState: string
-  stopGenerating: string
-  retry: string
-  title: string
-  closeLabel: string
-  ratePositiveLabel: string
-  rateNegativeLabel: string
+  placeholder: string // AiChatInput placeholder
+  send: string // AiChatInput send button accessible name
+  errorMessage: string // shown on error / rate-limit
+  emptyState: string // AiChatPanel empty state
+  stopGenerating: string // AiChatInput stop button accessible name
+  title: string // AiChatHeader title
+  closeLabel: string // AiChatHeader close button accessible name
 }
 ```
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -19450,16 +19450,13 @@ interface AnalyticsBridgeConfig {
 
 ```tsx
 interface AiChatStrings {
-  placeholder: string
-  send: string
-  errorMessage: string
-  emptyState: string
-  stopGenerating: string
-  retry: string
-  title: string
-  closeLabel: string
-  ratePositiveLabel: string
-  rateNegativeLabel: string
+  placeholder: string // AiChatInput placeholder
+  send: string // AiChatInput send button accessible name
+  errorMessage: string // shown on error / rate-limit
+  emptyState: string // AiChatPanel empty state
+  stopGenerating: string // AiChatInput stop button accessible name
+  title: string // AiChatHeader title
+  closeLabel: string // AiChatHeader close button accessible name
 }
 ```
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,6 +1,6 @@
 # @tour-kit/ai
 
-> React AI chat widget with RAG & tour context — drop-in conversational assistant powered by Vercel AI SDK with vector search.
+> React AI chat widget with RAG & tour context — a drop-in conversational assistant, built as a UI + orchestration layer over the Vercel AI SDK.
 
 [![npm version](https://img.shields.io/npm/v/@tour-kit/ai.svg)](https://www.npmjs.com/package/@tour-kit/ai)
 [![npm downloads](https://img.shields.io/npm/dm/@tour-kit/ai.svg)](https://www.npmjs.com/package/@tour-kit/ai)

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -20,7 +20,7 @@ Drop-in **AI chat assistant** for React onboarding flows — a **UI + orchestrat
 - **RAG** (Retrieval-Augmented Generation) — retrieval over an in-memory vector store (linear cosine search) via `createInMemoryVectorStore`; swap in a persistent backend with a custom `VectorStoreAdapter`
 - **Suggestion chips** — AI-generated follow-up prompts
 - **Rate limiting** — sliding window on both the client (`AiChatConfig.rateLimit`, UX protection) and the server (`options.rateLimit`, cost protection)
-- **Configurable UI strings** — override any label via `AiChatConfig.strings` (English defaults otherwise)
+- **Configurable UI strings** — override the built-in chat labels (placeholder, title, send, close, stop, empty state, error) via `AiChatConfig.strings` (English defaults otherwise)
 - **Strict client/server split** — server entry never imports React or browser APIs
 - **Vercel AI SDK** — works with OpenAI, Anthropic, Google, Mistral, and any AI SDK provider
 - **TypeScript-first**, supports React 18 & 19

--- a/packages/ai/src/__tests__/context/ai-chat-provider.test.tsx
+++ b/packages/ai/src/__tests__/context/ai-chat-provider.test.tsx
@@ -75,7 +75,7 @@ describe('AiChatProvider — client trio WIRE (US-4)', () => {
     expect(result.current.strings.title).toBe('Helpdesk')
     expect(result.current.strings.placeholder).toBe('Ask away')
     // …unset keys fall back to DEFAULT_STRINGS (today's shipped text)
-    expect(result.current.strings.send).toBe('Send')
+    expect(result.current.strings.send).toBe('Send message')
     expect(result.current.strings.closeLabel).toBe('Close chat')
   })
 

--- a/packages/ai/src/__tests__/core/strings.test.ts
+++ b/packages/ai/src/__tests__/core/strings.test.ts
@@ -11,11 +11,8 @@ describe('DEFAULT_STRINGS', () => {
       'errorMessage',
       'emptyState',
       'stopGenerating',
-      'retry',
       'title',
       'closeLabel',
-      'ratePositiveLabel',
-      'rateNegativeLabel',
     ]
     for (const key of requiredKeys) {
       expect(DEFAULT_STRINGS).toHaveProperty(key)
@@ -31,9 +28,9 @@ describe('DEFAULT_STRINGS', () => {
 
   it('has English defaults that mirror the shipped UI literals', () => {
     expect(DEFAULT_STRINGS.placeholder).toBe('Type a message...')
-    expect(DEFAULT_STRINGS.send).toBe('Send')
+    expect(DEFAULT_STRINGS.send).toBe('Send message')
     expect(DEFAULT_STRINGS.errorMessage).toBe('Something went wrong. Please try again.')
-    expect(DEFAULT_STRINGS.emptyState).toBe('How can I help you?')
+    expect(DEFAULT_STRINGS.emptyState).toBe('Ask me anything!')
     expect(DEFAULT_STRINGS.title).toBe('AI Assistant')
   })
 })
@@ -57,15 +54,12 @@ describe('resolveStrings', () => {
   it('overrides a single field while keeping all other defaults', () => {
     const strings = resolveStrings({ placeholder: 'Custom placeholder' })
     expect(strings.placeholder).toBe('Custom placeholder')
-    expect(strings.send).toBe('Send')
+    expect(strings.send).toBe('Send message')
     expect(strings.errorMessage).toBe('Something went wrong. Please try again.')
-    expect(strings.emptyState).toBe('How can I help you?')
+    expect(strings.emptyState).toBe('Ask me anything!')
     expect(strings.stopGenerating).toBe('Stop generating')
-    expect(strings.retry).toBe('Retry')
     expect(strings.title).toBe('AI Assistant')
     expect(strings.closeLabel).toBe('Close chat')
-    expect(strings.ratePositiveLabel).toBe('Helpful')
-    expect(strings.rateNegativeLabel).toBe('Not helpful')
   })
 
   it('overrides multiple fields simultaneously', () => {
@@ -78,7 +72,7 @@ describe('resolveStrings', () => {
     expect(strings.send).toBe('Submit')
     expect(strings.title).toBe('Help')
     expect(strings.errorMessage).toBe(DEFAULT_STRINGS.errorMessage)
-    expect(strings.retry).toBe(DEFAULT_STRINGS.retry)
+    expect(strings.emptyState).toBe(DEFAULT_STRINGS.emptyState)
   })
 
   it('overrides all fields at once', () => {
@@ -88,11 +82,8 @@ describe('resolveStrings', () => {
       errorMessage: 'e',
       emptyState: 'em',
       stopGenerating: 'sg',
-      retry: 'r',
       title: 't',
       closeLabel: 'cl',
-      ratePositiveLabel: 'rp',
-      rateNegativeLabel: 'rn',
     }
     const strings = resolveStrings(custom)
     expect(strings).toEqual(custom)

--- a/packages/ai/src/__tests__/coverage-gaps/components-coverage.test.tsx
+++ b/packages/ai/src/__tests__/coverage-gaps/components-coverage.test.tsx
@@ -184,4 +184,48 @@ describe('Component coverage gaps', () => {
       expect(container.querySelector('[role="log"]')).toBeNull()
     })
   })
+
+  // Guards that the components READ the resolved strings instead of hardcoding
+  // them — a regression that re-inlines a literal passes every provider test
+  // (those check resolution) but fails here (these check consumption).
+  describe('wired strings consumption (guard)', () => {
+    it('AiChatInput labels the send button from strings.send', async () => {
+      mockUseAiChat.mockReturnValue(
+        buildChatState({ status: 'ready', strings: { ...DEFAULT_STRINGS, send: 'Envoyer' } })
+      )
+      const { AiChatInput } = await import('../../components/ai-chat-input')
+      render(<AiChatInput />)
+
+      // Icon-only submit button — its accessible name must come from config.
+      expect(screen.getByRole('button', { name: 'Envoyer' })).toBeDefined()
+    })
+
+    it('AiChatPanel falls back to strings.emptyState when no prop is given', async () => {
+      mockUseAiChat.mockReturnValue(
+        buildChatState({
+          isOpen: true,
+          messages: [],
+          strings: { ...DEFAULT_STRINGS, emptyState: 'Comment puis-je aider ?' },
+        })
+      )
+      const { AiChatPanel } = await import('../../components/ai-chat-panel')
+      render(<AiChatPanel showSuggestions={false} />)
+
+      expect(await screen.findByText('Comment puis-je aider ?')).toBeDefined()
+    })
+
+    it('AiChatPanel: an explicit emptyState prop still wins over strings', async () => {
+      mockUseAiChat.mockReturnValue(
+        buildChatState({
+          isOpen: true,
+          messages: [],
+          strings: { ...DEFAULT_STRINGS, emptyState: 'from-strings' },
+        })
+      )
+      const { AiChatPanel } = await import('../../components/ai-chat-panel')
+      render(<AiChatPanel showSuggestions={false} emptyState="from-prop" />)
+
+      expect(await screen.findByText('from-prop')).toBeDefined()
+    })
+  })
 })

--- a/packages/ai/src/components/ai-chat-input.tsx
+++ b/packages/ai/src/components/ai-chat-input.tsx
@@ -54,7 +54,7 @@ export function AiChatInput({ className, placeholder, disabled }: AiChatInputPro
           type="submit"
           disabled={isDisabled || !value.trim()}
           className="shrink-0 rounded-md p-1 text-muted-foreground hover:text-foreground transition-colors disabled:opacity-30"
-          aria-label="Send message"
+          aria-label={strings.send}
         >
           <svg
             width="12"

--- a/packages/ai/src/components/ai-chat-panel.tsx
+++ b/packages/ai/src/components/ai-chat-panel.tsx
@@ -27,13 +27,15 @@ export function AiChatPanel({
   size = 'default',
   position = 'bottom-right',
   title,
-  emptyState = 'Ask me anything!',
+  emptyState,
   showSuggestions = true,
   className,
   children,
   renderMessage,
 }: AiChatPanelProps) {
-  const { isOpen, close } = useAiChat()
+  const { isOpen, close, strings } = useAiChat()
+  // Explicit prop wins; otherwise fall back to the resolved config string.
+  const resolvedEmptyState = emptyState ?? strings.emptyState
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -69,7 +71,7 @@ export function AiChatPanel({
           <>
             <AiChatHeader title={title} />
             <div className="py-3">
-              <AiChatMessageList emptyState={emptyState} renderMessage={renderMessage} />
+              <AiChatMessageList emptyState={resolvedEmptyState} renderMessage={renderMessage} />
             </div>
             {showSuggestions && <AiChatSuggestions className="px-0 pb-2" />}
             <div className="border-t pt-3">

--- a/packages/ai/src/context/ai-chat-provider.tsx
+++ b/packages/ai/src/context/ai-chat-provider.tsx
@@ -7,7 +7,7 @@ import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } fro
 import { type SlidingWindowRateLimiter, createRateLimiter } from '../core/rate-limiter'
 import { resolveStrings } from '../core/strings'
 import { usePersistence } from '../hooks/use-persistence'
-import type { AiChatConfig, AiChatStrings, ChatStatus } from '../types'
+import type { AiChatConfig, AiChatEvent, AiChatStrings, ChatStatus } from '../types'
 import { AiChatContext, type AiChatContextValue } from './ai-chat-context'
 
 interface AiChatProviderProps {
@@ -40,30 +40,23 @@ export function AiChatProvider({ config, children, tourContextValue }: AiChatPro
     [config.endpoint]
   )
 
-  const chatHelpers = useChat({
-    transport,
-    onFinish: ({ message }) => {
+  // Single funnel for every analytics event: stamp the timestamp and swallow any
+  // onEvent error so a misbehaving callback can never break the chat.
+  const emit = useCallback(
+    (type: AiChatEvent['type'], data: Record<string, unknown>) => {
       try {
-        config.onEvent?.({
-          type: 'response_received',
-          data: { messageId: message.id },
-          timestamp: new Date(),
-        })
+        config.onEvent?.({ type, data, timestamp: new Date() })
       } catch {
         // onEvent errors must never break chat
       }
     },
-    onError: (error) => {
-      try {
-        config.onEvent?.({
-          type: 'error',
-          data: { message: error.message },
-          timestamp: new Date(),
-        })
-      } catch {
-        // swallow
-      }
-    },
+    [config]
+  )
+
+  const chatHelpers = useChat({
+    transport,
+    onFinish: ({ message }) => emit('response_received', { messageId: message.id }),
+    onError: (error) => emit('error', { message: error.message }),
   })
 
   // Keep a ref to chatHelpers so callbacks always use the latest version.
@@ -124,29 +117,13 @@ export function AiChatProvider({ config, children, tourContextValue }: AiChatPro
       // Client rate limit: when at cap, surface a rate-limited error and do not
       // forward to the transport (protects the user's API spend / UX).
       if (limiterRef.current && !limiterRef.current.recordMessage()) {
-        try {
-          config.onEvent?.({
-            type: 'error',
-            data: { reason: 'rate_limited', message: strings.errorMessage },
-            timestamp: new Date(),
-          })
-        } catch {
-          // onEvent errors must never break chat
-        }
+        emit('error', { reason: 'rate_limited', message: strings.errorMessage })
         return
       }
-      try {
-        config.onEvent?.({
-          type: 'message_sent',
-          data: { text: input.text },
-          timestamp: new Date(),
-        })
-      } catch {
-        // onEvent errors must never break chat
-      }
+      emit('message_sent', { text: input.text })
       helpersRef.current.sendMessage({ text: input.text })
     },
-    [config, strings]
+    [emit, strings]
   )
 
   const stop = useCallback(() => {
@@ -169,29 +146,13 @@ export function AiChatProvider({ config, children, tourContextValue }: AiChatPro
 
   const open = useCallback(() => {
     setIsOpen(true)
-    try {
-      config.onEvent?.({
-        type: 'chat_opened',
-        data: {},
-        timestamp: new Date(),
-      })
-    } catch {
-      // swallow
-    }
-  }, [config])
+    emit('chat_opened', {})
+  }, [emit])
 
   const close = useCallback(() => {
     setIsOpen(false)
-    try {
-      config.onEvent?.({
-        type: 'chat_closed',
-        data: {},
-        timestamp: new Date(),
-      })
-    } catch {
-      // swallow
-    }
-  }, [config])
+    emit('chat_closed', {})
+  }, [emit])
 
   const toggle = useCallback(() => {
     setIsOpen((prev) => !prev)

--- a/packages/ai/src/core/strings.ts
+++ b/packages/ai/src/core/strings.ts
@@ -1,19 +1,17 @@
 import type { AiChatStrings } from '../types'
 
-// Single source of truth for the chat UI's English copy. Values mirror what the
-// components shipped as inline literals before Slice 4 wired this in, so an
-// unset `config.strings` renders exactly today's text.
+// Single source of truth for the chat UI's English copy. Every key maps to a
+// label the shipped components actually render; values mirror the inline
+// literals from before Slice 4 wired this in, so an unset `config.strings`
+// renders exactly today's text.
 export const DEFAULT_STRINGS: AiChatStrings = {
   placeholder: 'Type a message...',
-  send: 'Send',
+  send: 'Send message',
   errorMessage: 'Something went wrong. Please try again.',
-  emptyState: 'How can I help you?',
+  emptyState: 'Ask me anything!',
   stopGenerating: 'Stop generating',
-  retry: 'Retry',
   title: 'AI Assistant',
   closeLabel: 'Close chat',
-  ratePositiveLabel: 'Helpful',
-  rateNegativeLabel: 'Not helpful',
 }
 
 /**

--- a/packages/ai/src/types/config.ts
+++ b/packages/ai/src/types/config.ts
@@ -51,26 +51,20 @@ export interface ClientRateLimitConfig {
 }
 
 export interface AiChatStrings {
-  /** Input placeholder text */
+  /** Input placeholder text (`AiChatInput`) */
   placeholder: string
-  /** Send button label */
+  /** Send button accessible name (`AiChatInput`, icon-only button) */
   send: string
-  /** Error message shown to user */
+  /** Error message shown to the user (also used for rate-limit errors) */
   errorMessage: string
-  /** Empty state message */
+  /** Empty-state message (`AiChatPanel` default before any messages) */
   emptyState: string
-  /** Stop generating button label */
+  /** Stop generating button accessible name (`AiChatInput`) */
   stopGenerating: string
-  /** Retry button label */
-  retry: string
-  /** Chat panel title */
+  /** Chat panel title (`AiChatHeader`) */
   title: string
-  /** Close button aria-label */
+  /** Close button accessible name (`AiChatHeader`) */
   closeLabel: string
-  /** Rating positive aria-label */
-  ratePositiveLabel: string
-  /** Rating negative aria-label */
-  rateNegativeLabel: string
 }
 
 // ── Chat State ──


### PR DESCRIPTION
## Why this PR exists

PR #110 merged Slice 4 **without** my last 3 commits (they were never pushed before the merge), and the version PR #111 then published `@tour-kit/ai@0.13.0` from that incomplete state. npm versions are immutable, so this lands the **Finding-1 fix as `0.13.1`** (rebased onto `main` after the `0.13.0` release; the original slice-4 changeset was consumed by #111, so this carries a fresh patch changeset).

`0.13.0` works, but its `config.strings` is only half-honest: the send-button label and `emptyState` are inert, and 3 unbuilt-UI labels are still typed. This completes it.

## What `0.13.1` adds over `0.13.0`

- **Wired `send`** — `AiChatInput`'s icon-only submit button read a hard-coded `aria-label="Send message"`; now reads `strings.send`, so `config.strings.send` applies.
- **Wired `emptyState`** — `AiChatPanel` now falls back to `strings.emptyState` (explicit prop still wins) instead of a literal that ignored config.
- **Removed `retry`, `ratePositiveLabel`, `rateNegativeLabel`** from `AiChatStrings` — labelled a retry/rating UI the package doesn't ship (no component, no `rate()` API, `message_rated` never emitted). They rendered nothing, so removal changes no runtime behavior. `AiChatStrings` is now exactly the 7 labels the components render.
- Drops the residual "vector search" superlative from the README tagline; funnels provider analytics events through one internal `emit()` helper (no API change).
- Adds 2 component guard tests (send label + emptyState fallback) that fail if a label is ever re-hardcoded.
- Syncs README, API reference, and `llms-full.txt`.

## Verification

`typecheck` green; **458 tests** pass (+3 guards); `biome` clean; `ai:client` 4540/5000 gz. Browser-QA'd in `examples/qa-next` (real tarball install): all wired strings render from config, title prop precedence holds, and client `rateLimit` blocks the 3rd send with a `rate_limited` event carrying the configured `errorMessage`.

> Note: the `rag-integration.test.ts` "< 50ms" perf assertion is a known wall-clock flake on shared CI runners (unrelated to this diff) — re-run if it trips.

Bump rationale: **patch**. The substantive change is a bugfix (advertised `config.strings` keys now apply); the only breaking element removes three labels that rendered no UI and had zero runtime path, so no working code breaks.