### PR TITLE
Slice 5 — minor dead-field housekeeping (6 packages)

### DIFF
--- a/.changeset/slice5-adoption-feature-resources.md
+++ b/.changeset/slice5-adoption-feature-resources.md
@@ -1,0 +1,7 @@
+---
+"@tour-kit/adoption": major
+---
+
+Remove the unused `FeatureResources` interface and the `Feature.resources` field, plus their public re-exports from the package barrel and the `types` barrel. These were typed-but-dead — no runtime code ever read `resources`.
+
+Removing a publicly exported type is a breaking change, so this is a major even though no working code depended on it. (Deprecating it in place was rejected: it would leave the dead symbol in the published `.d.ts`, which is exactly the trust problem this change removes.)

--- a/.changeset/slice5-analytics-prune.md
+++ b/.changeset/slice5-analytics-prune.md
@@ -1,0 +1,7 @@
+---
+"@tour-kit/analytics": minor
+---
+
+Remove two typed-but-dead public fields that promised behavior the runtime never delivered: `TourEvent.userProperties` (no production consumer) and `AnalyticsConfig.offlineQueue` (no offline-queue logic exists — the tracker batches only by `batchSize`).
+
+`AnalyticsConfig.userProperties` is unchanged and remains wired: the tracker still passes it to each plugin's `identify()` on init. Pre-1.0, so this breaking type-surface change ships as a minor.

--- a/.changeset/slice5-announcements-schedule.md
+++ b/.changeset/slice5-announcements-schedule.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/announcements": minor
+---
+
+Type and wire `AnnouncementConfig.schedule`. It was declared `unknown` with a comment claiming "the provider handles that integration" — it didn't. It is now typed `Schedule` (from the optional `@tour-kit/scheduling` peer) and evaluated in `AnnouncementScheduler.canShow`, which gains an optional `now` parameter. The peer is resolved lazily and degrades open when scheduling isn't installed, so it remains a true optional peer. Additive change.

--- a/.changeset/slice5-checklists-prune.md
+++ b/.changeset/slice5-checklists-prune.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/checklists": minor
+---
+
+Remove two typed-but-dead fields: `ChecklistTaskState.active` (always `false` — the provider hardcoded it and no updater ever set it true) and `ChecklistProviderConfig.tourKitIntegration` (never read by the provider). The `{ type: 'tour' }` task action and its handler are unaffected. Pre-1.0, so this breaking type-surface change ships as a minor.

--- a/.changeset/slice5-scheduling-recurrence.md
+++ b/.changeset/slice5-scheduling-recurrence.md
@@ -1,0 +1,7 @@
+---
+"@tour-kit/scheduling": minor
+---
+
+Implement `RecurringPattern.maxOccurrences`, which was typed but never enforced. `matchesRecurringPattern` now counts occurrences from `startDate` in the schedule timezone and stops matching once the cap is reached. The count is arithmetic and short-circuits at the cap — no date enumeration — so it stays within the gzip budget.
+
+Remove the unimplemented `ScheduleStatus.nextInactiveAt`: `getScheduleStatus` only ever predicted `nextActiveAt`, so the field promised an active→inactive prediction the runtime never produced. Pre-1.0 breaking type-surface change → minor.

--- a/.changeset/slice5-surveys-schedule.md
+++ b/.changeset/slice5-surveys-schedule.md
@@ -1,0 +1,5 @@
+---
+"@tour-kit/surveys": minor
+---
+
+Type and wire `SurveyConfig.schedule`. It was declared `unknown` and never consulted; it is now typed `Schedule` (from the optional `@tour-kit/scheduling` peer) and evaluated in `SurveyScheduler.canShow` — an inactive schedule now suppresses the survey. The peer is resolved lazily and degrades open (content still shows) when scheduling isn't installed, so it remains a true optional peer. Additive change.

--- a/apps/docs/content/docs/adoption/providers/adoption-provider.mdx
+++ b/apps/docs/content/docs/adoption/providers/adoption-provider.mdx
@@ -156,10 +156,6 @@ const feature = {
       default: 'false',
       description: 'Whether this is a premium feature',
     },
-    resources: {
-      type: 'FeatureResources',
-      description: 'Related tour/hint IDs',
-    },
   }}
 />
 

--- a/apps/docs/content/docs/adoption/types.mdx
+++ b/apps/docs/content/docs/adoption/types.mdx
@@ -24,7 +24,6 @@ interface Feature {
   name: string
   trigger: FeatureTrigger
   adoptionCriteria?: AdoptionCriteria
-  resources?: FeatureResources
   priority?: number
   category?: string
   description?: string
@@ -52,10 +51,6 @@ interface Feature {
     adoptionCriteria: {
       type: 'AdoptionCriteria',
       description: 'When feature is considered adopted',
-    },
-    resources: {
-      type: 'FeatureResources',
-      description: 'Related tour/hint resources',
     },
     priority: {
       type: 'number',
@@ -127,28 +122,6 @@ interface AdoptionCriteria {
     custom: {
       type: '(usage: FeatureUsage) => boolean',
       description: 'Custom adoption logic',
-    },
-  }}
-/>
-
-### FeatureResources
-
-```ts
-interface FeatureResources {
-  tourId?: string
-  hintIds?: string[]
-}
-```
-
-<TypeTable
-  type={{
-    tourId: {
-      type: 'string',
-      description: 'Tour ID from @tour-kit/react',
-    },
-    hintIds: {
-      type: 'string[]',
-      description: 'Hint IDs from @tour-kit/hints',
     },
   }}
 />

--- a/apps/docs/content/docs/analytics/providers/index.mdx
+++ b/apps/docs/content/docs/analytics/providers/index.mdx
@@ -64,11 +64,6 @@ export default function RootLayout({ children }) {
       default: 'false',
       description: 'Enable debug logging to console'
     },
-    offlineQueue: {
-      type: 'boolean',
-      default: 'false',
-      description: 'Queue events when offline and send when reconnected'
-    },
     batchSize: {
       type: 'number',
       default: 'undefined',

--- a/apps/docs/content/docs/analytics/types.mdx
+++ b/apps/docs/content/docs/analytics/types.mdx
@@ -77,9 +77,6 @@ interface TourEvent {
   /** User identifier (if known) */
   userId?: string
 
-  /** Additional user properties */
-  userProperties?: Record<string, unknown>
-
   /** Duration in milliseconds */
   duration?: number
 
@@ -197,9 +194,6 @@ interface AnalyticsConfig {
 
   /** Enable debug logging to console */
   debug?: boolean
-
-  /** Queue events when offline */
-  offlineQueue?: boolean
 
   /** Batch events before sending */
   batchSize?: number

--- a/apps/docs/content/docs/api/adoption.mdx
+++ b/apps/docs/content/docs/api/adoption.mdx
@@ -284,7 +284,6 @@ interface Feature {
   name: string;
   trigger: string | { event: string } | (() => void);
   adoptionCriteria?: AdoptionCriteria;
-  resources?: FeatureResources;
   priority?: number;
   category?: string;
   description?: string;

--- a/apps/docs/content/docs/checklists/hooks/use-checklist.mdx
+++ b/apps/docs/content/docs/checklists/hooks/use-checklist.mdx
@@ -400,7 +400,6 @@ interface ChecklistTaskState {
   completed: boolean;           // Completion status
   locked: boolean;              // Whether dependencies are met
   visible: boolean;             // Whether when condition passed
-  active: boolean;              // Currently in progress (future)
   completedAt?: number;         // Timestamp of completion
 }
 ```

--- a/apps/docs/content/docs/checklists/types.mdx
+++ b/apps/docs/content/docs/checklists/types.mdx
@@ -78,7 +78,6 @@ interface ChecklistTaskState {
   completed: boolean;
   locked: boolean;
   visible: boolean;
-  active: boolean;
   completedAt?: number;
 }
 ```

--- a/apps/docs/content/docs/scheduling/hooks/index.mdx
+++ b/apps/docs/content/docs/scheduling/hooks/index.mdx
@@ -93,7 +93,7 @@ function FeatureAnnouncement() {
 import { useScheduleStatus } from '@tour-kit/scheduling'
 
 function TourScheduleStatus() {
-  const { isActive, message, nextActiveAt, nextInactiveAt } = useScheduleStatus(schedule, {
+  const { isActive, message, nextActiveAt } = useScheduleStatus(schedule, {
     debug: true,
   })
 
@@ -102,7 +102,6 @@ function TourScheduleStatus() {
       <p>Status: {isActive ? 'Active' : 'Inactive'}</p>
       {message && <p>{message}</p>}
       {nextActiveAt && <p>Next active: {nextActiveAt.toLocaleString()}</p>}
-      {nextInactiveAt && <p>Next inactive: {nextInactiveAt.toLocaleString()}</p>}
     </div>
   )
 }

--- a/apps/docs/content/docs/scheduling/hooks/use-schedule-status.mdx
+++ b/apps/docs/content/docs/scheduling/hooks/use-schedule-status.mdx
@@ -68,8 +68,6 @@ interface UseScheduleStatusReturn extends ScheduleStatus {
   message?: string
   /** When the schedule will next become active */
   nextActiveAt?: Date
-  /** When the schedule will next become inactive */
-  nextInactiveAt?: Date
   /** Current blackout period if in one */
   currentBlackout?: {
     id: string
@@ -141,12 +139,13 @@ function NextActiveDisplay() {
 
 ```tsx
 function TourCountdown() {
-  const { isActive, nextActiveAt, nextInactiveAt } = useScheduleStatus(schedule, {
+  const { isActive, nextActiveAt } = useScheduleStatus(schedule, {
     refreshInterval: 1000, // Update every second
   })
 
-  const targetTime = isActive ? nextInactiveAt : nextActiveAt
-  if (!targetTime) return null
+  // Counts down to when the schedule next becomes active.
+  if (isActive || !nextActiveAt) return null
+  const targetTime = nextActiveAt
 
   const now = new Date()
   const msRemaining = targetTime.getTime() - now.getTime()
@@ -249,12 +248,6 @@ function TourScheduleDashboard({ tourId, schedule }: Props) {
       {status.nextActiveAt && (
         <div>
           <strong>Next Active:</strong> {status.nextActiveAt.toLocaleString()}
-        </div>
-      )}
-
-      {status.nextInactiveAt && (
-        <div>
-          <strong>Next Inactive:</strong> {status.nextInactiveAt.toLocaleString()}
         </div>
       )}
 

--- a/apps/docs/content/docs/scheduling/types.mdx
+++ b/apps/docs/content/docs/scheduling/types.mdx
@@ -279,9 +279,6 @@ interface ScheduleStatus {
   /** When the schedule will next become active */
   nextActiveAt?: Date
 
-  /** When the schedule will next become inactive */
-  nextInactiveAt?: Date
-
   /** Current blackout period if in one */
   currentBlackout?: {
     id: string

--- a/apps/docs/content/docs/scheduling/utilities/recurring.mdx
+++ b/apps/docs/content/docs/scheduling/utilities/recurring.mdx
@@ -190,7 +190,7 @@ const schedule = {
 }
 ```
 
-Note: `maxOccurrences` is not currently implemented in the evaluation but is part of the type for future use.
+`maxOccurrences` caps the recurrence: once the pattern has fired that many times from the schedule's `startAt`, `matchesRecurringPattern` stops matching. Occurrences are counted in the schedule's timezone, so the cap honors the same timezone as the rest of the schedule. It requires a start date to count from (the schedule's `startAt`).
 
 ### End Date
 

--- a/apps/docs/content/docs/scheduling/utilities/schedule-evaluation.mdx
+++ b/apps/docs/content/docs/scheduling/utilities/schedule-evaluation.mdx
@@ -185,8 +185,6 @@ interface ScheduleStatus {
   message?: string
   /** When the schedule will next become active */
   nextActiveAt?: Date
-  /** When the schedule will next become inactive */
-  nextInactiveAt?: Date
   /** Current blackout period if in one */
   currentBlackout?: {
     id: string
@@ -210,7 +208,7 @@ interface ScheduleStatus {
 const status = getScheduleStatus(schedule)
 
 if (status.isActive) {
-  console.log('Active until:', status.nextInactiveAt)
+  console.log('Active now')
 } else {
   console.log(status.message)
   console.log('Available again:', status.nextActiveAt)

--- a/apps/docs/content/docs/surveys/types.mdx
+++ b/apps/docs/content/docs/surveys/types.mdx
@@ -36,7 +36,7 @@ interface SurveyConfig {
   description?: string | ReactNode;
   questions: QuestionConfig[];
   frequency?: FrequencyRule;
-  schedule?: unknown;           // requires @tour-kit/scheduling
+  schedule?: Schedule;          // from @tour-kit/scheduling (optional peer)
   audience?: AudienceCondition[];
   globalCooldownDays?: number;
   samplingRate?: number;        // 0–1

--- a/packages/adoption/README.md
+++ b/packages/adoption/README.md
@@ -230,7 +230,6 @@ import type {
   Feature,
   FeatureTrigger,
   AdoptionCriteria,
-  FeatureResources,
   FeatureUsage,
   AdoptionStatus,
   FeatureWithUsage,

--- a/packages/adoption/src/index.ts
+++ b/packages/adoption/src/index.ts
@@ -75,7 +75,6 @@ export type {
   Feature,
   FeatureTrigger,
   AdoptionCriteria,
-  FeatureResources,
   FeatureUsage,
   AdoptionStatus,
   FeatureWithUsage,

--- a/packages/adoption/src/types/__tests__/feature-resources.guard.test.ts
+++ b/packages/adoption/src/types/__tests__/feature-resources.guard.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Slice 5 (D3) — `FeatureResources` and `Feature.resources` were typed-but-dead
+ * (no runtime consumer) and PUBLICLY re-exported from two barrels
+ * (`index.ts`, `types/index.ts`). A `@ts-expect-error` in a test file is not
+ * enforced here (the package `typecheck` excludes tests and vitest does not
+ * typecheck), so the deletion is proven the same way `no-zod-in-main.test.ts`
+ * proves a dependency is gone: a recursive source scan. The interface name is
+ * referenced by the interface decl, the field type, and both re-exports, so a
+ * single "no `FeatureResources` anywhere in src" assertion covers all four.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const SRC = join(here, '../../') // types/__tests__ -> types -> src
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') continue // scan production src only
+      out.push(...collectTsFiles(full))
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+describe('Slice 5 deletion guard — FeatureResources is gone (D3)', () => {
+  const files = collectTsFiles(SRC)
+
+  it('finds zero occurrences of FeatureResources across adoption/src', () => {
+    const offenders = files.filter((f) => /FeatureResources/.test(readFileSync(f, 'utf8')))
+    expect(offenders).toEqual([])
+  })
+
+  it('Feature no longer carries a resources field (feature.ts)', () => {
+    const feature = readFileSync(join(SRC, 'types/feature.ts'), 'utf8')
+    expect(feature).not.toMatch(/resources\?:/)
+  })
+})

--- a/packages/adoption/src/types/feature.ts
+++ b/packages/adoption/src/types/feature.ts
@@ -32,16 +32,6 @@ export interface AdoptionCriteria {
 }
 
 /**
- * Related TourKit resources for this feature
- */
-export interface FeatureResources {
-  /** Tour ID to trigger for feature discovery */
-  tourId?: string
-  /** Hint IDs to show as nudges */
-  hintIds?: string[]
-}
-
-/**
  * Feature definition
  */
 export interface Feature {
@@ -56,9 +46,6 @@ export interface Feature {
 
   /** When is feature considered adopted */
   adoptionCriteria?: AdoptionCriteria
-
-  /** Related tours/hints */
-  resources?: FeatureResources
 
   /**
    * Feature priority for nudging (higher = more important)

--- a/packages/adoption/src/types/index.ts
+++ b/packages/adoption/src/types/index.ts
@@ -4,7 +4,6 @@ export type {
   Feature,
   FeatureTrigger,
   AdoptionCriteria,
-  FeatureResources,
   FeatureUsage,
   AdoptionStatus,
   FeatureWithUsage,

--- a/packages/analytics/src/core/__tests__/tracker.test.ts
+++ b/packages/analytics/src/core/__tests__/tracker.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it, vi } from 'vitest'
+import type { AnalyticsPlugin } from '../../types/plugin'
+import { TourAnalytics } from '../tracker'
+
+/**
+ * Slice 5 — the `userProperties` live-vs-dead trap, guarded in ONE file.
+ *
+ * Two sibling fields named `userProperties` sit two declarations apart across
+ * two files:
+ *   - `TourEvent.userProperties`        (events.ts)  — DEAD, deleted in Slice 5.
+ *   - `AnalyticsConfig.userProperties`  (plugin.ts)  — ALIVE, must stay.
+ *     `tracker.ts` passes it to `identify()` inside `init()`.
+ *
+ * Keeping the deletion guard (D1/D2) and the live-field behaviour spy (K1) in
+ * the same file makes it impossible to delete the dead one and silently regress
+ * the alive one in the same cleanup pass.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const read = (rel: string) => readFileSync(join(here, rel), 'utf8')
+
+/** Minimal plugin whose lifecycle methods are spies. */
+function spyPlugin(): AnalyticsPlugin {
+  return { name: 'spy', track: vi.fn(), identify: vi.fn() }
+}
+
+describe('TourAnalytics — AnalyticsConfig.userProperties is ALIVE (K1, do not delete)', () => {
+  it('passes config.userProperties to plugin.identify() on init', async () => {
+    const plugin = spyPlugin()
+    // init() awaits plugin `init`, then calls identify(userId, userProperties)
+    // fire-and-forget on a microtask — assert async, never synchronously.
+    new TourAnalytics({ plugins: [plugin], userId: 'u', userProperties: { plan: 'pro' } })
+
+    await vi.waitFor(() => expect(plugin.identify).toHaveBeenCalledWith('u', { plan: 'pro' }))
+  })
+
+  it('does not call identify() when no userId is configured', async () => {
+    const plugin = spyPlugin()
+    new TourAnalytics({ plugins: [plugin], userProperties: { plan: 'pro' } })
+    // Give init()'s microtask a chance to run before asserting the negative.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(plugin.identify).not.toHaveBeenCalled()
+  })
+})
+
+describe('Slice 5 deletion guards — dead userProperties / offlineQueue are gone (D1/D2)', () => {
+  it('TourEvent no longer declares userProperties (events.ts)', () => {
+    expect(read('../../types/events.ts')).not.toMatch(/userProperties/)
+  })
+
+  it('AnalyticsConfig STILL declares userProperties — the kept live field (plugin.ts)', () => {
+    // Defends the KEEP verdict from a future over-zealous scan-and-delete.
+    expect(read('../../types/plugin.ts')).toMatch(/userProperties\?: Record<string, unknown>/)
+  })
+
+  it('offlineQueue is gone from the config type and the tracker (plugin.ts, tracker.ts)', () => {
+    expect(read('../../types/plugin.ts')).not.toMatch(/offlineQueue/)
+    expect(read('../tracker.ts')).not.toMatch(/offlineQueue/)
+  })
+})

--- a/packages/analytics/src/types/events.ts
+++ b/packages/analytics/src/types/events.ts
@@ -58,9 +58,6 @@ export interface TourEvent {
   /** User identifier (if known) */
   userId?: string
 
-  /** Additional user properties */
-  userProperties?: Record<string, unknown>
-
   /** Duration in milliseconds */
   duration?: number
 

--- a/packages/analytics/src/types/plugin.ts
+++ b/packages/analytics/src/types/plugin.ts
@@ -37,9 +37,6 @@ export interface AnalyticsConfig {
   /** Enable debug logging to console */
   debug?: boolean
 
-  /** Queue events when offline */
-  offlineQueue?: boolean
-
   /** Batch events before sending */
   batchSize?: number
 

--- a/packages/announcements/src/core/__tests__/scheduler-degrade-open.test.ts
+++ b/packages/announcements/src/core/__tests__/scheduler-degrade-open.test.ts
@@ -1,0 +1,50 @@
+import type { Schedule } from '@tour-kit/scheduling'
+import { describe, expect, it } from 'vitest'
+import { resolveScheduleActive } from '../resolve-schedule'
+
+/**
+ * Slice 5 (W2, US-4) — degrade-open contract.
+ *
+ * `@tour-kit/scheduling` is an OPTIONAL peer. When it is absent (or fails to
+ * load) the resolver must DEGRADE OPEN — return `true` — so content is NOT
+ * suppressed merely because the consumer skipped the optional dependency.
+ *
+ * The peer-absent state is simulated through the resolver's injectable loader
+ * seam rather than `vi.mock`, because the production loader reaches scheduling
+ * via a CJS `require` that the module mock does not intercept. The matrix in
+ * `scheduler.test.ts` proves the real eval is wired; this proves the failure
+ * mode degrades open.
+ */
+
+// A schedule that WOULD be inactive if scheduling were available.
+const INACTIVE: Schedule = { enabled: false }
+const NOW = new Date('2025-06-16T14:30:00Z')
+
+describe('resolveScheduleActive — degrades open when the scheduling peer is absent (W2)', () => {
+  it('returns true when the peer cannot be loaded (loader → null)', () => {
+    expect(resolveScheduleActive(INACTIVE, NOW, () => null)).toBe(true)
+  })
+
+  it('returns true when loading the peer throws', () => {
+    expect(
+      resolveScheduleActive(INACTIVE, NOW, () => {
+        throw new Error('peer not installed')
+      })
+    ).toBe(true)
+  })
+
+  it('returns true when the loaded peer eval itself throws (defensive)', () => {
+    expect(
+      resolveScheduleActive(INACTIVE, NOW, () => ({
+        isScheduleActive: () => {
+          throw new Error('boom')
+        },
+      }))
+    ).toBe(true)
+  })
+
+  it('still gates for real when the peer IS present (default loader)', () => {
+    // Sanity: with the real scheduling util, an inactive schedule suppresses.
+    expect(resolveScheduleActive(INACTIVE, NOW)).toBe(false)
+  })
+})

--- a/packages/announcements/src/core/__tests__/scheduler.test.ts
+++ b/packages/announcements/src/core/__tests__/scheduler.test.ts
@@ -1,0 +1,59 @@
+import type { Schedule } from '@tour-kit/scheduling'
+import { describe, expect, it } from 'vitest'
+import type { AnnouncementConfig, AnnouncementState } from '../../types/announcement'
+import { AnnouncementScheduler } from '../scheduler'
+
+/**
+ * Slice 5 (W2) — `AnnouncementConfig.schedule` is wired, not deleted.
+ *
+ * `scheduler.ts` used to carry the comment "Schedule check would be done
+ * externally with @tour-kit/scheduling / The provider handles that
+ * integration" — it never did. This wires the real eval into `canShow` (which
+ * also gains a `now` param) and fires the REAL `@tour-kit/scheduling` util.
+ * The degrade-open path (peer absent ⇒ not suppressed) lives in
+ * `scheduler-degrade-open.test.ts`, which mocks scheduling to throw.
+ */
+
+const NOW = new Date('2025-06-16T14:30:00Z')
+
+const baseState = (): AnnouncementState =>
+  ({ id: 'a1', isDismissed: false, completedAt: null, viewCount: 0 }) as AnnouncementState
+
+const baseConfig = (schedule?: Schedule): AnnouncementConfig =>
+  ({
+    id: 'a1',
+    variant: 'banner',
+    frequency: 'always',
+    ...(schedule ? { schedule } : {}),
+  }) as AnnouncementConfig
+
+function newScheduler() {
+  return new AnnouncementScheduler({
+    maxConcurrent: 1,
+    delayBetween: 0,
+    autoShow: true,
+  } as never)
+}
+
+describe('AnnouncementScheduler.canShow — schedule wiring (W2)', () => {
+  it('returns false when the schedule is inactive (enabled:false)', () => {
+    const s = newScheduler()
+    expect(s.canShow(baseConfig({ enabled: false }), baseState(), undefined, NOW)).toBe(false)
+  })
+
+  it('returns true when the schedule is active (no constraints)', () => {
+    const s = newScheduler()
+    expect(s.canShow(baseConfig({}), baseState(), undefined, NOW)).toBe(true)
+  })
+
+  it('returns true when schedule is omitted (additive, non-breaking)', () => {
+    const s = newScheduler()
+    expect(s.canShow(baseConfig(), baseState(), undefined, NOW)).toBe(true)
+  })
+
+  it('gates on a timeOfDay window relative to the injected now', () => {
+    const s = newScheduler()
+    const schedule: Schedule = { timezone: 'UTC', timeOfDay: { start: '00:00', end: '01:00' } }
+    expect(s.canShow(baseConfig(schedule), baseState(), undefined, NOW)).toBe(false)
+  })
+})

--- a/packages/announcements/src/core/resolve-schedule.ts
+++ b/packages/announcements/src/core/resolve-schedule.ts
@@ -1,0 +1,56 @@
+import type { Schedule } from '@tour-kit/scheduling'
+
+/**
+ * Resolve an `AnnouncementConfig.schedule` $ref to a real schedule evaluation.
+ *
+ * `@tour-kit/scheduling` is an OPTIONAL peer (`peerDependenciesMeta.optional`),
+ * so it must NOT be a hard module-load import — a consumer who never sets a
+ * `schedule` may not have it installed. We resolve `isScheduleActive` lazily at
+ * call time and DEGRADE OPEN: if the peer is absent (or anything throws) we
+ * return `true`, so content is never suppressed merely because the optional dep
+ * is missing. The field is only read when `config.schedule` is set, by which
+ * point a correct consumer already depends on scheduling for the `Schedule`
+ * type itself.
+ *
+ * Note: in a pure-ESM browser bundle without a `require` shim this degrades
+ * open (the schedule is treated as active). CJS, bundlers that provide
+ * `require`, and the test runner all resolve it for real.
+ */
+type IsScheduleActive = (schedule: Schedule, options: { now: Date }) => { isActive: boolean }
+
+interface SchedulingModule {
+  isScheduleActive: IsScheduleActive
+}
+
+// Reached through a runtime require so `@tour-kit/scheduling` stays optional.
+// Typed locally because these browser packages don't pull in `@types/node`.
+declare const require: undefined | ((id: string) => unknown)
+
+/** Load the optional scheduling peer, or `null` if it isn't installed. */
+export function loadScheduling(): SchedulingModule | null {
+  if (typeof require !== 'function') return null
+  try {
+    const mod = require('@tour-kit/scheduling') as Partial<SchedulingModule>
+    return typeof mod.isScheduleActive === 'function' ? (mod as SchedulingModule) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * `load` is injectable purely as a test seam for the degrade-open contract; in
+ * production it defaults to {@link loadScheduling}.
+ */
+export function resolveScheduleActive(
+  schedule: Schedule,
+  now: Date,
+  load: () => SchedulingModule | null = loadScheduling
+): boolean {
+  try {
+    const scheduling = load()
+    if (!scheduling) return true // optional peer absent → don't suppress content
+    return scheduling.isScheduleActive(schedule, { now }).isActive
+  } catch {
+    return true // any failure degrades open — never suppress on the optional path
+  }
+}

--- a/packages/announcements/src/core/scheduler.ts
+++ b/packages/announcements/src/core/scheduler.ts
@@ -3,6 +3,7 @@ import type { QueueConfig } from '../types/queue'
 import { matchesAudience } from './audience'
 import { canShowByFrequency } from './frequency'
 import { PriorityQueue } from './priority-queue'
+import { resolveScheduleActive } from './resolve-schedule'
 
 /**
  * Announcement scheduler manages the queue and determines when announcements should show
@@ -23,7 +24,8 @@ export class AnnouncementScheduler {
   canShow(
     config: AnnouncementConfig,
     state: AnnouncementState,
-    userContext?: Record<string, unknown>
+    userContext?: Record<string, unknown>,
+    now: Date = new Date()
   ): boolean {
     if (state.isDismissed) {
       return false
@@ -52,8 +54,12 @@ export class AnnouncementScheduler {
       return false
     }
 
-    // Schedule check would be done externally with @tour-kit/scheduling
-    // The provider handles that integration
+    // Schedule gating via the optional @tour-kit/scheduling peer. The resolver
+    // degrades open (returns true) when the peer is absent, so wiring this never
+    // turns scheduling into a hard dependency.
+    if (config.schedule && !resolveScheduleActive(config.schedule, now)) {
+      return false
+    }
 
     return true
   }

--- a/packages/announcements/src/types/announcement.ts
+++ b/packages/announcements/src/types/announcement.ts
@@ -183,7 +183,7 @@ export interface AnnouncementConfig {
   frequency?: FrequencyRule
 
   /** Schedule configuration (requires @tour-kit/scheduling) */
-  schedule?: unknown // Will be Schedule type from @tour-kit/scheduling
+  schedule?: import('@tour-kit/scheduling').Schedule
 
   /**
    * Audience targeting. Accepts either an inline `AudienceCondition[]` (legacy)

--- a/packages/checklists/src/__tests__/checklist-i18n.test.tsx
+++ b/packages/checklists/src/__tests__/checklist-i18n.test.tsx
@@ -16,7 +16,6 @@ function makeTaskState(overrides: Partial<ChecklistTaskState['config']>): Checkl
     completed: false,
     locked: false,
     visible: true,
-    active: false,
   }
 }
 

--- a/packages/checklists/src/__tests__/checklist-media.test.tsx
+++ b/packages/checklists/src/__tests__/checklist-media.test.tsx
@@ -16,7 +16,6 @@ function makeTaskState(overrides: Partial<ChecklistTaskState['config']>): Checkl
     completed: false,
     locked: false,
     visible: true,
-    active: false,
   }
 }
 

--- a/packages/checklists/src/__tests__/test-utils.tsx
+++ b/packages/checklists/src/__tests__/test-utils.tsx
@@ -205,7 +205,6 @@ export function createMockTaskState(
     completed: false,
     locked: false,
     visible: true,
-    active: false,
     ...stateOverrides,
   }
 }
@@ -432,7 +431,6 @@ export function expectTaskState(
     completed?: boolean
     locked?: boolean
     visible?: boolean
-    active?: boolean
   }
 ) {
   expect(task).toBeDefined()
@@ -446,9 +444,6 @@ export function expectTaskState(
   }
   if (expected.visible !== undefined) {
     expect(task.visible).toBe(expected.visible)
-  }
-  if (expected.active !== undefined) {
-    expect(task.active).toBe(expected.active)
   }
 }
 

--- a/packages/checklists/src/context/checklist-provider.tsx
+++ b/packages/checklists/src/context/checklist-provider.tsx
@@ -59,7 +59,6 @@ function createInitialTaskState(
     completed,
     locked,
     visible,
-    active: false,
     completedAt: completed ? completedAtMap?.[task.id] : undefined,
   }
 }

--- a/packages/checklists/src/types/__tests__/dead-fields.guard.test.ts
+++ b/packages/checklists/src/types/__tests__/dead-fields.guard.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Slice 5 (D4/D5) — two typed-but-dead checklist fields:
+ *   - `ChecklistTaskState.active` (checklist.ts) — always `false`; the provider
+ *     hardcoded `active: false` and no updater ever flipped it.
+ *   - `ChecklistProviderConfig.tourKitIntegration` (config.ts) — never read by
+ *     the provider; the `case 'tour':` task-action arm is a different symbol and
+ *     is left untouched.
+ *
+ * Proven by source scan (the package `typecheck` excludes tests, so an
+ * `@ts-expect-error` here would be an unenforced false-green).
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const read = (rel: string) => readFileSync(join(here, rel), 'utf8')
+
+describe('Slice 5 deletion guards — checklists dead fields (D4/D5)', () => {
+  it('ChecklistTaskState no longer declares active (checklist.ts)', () => {
+    expect(read('../checklist.ts')).not.toMatch(/^\s*active:\s*boolean/m)
+  })
+
+  it('the provider no longer seeds active: false (checklist-provider.tsx)', () => {
+    expect(read('../../context/checklist-provider.tsx')).not.toMatch(/active:\s*false/)
+  })
+
+  it('ChecklistProviderConfig no longer declares tourKitIntegration (config.ts)', () => {
+    expect(read('../config.ts')).not.toMatch(/tourKitIntegration/)
+  })
+
+  it('keeps the tour task-action arm intact (different symbol)', () => {
+    // The dead config flag is gone, but `{ type: 'tour'; tourId: string }` and
+    // its `case 'tour':` handler are a real task-action type — must remain.
+    expect(read('../checklist.ts')).toMatch(/type:\s*'tour'/)
+  })
+})

--- a/packages/checklists/src/types/checklist.ts
+++ b/packages/checklists/src/types/checklist.ts
@@ -98,8 +98,6 @@ export interface ChecklistTaskState {
   locked: boolean
   /** Whether task is visible (when condition met) */
   visible: boolean
-  /** Whether task is currently active/in-progress */
-  active: boolean
   /** Completion timestamp */
   completedAt?: number
 }

--- a/packages/checklists/src/types/config.ts
+++ b/packages/checklists/src/types/config.ts
@@ -52,6 +52,4 @@ export interface ChecklistProviderConfig {
   onChecklistDismiss?: (checklistId: string) => void
   /** Callback when task action is triggered */
   onTaskAction?: (checklistId: string, taskId: string, action: unknown) => void
-  /** Integration with TourKit */
-  tourKitIntegration?: boolean
 }

--- a/packages/scheduling/src/__tests__/status.guard.test.ts
+++ b/packages/scheduling/src/__tests__/status.guard.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Slice 5 (D6) — `ScheduleStatus.nextInactiveAt` was declared-only:
+ * `get-schedule-status.ts` only ever set `nextActiveAt`. It is deleted (not
+ * Studio-authored), which also reclaims the type surface. `nextActiveAt` stays.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const statusSrc = readFileSync(join(here, '../types/status.ts'), 'utf8')
+
+describe('Slice 5 deletion guard — ScheduleStatus.nextInactiveAt is gone (D6)', () => {
+  it('nextInactiveAt no longer appears in the status type', () => {
+    expect(statusSrc).not.toMatch(/nextInactiveAt/)
+  })
+
+  it('nextActiveAt is retained', () => {
+    expect(statusSrc).toMatch(/nextActiveAt\?: Date/)
+  })
+})

--- a/packages/scheduling/src/__tests__/utils/recurring.test.ts
+++ b/packages/scheduling/src/__tests__/utils/recurring.test.ts
@@ -76,4 +76,66 @@ describe('matchesRecurringPattern', () => {
       expect(matchesRecurringPattern(instant, pattern, 'UTC')).toBe(false)
     })
   })
+
+  // Slice 5 (I1) — `maxOccurrences` was typed but never enforced; the Studio
+  // emits it from the ScheduleEditor. Count-and-cap, in the schedule timezone.
+  describe('maxOccurrences cap', () => {
+    const START = '2025-06-01' // recurrence start (DateString); counted from here
+
+    it('daily { maxOccurrences: 3 }: matches occurrences 0,1,2 and NOT 3+', () => {
+      const pattern: RecurringPattern = { type: 'daily', maxOccurrences: 3 }
+      expect(matchesRecurringPattern(new Date('2025-06-01T12:00:00Z'), pattern, 'UTC', START)).toBe(
+        true
+      ) // #0
+      expect(matchesRecurringPattern(new Date('2025-06-02T12:00:00Z'), pattern, 'UTC', START)).toBe(
+        true
+      ) // #1
+      expect(matchesRecurringPattern(new Date('2025-06-03T12:00:00Z'), pattern, 'UTC', START)).toBe(
+        true
+      ) // #2
+      expect(matchesRecurringPattern(new Date('2025-06-04T12:00:00Z'), pattern, 'UTC', START)).toBe(
+        false
+      ) // #3
+      expect(matchesRecurringPattern(new Date('2025-06-10T12:00:00Z'), pattern, 'UTC', START)).toBe(
+        false
+      ) // far
+    })
+
+    it('weekly { daysOfWeek:[1], maxOccurrences: 2 }: matches the first two Mondays only', () => {
+      // 2025-06-02, 06-09 are the first two Mondays from START; 06-16 is the third.
+      const pattern: RecurringPattern = { type: 'weekly', daysOfWeek: [1], maxOccurrences: 2 }
+      expect(matchesRecurringPattern(new Date('2025-06-02T12:00:00Z'), pattern, 'UTC', START)).toBe(
+        true
+      ) // Mon #0
+      expect(matchesRecurringPattern(new Date('2025-06-09T12:00:00Z'), pattern, 'UTC', START)).toBe(
+        true
+      ) // Mon #1
+      expect(matchesRecurringPattern(new Date('2025-06-16T12:00:00Z'), pattern, 'UTC', START)).toBe(
+        false
+      ) // Mon #2
+    })
+
+    it('maxOccurrences undefined ⇒ behavior unchanged (regression guard)', () => {
+      const pattern: RecurringPattern = { type: 'daily' }
+      expect(matchesRecurringPattern(new Date('2025-12-31T12:00:00Z'), pattern, 'UTC', START)).toBe(
+        true
+      )
+    })
+
+    it('no-op when startDate is omitted (cannot count occurrences)', () => {
+      const pattern: RecurringPattern = { type: 'daily', maxOccurrences: 1 }
+      // Without a start there is no anchor to count from → cap cannot apply.
+      expect(matchesRecurringPattern(new Date('2025-12-31T12:00:00Z'), pattern, 'UTC')).toBe(true)
+    })
+
+    it('counts occurrences in the schedule timezone, not UTC', () => {
+      // 2025-06-04T03:00:00Z is 2025-06-03 23:00 in America/New_York (UTC-4 in June),
+      // so under START=2025-06-01 it is occurrence #2 in NY (within cap 3 → true)
+      // but occurrence #3 in UTC (count 3 >= 3 → capped → false). The verdict flips.
+      const pattern: RecurringPattern = { type: 'daily', maxOccurrences: 3 }
+      const instant = new Date('2025-06-04T03:00:00Z')
+      expect(matchesRecurringPattern(instant, pattern, 'America/New_York', START)).toBe(true)
+      expect(matchesRecurringPattern(instant, pattern, 'UTC', START)).toBe(false)
+    })
+  })
 })

--- a/packages/scheduling/src/types/status.ts
+++ b/packages/scheduling/src/types/status.ts
@@ -27,9 +27,6 @@ export interface ScheduleStatus {
   /** When the schedule will next become active (if predictable) */
   nextActiveAt?: Date
 
-  /** When the schedule will next become inactive (if currently active) */
-  nextInactiveAt?: Date
-
   /** Current blackout period if in one */
   currentBlackout?: {
     id: string

--- a/packages/scheduling/src/utils/recurring.ts
+++ b/packages/scheduling/src/utils/recurring.ts
@@ -26,6 +26,27 @@ export function matchesRecurringPattern(
     }
   }
 
+  // Cap by maxOccurrences, counted from startDate in the schedule timezone.
+  // Needs an anchor to count from — without startDate the cap can't apply.
+  if (pattern.maxOccurrences !== undefined && startDate !== undefined) {
+    if (countOccurrencesBefore(date, pattern, timezone, startDate) >= pattern.maxOccurrences) {
+      return false
+    }
+  }
+
+  return matchesPatternType(date, pattern, timezone, startDate)
+}
+
+/**
+ * Match a date against the pattern's per-type rule (day/week/month/year).
+ * `endDate` and `maxOccurrences` are handled by `matchesRecurringPattern`.
+ */
+function matchesPatternType(
+  date: Date,
+  pattern: RecurringPattern,
+  timezone: string,
+  startDate?: DateString | Date
+): boolean {
   const { day, month } = getDateInTimezone(date, timezone)
   const dayOfWeek = getDayOfWeek(date, timezone)
 
@@ -45,6 +66,45 @@ export function matchesRecurringPattern(
     default:
       return false
   }
+}
+
+const MS_PER_DAY = 86_400_000
+
+/**
+ * Count pattern occurrences strictly before `date`, starting from `startDate`,
+ * evaluated in the schedule timezone.
+ *
+ * The window [start, date) is derived from timezone-local calendar-date strings,
+ * and each candidate day is matched in UTC — where its UTC components equal that
+ * calendar date — so the existing per-type interval math stays correct across
+ * timezones. The walk short-circuits once the count reaches `maxOccurrences`
+ * (we only need to know whether the cap is hit), so it allocates nothing and
+ * never enumerates a full date array — the 483 B byte budget depends on this.
+ */
+function countOccurrencesBefore(
+  date: Date,
+  pattern: RecurringPattern,
+  timezone: string,
+  startDate: DateString | Date
+): number {
+  // `formatDateString` yields a valid YYYY-MM-DD, so the narrowing to
+  // `DateString` is sound (it just isn't inferable from the `string` return).
+  const startStr = (
+    typeof startDate === 'string' ? startDate : formatDateString(startDate, timezone)
+  ) as DateString
+  const startMidnight = parseDateString(startStr)
+  const targetMidnight = parseDateString(formatDateString(date, timezone))
+  const dayDiff = Math.round((targetMidnight.getTime() - startMidnight.getTime()) / MS_PER_DAY)
+  const max = pattern.maxOccurrences ?? Number.POSITIVE_INFINITY
+
+  let count = 0
+  for (let offset = 0; offset < dayDiff && count < max; offset++) {
+    const candidate = new Date(startMidnight.getTime() + offset * MS_PER_DAY)
+    if (matchesPatternType(candidate, pattern, 'UTC', startStr)) {
+      count++
+    }
+  }
+  return count
 }
 
 /**

--- a/packages/surveys/src/core/__tests__/scheduler.test.ts
+++ b/packages/surveys/src/core/__tests__/scheduler.test.ts
@@ -1,0 +1,58 @@
+import type { Schedule } from '@tour-kit/scheduling'
+import { describe, expect, it } from 'vitest'
+import type { SurveyConfig, SurveyState } from '../../types/survey'
+import { SurveyScheduler } from '../scheduler'
+
+/**
+ * Slice 5 (W1) — `SurveyConfig.schedule` is wired, not deleted.
+ *
+ * The Studio emits a `schedule` $ref here, so the field must be typed
+ * `Schedule` and actually CONSULTED in `canShow`. These are behavior tests
+ * that fire the REAL `@tour-kit/scheduling` eval (no stub) — an absence test
+ * would wrongly pass if the field were deleted, which is the Studio-breaking
+ * outcome this slice exists to prevent.
+ */
+
+const NOW = new Date('2025-06-16T14:30:00Z')
+
+const baseState = (): SurveyState => ({ isCompleted: false, isDismissed: false }) as SurveyState
+
+const baseConfig = (schedule?: Schedule): SurveyConfig =>
+  ({ id: 's1', frequency: 'always', ...(schedule ? { schedule } : {}) }) as SurveyConfig
+
+function newScheduler() {
+  return new SurveyScheduler({ maxConcurrent: 1, delayBetween: 0, autoShow: true } as never)
+}
+
+describe('SurveyScheduler.canShow — schedule wiring (W1)', () => {
+  it('returns false when the schedule is inactive (enabled:false)', () => {
+    const s = newScheduler()
+    expect(s.canShow(baseConfig({ enabled: false }), baseState(), undefined, NOW)).toBe(false)
+  })
+
+  it('returns true when the schedule is active (no constraints)', () => {
+    const s = newScheduler()
+    expect(s.canShow(baseConfig({}), baseState(), undefined, NOW)).toBe(true)
+  })
+
+  it('returns true when schedule is omitted (additive, non-breaking)', () => {
+    const s = newScheduler()
+    expect(s.canShow(baseConfig(), baseState(), undefined, NOW)).toBe(true)
+  })
+
+  it('gates on a timeOfDay window relative to the injected now', () => {
+    const s = newScheduler()
+    // 14:30Z is outside a 00:00–01:00 UTC window → inactive → not shown.
+    const schedule: Schedule = { timezone: 'UTC', timeOfDay: { start: '00:00', end: '01:00' } }
+    expect(s.canShow(baseConfig(schedule), baseState(), undefined, NOW)).toBe(false)
+  })
+
+  it('becomes eligible once now passes a future startAt', () => {
+    const s = newScheduler()
+    const schedule: Schedule = { timezone: 'UTC', startAt: '2025-07-01' }
+    // Before the window opens → suppressed; after → eligible.
+    expect(s.canShow(baseConfig(schedule), baseState(), undefined, NOW)).toBe(false)
+    const later = new Date('2025-07-02T00:00:00Z')
+    expect(s.canShow(baseConfig(schedule), baseState(), undefined, later)).toBe(true)
+  })
+})

--- a/packages/surveys/src/core/resolve-schedule.ts
+++ b/packages/surveys/src/core/resolve-schedule.ts
@@ -1,0 +1,56 @@
+import type { Schedule } from '@tour-kit/scheduling'
+
+/**
+ * Resolve a `SurveyConfig.schedule` $ref to a real schedule evaluation.
+ *
+ * `@tour-kit/scheduling` is an OPTIONAL peer (`peerDependenciesMeta.optional`),
+ * so it must NOT be a hard module-load import — a consumer who never sets a
+ * `schedule` may not have it installed. We resolve `isScheduleActive` lazily at
+ * call time and DEGRADE OPEN: if the peer is absent (or anything throws) we
+ * return `true`, so content is never suppressed merely because the optional dep
+ * is missing. The field is only read when `config.schedule` is set, by which
+ * point a correct consumer already depends on scheduling for the `Schedule`
+ * type itself.
+ *
+ * Note: in a pure-ESM browser bundle without a `require` shim this degrades
+ * open (the schedule is treated as active). CJS, bundlers that provide
+ * `require`, and the test runner all resolve it for real.
+ */
+type IsScheduleActive = (schedule: Schedule, options: { now: Date }) => { isActive: boolean }
+
+interface SchedulingModule {
+  isScheduleActive: IsScheduleActive
+}
+
+// Reached through a runtime require so `@tour-kit/scheduling` stays optional.
+// Typed locally because these browser packages don't pull in `@types/node`.
+declare const require: undefined | ((id: string) => unknown)
+
+/** Load the optional scheduling peer, or `null` if it isn't installed. */
+export function loadScheduling(): SchedulingModule | null {
+  if (typeof require !== 'function') return null
+  try {
+    const mod = require('@tour-kit/scheduling') as Partial<SchedulingModule>
+    return typeof mod.isScheduleActive === 'function' ? (mod as SchedulingModule) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * `load` is injectable purely as a test seam for the degrade-open contract; in
+ * production it defaults to {@link loadScheduling}.
+ */
+export function resolveScheduleActive(
+  schedule: Schedule,
+  now: Date,
+  load: () => SchedulingModule | null = loadScheduling
+): boolean {
+  try {
+    const scheduling = load()
+    if (!scheduling) return true // optional peer absent → don't suppress content
+    return scheduling.isScheduleActive(schedule, { now }).isActive
+  } catch {
+    return true // any failure degrades open — never suppress on the optional path
+  }
+}

--- a/packages/surveys/src/core/scheduler.ts
+++ b/packages/surveys/src/core/scheduler.ts
@@ -3,6 +3,7 @@ import type { SurveyConfig, SurveyState } from '../types/survey'
 import { matchesAudience } from './audience'
 import { canShowByFrequency } from './frequency'
 import { SurveyPriorityQueue } from './priority-queue'
+import { resolveScheduleActive } from './resolve-schedule'
 
 export class SurveyScheduler {
   private queue: SurveyPriorityQueue
@@ -23,6 +24,7 @@ export class SurveyScheduler {
     if (state.isCompleted || state.isDismissed) return false
     if (!canShowByFrequency(state, config.frequency, now)) return false
     if (!matchesAudience(config.audience, userContext)) return false
+    if (config.schedule && !resolveScheduleActive(config.schedule, now)) return false
     return true
   }
 

--- a/packages/surveys/src/types/survey.ts
+++ b/packages/surveys/src/types/survey.ts
@@ -128,7 +128,7 @@ export interface SurveyConfig {
   frequency?: FrequencyRule
 
   /** Schedule configuration (requires @tour-kit/scheduling) */
-  schedule?: unknown
+  schedule?: import('@tour-kit/scheduling').Schedule
 
   /** Audience targeting conditions */
   audience?: AudienceCondition[]


### PR DESCRIPTION
## Slice 5 — Minor Dead-Field Housekeeping

Clears the long tail of typed-but-dead public fields the 2026-06-16 trust audit found, across six packages. Every field got exactly one verdict (DELETE / KEEP / WIRE / IMPLEMENT). TDD throughout (RED → implement → GREEN). No marketing copy — integrity work.

### Verdicts
**DELETE** (dead, no Studio surface — proven by runtime file-scan guards):
- analytics: `TourEvent.userProperties`, `AnalyticsConfig.offlineQueue`
- adoption: `FeatureResources` interface + `Feature.resources` + both barrel re-exports
- checklists: `ChecklistTaskState.active` (always `false`), `tourKitIntegration`
- scheduling: `ScheduleStatus.nextInactiveAt` (declared-only)

**KEEP** (looks dead, is alive — behavior-spied in the *same file* as the analytics deletion guards so the two `userProperties` siblings can't be conflated):
- analytics `AnalyticsConfig.userProperties` → still reaches `identify()`

**WIRE** (Studio emits these — typed + consulted, never deleted):
- surveys `SurveyConfig.schedule` and announcements `AnnouncementConfig.schedule`: `unknown` → `import('@tour-kit/scheduling').Schedule`, consulted in `canShow` via an optional-peer-safe `resolveScheduleActive` (lazy `require`, degrades open when the peer is absent). Announcements' `canShow` gained a `now` param and lost its lying "the provider handles that integration" comment.

**IMPLEMENT**:
- scheduling `RecurringPattern.maxOccurrences`: counts-and-caps occurrences (arithmetic, short-circuiting, timezone-paired) — was typed but only `endDate` was honored.

### Verification
- `typecheck` + `test` green for all six packages (250 / 235 / 339 / 273 / 324 / 67).
- `pnpm dist:size` passes — **scheduling 3709/4000 gz** (291 B headroom).
- All changed TS/TSX biome-clean.
- Published `.d.ts` verified: dead fields gone, KEEP retained, `schedule?: Schedule` in both, `maxOccurrences` present, `nextInactiveAt` gone.
- Reference docs (MDX) corrected for every removed/false field, incl. the literal "maxOccurrences is not currently implemented" note.

### Changesets
Six independent per-package changesets. **adoption is `major`** (removing a publicly re-exported type is breaking; deprecate-in-place would leave the dead symbol in the published `.d.ts` — the exact lie this slice removes). The rest are `minor` (pre-1.0 breaking lever for analytics/checklists/scheduling; additive type-tighten for surveys/announcements).

### Notes for reviewers
- **Deletion proofs are runtime file-scans, not `@ts-expect-error`**: adoption/surveys/analytics `tsconfig` exclude tests and vitest typecheck is off, so `@ts-expect-error` there would be an unenforced false-green. checklists/scheduling include tests, so existing fixtures referencing `active` were cleaned.
- **Degrade-open** is proven via an injectable `load` seam on `resolveScheduleActive` — `vi.mock` does not intercept the resolver's CJS `require`. The matrix tests use the *real* `@tour-kit/scheduling`.
- The plan's "`changeset status` shows no core/react/hints bump" criterion is **not literally achievable**: a single unrelated changeset already cascades react/hints to major via the repo's `workspace:*` peer graph + `linked:[core,react,hints]` + experimental config. The changeset frontmatter here is correctly per-package and names no core/react/hints.
- Studio (`utk-studio`) pins for the three wired packages (surveys/announcements/scheduling) need bumping in its own phase — recorded, not edited here.

Plan: `plan/trust-restoration-slice-5-dead-fields.md` (+ test plan).