### PR TITLE
test: Slice 7 — coverage truth (earned floors, no more phase-5 lows)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,14 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
 ### Quality Gates
 
 - TypeScript strict mode enabled
-- Test coverage: thresholds are **per-package** (`packages/*/vitest.config.ts`), not a blanket
-  80%. Most packages enforce ≥80% statements/functions/lines (core branches 65); the following
-  are temporarily lowered and are scheduled to be restored toward 80% in **Slice 7** (issue #13),
-  given as statements/branches/functions/lines: `announcements` 70/60/70/70, `surveys` 72/64/67/74,
-  `scheduling` 51/39/65/51, `media` 50/41/31/50. `ai` has no per-key threshold yet.
+- Test coverage: thresholds are enforced **per-package** in each `packages/*/vitest.config.ts`,
+  not as a blanket repo number. Eight packages hold the canonical floor — ≥80% statements,
+  functions, and lines with ≥75% branches: `core`, `react`, `hints`, `adoption`, `checklists`,
+  `analytics`, `license`, and `surveys`. Three feature packages enforce honest, earned floors
+  below canonical (statements/branches/functions/lines): `announcements` 75/70/80/75,
+  `scheduling` 75/65/80/75, and `media` 70/60/70/70. `ai` has no per-key threshold yet. Slice 7
+  raised these from the temporary phase-5 lows with real behavior tests, and measured coverage
+  exceeds every enforced floor (kept in sync by `coverage-claim-alignment.test.ts`).
 - Bundle sizes (gzipped): enforced by `tooling/bundle-check/check-dist-gzip.mjs`
   (the binding merge gate, raw `dist/index.js` gzip bytes — run `pnpm dist:size`).
   `size-limit` (root [`/.size-limit.json`](/.size-limit.json)) is a secondary

--- a/apps/docs/public/context/adoption.txt
+++ b/apps/docs/public/context/adoption.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/adoption Context File
-Version: 2.1.9 | Generated: 2026-06-11
+Version: 2.1.10 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/adoption.
 =========================================================================
 
@@ -37,7 +37,6 @@ Types:
     Feature
     FeatureTrigger
     AdoptionCriteria
-    FeatureResources
     FeatureUsage
     AdoptionStatus
     FeatureWithUsage
@@ -289,7 +288,6 @@ Example 1: Feature
       name: string
       trigger: FeatureTrigger
       adoptionCriteria?: AdoptionCriteria
-      resources?: FeatureResources
       priority?: number
       category?: string
       description?: string

--- a/apps/docs/public/context/analytics.txt
+++ b/apps/docs/public/context/analytics.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/analytics Context File
-Version: 0.11.9 | Generated: 2026-06-11
+Version: 0.11.10 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/analytics.
 =========================================================================
 
@@ -109,9 +109,6 @@ TYPES
       /** User identifier (if known) */
       userId?: string
     
-      /** Additional user properties */
-      userProperties?: Record<string, unknown>
-    
       /** Duration in milliseconds */
       duration?: number
     
@@ -154,7 +151,50 @@ TYPES
       // Scheduling events
       | 'schedule_evaluated'
 
-    ... and 2 more types. See source for full definitions.
+    /**
+     * Tour analytics event payload
+     */
+    export interface TourEvent {
+      /** Event type */
+      eventName: TourEventName
+    
+      /** Unix timestamp */
+      timestamp: number
+    
+      /** Unique session identifier */
+      sessionId: string
+    
+      /** Tour identifier */
+      tourId: string
+    
+      /** Current step identifier */
+      stepId?: string
+    
+      /** Current step index (0-based) */
+      stepIndex?: number
+    
+      /** Total number of steps in tour */
+      totalSteps?: number
+    
+      /** User identifier (if known) */
+      userId?: string
+    
+      /** Duration in milliseconds */
+      duration?: number
+    
+      /** Number of interactions during step */
+      interactionCount?: number
+    
+      /** Custom metadata */
+      metadata?: Record<string, unknown>
+    }
+    
+    /**
+     * Event data without auto-generated fields
+     */
+    export type TourEventData = Omit<TourEvent, 'timestamp' | 'sessionId' | 'eventName'>
+
+    ... and 1 more types. See source for full definitions.
 
 HOOKS
 -----
@@ -220,9 +260,6 @@ Example 2: TourEvent
     
       /** User identifier (if known) */
       userId?: string
-    
-      /** Additional user properties */
-      userProperties?: Record<string, unknown>
     
       /** Duration in milliseconds */
       duration?: number

--- a/apps/docs/public/context/announcements.txt
+++ b/apps/docs/public/context/announcements.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/announcements Context File
-Version: 4.1.6 | Generated: 2026-06-11
+Version: 5.0.0 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/announcements.
 =========================================================================
 

--- a/apps/docs/public/context/checklists.txt
+++ b/apps/docs/public/context/checklists.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/checklists Context File
-Version: 0.13.9 | Generated: 2026-06-11
+Version: 0.13.10 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/checklists.
 =========================================================================
 

--- a/apps/docs/public/context/core.txt
+++ b/apps/docs/public/context/core.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/core Context File
-Version: 1.0.6 | Generated: 2026-06-11
+Version: 1.0.7 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/core.
 =========================================================================
 

--- a/apps/docs/public/context/hints.txt
+++ b/apps/docs/public/context/hints.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/hints Context File
-Version: 1.0.6 | Generated: 2026-06-11
+Version: 1.0.7 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/hints.
 =========================================================================
 

--- a/apps/docs/public/context/media.txt
+++ b/apps/docs/public/context/media.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/media Context File
-Version: 0.13.2 | Generated: 2026-06-11
+Version: 0.13.3 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/media.
 =========================================================================
 

--- a/apps/docs/public/context/react.txt
+++ b/apps/docs/public/context/react.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/react Context File
-Version: 1.0.6 | Generated: 2026-06-11
+Version: 1.0.7 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/react.
 =========================================================================
 

--- a/apps/docs/public/context/scheduling.txt
+++ b/apps/docs/public/context/scheduling.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/scheduling Context File
-Version: 0.11.9 | Generated: 2026-06-11
+Version: 0.12.0 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/scheduling.
 =========================================================================
 

--- a/apps/docs/public/context/surveys.txt
+++ b/apps/docs/public/context/surveys.txt
@@ -1,5 +1,5 @@
 userTourKit — @tour-kit/surveys Context File
-Version: 3.0.9 | Generated: 2026-06-11
+Version: 4.0.0 | Generated: 2026-06-20
 Paste this into your LLM to get accurate answers about @tour-kit/surveys.
 =========================================================================
 
@@ -135,23 +135,6 @@ TYPES
       | 'always'
       | { type: 'times'; count: number }
 
-    /** Position options for slideout variant */
-    export type SlideoutPosition = 'left' | 'right'
-    
-    /** Position options for banner variant */
-    export type BannerPosition = 'top' | 'bottom'
-    
-    /** Position options for popover variant */
-    export type PopoverPosition = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
-    
-    /** Modal variant options */
-    export interface ModalOptions {
-      size?: 'sm' | 'md' | 'lg'
-      closeOnOverlayClick?: boolean
-      closeOnEscape?: boolean
-      showCloseButton?: boolean
-    }
-
     /** Slideout variant options */
     export interface SlideoutOptions {
       position?: SlideoutPosition
@@ -203,7 +186,7 @@ TYPES
       frequency?: FrequencyRule
     
       /** Schedule configuration (requires @tour-kit/scheduling) */
-      schedule?: unknown
+      schedule?: import('@tour-kit/scheduling').Schedule
     
       /** Audience targeting conditions */
       audience?: AudienceCondition[]
@@ -267,7 +250,16 @@ TYPES
       | 'always'
       | { type: 'times';
 
-    ... and 28 more types. See source for full definitions.
+    /** Reasons a survey was dismissed */
+    export type DismissalReason =
+      | 'close_button'
+      | 'overlay_click'
+      | 'escape_key'
+      | 'snooze'
+      | 'completed'
+      | 'programmatic'
+
+    ... and 27 more types. See source for full definitions.
 
 HOOKS
 -----
@@ -318,7 +310,7 @@ Example 2: SurveyConfig
       description?: string | ReactNode;
       questions: QuestionConfig[];
       frequency?: FrequencyRule;
-      schedule?: unknown;           // requires @tour-kit/scheduling
+      schedule?: Schedule;          // from @tour-kit/scheduling (optional peer)
       audience?: AudienceCondition[];
       globalCooldownDays?: number;
       samplingRate?: number;        // 0–1
@@ -354,4 +346,6 @@ Example 3: SurveyState
       snoozeUntil: Date | null;
       currentStep: number;
       responses: Map<string, AnswerValue>;
+      /** Transient per-question validation errors — never persisted. */
+      validationErrors: Map<string, string>;
     }

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -1,4 +1,4 @@
-# userTourKit v1.0.6 — Generated 2026-06-11T07:31:35Z
+# userTourKit v1.0.7 — Generated 2026-06-20T03:32:00Z
 
 # Feature Adoption Tracking
 
@@ -5699,7 +5699,6 @@ interface Feature {
   name: string
   trigger: FeatureTrigger
   adoptionCriteria?: AdoptionCriteria
-  resources?: FeatureResources
   priority?: number
   category?: string
   description?: string
@@ -5759,15 +5758,6 @@ interface AdoptionCriteria {
     },
   }}
 />
-
-### FeatureResources
-
-```ts
-interface FeatureResources {
-  tourId?: string
-  hintIds?: string[]
-}
-```
 
 ### FeatureUsage
 
@@ -10691,11 +10681,6 @@ export default function RootLayout({ children }) {
       default: 'false',
       description: 'Enable debug logging to console'
     },
-    offlineQueue: {
-      type: 'boolean',
-      default: 'false',
-      description: 'Queue events when offline and send when reconnected'
-    },
     batchSize: {
       type: 'number',
       default: 'undefined',
@@ -11025,9 +11010,6 @@ interface TourEvent {
   /** User identifier (if known) */
   userId?: string
 
-  /** Additional user properties */
-  userProperties?: Record<string, unknown>
-
   /** Duration in milliseconds */
   duration?: number
 
@@ -11145,9 +11127,6 @@ interface AnalyticsConfig {
 
   /** Enable debug logging to console */
   debug?: boolean
-
-  /** Queue events when offline */
-  offlineQueue?: boolean
 
   /** Batch events before sending */
   batchSize?: number
@@ -19173,7 +19152,6 @@ interface Feature {
   name: string;
   trigger: string | { event: string } | (() => void);
   adoptionCriteria?: AdoptionCriteria;
-  resources?: FeatureResources;
   priority?: number;
   category?: string;
   description?: string;
@@ -26141,7 +26119,6 @@ interface ChecklistTaskState {
   completed: boolean;           // Completion status
   locked: boolean;              // Whether dependencies are met
   visible: boolean;             // Whether when condition passed
-  active: boolean;              // Currently in progress (future)
   completedAt?: number;         // Timestamp of completion
 }
 ```
@@ -28373,7 +28350,6 @@ interface ChecklistTaskState {
   completed: boolean;
   locked: boolean;
   visible: boolean;
-  active: boolean;
   completedAt?: number;
 }
 ```
@@ -59991,6 +59967,7 @@ interface Schedule {
   timezone?: string
   blackouts?: BlackoutPeriod[]
   recurring?: RecurringPattern
+  businessHours?: BusinessHours
   metadata?: Record<string, unknown>
 }
 ```
@@ -60143,14 +60120,24 @@ const schedule = {
 
 ### Business Hours
 
+Attach a `businessHours` window and the schedule is active only inside that
+window, evaluated in the schedule's timezone. The `standard` preset opens
+Monday–Friday 9:00–17:00 and is closed on weekends.
+
 ```tsx
 import { BUSINESS_HOURS_PRESETS } from '@tour-kit/scheduling'
 
 const schedule = {
-  timeOfDay: BUSINESS_HOURS_PRESETS.standard.days[1].hours[0],
-  // { start: '09:00', end: '17:00' }
+  businessHours: BUSINESS_HOURS_PRESETS.standard, // Mon–Fri 9:00–17:00
+  timezone: 'America/New_York',
 }
+// Active at 10:30 in New York; inactive at the same instant in Tokyo (23:30),
+// outside the window → reason: 'outside_business_hours'.
 ```
+
+`businessHours` is independent of `timeOfDay` — set both and a schedule must
+satisfy both to be active. To pin a store's hours regardless of the schedule's
+timezone, set `businessHours.timezone`; it takes precedence.
 
 ### Limited-Time Campaign
 
@@ -60322,7 +60309,7 @@ function FeatureAnnouncement() {
 import { useScheduleStatus } from '@tour-kit/scheduling'
 
 function TourScheduleStatus() {
-  const { isActive, message, nextActiveAt, nextInactiveAt } = useScheduleStatus(schedule, {
+  const { isActive, message, nextActiveAt } = useScheduleStatus(schedule, {
     debug: true,
   })
 
@@ -60331,7 +60318,6 @@ function TourScheduleStatus() {
       <p>Status: {isActive ? 'Active' : 'Inactive'}</p>
       {message && <p>{message}</p>}
       {nextActiveAt && <p>Next active: {nextActiveAt.toLocaleString()}</p>}
-      {nextInactiveAt && <p>Next inactive: {nextInactiveAt.toLocaleString()}</p>}
     </div>
   )
 }
@@ -60657,8 +60643,6 @@ interface UseScheduleStatusReturn extends ScheduleStatus {
   message?: string
   /** When the schedule will next become active */
   nextActiveAt?: Date
-  /** When the schedule will next become inactive */
-  nextInactiveAt?: Date
   /** Current blackout period if in one */
   currentBlackout?: {
     id: string
@@ -60730,12 +60714,13 @@ function NextActiveDisplay() {
 
 ```tsx
 function TourCountdown() {
-  const { isActive, nextActiveAt, nextInactiveAt } = useScheduleStatus(schedule, {
+  const { isActive, nextActiveAt } = useScheduleStatus(schedule, {
     refreshInterval: 1000, // Update every second
   })
 
-  const targetTime = isActive ? nextInactiveAt : nextActiveAt
-  if (!targetTime) return null
+  // Counts down to when the schedule next becomes active.
+  if (isActive || !nextActiveAt) return null
+  const targetTime = nextActiveAt
 
   const now = new Date()
   const msRemaining = targetTime.getTime() - now.getTime()
@@ -60838,12 +60823,6 @@ function TourScheduleDashboard({ tourId, schedule }: Props) {
       {status.nextActiveAt && (
         <div>
           <strong>Next Active:</strong> {status.nextActiveAt.toLocaleString()}
-        </div>
-      )}
-
-      {status.nextInactiveAt && (
-        <div>
-          <strong>Next Inactive:</strong> {status.nextInactiveAt.toLocaleString()}
         </div>
       )}
 
@@ -61726,9 +61705,6 @@ interface ScheduleStatus {
 
   /** When the schedule will next become active */
   nextActiveAt?: Date
-
-  /** When the schedule will next become inactive */
-  nextInactiveAt?: Date
 
   /** Current blackout period if in one */
   currentBlackout?: {
@@ -63373,7 +63349,7 @@ const schedule = {
 }
 ```
 
-Note: `maxOccurrences` is not currently implemented in the evaluation but is part of the type for future use.
+`maxOccurrences` caps the recurrence: once the pattern has fired that many times from the schedule's `startAt`, `matchesRecurringPattern` stops matching. Occurrences are counted in the schedule's timezone, so the cap honors the same timezone as the rest of the schedule. It requires a start date to count from (the schedule's `startAt`).
 
 ### End Date
 
@@ -63706,8 +63682,6 @@ interface ScheduleStatus {
   message?: string
   /** When the schedule will next become active */
   nextActiveAt?: Date
-  /** When the schedule will next become inactive */
-  nextInactiveAt?: Date
   /** Current blackout period if in one */
   currentBlackout?: {
     id: string
@@ -63731,7 +63705,7 @@ interface ScheduleStatus {
 const status = getScheduleStatus(schedule)
 
 if (status.isActive) {
-  console.log('Active until:', status.nextInactiveAt)
+  console.log('Active now')
 } else {
   console.log(status.message)
   console.log('Available again:', status.nextActiveAt)
@@ -66688,8 +66662,9 @@ function NPSSurvey() {
       description: 'Record an answer. Persists immediately to storage.',
     },
     nextQuestion: {
-      type: '() => void',
-      description: 'Increment currentStep by 1.',
+      type: '() => string | null',
+      description:
+        'Advance to the next question. If the current question has a `validation` function that returns a non-null string, the survey does NOT advance and that string is returned; otherwise advances and returns null.',
     },
     prevQuestion: {
       type: '() => void',
@@ -66702,6 +66677,11 @@ function NPSSurvey() {
     reset: {
       type: '() => void',
       description: 'Reset the survey to its initial state, clearing all responses and flags.',
+    },
+    validationError: {
+      type: '(questionId: string) => string | undefined',
+      description:
+        'Read the transient validation error for a question, or undefined if it currently validates. Cleared on a passing nextQuestion.',
     },
   }}
 />
@@ -66972,8 +66952,9 @@ function SurveyDebugPanel() {
       description: 'Record an answer. Persists immediately.',
     },
     nextQuestion: {
-      type: '(surveyId: string) => void',
-      description: 'Advance the survey one step.',
+      type: '(surveyId: string) => string | null',
+      description:
+        'Advance the survey one step. Returns the validation error string if the current question blocks advancing, otherwise null.',
     },
     prevQuestion: {
       type: '(surveyId: string) => void',
@@ -66994,6 +66975,11 @@ function SurveyDebugPanel() {
     getState: {
       type: '(id: string) => SurveyState | undefined',
       description: 'Get state for a specific survey.',
+    },
+    getValidationError: {
+      type: '(surveyId: string, questionId: string) => string | undefined',
+      description:
+        'Read the transient validation error for a question, or undefined if it currently validates.',
     },
     getConfig: {
       type: '(id: string) => SurveyConfig | undefined',
@@ -67265,7 +67251,7 @@ interface SurveyConfig {
   description?: string | ReactNode;
   questions: QuestionConfig[];
   frequency?: FrequencyRule;
-  schedule?: unknown;           // requires @tour-kit/scheduling
+  schedule?: Schedule;          // from @tour-kit/scheduling (optional peer)
   audience?: AudienceCondition[];
   globalCooldownDays?: number;
   samplingRate?: number;        // 0–1
@@ -67305,6 +67291,8 @@ interface SurveyState {
   snoozeUntil: Date | null;
   currentStep: number;
   responses: Map<string, AnswerValue>;
+  /** Transient per-question validation errors — never persisted. */
+  validationErrors: Map<string, string>;
 }
 ```
 
@@ -67414,6 +67402,18 @@ interface RatingScale {
 }
 ```
 
+`step` controls the increment between rating options (default `1`). The scale renders
+every value from `min` to `max` inclusive, stepping by `step` — so `{ min: 0, max: 10, step: 5 }`
+renders exactly three options: `0`, `5`, `10`.
+
+```tsx
+<QuestionRating
+  id="effort"
+  label="How much effort did that take?"
+  ratingScale={{ min: 0, max: 10, step: 5 }} // → 0, 5, 10
+/>
+```
+
 ### SelectOption
 
 ```ts
@@ -67432,6 +67432,43 @@ interface SkipLogic {
   condition: (answer: AnswerValue) => boolean;
   skipTo: string;
 }
+```
+
+### Validation
+
+`QuestionConfig.validation` runs at the **advance** boundary (when you call
+`nextQuestion`), not on every keystroke. Return a string to block advancing and
+surface it as a field error; return `null` or `undefined` to allow the survey to
+move on. `nextQuestion` returns that same string (or `null` on success), and the
+error is also readable via `getValidationError(surveyId, questionId)` on the
+context — or `validationError(questionId)` from `useSurvey`. Errors are transient
+UI state and are never persisted, so a reload starts clean.
+
+The value passed to `validation` is the answer recorded so far, which is
+`undefined` until the question is answered — that's the case to guard for a
+required field. Handle a falsy value rather than assuming a populated answer.
+
+```tsx
+const question: QuestionConfig = {
+  id: 'email',
+  type: 'text',
+  text: 'Work email',
+  required: true,
+  validation: (value) =>
+    typeof value === 'string' && value.includes('@') ? null : 'Enter a valid email',
+};
+
+// In a question UI built on the headless hook:
+const { nextQuestion, validationError } = useSurvey('signup');
+const error = validationError('email'); // string while invalid, undefined once it passes
+
+<input
+  aria-invalid={error ? true : undefined}
+  aria-describedby={error ? 'email-error' : undefined}
+  onChange={(e) => answer('email', e.target.value)}
+/>;
+{error && <p id="email-error" role="alert">{error}</p>}
+<button onClick={() => nextQuestion()}>Next</button>; // stays put until `value` validates
 ```
 
 ---
@@ -67498,12 +67535,14 @@ interface SurveysContextValue {
   dismiss: (id: string, reason?: DismissalReason) => void;
   snooze: (id: string) => void;
   answer: (surveyId: string, questionId: string, value: AnswerValue) => void;
-  nextQuestion: (surveyId: string) => void;
+  /** Returns the validation error string when the current question blocks advance, else `null`. */
+  nextQuestion: (surveyId: string) => string | null;
   prevQuestion: (surveyId: string) => void;
   complete: (surveyId: string) => void;
   reset: (id: string) => void;
   resetAll: () => void;
   getState: (id: string) => SurveyState | undefined;
+  getValidationError: (surveyId: string, questionId: string) => string | undefined;
   getConfig: (id: string) => SurveyConfig | undefined;
   canShow: (id: string) => boolean;
 }

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,4 +1,4 @@
-# userTourKit v1.0.6 — Generated 2026-06-11T07:31:35Z
+# userTourKit v1.0.7 — Generated 2026-06-20T03:32:00Z
 
 # userTourKit
 

--- a/packages/announcements/src/__tests__/components/announcement-actions.test.tsx
+++ b/packages/announcements/src/__tests__/components/announcement-actions.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AnnouncementActions } from '../../components/announcement-actions'
+
+describe('AnnouncementActions', () => {
+  it('renders nothing when there are no actions or children', () => {
+    const { container } = render(<AnnouncementActions />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders primary and secondary buttons and fires their onClick + onAction', () => {
+    const onPrimary = vi.fn()
+    const onSecondary = vi.fn()
+    const onAction = vi.fn()
+
+    render(
+      <AnnouncementActions
+        primaryAction={{ label: 'Confirm', onClick: onPrimary }}
+        secondaryAction={{ label: 'Later', onClick: onSecondary }}
+        onAction={onAction}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    expect(onPrimary).toHaveBeenCalledTimes(1)
+    expect(onAction).toHaveBeenCalledWith('primary')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Later' }))
+    expect(onSecondary).toHaveBeenCalledTimes(1)
+    expect(onAction).toHaveBeenCalledWith('secondary')
+  })
+
+  it('calls onDismiss when an action has dismissOnClick', () => {
+    const onDismiss = vi.fn()
+    render(
+      <AnnouncementActions
+        primaryAction={{ label: 'Go', dismissOnClick: true }}
+        onDismiss={onDismiss}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onDismiss when dismissOnClick is absent', () => {
+    const onDismiss = vi.fn()
+    render(<AnnouncementActions primaryAction={{ label: 'Stay' }} onDismiss={onDismiss} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stay' }))
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('renders an action with href as an anchor', () => {
+    render(<AnnouncementActions primaryAction={{ label: 'Docs', href: '/docs' }} />)
+    const link = screen.getByRole('link', { name: 'Docs' })
+    expect(link).toHaveAttribute('href', '/docs')
+  })
+})

--- a/packages/announcements/src/__tests__/components/announcement-close-overlay.test.tsx
+++ b/packages/announcements/src/__tests__/components/announcement-close-overlay.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AnnouncementClose } from '../../components/announcement-close'
+import { AnnouncementOverlay } from '../../components/announcement-overlay'
+
+describe('AnnouncementClose', () => {
+  it('renders a labelled close button with the default icon', () => {
+    render(<AnnouncementClose />)
+    const btn = screen.getByRole('button', { name: 'Close' })
+    expect(btn).toHaveAttribute('type', 'button')
+    expect(btn.querySelector('svg')).not.toBeNull()
+  })
+
+  it('fires onClose on click', () => {
+    const onClose = vi.fn()
+    render(<AnnouncementClose onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('still runs onClick, and skips onClose when the event is defaultPrevented', () => {
+    const onClose = vi.fn()
+    const onClick = vi.fn((e: React.MouseEvent) => e.preventDefault())
+    render(<AnnouncementClose onClose={onClose} onClick={onClick} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('renders custom children instead of the default icon', () => {
+    render(<AnnouncementClose>Dismiss</AnnouncementClose>)
+    expect(screen.getByRole('button', { name: 'Close' })).toHaveTextContent('Dismiss')
+  })
+})
+
+describe('AnnouncementOverlay', () => {
+  it('renders nothing when open is false', () => {
+    const { container } = render(<AnnouncementOverlay open={false} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders an aria-hidden overlay and fires onClose on click', () => {
+    const onClose = vi.fn()
+    const { container } = render(<AnnouncementOverlay onClose={onClose} />)
+    const overlay = container.querySelector('div[aria-hidden="true"]')
+    expect(overlay).not.toBeNull()
+    expect(overlay).toHaveAttribute('data-state', 'open')
+
+    fireEvent.click(overlay as Element)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onClose when click is defaultPrevented by consumer onClick', () => {
+    const onClose = vi.fn()
+    const onClick = vi.fn((e: React.MouseEvent) => e.preventDefault())
+    const { container } = render(<AnnouncementOverlay onClose={onClose} onClick={onClick} />)
+    fireEvent.click(container.querySelector('div[aria-hidden="true"]') as Element)
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/packages/announcements/src/__tests__/components/announcement-toast-render.test.tsx
+++ b/packages/announcements/src/__tests__/components/announcement-toast-render.test.tsx
@@ -1,0 +1,86 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { AnnouncementToast } from '../../components/announcement-toast'
+import { AnnouncementsProvider } from '../../context/announcements-provider'
+import { useAnnouncement } from '../../hooks/use-announcement'
+import type { AnnouncementConfig } from '../../types/announcement'
+
+function renderWith(ui: React.ReactNode, announcements: AnnouncementConfig[]) {
+  return render(
+    <AnnouncementsProvider announcements={announcements} storage={null}>
+      {ui}
+    </AnnouncementsProvider>
+  )
+}
+
+const cfg: AnnouncementConfig = {
+  id: 'toast',
+  variant: 'toast',
+  title: 'Saved',
+  description: 'Your changes were saved',
+  autoShow: false,
+}
+
+describe('AnnouncementToast (portal render)', () => {
+  it('renders title + description in a polite alert region', async () => {
+    renderWith(<AnnouncementToast id="toast" open options={{ autoDismiss: false }} />, [cfg])
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveAttribute('aria-live', 'polite')
+    expect(alert).toHaveTextContent('Saved')
+    expect(screen.getByText('Your changes were saved')).toBeInTheDocument()
+  })
+
+  it('renders nothing when closed', () => {
+    renderWith(<AnnouncementToast id="toast" open={false} />, [cfg])
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('close button dismisses the announcement', async () => {
+    function Probe() {
+      const a = useAnnouncement('toast')
+      return <span data-testid="dismissed">{String(a.isDismissed)}</span>
+    }
+    renderWith(
+      <>
+        <AnnouncementToast id="toast" open options={{ autoDismiss: false }} />
+        <Probe />
+      </>,
+      [cfg]
+    )
+
+    await screen.findByRole('alert')
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    await waitFor(() => {
+      expect(screen.getByTestId('dismissed')).toHaveTextContent('true')
+    })
+  })
+
+  it('renders the progress bar when showProgress + autoDismiss are on', async () => {
+    vi.useFakeTimers()
+    try {
+      renderWith(
+        <AnnouncementToast
+          id="toast"
+          open
+          options={{ autoDismiss: true, showProgress: true, autoDismissDelay: 5000 }}
+        />,
+        [cfg]
+      )
+
+      // flush the mount effect that gates the portal
+      act(() => {
+        vi.advanceTimersByTime(0)
+      })
+
+      const alert = screen.getByRole('alert')
+      // progress element is the last styled child with a width style
+      const progress = alert.querySelector('[style*="width"]')
+      expect(progress).not.toBeNull()
+    } finally {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/announcements/src/__tests__/components/announcement-variants-render.test.tsx
+++ b/packages/announcements/src/__tests__/components/announcement-variants-render.test.tsx
@@ -1,0 +1,275 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AnnouncementBanner } from '../../components/announcement-banner'
+import { AnnouncementModal } from '../../components/announcement-modal'
+import { AnnouncementSlideout } from '../../components/announcement-slideout'
+import { AnnouncementSpotlight } from '../../components/announcement-spotlight'
+import { AnnouncementsProvider } from '../../context/announcements-provider'
+import { useAnnouncement } from '../../hooks/use-announcement'
+import type { AnnouncementConfig } from '../../types/announcement'
+
+function renderWith(ui: React.ReactNode, announcements: AnnouncementConfig[]) {
+  return render(
+    <AnnouncementsProvider announcements={announcements} storage={null}>
+      {ui}
+    </AnnouncementsProvider>
+  )
+}
+
+describe('AnnouncementBanner', () => {
+  it('renders title + description from config and fires the primary action', () => {
+    const onClick = vi.fn()
+    const cfg: AnnouncementConfig = {
+      id: 'banner',
+      variant: 'banner',
+      title: 'New feature',
+      description: 'Now available',
+      autoShow: false,
+      primaryAction: { label: 'Try it', onClick },
+    }
+    renderWith(<AnnouncementBanner id="banner" open />, [cfg])
+
+    expect(screen.getByRole('alert')).toHaveTextContent('New feature')
+    expect(screen.getByText('Now available')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try it' }))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders nothing when closed', () => {
+    const cfg: AnnouncementConfig = { id: 'banner', variant: 'banner', title: 'x', autoShow: false }
+    const { container } = renderWith(<AnnouncementBanner id="banner" open={false} />, [cfg])
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('close button dismisses the announcement', () => {
+    const cfg: AnnouncementConfig = {
+      id: 'banner',
+      variant: 'banner',
+      title: 'Closable',
+      autoShow: false,
+    }
+    function Probe() {
+      const a = useAnnouncement('banner')
+      return <span data-testid="dismissed">{String(a.isDismissed)}</span>
+    }
+    renderWith(
+      <>
+        <AnnouncementBanner id="banner" open />
+        <Probe />
+      </>,
+      [cfg]
+    )
+
+    expect(screen.getByTestId('dismissed')).toHaveTextContent('false')
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(screen.getByTestId('dismissed')).toHaveTextContent('true')
+  })
+
+  it('renders children when useConfig is false', () => {
+    const cfg: AnnouncementConfig = {
+      id: 'banner',
+      variant: 'banner',
+      title: 'hidden',
+      autoShow: false,
+    }
+    renderWith(
+      <AnnouncementBanner id="banner" open useConfig={false}>
+        <span>custom banner body</span>
+      </AnnouncementBanner>,
+      [cfg]
+    )
+    expect(screen.getByText('custom banner body')).toBeInTheDocument()
+    expect(screen.queryByText('hidden')).toBeNull()
+  })
+})
+
+describe('AnnouncementModal — dismissal paths', () => {
+  const cfg: AnnouncementConfig = {
+    id: 'modal',
+    variant: 'modal',
+    title: 'Release',
+    description: 'Notes here',
+    autoShow: false,
+    primaryAction: { label: 'Got it' },
+  }
+
+  it('clicking the overlay dismisses via overlay_click', async () => {
+    function Probe() {
+      const a = useAnnouncement('modal')
+      return <span data-testid="reason">{a.state?.dismissalReason ?? 'none'}</span>
+    }
+    renderWith(
+      <>
+        <AnnouncementModal id="modal" open />
+        <Probe />
+      </>,
+      [cfg]
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Release' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId('dialog-overlay'))
+    expect(screen.getByTestId('reason')).toHaveTextContent('overlay_click')
+  })
+
+  it('primary action completes the announcement', async () => {
+    function Probe() {
+      const a = useAnnouncement('modal')
+      return <span data-testid="completed">{String(Boolean(a.state?.completedAt))}</span>
+    }
+    renderWith(
+      <>
+        <AnnouncementModal id="modal" open />
+        <Probe />
+      </>,
+      [cfg]
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Got it' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Got it' }))
+    expect(screen.getByTestId('completed')).toHaveTextContent('true')
+  })
+})
+
+describe('AnnouncementSlideout — dismissal paths', () => {
+  const cfg: AnnouncementConfig = {
+    id: 'slide',
+    variant: 'slideout',
+    title: 'Details',
+    description: 'Side panel content',
+    autoShow: false,
+  }
+
+  it('renders title + description through dialog primitives', async () => {
+    renderWith(<AnnouncementSlideout id="slide" open />, [cfg])
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Details' })).toBeInTheDocument()
+    })
+    expect(screen.getByText('Side panel content')).toBeInTheDocument()
+  })
+
+  it('overlay click dismisses the slideout', async () => {
+    function Probe() {
+      const a = useAnnouncement('slide')
+      return <span data-testid="reason">{a.state?.dismissalReason ?? 'none'}</span>
+    }
+    renderWith(
+      <>
+        <AnnouncementSlideout id="slide" open />
+        <Probe />
+      </>,
+      [cfg]
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Details' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId('dialog-overlay'))
+    expect(screen.getByTestId('reason')).toHaveTextContent('overlay_click')
+  })
+
+  it('close button dismisses the slideout', async () => {
+    function Probe() {
+      const a = useAnnouncement('slide')
+      return <span data-testid="dismissed">{String(a.isDismissed)}</span>
+    }
+    renderWith(
+      <>
+        <AnnouncementSlideout id="slide" open />
+        <Probe />
+      </>,
+      [cfg]
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Details' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(screen.getByTestId('dismissed')).toHaveTextContent('true')
+  })
+})
+
+describe('AnnouncementSpotlight — spotlightOptions merge + mask', () => {
+  let target: HTMLElement
+  beforeEach(() => {
+    target = document.createElement('div')
+    target.id = 'spot-merge-target'
+    document.body.appendChild(target)
+  })
+  afterEach(() => {
+    target.remove()
+  })
+
+  it('builds a radial-gradient overlay using the merged overlayOpacity override', () => {
+    const cfg: AnnouncementConfig = {
+      id: 'spot',
+      variant: 'spotlight',
+      title: 'Look here',
+      autoShow: false,
+      spotlightOptions: {
+        targetSelector: '#spot-merge-target',
+        overlayOpacity: 0.8,
+        offset: 24,
+        closeOnOverlayClick: true,
+      },
+    }
+    render(
+      <AnnouncementsProvider announcements={[cfg]} storage={null}>
+        <AnnouncementSpotlight id="spot" open />
+      </AnnouncementsProvider>
+    )
+
+    const overlay = screen.getByRole('button', { name: /close spotlight/i })
+    // overlayOpacity flows into the radial-gradient rgba alpha.
+    expect(overlay.getAttribute('style')).toContain('radial-gradient')
+    expect(overlay.getAttribute('style')).toContain('0.8')
+  })
+
+  it('renders the cutout + arrow in the default variant', () => {
+    const cfg: AnnouncementConfig = {
+      id: 'spot',
+      variant: 'spotlight',
+      title: 'Look here',
+      autoShow: false,
+      spotlightOptions: { targetSelector: '#spot-merge-target' },
+    }
+    render(
+      <AnnouncementsProvider announcements={[cfg]} storage={null}>
+        <AnnouncementSpotlight id="spot" open />
+      </AnnouncementsProvider>
+    )
+
+    expect(document.querySelector('[data-tk-spotlight-cutout]')).not.toBeNull()
+    expect(document.querySelector('[data-tk-spotlight-arrow]')).not.toBeNull()
+  })
+
+  it('legacy-spotlight variant omits the cutout/arrow but keeps the radial overlay', () => {
+    const cfg: AnnouncementConfig = {
+      id: 'spot',
+      variant: 'spotlight',
+      title: 'Look here',
+      autoShow: false,
+      spotlightOptions: { targetSelector: '#spot-merge-target' },
+    }
+    render(
+      <AnnouncementsProvider announcements={[cfg]} storage={null}>
+        <AnnouncementSpotlight id="spot" open variant="legacy-spotlight" />
+      </AnnouncementsProvider>
+    )
+
+    expect(document.querySelector('[data-tk-spotlight-cutout]')).toBeNull()
+    expect(document.querySelector('[data-tk-spotlight-arrow]')).toBeNull()
+    expect(
+      screen.getByRole('button', { name: /close spotlight/i }).getAttribute('style')
+    ).toContain('radial-gradient')
+  })
+})

--- a/packages/announcements/src/__tests__/components/headless-variants.test.tsx
+++ b/packages/announcements/src/__tests__/components/headless-variants.test.tsx
@@ -1,0 +1,371 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HeadlessBanner } from '../../components/headless/headless-banner'
+import { HeadlessModal } from '../../components/headless/headless-modal'
+import { HeadlessSlideout } from '../../components/headless/headless-slideout'
+import { HeadlessSpotlight } from '../../components/headless/headless-spotlight'
+import { AnnouncementsProvider } from '../../context/announcements-provider'
+import type { AnnouncementConfig } from '../../types/announcement'
+
+function renderWith(ui: React.ReactNode, announcements: AnnouncementConfig[]) {
+  return render(
+    <AnnouncementsProvider announcements={announcements} storage={null}>
+      {ui}
+    </AnnouncementsProvider>
+  )
+}
+
+describe('HeadlessBanner', () => {
+  const cfg: AnnouncementConfig = {
+    id: 'b1',
+    variant: 'banner',
+    title: 'Banner title',
+    autoShow: false,
+    bannerOptions: { intent: 'warning', position: 'bottom' },
+  }
+
+  it('passes open/state/config + merged options to the render prop', () => {
+    const seen: { open?: boolean; intent?: string; position?: string; role?: string } = {}
+    renderWith(
+      <HeadlessBanner id="b1" open options={{ intent: 'info' }}>
+        {(props) => {
+          seen.open = props.open
+          seen.intent = props.options.intent
+          seen.position = props.options.position
+          seen.role = props.bannerProps.role
+          return <div data-testid="banner">{String(props.config?.title)}</div>
+        }}
+      </HeadlessBanner>,
+      [cfg]
+    )
+
+    expect(seen.open).toBe(true)
+    // config.bannerOptions wins over the inline `options` prop
+    expect(seen.intent).toBe('warning')
+    expect(seen.position).toBe('bottom')
+    expect(seen.role).toBe('alert')
+    expect(screen.getByTestId('banner')).toHaveTextContent('Banner title')
+  })
+
+  it('dismiss() from the render prop dismisses the announcement and notifies onOpenChange', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessBanner id="b1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          <button type="button" onClick={() => props.dismiss()}>
+            close
+          </button>
+        )}
+      </HeadlessBanner>,
+      [cfg]
+    )
+
+    fireEvent.click(screen.getByText('close'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('uncontrolled open reflects announcement visibility (closed by default)', () => {
+    renderWith(
+      <HeadlessBanner id="b1">
+        {(props) => <div data-testid="banner-state">{props.open ? 'open' : 'closed'}</div>}
+      </HeadlessBanner>,
+      [cfg]
+    )
+    expect(screen.getByTestId('banner-state')).toHaveTextContent('closed')
+  })
+})
+
+describe('HeadlessModal', () => {
+  const cfg: AnnouncementConfig = {
+    id: 'm1',
+    variant: 'modal',
+    title: 'Modal title',
+    autoShow: false,
+    modalOptions: { closeOnEscape: true, closeOnOverlayClick: true },
+  }
+
+  it('exposes contentProps/overlayProps and complete/close/dismiss handlers', () => {
+    const seen: Record<string, unknown> = {}
+    renderWith(
+      <HeadlessModal id="m1" open>
+        {(props) => {
+          seen.role = props.contentProps.role
+          seen.ariaModal = props.contentProps['aria-modal']
+          seen.labelledBy = props.contentProps['aria-labelledby']
+          return <div data-testid="modal">{String(props.config?.title)}</div>
+        }}
+      </HeadlessModal>,
+      [cfg]
+    )
+
+    expect(seen.role).toBe('dialog')
+    expect(seen.ariaModal).toBe(true)
+    expect(seen.labelledBy).toBe('m1-title')
+    expect(screen.getByTestId('modal')).toHaveTextContent('Modal title')
+  })
+
+  it('Escape key on contentProps dismisses when closeOnEscape is set', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessModal id="m1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          // biome-ignore lint/a11y/useKeyWithClickEvents: test harness
+          <div data-testid="modal-content" onKeyDown={props.contentProps.onKeyDown} tabIndex={-1}>
+            content
+          </div>
+        )}
+      </HeadlessModal>,
+      [cfg]
+    )
+
+    fireEvent.keyDown(screen.getByTestId('modal-content'), { key: 'Escape' })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('overlayProps.onClick dismisses (overlay_click) when closeOnOverlayClick is set', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessModal id="m1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          // biome-ignore lint/a11y/useKeyWithClickEvents: test harness
+          <div data-testid="overlay" onClick={props.overlayProps.onClick} />
+        )}
+      </HeadlessModal>,
+      [cfg]
+    )
+
+    fireEvent.click(screen.getByTestId('overlay'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('complete() triggers onOpenChange(false)', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessModal id="m1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          <button type="button" onClick={props.complete}>
+            done
+          </button>
+        )}
+      </HeadlessModal>,
+      [cfg]
+    )
+
+    fireEvent.click(screen.getByText('done'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('controlled close() does not hide but still calls onOpenChange', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessModal id="m1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          <button type="button" onClick={props.close}>
+            x
+          </button>
+        )}
+      </HeadlessModal>,
+      [cfg]
+    )
+
+    fireEvent.click(screen.getByText('x'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('HeadlessSlideout', () => {
+  const cfg: AnnouncementConfig = {
+    id: 's1',
+    variant: 'slideout',
+    title: 'Slideout title',
+    autoShow: false,
+    slideoutOptions: { position: 'left', closeOnEscape: false },
+  }
+
+  it('merges options (config wins) and surfaces dialog content props', () => {
+    const seen: Record<string, unknown> = {}
+    renderWith(
+      <HeadlessSlideout id="s1" open options={{ position: 'right' }}>
+        {(props) => {
+          seen.position = props.options.position
+          seen.role = props.contentProps.role
+          return <div data-testid="slideout">{String(props.config?.title)}</div>
+        }}
+      </HeadlessSlideout>,
+      [cfg]
+    )
+
+    expect(seen.position).toBe('left')
+    expect(seen.role).toBe('dialog')
+    expect(screen.getByTestId('slideout')).toHaveTextContent('Slideout title')
+  })
+
+  it('Escape does NOT dismiss when closeOnEscape is false', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessSlideout id="s1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          // biome-ignore lint/a11y/useKeyWithClickEvents: test harness
+          <div
+            data-testid="slideout-content"
+            onKeyDown={props.contentProps.onKeyDown}
+            tabIndex={-1}
+          >
+            content
+          </div>
+        )}
+      </HeadlessSlideout>,
+      [cfg]
+    )
+
+    fireEvent.keyDown(screen.getByTestId('slideout-content'), { key: 'Escape' })
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('dismiss() with explicit reason notifies onOpenChange', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessSlideout id="s1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          <button type="button" onClick={() => props.dismiss('secondary_action')}>
+            no thanks
+          </button>
+        )}
+      </HeadlessSlideout>,
+      [cfg]
+    )
+
+    fireEvent.click(screen.getByText('no thanks'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('close() and complete() both notify onOpenChange', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessSlideout id="s1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          <>
+            <button type="button" onClick={props.close}>
+              close
+            </button>
+            <button type="button" onClick={props.complete}>
+              complete
+            </button>
+          </>
+        )}
+      </HeadlessSlideout>,
+      [cfg]
+    )
+
+    fireEvent.click(screen.getByText('close'))
+    fireEvent.click(screen.getByText('complete'))
+    expect(onOpenChange).toHaveBeenCalledTimes(2)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('overlayProps.onClick dismisses (overlay_click) when closeOnOverlayClick is set', () => {
+    const onOpenChange = vi.fn()
+    const cfgOverlay: AnnouncementConfig = {
+      id: 's2',
+      variant: 'slideout',
+      title: 'Overlay slideout',
+      autoShow: false,
+      slideoutOptions: { closeOnOverlayClick: true },
+    }
+    renderWith(
+      <HeadlessSlideout id="s2" open onOpenChange={onOpenChange}>
+        {(props) => (
+          // biome-ignore lint/a11y/useKeyWithClickEvents: test harness
+          <div data-testid="s2-overlay" onClick={props.overlayProps.onClick} />
+        )}
+      </HeadlessSlideout>,
+      [cfgOverlay]
+    )
+
+    fireEvent.click(screen.getByTestId('s2-overlay'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('HeadlessSpotlight', () => {
+  const cfg: AnnouncementConfig = {
+    id: 'sp1',
+    variant: 'spotlight',
+    title: 'Spotlight title',
+    autoShow: false,
+    spotlightOptions: { targetSelector: '#sp-target', offset: 16 },
+  }
+
+  let target: HTMLElement
+  beforeEach(() => {
+    target = document.createElement('div')
+    target.id = 'sp-target'
+    document.body.appendChild(target)
+  })
+  afterEach(() => {
+    target.remove()
+  })
+
+  it('resolves the target element and exposes floating props + merged options', () => {
+    const seen: Record<string, unknown> = {}
+    renderWith(
+      <HeadlessSpotlight id="sp1" open>
+        {(props) => {
+          seen.target = props.targetElement
+          seen.offset = props.options.offset
+          seen.role = props.contentProps.role
+          seen.hasSetFloating = typeof props.setFloating === 'function'
+          return <div data-testid="spotlight">{String(props.config?.title)}</div>
+        }}
+      </HeadlessSpotlight>,
+      [cfg]
+    )
+
+    expect(seen.target).toBe(target)
+    expect(seen.offset).toBe(16)
+    expect(seen.role).toBe('dialog')
+    expect(seen.hasSetFloating).toBe(true)
+    expect(screen.getByTestId('spotlight')).toHaveTextContent('Spotlight title')
+  })
+
+  it('overlayProps.onClick dismisses on overlay click', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessSpotlight id="sp1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          // biome-ignore lint/a11y/useKeyWithClickEvents: test harness
+          <div data-testid="sp-overlay" onClick={props.overlayProps.onClick} />
+        )}
+      </HeadlessSpotlight>,
+      [cfg]
+    )
+
+    fireEvent.click(screen.getByTestId('sp-overlay'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('complete() and close() both notify onOpenChange', () => {
+    const onOpenChange = vi.fn()
+    renderWith(
+      <HeadlessSpotlight id="sp1" open onOpenChange={onOpenChange}>
+        {(props) => (
+          <>
+            <button type="button" onClick={props.complete}>
+              complete
+            </button>
+            <button type="button" onClick={props.close}>
+              close
+            </button>
+          </>
+        )}
+      </HeadlessSpotlight>,
+      [cfg]
+    )
+
+    fireEvent.click(screen.getByText('complete'))
+    fireEvent.click(screen.getByText('close'))
+    expect(onOpenChange).toHaveBeenCalledTimes(2)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/packages/announcements/src/__tests__/hooks/use-announcement-queue.test.tsx
+++ b/packages/announcements/src/__tests__/hooks/use-announcement-queue.test.tsx
@@ -1,0 +1,120 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type * as React from 'react'
+import { describe, expect, it } from 'vitest'
+import { useAnnouncementsContext } from '../../context/announcements-context'
+import { AnnouncementsProvider } from '../../context/announcements-provider'
+import { useAnnouncementQueue } from '../../hooks/use-announcement-queue'
+import type { AnnouncementConfig } from '../../types/announcement'
+import type { QueueConfig } from '../../types/queue'
+
+function makeWrapper(announcements: AnnouncementConfig[], queueConfig?: Partial<QueueConfig>) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <AnnouncementsProvider announcements={announcements} queueConfig={queueConfig} storage={null}>
+        {children}
+      </AnnouncementsProvider>
+    )
+  }
+}
+
+const high: AnnouncementConfig = {
+  id: 'first',
+  variant: 'modal',
+  title: 'First',
+  priority: 'critical',
+}
+const low: AnnouncementConfig = {
+  id: 'second',
+  variant: 'modal',
+  title: 'Second',
+  priority: 'high',
+}
+
+describe('useAnnouncementQueue', () => {
+  it('reports an empty queue and the active config when nothing is pending', () => {
+    const { result } = renderHook(() => useAnnouncementQueue(), {
+      wrapper: makeWrapper([{ id: 'solo', variant: 'banner', autoShow: false }]),
+    })
+
+    expect(result.current.queue).toEqual([])
+    expect(result.current.size).toBe(0)
+    expect(result.current.isEmpty).toBe(true)
+    // queueConfig is surfaced from the provider (defaults merged)
+    expect(result.current.config.maxConcurrent).toBeGreaterThanOrEqual(1)
+    expect(result.current.isQueued('solo')).toBe(false)
+    expect(result.current.getPosition('solo')).toBe(-1)
+  })
+
+  it('reflects an enqueued announcement once one is active at maxConcurrent', async () => {
+    const { result } = renderHook(() => useAnnouncementQueue(), {
+      wrapper: makeWrapper([high, low], {
+        maxConcurrent: 1,
+        stackBehavior: 'queue',
+        delayBetween: 1_000_000, // keep the queued item pending for assertions
+      }),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isEmpty).toBe(false)
+    })
+
+    expect(result.current.queue).toContain('second')
+    expect(result.current.size).toBe(1)
+    expect(result.current.isQueued('second')).toBe(true)
+    expect(result.current.getPosition('second')).toBe(0)
+    expect(result.current.isQueued('first')).toBe(false)
+  })
+
+  it('clear() empties the queue', async () => {
+    const { result } = renderHook(() => useAnnouncementQueue(), {
+      wrapper: makeWrapper([high, low], {
+        maxConcurrent: 1,
+        stackBehavior: 'queue',
+        delayBetween: 1_000_000,
+      }),
+    })
+
+    await waitFor(() => {
+      expect(result.current.queue).toContain('second')
+    })
+
+    act(() => {
+      result.current.clear()
+    })
+
+    expect(result.current.queue).toEqual([])
+    expect(result.current.isEmpty).toBe(true)
+    expect(result.current.isQueued('second')).toBe(false)
+  })
+
+  it('showNext() promotes a queued announcement once a slot is free', async () => {
+    const { result } = renderHook(
+      () => ({ queue: useAnnouncementQueue(), ctx: useAnnouncementsContext() }),
+      {
+        wrapper: makeWrapper([high, low], {
+          maxConcurrent: 1,
+          stackBehavior: 'queue',
+          delayBetween: 1_000_000, // suppress the auto-advance timer
+        }),
+      }
+    )
+
+    await waitFor(() => {
+      expect(result.current.queue.queue).toContain('second')
+    })
+
+    // Free the single concurrency slot by dismissing the active announcement.
+    act(() => {
+      result.current.ctx.dismiss('first')
+    })
+
+    // Now showNext() can dequeue + display 'second', removing it from the queue.
+    act(() => {
+      result.current.queue.showNext()
+    })
+
+    await waitFor(() => {
+      expect(result.current.queue.queue).not.toContain('second')
+    })
+  })
+})

--- a/packages/announcements/src/__tests__/hooks/use-announcements.test.tsx
+++ b/packages/announcements/src/__tests__/hooks/use-announcements.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from '@testing-library/react'
+import type * as React from 'react'
+import { describe, expect, it } from 'vitest'
+import { AnnouncementsProvider } from '../../context/announcements-provider'
+import { useAnnouncement } from '../../hooks/use-announcement'
+import { useAnnouncements } from '../../hooks/use-announcements'
+import type { AnnouncementConfig } from '../../types/announcement'
+
+const configs: AnnouncementConfig[] = [
+  { id: 'modal-a', variant: 'modal', title: 'Modal A', autoShow: false },
+  { id: 'banner-b', variant: 'banner', title: 'Banner B', autoShow: false },
+  { id: 'toast-c', variant: 'toast', title: 'Toast C', autoShow: false },
+]
+
+function createWrapper(announcements: AnnouncementConfig[] = configs) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <AnnouncementsProvider announcements={announcements} storage={null}>
+        {children}
+      </AnnouncementsProvider>
+    )
+  }
+}
+
+describe('useAnnouncements', () => {
+  it('exposes every registered announcement state and ids', () => {
+    const { result } = renderHook(() => useAnnouncements(), { wrapper: createWrapper() })
+
+    expect(result.current.count).toBe(3)
+    expect(result.current.announcements.size).toBe(3)
+    expect(result.current.ids.sort()).toEqual(['banner-b', 'modal-a', 'toast-c'])
+    expect(result.current.activeId).toBeNull()
+  })
+
+  it('getFiltered narrows by variant', () => {
+    const { result } = renderHook(() => useAnnouncements(), { wrapper: createWrapper() })
+
+    const modals = result.current.getFiltered({ variant: 'modal' })
+    expect(modals).toHaveLength(1)
+    expect(modals[0]?.id).toBe('modal-a')
+
+    const modalOrBanner = result.current.getFiltered({ variant: ['modal', 'banner'] })
+    expect(modalOrBanner.map((s) => s.id).sort()).toEqual(['banner-b', 'modal-a'])
+  })
+
+  it('getFiltered honors a custom filter predicate against state + config', () => {
+    const { result } = renderHook(() => useAnnouncements(), { wrapper: createWrapper() })
+
+    const onlyToast = result.current.getFiltered({
+      filter: (_state, config) => config.variant === 'toast',
+    })
+    expect(onlyToast.map((s) => s.id)).toEqual(['toast-c'])
+  })
+
+  it('visible / dismissed views and activeId reflect provider transitions', () => {
+    const { result } = renderHook(
+      () => ({ all: useAnnouncements(), one: useAnnouncement('modal-a') }),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current.all.visible).toHaveLength(0)
+    expect(result.current.all.dismissed).toHaveLength(0)
+
+    act(() => {
+      result.current.one.show()
+    })
+
+    expect(result.current.all.visible.map((s) => s.id)).toEqual(['modal-a'])
+    expect(result.current.all.activeId).toBe('modal-a')
+
+    act(() => {
+      result.current.one.dismiss('close_button')
+    })
+
+    expect(result.current.all.visible).toHaveLength(0)
+    expect(result.current.all.dismissed.map((s) => s.id)).toEqual(['modal-a'])
+  })
+
+  it('resetAll clears dismissed flags across all announcements', () => {
+    const { result } = renderHook(
+      () => ({
+        all: useAnnouncements(),
+        a: useAnnouncement('modal-a'),
+        b: useAnnouncement('banner-b'),
+      }),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      result.current.a.show()
+      result.current.a.dismiss()
+      result.current.b.show()
+      result.current.b.dismiss()
+    })
+
+    expect(result.current.all.dismissed).toHaveLength(2)
+
+    act(() => {
+      result.current.all.resetAll()
+    })
+
+    expect(result.current.all.dismissed).toHaveLength(0)
+  })
+})

--- a/packages/announcements/vitest.config.ts
+++ b/packages/announcements/vitest.config.ts
@@ -17,15 +17,14 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/', 'src/__tests__/', 'dist/', '**/*.d.ts', '**/index.ts'],
-      // Thresholds temporarily lowered from 80/75/80/80 — actuals on
-      // chore/code-health-phase-5: stmts 74.70 / branches 64.61 / funcs 75.82 /
-      // lines 74.81. Phase 5 deferred per failure protocol.
-      // Follow-up: https://github.com/domidex01/tour-kit/issues/13
+      // Slice 7 coverage-truth floor (raised from the phase-5 lows with wired
+      // schedule-$ref / frequency / spotlight-merge / hook / headless + variant
+      // render behavior tests). Earned actuals well above these.
       thresholds: {
-        statements: 70,
-        branches: 60,
-        functions: 70,
-        lines: 70,
+        statements: 75,
+        branches: 70,
+        functions: 80,
+        lines: 75,
       },
     },
   },

--- a/packages/core/src/__tests__/coverage-claim-alignment.test.ts
+++ b/packages/core/src/__tests__/coverage-claim-alignment.test.ts
@@ -1,0 +1,117 @@
+// ANTI-DRIFT META-TEST — the CLAUDE.md coverage claim must match the enforced
+// per-package thresholds. Without this, an author could raise a config and forget
+// the doc (or vice-versa) and the headline claim silently becomes a lie again —
+// the exact failure Slice 0 left behind.
+//
+// Models: no-zod-in-main.test.ts (file scan) + vitest-config-alignment.test.ts
+// (config read). The ENFORCED_FLOORS table below is the single source of truth;
+// a future slice that raises a config updates this table AND the CLAUDE.md line
+// in the SAME change — the test reds if it touches only one.
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..')
+
+type Floor = { statements: number; branches: number; functions: number; lines: number }
+const METRICS = ['statements', 'branches', 'functions', 'lines'] as const
+
+// The canonical repo shape. NOTE branches is 75, not 80 — so "clears canonical"
+// is the right yardstick, not "≥80 on all four" (no package with branches:75 can
+// meet that). A package is "reduced" when any metric sits below this shape.
+const CANONICAL: Floor = { statements: 80, branches: 75, functions: 80, lines: 80 }
+
+// The five packages Slice 7 raised from the phase-5 lows. Single source of truth.
+const ENFORCED_FLOORS: Record<string, Floor> = {
+  scheduling: { statements: 75, branches: 65, functions: 80, lines: 75 },
+  media: { statements: 70, branches: 60, functions: 70, lines: 70 },
+  surveys: { statements: 80, branches: 75, functions: 80, lines: 80 },
+  announcements: { statements: 75, branches: 70, functions: 80, lines: 75 },
+  core: { statements: 80, branches: 75, functions: 80, lines: 80 }, // branches raised 65→75
+}
+
+function readConfig(pkg: string): string {
+  return readFileSync(join(REPO_ROOT, 'packages', pkg, 'vitest.config.ts'), 'utf8')
+}
+
+/** Pull a numeric threshold out of a `thresholds:` block, e.g. `branches: 75`. */
+function thresholdOf(cfg: string, metric: (typeof METRICS)[number]): number {
+  const m = cfg.match(new RegExp(`${metric}:\\s*(\\d+)`))
+  expect(m, `no ${metric} threshold found`).not.toBeNull()
+  return Number((m as RegExpMatchArray)[1])
+}
+
+function isReduced(floor: Floor): boolean {
+  return METRICS.some((m) => floor[m] < CANONICAL[m])
+}
+
+// Extract the full "Test coverage" bullet (the line + its indented continuation
+// lines) so the claim can span multiple lines and still be checked as one block.
+const CLAUDE_MD = readFileSync(join(REPO_ROOT, 'CLAUDE.md'), 'utf8')
+const claimBlock = (() => {
+  const lines = CLAUDE_MD.split('\n')
+  const start = lines.findIndex((l) => /Test coverage/i.test(l))
+  if (start === -1) return ''
+  let block = lines[start]
+  for (let i = start + 1; i < lines.length; i++) {
+    const l = lines[i]
+    if (/^- /.test(l) || /^#{1,6}\s/.test(l) || l.trim() === '') break
+    block += `\n${l}`
+  }
+  return block
+})()
+
+describe('coverage claim ⟂ enforced config (anti-drift)', () => {
+  it('each config enforces AT LEAST the floor this slice promised', () => {
+    for (const [pkg, floor] of Object.entries(ENFORCED_FLOORS)) {
+      const cfg = readConfig(pkg)
+      for (const metric of METRICS) {
+        expect(
+          thresholdOf(cfg, metric),
+          `${pkg}.${metric} config threshold dropped below the Slice-7 floor`
+        ).toBeGreaterThanOrEqual(floor[metric])
+      }
+    }
+  })
+
+  it('the CLAUDE.md claim is present, not a placeholder, and points at the per-package configs', () => {
+    expect(claimBlock, 'no "Test coverage" claim found in CLAUDE.md').not.toBe('')
+    expect(claimBlock, 'CLAUDE.md coverage claim still reads as a placeholder').not.toMatch(
+      /placeholder/i
+    )
+    // It must NOT assert a blanket > 80% it cannot keep (feature packages are below 80).
+    expect(claimBlock, 'claim asserts a blanket >80% it does not enforce').not.toMatch(
+      /coverage\s*>\s*80%\s*$/im
+    )
+    // It must direct readers to the enforced source of truth.
+    expect(claimBlock, 'claim must say thresholds are per-package').toMatch(/per-package/i)
+    expect(claimBlock, 'claim must reference the per-package vitest.config enforcement').toMatch(
+      /vitest\.config/i
+    )
+  })
+
+  it('every below-canonical package is named in the claim', () => {
+    for (const [pkg, floor] of Object.entries(ENFORCED_FLOORS)) {
+      if (isReduced(floor)) {
+        expect(claimBlock, `claim omits ${pkg}, which enforces a below-canonical floor`).toMatch(
+          new RegExp(`\\b${pkg}\\b`, 'i')
+        )
+      }
+    }
+  })
+
+  it('no phase-5 "temporarily lowered" / issues/13 follow-up comment survives in the raised configs', () => {
+    for (const pkg of Object.keys(ENFORCED_FLOORS)) {
+      const cfg = readConfig(pkg)
+      expect(cfg, `${pkg} still carries a phase-5 lowered comment`).not.toMatch(
+        /temporarily lowered/i
+      )
+      expect(cfg, `${pkg} still carries a stale issues/13 follow-up link`).not.toMatch(
+        /Follow-up:\s*https:\/\/github\.com\/[^\s]+\/issues\/13\b/
+      )
+    }
+  })
+})

--- a/packages/core/src/__tests__/vitest-config-alignment.test.ts
+++ b/packages/core/src/__tests__/vitest-config-alignment.test.ts
@@ -23,11 +23,20 @@ const PACKAGES = [
 const REPO_ROOT = join(__dirname, '..', '..', '..', '..')
 const NON_AI = PACKAGES.filter((p) => p !== 'ai')
 
-// Packages with thresholds temporarily lowered in Phase 5; each must carry a
-// `Follow-up: https://github.com/.../issues/<N>` comment in its vitest.config.ts.
-// See plan/code-health-coverage-snapshot.md.
-const PHASE_5_LOWERED = new Set<string>(['core', 'announcements', 'surveys', 'media', 'scheduling'])
-const CANONICAL_THRESHOLDS = NON_AI.filter((p) => !PHASE_5_LOWERED.has(p))
+// Slice 7 (coverage truth) raised the phase-5 lows. Three feature packages
+// enforce honest, below-canonical floors backed by real behavior tests; everyone
+// else — including core and surveys, both restored — holds the canonical
+// 80/75/80/80. `coverage-claim-alignment.test.ts` is the forward guard that keeps
+// the CLAUDE.md claim in sync with these enforced numbers.
+const REDUCED_FLOORS: Record<
+  string,
+  { statements: number; branches: number; functions: number; lines: number }
+> = {
+  announcements: { statements: 75, branches: 70, functions: 80, lines: 75 },
+  scheduling: { statements: 75, branches: 65, functions: 80, lines: 75 },
+  media: { statements: 70, branches: 60, functions: 70, lines: 70 },
+}
+const CANONICAL_THRESHOLDS = NON_AI.filter((p) => !(p in REDUCED_FLOORS))
 
 function readConfig(pkg: string): string {
   return readFileSync(join(REPO_ROOT, 'packages', pkg, 'vitest.config.ts'), 'utf8')
@@ -52,12 +61,26 @@ describe('Phase 4 — vitest config alignment', () => {
       expect(cfg).toMatch(/lines:\s*80\b/)
     })
 
-    it.each([...PHASE_5_LOWERED])(
-      '%s has Phase 5 follow-up issue link in vitest.config.ts',
+    it.each(Object.entries(REDUCED_FLOORS))(
+      '%s enforces its Slice-7 earned floor',
+      (pkg, floor) => {
+        const cfg = readConfig(pkg)
+        expect(cfg).toMatch(new RegExp(`statements:\\s*${floor.statements}\\b`))
+        expect(cfg).toMatch(new RegExp(`branches:\\s*${floor.branches}\\b`))
+        expect(cfg).toMatch(new RegExp(`functions:\\s*${floor.functions}\\b`))
+        expect(cfg).toMatch(new RegExp(`lines:\\s*${floor.lines}\\b`))
+      }
+    )
+
+    it.each(NON_AI)(
+      '%s no longer carries a phase-5 "temporarily lowered" / follow-up comment',
       (pkg) => {
         const cfg = readConfig(pkg)
-        expect(cfg, `${pkg} missing follow-up issue comment`).toMatch(
-          /Follow-up:\s*https:\/\/github\.com\/[^\s]+\/issues\/\d+/
+        expect(cfg, `${pkg} still carries a phase-5 lowered comment`).not.toMatch(
+          /temporarily lowered/i
+        )
+        expect(cfg, `${pkg} still carries a stale issues/13 follow-up link`).not.toMatch(
+          /Follow-up:\s*https:\/\/github\.com\/[^\s]+\/issues\/13\b/
         )
       }
     )

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -12,9 +12,9 @@ export default defineConfig({
       exclude: ['node_modules/', 'src/__tests__/', 'dist/', '**/*.d.ts'],
       thresholds: {
         statements: 80,
-        // Temporarily lowered from 75 — actual 70.34% on chore/code-health-phase-5.
-        // Follow-up: https://github.com/domidex01/tour-kit/issues/13
-        branches: 65,
+        // Slice 7 coverage-truth: branches restored to canonical 75
+        // (dead position.ts engine removed in S0 shrank the uncovered denominator).
+        branches: 75,
         functions: 80,
         lines: 80,
       },

--- a/packages/media/src/__tests__/components/embeds.test.tsx
+++ b/packages/media/src/__tests__/components/embeds.test.tsx
@@ -1,0 +1,223 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { GifPlayer } from '../../components/embeds/gif-player'
+import { LoomEmbed } from '../../components/embeds/loom-embed'
+import { NativeVideo } from '../../components/embeds/native-video'
+import { VimeoEmbed } from '../../components/embeds/vimeo-embed'
+import { WistiaEmbed } from '../../components/embeds/wistia-embed'
+import { YouTubeEmbed } from '../../components/embeds/youtube-embed'
+
+describe('YouTubeEmbed', () => {
+  it('renders an iframe pointing at youtube-nocookie with the video id', () => {
+    render(<YouTubeEmbed videoId="dQw4w9WgXcQ" title="Demo video" />)
+    const iframe = screen.getByTitle('Demo video') as HTMLIFrameElement
+    expect(iframe.tagName).toBe('IFRAME')
+    expect(iframe.src).toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ')
+    expect(iframe).toHaveAttribute('allowfullscreen')
+    expect(iframe.getAttribute('allow')).toContain('autoplay')
+  })
+
+  it('reflects autoplay/muted options in the iframe src', () => {
+    render(<YouTubeEmbed videoId="dQw4w9WgXcQ" title="Auto" autoplay muted />)
+    const iframe = screen.getByTitle('Auto') as HTMLIFrameElement
+    expect(iframe.src).toContain('autoplay=1')
+    expect(iframe.src).toContain('mute=1')
+  })
+
+  it('fires onLoad when the iframe loads', () => {
+    const onLoad = vi.fn()
+    render(<YouTubeEmbed videoId="dQw4w9WgXcQ" title="L" onLoad={onLoad} />)
+    fireEvent.load(screen.getByTitle('L'))
+    expect(onLoad).toHaveBeenCalledTimes(1)
+  })
+
+  it('reflects controls=false and startTime in the iframe src', () => {
+    render(<YouTubeEmbed videoId="dQw4w9WgXcQ" title="Opts" controls={false} startTime={42} />)
+    const iframe = screen.getByTitle('Opts') as HTMLIFrameElement
+    expect(iframe.src).toContain('controls=0')
+    expect(iframe.src).toContain('start=42')
+  })
+})
+
+describe('VimeoEmbed', () => {
+  it('renders an iframe to player.vimeo.com with the video id', () => {
+    render(<VimeoEmbed videoId="123456789" title="Vimeo demo" />)
+    const iframe = screen.getByTitle('Vimeo demo') as HTMLIFrameElement
+    expect(iframe.src).toContain('player.vimeo.com/video/123456789')
+    expect(iframe).toHaveAttribute('allowfullscreen')
+  })
+
+  it('reflects loop option in the iframe src', () => {
+    render(<VimeoEmbed videoId="123456789" title="Loop" loop />)
+    expect((screen.getByTitle('Loop') as HTMLIFrameElement).src).toContain('loop=1')
+  })
+
+  it('fires onLoad when the iframe loads', () => {
+    const onLoad = vi.fn()
+    render(<VimeoEmbed videoId="123456789" title="VL" onLoad={onLoad} />)
+    fireEvent.load(screen.getByTitle('VL'))
+    expect(onLoad).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('LoomEmbed', () => {
+  it('renders an iframe to loom.com/embed with the video id', () => {
+    render(<LoomEmbed videoId="abc123" title="Loom demo" />)
+    const iframe = screen.getByTitle('Loom demo') as HTMLIFrameElement
+    expect(iframe.src).toContain('loom.com/embed/abc123')
+    expect(iframe).toHaveAttribute('allowfullscreen')
+  })
+
+  it('passes hideControls through to hide_controls param', () => {
+    render(<LoomEmbed videoId="abc123" title="HC" hideControls />)
+    expect((screen.getByTitle('HC') as HTMLIFrameElement).src).toContain('hide_controls=true')
+  })
+
+  it('fires onLoad when the iframe loads', () => {
+    const onLoad = vi.fn()
+    render(<LoomEmbed videoId="abc123" title="LL" onLoad={onLoad} />)
+    fireEvent.load(screen.getByTitle('LL'))
+    expect(onLoad).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('WistiaEmbed', () => {
+  it('renders an iframe to fast.wistia.net with the video id', () => {
+    render(<WistiaEmbed videoId="abc123" title="Wistia demo" />)
+    const iframe = screen.getByTitle('Wistia demo') as HTMLIFrameElement
+    expect(iframe.src).toContain('fast.wistia.net/embed/iframe/abc123')
+    expect(iframe).toHaveAttribute('allowfullscreen')
+  })
+
+  it('passes controlsVisibleOnLoad=false through', () => {
+    render(<WistiaEmbed videoId="abc123" title="NoCtl" controlsVisibleOnLoad={false} />)
+    expect((screen.getByTitle('NoCtl') as HTMLIFrameElement).src).toContain(
+      'controlsVisibleOnLoad=false'
+    )
+  })
+
+  it('fires onLoad when the iframe loads', () => {
+    const onLoad = vi.fn()
+    render(<WistiaEmbed videoId="abc123" title="WL" onLoad={onLoad} />)
+    fireEvent.load(screen.getByTitle('WL'))
+    expect(onLoad).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('NativeVideo', () => {
+  it('renders a <video> element with src and controls', () => {
+    render(<NativeVideo src="/clip.mp4" alt="Native clip" controls />)
+    const video = screen.getByLabelText('Native clip') as HTMLVideoElement
+    expect(video.tagName).toBe('VIDEO')
+    expect(video.getAttribute('src')).toBe('/clip.mp4')
+    expect(video).toHaveAttribute('controls')
+  })
+
+  it('maps muted and loop props onto the element', () => {
+    render(<NativeVideo src="/clip.mp4" alt="Muted clip" muted loop />)
+    const video = screen.getByLabelText('Muted clip') as HTMLVideoElement
+    expect(video.muted).toBe(true)
+    expect(video.loop).toBe(true)
+  })
+
+  it('renders <source> and <track> children for sources and captions', () => {
+    const { container } = render(
+      <NativeVideo
+        src="/clip.mp4"
+        alt="With tracks"
+        sources={[{ src: '/clip.webm', type: 'video/webm' }]}
+        captions={[{ src: '/en.vtt', srclang: 'en', label: 'English', default: true }]}
+      />
+    )
+    expect(container.querySelector('source[src="/clip.webm"]')).not.toBeNull()
+    expect(container.querySelector('track[srclang="en"]')).not.toBeNull()
+  })
+
+  it('invokes onTimeUpdate with currentTime and duration', () => {
+    const onTimeUpdate = vi.fn()
+    render(<NativeVideo src="/clip.mp4" alt="TU" onTimeUpdate={onTimeUpdate} />)
+    fireEvent.timeUpdate(screen.getByLabelText('TU'))
+    expect(onTimeUpdate).toHaveBeenCalledWith(0, 100)
+  })
+
+  it('fires onError and onLoadedData handlers', () => {
+    const onError = vi.fn()
+    const onLoadedData = vi.fn()
+    render(<NativeVideo src="/clip.mp4" alt="Errv" onError={onError} onLoadedData={onLoadedData} />)
+    const video = screen.getByLabelText('Errv')
+    fireEvent.error(video)
+    fireEvent.loadedData(video)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onLoadedData).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onPlay/onPause/onEnded handlers', () => {
+    const onPlay = vi.fn()
+    const onPause = vi.fn()
+    const onEnded = vi.fn()
+    render(
+      <NativeVideo src="/clip.mp4" alt="Cb" onPlay={onPlay} onPause={onPause} onEnded={onEnded} />
+    )
+    const video = screen.getByLabelText('Cb')
+    fireEvent.play(video)
+    fireEvent.pause(video)
+    fireEvent.ended(video)
+    expect(onPlay).toHaveBeenCalledTimes(1)
+    expect(onPause).toHaveBeenCalledTimes(1)
+    expect(onEnded).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('GifPlayer', () => {
+  // NOTE: core useReducedMotion() defaults to `true` on the first commit, so the
+  // GifPlayer's reduced-motion effect pauses an autoplay gif on mount even though
+  // matchMedia later reports no-preference. Tests assert this real behavior:
+  // after mount, an autoplay gif is paused and shows the poster.
+  it('renders an img and starts paused under default reduced-motion (shows poster)', () => {
+    render(<GifPlayer src="/anim.gif" alt="Loading bar" poster="/static.png" autoplay />)
+    const img = screen.getByAltText('Loading bar') as HTMLImageElement
+    expect(img.getAttribute('src')).toBe('/static.png')
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('toggles play/pause on click, swapping between gif and poster src', () => {
+    render(<GifPlayer src="/anim.gif" alt="Toggle me" poster="/static.png" autoplay />)
+    const img = screen.getByAltText('Toggle me') as HTMLImageElement
+    const button = screen.getByRole('button')
+    // Starts paused (poster) due to default reduced-motion
+    expect(img.getAttribute('src')).toBe('/static.png')
+    // Click → play → gif
+    fireEvent.click(button)
+    expect(img.getAttribute('src')).toBe('/anim.gif')
+    expect(button).toHaveAttribute('aria-pressed', 'true')
+    // Click → pause → poster
+    fireEvent.click(button)
+    expect(img.getAttribute('src')).toBe('/static.png')
+    expect(button).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('exposes an accessible play/pause label reflecting current state', () => {
+    render(<GifPlayer src="/anim.gif" alt="A11y gif" poster="/static.png" autoplay />)
+    const button = screen.getByRole('button')
+    // Paused on mount → "Play"
+    expect(button.getAttribute('aria-label')).toBe('Play A11y gif')
+    fireEvent.click(button)
+    // Now playing → "Pause"
+    expect(button.getAttribute('aria-label')).toBe('Pause A11y gif')
+  })
+
+  it('fires onLoad when the underlying img loads', () => {
+    const onLoad = vi.fn()
+    render(<GifPlayer src="/anim.gif" alt="Load gif" onLoad={onLoad} />)
+    fireEvent.load(screen.getByAltText('Load gif'))
+    expect(onLoad).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to gif src when no poster is provided and paused', () => {
+    // displaySrc = isPlaying ? src : (poster ?? src); no poster → always gif src
+    render(<GifPlayer src="/anim.gif" alt="No poster" autoplay />)
+    expect((screen.getByAltText('No poster') as HTMLImageElement).getAttribute('src')).toBe(
+      '/anim.gif'
+    )
+  })
+})

--- a/packages/media/src/__tests__/components/tour-media.test.tsx
+++ b/packages/media/src/__tests__/components/tour-media.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TourMedia } from '../../components/tour-media'
+
+function setReducedMotion(reduce: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)' ? reduce : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+describe('TourMedia auto-detection', () => {
+  it('renders a YouTube embed for a youtube.com URL', () => {
+    render(<TourMedia src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" alt="YT tour" />)
+    const iframe = screen.getByTitle('YT tour') as HTMLIFrameElement
+    expect(iframe.src).toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ')
+  })
+
+  it('renders a Vimeo embed for a vimeo.com URL', () => {
+    render(<TourMedia src="https://vimeo.com/123456789" alt="Vimeo tour" />)
+    expect((screen.getByTitle('Vimeo tour') as HTMLIFrameElement).src).toContain(
+      'player.vimeo.com/video/123456789'
+    )
+  })
+
+  it('renders a Loom embed for a loom.com URL', () => {
+    render(<TourMedia src="https://www.loom.com/share/abc123" alt="Loom tour" />)
+    expect((screen.getByTitle('Loom tour') as HTMLIFrameElement).src).toContain(
+      'loom.com/embed/abc123'
+    )
+  })
+
+  it('renders a Wistia embed for a wistia URL', () => {
+    render(<TourMedia src="https://fast.wistia.net/embed/iframe/abc123" alt="Wistia tour" />)
+    expect((screen.getByTitle('Wistia tour') as HTMLIFrameElement).src).toContain(
+      'fast.wistia.net/embed/iframe/abc123'
+    )
+  })
+
+  it('renders a native <video> for an .mp4 URL', () => {
+    render(<TourMedia src="/videos/demo.mp4" alt="MP4 tour" />)
+    const video = screen.getByLabelText('MP4 tour') as HTMLVideoElement
+    expect(video.tagName).toBe('VIDEO')
+    expect(video.getAttribute('src')).toBe('/videos/demo.mp4')
+  })
+
+  it('renders a GIF player (button + img) for a .gif URL', () => {
+    render(<TourMedia src="/anim.gif" alt="GIF tour" />)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+    expect((screen.getByAltText('GIF tour') as HTMLImageElement).getAttribute('src')).toBe(
+      '/anim.gif'
+    )
+  })
+
+  it('falls back to a plain <img> for an unknown / image URL', () => {
+    render(<TourMedia src="/images/photo.png" alt="Image tour" />)
+    const img = screen.getByAltText('Image tour') as HTMLImageElement
+    expect(img.tagName).toBe('IMG')
+    expect(img.getAttribute('src')).toBe('/images/photo.png')
+  })
+
+  it('wires onError through to the native video error message', () => {
+    const onError = vi.fn()
+    render(<TourMedia src="/videos/demo.mp4" alt="Err video" onError={onError} />)
+    fireEvent.error(screen.getByLabelText('Err video'))
+    expect(onError).toHaveBeenCalledWith('Failed to load video')
+  })
+
+  it('wires onError through to the image error message for the fallback path', () => {
+    const onError = vi.fn()
+    render(<TourMedia src="/images/photo.png" alt="Err img" onError={onError} />)
+    fireEvent.error(screen.getByAltText('Err img'))
+    expect(onError).toHaveBeenCalledWith('Failed to load image')
+  })
+
+  it('honors an explicit type over URL auto-detection', () => {
+    // .png would normally render an image; force video instead
+    render(<TourMedia src="/weird-name" type="video" alt="Forced video" />)
+    expect((screen.getByLabelText('Forced video') as HTMLVideoElement).tagName).toBe('VIDEO')
+  })
+
+  it('renders the reduced-motion fallback image for animated media when reduce is on', () => {
+    setReducedMotion(true)
+    render(<TourMedia src="/anim.gif" alt="RM gif" reducedMotionFallback="/static-fallback.png" />)
+    const img = screen.getByAltText('RM gif') as HTMLImageElement
+    expect(img.getAttribute('src')).toBe('/static-fallback.png')
+    // No play/pause button (GifPlayer) rendered in the fallback path
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('does NOT use the fallback when reduce is off (renders the real GifPlayer)', () => {
+    setReducedMotion(false)
+    render(
+      <TourMedia src="/anim.gif" alt="Live gif" reducedMotionFallback="/static-fallback.png" />
+    )
+    // GifPlayer renders a button; the fallback path does not
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+})
+
+afterEach(() => {
+  // Restore the default no-preference matchMedia stub from setup.ts
+  setReducedMotion(false)
+})

--- a/packages/media/src/__tests__/utils/embed-urls.test.ts
+++ b/packages/media/src/__tests__/utils/embed-urls.test.ts
@@ -4,6 +4,7 @@ import {
   buildVimeoEmbedUrl,
   buildWistiaEmbedUrl,
   buildYouTubeEmbedUrl,
+  getVimeoThumbnailUrl,
   getYouTubeThumbnailUrl,
 } from '../../utils/embed-urls'
 
@@ -160,5 +161,35 @@ describe('getYouTubeThumbnailUrl', () => {
   it('returns high quality', () => {
     const url = getYouTubeThumbnailUrl('dQw4w9WgXcQ', 'high')
     expect(url).toBe('https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg')
+  })
+})
+
+describe('getVimeoThumbnailUrl', () => {
+  it('returns the oEmbed JSON endpoint for the given id', () => {
+    expect(getVimeoThumbnailUrl('123456789')).toBe('https://vimeo.com/api/v2/video/123456789.json')
+  })
+})
+
+describe('embed URL option edge cases', () => {
+  it('YouTube omits start when startTime is 0', () => {
+    expect(buildYouTubeEmbedUrl('dQw4w9WgXcQ', { startTime: 0 })).not.toContain('start=')
+  })
+
+  it('Vimeo omits start fragment when startTime is 0', () => {
+    expect(buildVimeoEmbedUrl('123456789', { startTime: 0 })).not.toContain('#t=')
+  })
+
+  it('Loom omits start when startTime is 0', () => {
+    expect(buildLoomEmbedUrl('abc123', { startTime: 0 })).not.toContain('t=')
+  })
+
+  it('Wistia floors-free startTime passes through raw value', () => {
+    expect(buildWistiaEmbedUrl('abc123', { startTime: 12.5 })).toContain('time=12.5')
+  })
+
+  it('YouTube returns a clean URL with no query string when no toggling options set beyond defaults', () => {
+    // rel and modestbranding are always present, so a query string always exists
+    const url = buildYouTubeEmbedUrl('dQw4w9WgXcQ')
+    expect(url).toContain('?')
   })
 })

--- a/packages/media/src/__tests__/utils/extract-video-id.test.ts
+++ b/packages/media/src/__tests__/utils/extract-video-id.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractLoomId,
+  extractVimeoId,
+  extractWistiaId,
+  extractYouTubeId,
+  isLoomUrl,
+  isVimeoUrl,
+  isWistiaUrl,
+  isYouTubeUrl,
+} from '../../utils/extract-video-id'
+
+describe('extractYouTubeId', () => {
+  it('extracts from watch?v= URLs', () => {
+    expect(extractYouTubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('extracts from youtu.be short URLs', () => {
+    expect(extractYouTubeId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('extracts from /embed/ URLs', () => {
+    expect(extractYouTubeId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('extracts from /v/ URLs', () => {
+    expect(extractYouTubeId('https://www.youtube.com/v/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('extracts from youtube-nocookie.com/embed URLs', () => {
+    expect(extractYouTubeId('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')).toBe(
+      'dQw4w9WgXcQ'
+    )
+  })
+
+  it('returns null for non-YouTube URLs', () => {
+    expect(extractYouTubeId('https://vimeo.com/123456789')).toBeNull()
+  })
+
+  it('returns null when the id is the wrong length', () => {
+    expect(extractYouTubeId('https://youtu.be/short')).toBeNull()
+  })
+})
+
+describe('extractVimeoId', () => {
+  it('extracts from vimeo.com URLs', () => {
+    expect(extractVimeoId('https://vimeo.com/123456789')).toBe('123456789')
+  })
+
+  it('extracts from player.vimeo.com/video URLs', () => {
+    expect(extractVimeoId('https://player.vimeo.com/video/987654321')).toBe('987654321')
+  })
+
+  it('returns null for non-Vimeo URLs', () => {
+    expect(extractVimeoId('https://youtu.be/dQw4w9WgXcQ')).toBeNull()
+  })
+})
+
+describe('extractLoomId', () => {
+  it('extracts from loom.com/share URLs', () => {
+    expect(extractLoomId('https://www.loom.com/share/abc123def456')).toBe('abc123def456')
+  })
+
+  it('extracts from loom.com/embed URLs', () => {
+    expect(extractLoomId('https://www.loom.com/embed/xyz789')).toBe('xyz789')
+  })
+
+  it('returns null for non-Loom URLs', () => {
+    expect(extractLoomId('https://vimeo.com/123456789')).toBeNull()
+  })
+})
+
+describe('extractWistiaId', () => {
+  it('extracts from wistia.com/medias URLs', () => {
+    expect(extractWistiaId('https://mybrand.wistia.com/medias/abc123')).toBe('abc123')
+  })
+
+  it('extracts from fast.wistia.net/embed/iframe URLs', () => {
+    expect(extractWistiaId('https://fast.wistia.net/embed/iframe/def456')).toBe('def456')
+  })
+
+  it('extracts from fast.wistia.com/embed/medias URLs', () => {
+    expect(extractWistiaId('https://fast.wistia.com/embed/medias/ghi789')).toBe('ghi789')
+  })
+
+  it('returns null for non-Wistia URLs', () => {
+    expect(extractWistiaId('https://youtu.be/dQw4w9WgXcQ')).toBeNull()
+  })
+})
+
+describe('platform URL guards', () => {
+  it('isYouTubeUrl distinguishes YouTube from others', () => {
+    expect(isYouTubeUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(true)
+    expect(isYouTubeUrl('https://vimeo.com/123456789')).toBe(false)
+  })
+
+  it('isVimeoUrl distinguishes Vimeo from others', () => {
+    expect(isVimeoUrl('https://player.vimeo.com/video/123456789')).toBe(true)
+    expect(isVimeoUrl('https://www.loom.com/share/abc123')).toBe(false)
+  })
+
+  it('isLoomUrl distinguishes Loom from others', () => {
+    expect(isLoomUrl('https://www.loom.com/embed/abc123')).toBe(true)
+    expect(isLoomUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(false)
+  })
+
+  it('isWistiaUrl distinguishes Wistia from others', () => {
+    expect(isWistiaUrl('https://fast.wistia.net/embed/iframe/abc123')).toBe(true)
+    expect(isWistiaUrl('https://vimeo.com/123456789')).toBe(false)
+  })
+})

--- a/packages/media/src/__tests__/utils/parse-media-url.test.ts
+++ b/packages/media/src/__tests__/utils/parse-media-url.test.ts
@@ -5,6 +5,7 @@ import {
   isNativeVideoType,
   isSupportedMediaUrl,
   parseMediaUrl,
+  supportsAutoplay,
 } from '../../utils/parse-media-url'
 
 describe('detectMediaType', () => {
@@ -162,6 +163,71 @@ describe('parseMediaUrl', () => {
       id: '/images/animation.gif',
       embedUrl: '/images/animation.gif',
     })
+  })
+
+  it('parses Wistia URLs correctly', () => {
+    const result = parseMediaUrl('https://fast.wistia.net/embed/iframe/abc123')
+    expect(result).toEqual({
+      type: 'wistia',
+      id: 'abc123',
+      embedUrl: expect.stringContaining('fast.wistia.net/embed/iframe/abc123'),
+    })
+  })
+
+  it('parses Lottie (.json) URLs correctly', () => {
+    const result = parseMediaUrl('/animations/loader.json')
+    expect(result).toEqual({
+      type: 'lottie',
+      id: '/animations/loader.json',
+      embedUrl: '/animations/loader.json',
+    })
+  })
+
+  it('parses .lottie URLs correctly', () => {
+    const result = parseMediaUrl('/animations/loader.lottie')
+    expect(result?.type).toBe('lottie')
+  })
+
+  it('falls back to image for unknown URLs', () => {
+    const result = parseMediaUrl('https://example.com/unknown')
+    expect(result).toEqual({
+      type: 'image',
+      id: 'https://example.com/unknown',
+      embedUrl: 'https://example.com/unknown',
+    })
+  })
+
+  it('parses image extension URLs as image', () => {
+    const result = parseMediaUrl('/images/photo.png')
+    expect(result?.type).toBe('image')
+    expect(result?.embedUrl).toBe('/images/photo.png')
+  })
+
+  it('returns null when a URL is detected as YouTube but has no extractable id', () => {
+    // "youtube.com/watch?v=" with an id that is too short fails extraction,
+    // but detectMediaType only fires when the regex matches an 11-char id,
+    // so use a malformed-but-detected case via youtube-nocookie embed path.
+    // A bare 11-char match is required; a short id is not detected as youtube
+    // at all, so this asserts the negative branch through detectMediaType.
+    expect(parseMediaUrl('https://www.youtube.com/watch?v=short')).toEqual({
+      type: 'image',
+      id: 'https://www.youtube.com/watch?v=short',
+      embedUrl: 'https://www.youtube.com/watch?v=short',
+    })
+  })
+})
+
+describe('supportsAutoplay', () => {
+  it('returns true for video media types', () => {
+    expect(supportsAutoplay('youtube')).toBe(true)
+    expect(supportsAutoplay('vimeo')).toBe(true)
+    expect(supportsAutoplay('video')).toBe(true)
+    expect(supportsAutoplay('gif')).toBe(true)
+    expect(supportsAutoplay('lottie')).toBe(true)
+  })
+
+  it('returns false for static images', () => {
+    expect(supportsAutoplay('image')).toBe(false)
   })
 })
 

--- a/packages/media/src/__tests__/utils/responsive.test.ts
+++ b/packages/media/src/__tests__/utils/responsive.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ResponsiveSource } from '../../types'
+import { getSourceType, selectResponsiveSource } from '../../utils/responsive'
+
+/**
+ * Helper to stub window.matchMedia so that only `matchingQuery` reports
+ * `matches: true`. Restored after each test via afterEach below.
+ */
+function stubMatchMedia(matchingQuery: string | null) {
+  const spy = vi.fn().mockImplementation((query: string) => ({
+    matches: matchingQuery !== null && query === matchingQuery,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+  Object.defineProperty(window, 'matchMedia', { writable: true, value: spy })
+  return spy
+}
+
+describe('selectResponsiveSource', () => {
+  afterEach(() => {
+    // Restore the default (matches: false) stub from setup.ts
+    stubMatchMedia(null)
+  })
+
+  it('returns defaultSrc when sources is undefined', () => {
+    expect(selectResponsiveSource(undefined, '/default.mp4')).toBe('/default.mp4')
+  })
+
+  it('returns defaultSrc when sources is empty', () => {
+    expect(selectResponsiveSource([], '/default.mp4')).toBe('/default.mp4')
+  })
+
+  it('returns defaultSrc when no source media query matches', () => {
+    stubMatchMedia(null) // nothing matches
+    const sources: ResponsiveSource[] = [
+      { src: '/mobile.mp4', media: '(max-width: 600px)' },
+      { src: '/desktop.mp4', media: '(min-width: 1200px)' },
+    ]
+    expect(selectResponsiveSource(sources, '/default.mp4')).toBe('/default.mp4')
+  })
+
+  it('picks the source whose media query matches', () => {
+    stubMatchMedia('(max-width: 600px)')
+    const sources: ResponsiveSource[] = [
+      { src: '/mobile.mp4', media: '(max-width: 600px)' },
+      { src: '/desktop.mp4', media: '(min-width: 1200px)' },
+    ]
+    expect(selectResponsiveSource(sources, '/default.mp4')).toBe('/mobile.mp4')
+  })
+
+  it('returns the first matching source when multiple match', () => {
+    // matchMedia returns true for every query here
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+    const sources: ResponsiveSource[] = [
+      { src: '/first.mp4', media: '(max-width: 600px)' },
+      { src: '/second.mp4', media: '(min-width: 1200px)' },
+    ]
+    expect(selectResponsiveSource(sources, '/default.mp4')).toBe('/first.mp4')
+  })
+
+  it('skips sources without a media query', () => {
+    stubMatchMedia('(min-width: 1200px)')
+    const sources: ResponsiveSource[] = [
+      { src: '/no-media.mp4' }, // no media → skipped
+      { src: '/desktop.mp4', media: '(min-width: 1200px)' },
+    ]
+    expect(selectResponsiveSource(sources, '/default.mp4')).toBe('/desktop.mp4')
+  })
+})
+
+describe('getSourceType', () => {
+  it('maps .mp4 to video/mp4', () => {
+    expect(getSourceType('/clip.mp4')).toBe('video/mp4')
+  })
+
+  it('maps .webm to video/webm', () => {
+    expect(getSourceType('/clip.webm')).toBe('video/webm')
+  })
+
+  it('maps .ogg to video/ogg', () => {
+    expect(getSourceType('/clip.ogg')).toBe('video/ogg')
+  })
+
+  it('maps .mov to video/quicktime', () => {
+    expect(getSourceType('/clip.mov')).toBe('video/quicktime')
+  })
+
+  it('maps .m4v to video/x-m4v', () => {
+    expect(getSourceType('/clip.m4v')).toBe('video/x-m4v')
+  })
+
+  it('is case-insensitive', () => {
+    expect(getSourceType('/CLIP.MP4')).toBe('video/mp4')
+  })
+
+  it('returns undefined for unknown extensions', () => {
+    expect(getSourceType('/clip.txt')).toBeUndefined()
+  })
+
+  it('returns undefined when there is no extension', () => {
+    expect(getSourceType('/clip')).toBeUndefined()
+  })
+})

--- a/packages/media/vitest.config.ts
+++ b/packages/media/vitest.config.ts
@@ -12,15 +12,15 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/', 'src/__tests__/', 'dist/', '**/*.d.ts', '**/index.ts'],
-      // Thresholds temporarily lowered from 80/75/80/80 — actuals on
-      // chore/code-health-phase-5: stmts 55.59 / branches 46.69 / funcs 36.48 /
-      // lines 55.63. Case-(c): functions <50.
-      // Follow-up: https://github.com/domidex01/tour-kit/issues/13
+      // Slice 7 coverage-truth floor (raised from the phase-5 lows with
+      // URL-parse / responsive / embed-builder + embed-component behavior tests;
+      // no S1-5 feature touched media — pure test-debt repayment).
+      // Earned actuals well above these; see CLAUDE.md coverage claim.
       thresholds: {
-        statements: 50,
-        branches: 41,
-        functions: 31,
-        lines: 50,
+        statements: 70,
+        branches: 60,
+        functions: 70,
+        lines: 70,
       },
     },
   },

--- a/packages/scheduling/src/__tests__/utils/business-hours.test.ts
+++ b/packages/scheduling/src/__tests__/utils/business-hours.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import type { BusinessHours, DayOfWeek } from '../../types'
+import { BUSINESS_HOURS_PRESETS } from '../../types/business-hours'
+import { getDayBusinessHours, isHoliday, isWithinBusinessHours } from '../../utils/business-hours'
+
+describe('isWithinBusinessHours', () => {
+  // Standard preset: Mon-Fri 09:00-17:00, default { open: false }.
+  const standard = BUSINESS_HOURS_PRESETS.standard
+
+  it('open weekday inside the window vs outside it', () => {
+    // Mon 2025-06-16 in UTC: 12:00 inside 09-17, 18:00 outside.
+    expect(isWithinBusinessHours(new Date('2025-06-16T12:00:00Z'), standard, 'UTC')).toBe(true)
+    expect(isWithinBusinessHours(new Date('2025-06-16T18:00:00Z'), standard, 'UTC')).toBe(false)
+  })
+
+  it('closed day (default open:false) returns false', () => {
+    // Sunday is not in the days map → falls back to default { open: false }.
+    expect(isWithinBusinessHours(new Date('2025-06-15T12:00:00Z'), standard, 'UTC')).toBe(false)
+  })
+
+  it('SAME instant flips verdict across a DST-spanning timezone pair', () => {
+    // 2025-06-16T14:30Z (a Monday): 10:30 in New York (inside 09-17) but
+    // 23:30 in Tokyo (outside). The verdict MUST differ by timezone.
+    const instant = new Date('2025-06-16T14:30:00Z')
+    expect(isWithinBusinessHours(instant, standard, 'America/New_York')).toBe(true)
+    expect(isWithinBusinessHours(instant, standard, 'Asia/Tokyo')).toBe(false)
+  })
+
+  it('holiday date forces closed even during open hours', () => {
+    const withHoliday: BusinessHours = {
+      ...standard,
+      holidays: ['2025-06-16'],
+    }
+    // Monday 12:00 would otherwise be open, but the date is a holiday.
+    expect(isWithinBusinessHours(new Date('2025-06-16T12:00:00Z'), withHoliday, 'UTC')).toBe(false)
+    // A non-holiday Monday is still open.
+    expect(isWithinBusinessHours(new Date('2025-06-23T12:00:00Z'), withHoliday, 'UTC')).toBe(true)
+  })
+
+  it('per-day config overrides the default', () => {
+    const config: BusinessHours = {
+      default: { open: true, hours: [{ start: '00:00', end: '23:59' }] },
+      days: { 1: { open: false } }, // Monday explicitly closed
+    }
+    // Monday → uses the per-day override (closed).
+    expect(isWithinBusinessHours(new Date('2025-06-16T12:00:00Z'), config, 'UTC')).toBe(false)
+    // Tuesday → falls back to default (open all day).
+    expect(isWithinBusinessHours(new Date('2025-06-17T12:00:00Z'), config, 'UTC')).toBe(true)
+  })
+
+  it('open day with no hours array means open all day', () => {
+    const config: BusinessHours = {
+      days: { 1: { open: true } }, // open, no hours → all day
+    }
+    expect(isWithinBusinessHours(new Date('2025-06-16T03:00:00Z'), config, 'UTC')).toBe(true)
+    expect(isWithinBusinessHours(new Date('2025-06-16T22:00:00Z'), config, 'UTC')).toBe(true)
+  })
+
+  it('returns false when no config and no default exist for the day', () => {
+    const config: BusinessHours = { days: {} } // no default, Monday unconfigured
+    expect(isWithinBusinessHours(new Date('2025-06-16T12:00:00Z'), config, 'UTC')).toBe(false)
+  })
+
+  it('honors multiple time-range windows in one day (split hours)', () => {
+    const config: BusinessHours = {
+      days: {
+        1: {
+          open: true,
+          hours: [
+            { start: '09:00', end: '12:00' },
+            { start: '13:00', end: '17:00' },
+          ],
+        },
+      },
+    }
+    expect(isWithinBusinessHours(new Date('2025-06-16T10:00:00Z'), config, 'UTC')).toBe(true) // morning
+    expect(isWithinBusinessHours(new Date('2025-06-16T14:00:00Z'), config, 'UTC')).toBe(true) // afternoon
+    expect(isWithinBusinessHours(new Date('2025-06-16T12:30:00Z'), config, 'UTC')).toBe(false) // lunch gap
+  })
+
+  it('falls back to businessHours.timezone when no explicit timezone is passed', () => {
+    const config: BusinessHours = { ...standard, timezone: 'America/New_York' }
+    // 14:30Z = 10:30 NY → inside, resolved via businessHours.timezone.
+    expect(isWithinBusinessHours(new Date('2025-06-16T14:30:00Z'), config)).toBe(true)
+  })
+})
+
+describe('getDayBusinessHours', () => {
+  it('returns closed with empty hours for a closed day', () => {
+    const result = getDayBusinessHours(0 as DayOfWeek, BUSINESS_HOURS_PRESETS.standard)
+    expect(result.isOpen).toBe(false)
+    expect(result.hours).toEqual([])
+  })
+
+  it('returns the configured hours for an open day', () => {
+    const result = getDayBusinessHours(1 as DayOfWeek, BUSINESS_HOURS_PRESETS.standard)
+    expect(result.isOpen).toBe(true)
+    expect(result.hours).toEqual([{ start: '09:00', end: '17:00' }])
+  })
+
+  it('defaults to all-day hours when an open day has no hours array', () => {
+    const config: BusinessHours = { days: { 2: { open: true } } }
+    const result = getDayBusinessHours(2 as DayOfWeek, config)
+    expect(result.isOpen).toBe(true)
+    expect(result.hours).toEqual([{ start: '00:00', end: '23:59' }])
+  })
+})
+
+describe('isHoliday', () => {
+  it('returns false when no holidays are configured', () => {
+    expect(isHoliday(new Date('2025-06-16T12:00:00Z'), { holidays: [] }, 'UTC')).toBe(false)
+    expect(isHoliday(new Date('2025-06-16T12:00:00Z'), {}, 'UTC')).toBe(false)
+  })
+
+  it('matches a holiday date string in the supplied timezone', () => {
+    const config: BusinessHours = { holidays: ['2025-12-25'] }
+    expect(isHoliday(new Date('2025-12-25T12:00:00Z'), config, 'UTC')).toBe(true)
+    expect(isHoliday(new Date('2025-12-26T12:00:00Z'), config, 'UTC')).toBe(false)
+  })
+
+  it('resolves the date in the timezone before comparing (boundary shift)', () => {
+    // 2025-12-25T02:00Z is 2025-12-24 21:00 in New York, so it is NOT yet the
+    // holiday there, but it IS the holiday in UTC.
+    const config: BusinessHours = { holidays: ['2025-12-25'] }
+    const instant = new Date('2025-12-25T02:00:00Z')
+    expect(isHoliday(instant, config, 'UTC')).toBe(true)
+    expect(isHoliday(instant, config, 'America/New_York')).toBe(false)
+  })
+})

--- a/packages/scheduling/src/__tests__/utils/day-of-week.test.ts
+++ b/packages/scheduling/src/__tests__/utils/day-of-week.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { DayName, DayOfWeek } from '../../types'
+import { DAY_NAMES } from '../../types'
+import {
+  DAY_GROUPS,
+  dayNameToNumber,
+  dayNumberToName,
+  getDayOfWeek,
+  getNextAllowedDay,
+  isAllowedDay,
+} from '../../utils/day-of-week'
+
+describe('getDayOfWeek', () => {
+  it('maps a Sunday UTC instant to 0 and a Monday to 1', () => {
+    expect(getDayOfWeek(new Date('2025-06-15T12:00:00Z'), 'UTC')).toBe(0)
+    expect(getDayOfWeek(new Date('2025-06-16T12:00:00Z'), 'UTC')).toBe(1)
+  })
+
+  it('shifts the weekday across the date line by timezone', () => {
+    // Mon 2025-06-16T14:30Z is still Mon in NY but already 23:30 Mon in Tokyo.
+    // Sun 2025-06-15T23:00Z is Sun in UTC but Mon 08:00 in Tokyo.
+    const instant = new Date('2025-06-15T23:00:00Z')
+    expect(getDayOfWeek(instant, 'UTC')).toBe(0) // Sunday
+    expect(getDayOfWeek(instant, 'Asia/Tokyo')).toBe(1) // Monday (+9h)
+  })
+})
+
+describe('isAllowedDay', () => {
+  it('returns true when the resolved day is in the list, false otherwise', () => {
+    const sun = new Date('2025-06-15T12:00:00Z')
+    expect(isAllowedDay(sun, [0, 6], 'UTC')).toBe(true)
+    expect(isAllowedDay(sun, [1, 2, 3, 4, 5], 'UTC')).toBe(false)
+  })
+})
+
+describe('dayNameToNumber / dayNumberToName round-trip', () => {
+  it('maps each name to its index and back', () => {
+    DAY_NAMES.forEach((name, index) => {
+      expect(dayNameToNumber(name as DayName)).toBe(index as DayOfWeek)
+      expect(dayNumberToName(index as DayOfWeek)).toBe(name)
+    })
+  })
+
+  it('maps boundary days sunday(0) and saturday(6)', () => {
+    expect(dayNameToNumber('sunday')).toBe(0)
+    expect(dayNameToNumber('saturday')).toBe(6)
+    expect(dayNumberToName(0)).toBe('sunday')
+    expect(dayNumberToName(6)).toBe('saturday')
+  })
+})
+
+describe('getNextAllowedDay', () => {
+  // 2025-06-15 is Sunday (0) in UTC.
+  const SUN = new Date('2025-06-15T12:00:00Z')
+
+  it('returns undefined when no days are allowed', () => {
+    expect(getNextAllowedDay(SUN, [], 'UTC')).toBeUndefined()
+  })
+
+  it('finds the nearest upcoming day and resets to local midnight', () => {
+    // From Sunday, next weekday is Monday → 1 day ahead.
+    const next = getNextAllowedDay(SUN, [1, 2, 3, 4, 5], 'UTC')
+    expect(next).toBeInstanceOf(Date)
+    expect(next!.getHours()).toBe(0)
+    expect(next!.getMinutes()).toBe(0)
+    // One day ahead of the Sunday instant.
+    expect(next!.getTime()).toBeGreaterThan(SUN.getTime())
+  })
+
+  it('wraps to next week when the only allowed day is today (daysAhead<=0 → +7)', () => {
+    // Today is Sunday(0); allowing only Sunday means the next match is 7 days out.
+    const next = getNextAllowedDay(SUN, [0], 'UTC')
+    expect(next).toBeInstanceOf(Date)
+    const days = Math.round((next!.getTime() - SUN.getTime()) / 86_400_000)
+    // 6 or 7 depending on the midnight reset; it must be in the next week, > 5.
+    expect(days).toBeGreaterThan(5)
+  })
+
+  it('picks the minimum gap when several days are allowed', () => {
+    // From Sunday, allowed {Saturday(6), Tuesday(2)} → Tuesday is nearer (2 vs 6).
+    const next = getNextAllowedDay(SUN, [6, 2], 'UTC')
+    const days = Math.round((next!.getTime() - SUN.getTime()) / 86_400_000)
+    expect(days).toBeLessThan(4)
+  })
+})
+
+describe('DAY_GROUPS', () => {
+  it('exposes weekday, weekend and full-week presets', () => {
+    expect(DAY_GROUPS.weekdays).toEqual([1, 2, 3, 4, 5])
+    expect(DAY_GROUPS.weekends).toEqual([0, 6])
+    expect(DAY_GROUPS.all).toEqual([0, 1, 2, 3, 4, 5, 6])
+  })
+})

--- a/packages/scheduling/src/__tests__/utils/get-schedule-status.test.ts
+++ b/packages/scheduling/src/__tests__/utils/get-schedule-status.test.ts
@@ -19,3 +19,174 @@ describe('getScheduleStatus — outside_business_hours', () => {
     expect(status.nextActiveAt).toBeUndefined()
   })
 })
+
+describe('getScheduleStatus — active schedule', () => {
+  // Mon 2025-06-16 10:30 NY, no constraints → active.
+  const MON_1430Z = new Date('2025-06-16T14:30:00Z')
+
+  it('returns isActive true, no reason, and the active message; no nextActiveAt', () => {
+    const status = getScheduleStatus({}, { now: MON_1430Z, userTimezone: 'UTC' })
+    expect(status.isActive).toBe(true)
+    expect(status.reason).toBeUndefined()
+    expect(status.message).toBe('Schedule is currently active')
+    expect(status.nextActiveAt).toBeUndefined()
+  })
+
+  it('populates the debug block with the resolved timezone, local time and day', () => {
+    // 14:30 UTC → 10:30 in America/New_York (EDT, UTC-4) on a Monday (dayOfWeek 1).
+    const status = getScheduleStatus({ timezone: 'America/New_York' }, { now: MON_1430Z })
+    expect(status.debug?.timezone).toBe('America/New_York')
+    expect(status.debug?.localTime).toBe('10:30')
+    expect(status.debug?.dayOfWeek).toBe(1)
+    expect(status.debug?.evaluatedAt).toEqual(MON_1430Z)
+  })
+})
+
+describe('getScheduleStatus — disabled', () => {
+  it('reason disabled, message, and no nextActiveAt (cannot predict)', () => {
+    const status = getScheduleStatus(
+      { enabled: false },
+      { now: new Date('2025-06-16T14:30:00Z'), userTimezone: 'UTC' }
+    )
+    expect(status.isActive).toBe(false)
+    expect(status.reason).toBe('disabled')
+    expect(status.message).toBe('Schedule is disabled')
+    expect(status.nextActiveAt).toBeUndefined()
+  })
+})
+
+describe('getScheduleStatus — not_started', () => {
+  const now = new Date('2025-06-16T14:30:00Z')
+
+  it('string startAt: message names the date and nextActiveAt is the start day', () => {
+    const status = getScheduleStatus({ startAt: '2025-07-01' }, { now, userTimezone: 'UTC' })
+    expect(status.reason).toBe('not_started')
+    expect(status.message).toBe('Schedule starts on 2025-07-01')
+    // getDateRangeStart('2025-07-01') → midnight UTC of that day.
+    expect(status.nextActiveAt).toEqual(new Date('2025-07-01T00:00:00Z'))
+  })
+
+  it('Date startAt: message formats the Date in the schedule timezone', () => {
+    const startAt = new Date('2025-07-01T00:00:00Z')
+    const status = getScheduleStatus({ startAt, timezone: 'UTC' }, { now })
+    expect(status.reason).toBe('not_started')
+    expect(status.message).toBe('Schedule starts on 2025-07-01')
+    expect(status.nextActiveAt).toEqual(startAt)
+  })
+})
+
+describe('getScheduleStatus — ended', () => {
+  const now = new Date('2025-06-16T14:30:00Z')
+
+  it('string endAt: message names the date; nextActiveAt undefined (never reactivates)', () => {
+    const status = getScheduleStatus({ endAt: '2025-06-01' }, { now, userTimezone: 'UTC' })
+    expect(status.reason).toBe('ended')
+    expect(status.message).toBe('Schedule ended on 2025-06-01')
+    expect(status.nextActiveAt).toBeUndefined()
+  })
+
+  it('Date endAt: message formats the Date in the schedule timezone', () => {
+    const endAt = new Date('2025-06-01T00:00:00Z')
+    const status = getScheduleStatus({ endAt, timezone: 'UTC' }, { now })
+    expect(status.message).toBe('Schedule ended on 2025-06-01')
+  })
+})
+
+describe('getScheduleStatus — wrong_day', () => {
+  // 2025-06-15 is a Sunday in UTC.
+  const SUN = new Date('2025-06-15T14:30:00Z')
+
+  it('message names the current weekday and nextActiveAt is the next allowed day', () => {
+    const status = getScheduleStatus(
+      { daysOfWeek: [1, 2, 3, 4, 5] },
+      { now: SUN, userTimezone: 'UTC' }
+    )
+    expect(status.reason).toBe('wrong_day')
+    expect(status.message).toBe('Not available on Sunday')
+    // Next allowed weekday after Sunday is Monday at local midnight (one day ahead).
+    expect(status.nextActiveAt).toBeInstanceOf(Date)
+    expect(status.nextActiveAt!.getTime()).toBeGreaterThan(SUN.getTime())
+  })
+})
+
+describe('getScheduleStatus — wrong_time', () => {
+  // 14:30 UTC, window 09:00–12:00 → outside.
+  const now = new Date('2025-06-16T14:30:00Z')
+
+  it('message names the window and nextActiveAt is the next start instant', () => {
+    const status = getScheduleStatus(
+      { timeOfDay: { start: '09:00', end: '12:00' } },
+      { now, userTimezone: 'UTC' }
+    )
+    expect(status.reason).toBe('wrong_time')
+    expect(status.message).toBe('Available between 09:00 and 12:00')
+    // Next 09:00 is tomorrow; the prediction is a future Date.
+    expect(status.nextActiveAt).toBeInstanceOf(Date)
+    expect(status.nextActiveAt!.getTime()).toBeGreaterThan(now.getTime())
+  })
+})
+
+describe('getScheduleStatus — blackout', () => {
+  const now = new Date('2025-06-15T14:30:00Z')
+
+  it('surfaces currentBlackout details, a reason-bearing message and a post-blackout nextActiveAt', () => {
+    const schedule: Schedule = {
+      blackouts: [
+        {
+          id: 'maint',
+          start: '2025-06-15',
+          end: '2025-06-15',
+          reason: 'Scheduled maintenance',
+        },
+      ],
+    }
+    const status = getScheduleStatus(schedule, { now, userTimezone: 'UTC' })
+    expect(status.reason).toBe('blackout')
+    expect(status.message).toBe('Unavailable: Scheduled maintenance')
+    expect(status.currentBlackout).toBeDefined()
+    expect(status.currentBlackout?.id).toBe('maint')
+    expect(status.currentBlackout?.reason).toBe('Scheduled maintenance')
+    expect(status.currentBlackout?.endsAt).toBeInstanceOf(Date)
+    // nextActiveAt = blackout end + 1s.
+    expect(status.nextActiveAt).toBeInstanceOf(Date)
+    expect(status.nextActiveAt!.getTime()).toBe(status.currentBlackout!.endsAt.getTime() + 1000)
+  })
+
+  it('blackout without a reason falls back to the generic message', () => {
+    const schedule: Schedule = {
+      blackouts: [{ id: 'maint', start: '2025-06-15', end: '2025-06-15' }],
+    }
+    const status = getScheduleStatus(schedule, { now, userTimezone: 'UTC' })
+    expect(status.reason).toBe('blackout')
+    expect(status.message).toBe('Currently in a blackout period')
+  })
+})
+
+describe('getScheduleStatus — recurring_mismatch', () => {
+  it('surfaces reason and message when the recurring pattern excludes the day', () => {
+    // 2025-06-16 is Monday (1); pattern only allows Sunday (0).
+    const schedule: Schedule = {
+      recurring: { type: 'weekly', daysOfWeek: [0] },
+    }
+    const status = getScheduleStatus(schedule, {
+      now: new Date('2025-06-16T14:30:00Z'),
+      userTimezone: 'UTC',
+    })
+    expect(status.reason).toBe('recurring_mismatch')
+    expect(status.message).toBe('Does not match recurring schedule')
+    // No predictor for recurring → nextActiveAt undefined.
+    expect(status.nextActiveAt).toBeUndefined()
+  })
+})
+
+describe('getScheduleStatus — useUserTimezone false forces UTC', () => {
+  it('resolves to UTC when useUserTimezone is false and no schedule.timezone', () => {
+    const status = getScheduleStatus(
+      { useUserTimezone: false },
+      { now: new Date('2025-06-16T14:30:00Z'), userTimezone: 'America/New_York' }
+    )
+    // userTimezone is ignored; debug timezone is UTC, localTime is 14:30.
+    expect(status.debug?.timezone).toBe('UTC')
+    expect(status.debug?.localTime).toBe('14:30')
+  })
+})

--- a/packages/scheduling/src/__tests__/utils/is-schedule-active.test.ts
+++ b/packages/scheduling/src/__tests__/utils/is-schedule-active.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Schedule } from '../../types'
 import { BUSINESS_HOURS_PRESETS } from '../../types/business-hours'
-import { isScheduleActive } from '../../utils/is-schedule-active'
+import { checkSchedule, isScheduleActive } from '../../utils/is-schedule-active'
 
 describe('isScheduleActive', () => {
   const fixedDate = new Date('2025-06-15T14:30:00Z') // Sunday, June 15, 2025, 2:30 PM UTC
@@ -186,6 +186,38 @@ describe('isScheduleActive', () => {
 
     it('no businessHours field → behavior unchanged (active)', () => {
       expect(isScheduleActive({}, { now: MON_1430Z }).isActive).toBe(true)
+    })
+  })
+
+  describe('recurring pattern integration', () => {
+    it('returns recurring_mismatch when the pattern excludes the day', () => {
+      // fixedDate is Sunday (0); pattern only allows Monday (1).
+      const schedule: Schedule = {
+        recurring: { type: 'weekly', daysOfWeek: [1] },
+      }
+      const result = isScheduleActive(schedule, { now: fixedDate, userTimezone: 'UTC' })
+      expect(result.isActive).toBe(false)
+      expect(result.reason).toBe('recurring_mismatch')
+    })
+
+    it('returns active when the recurring pattern matches', () => {
+      // fixedDate is Sunday (0); allow Sunday.
+      const schedule: Schedule = {
+        recurring: { type: 'weekly', daysOfWeek: [0] },
+      }
+      const result = isScheduleActive(schedule, { now: fixedDate, userTimezone: 'UTC' })
+      expect(result.isActive).toBe(true)
+    })
+  })
+
+  describe('checkSchedule (boolean wrapper)', () => {
+    it('returns the isActive boolean directly', () => {
+      expect(checkSchedule({}, { now: fixedDate, userTimezone: 'UTC' })).toBe(true)
+      expect(checkSchedule({ enabled: false }, { now: fixedDate })).toBe(false)
+    })
+
+    it('works without an options argument', () => {
+      expect(checkSchedule({ enabled: false })).toBe(false)
     })
   })
 

--- a/packages/scheduling/src/__tests__/utils/recurring.test.ts
+++ b/packages/scheduling/src/__tests__/utils/recurring.test.ts
@@ -52,6 +52,63 @@ describe('matchesRecurringPattern', () => {
     })
   })
 
+  describe('interval > 1 (weekly / monthly / yearly)', () => {
+    it('weekly interval 2 matches only on even week boundaries from start', () => {
+      // start Sun 2025-06-01; +14 days = 2025-06-15 (week 2 → match), +7 = 06-08 (week 1 → no).
+      const pattern: RecurringPattern = { type: 'weekly', interval: 2 }
+      expect(
+        matchesRecurringPattern(new Date('2025-06-15T12:00:00Z'), pattern, 'UTC', '2025-06-01')
+      ).toBe(true)
+      expect(
+        matchesRecurringPattern(new Date('2025-06-08T12:00:00Z'), pattern, 'UTC', '2025-06-01')
+      ).toBe(false)
+    })
+
+    it('weekly interval honors daysOfWeek mismatch before interval', () => {
+      // 2025-06-16 is Monday(1); pattern allows only Sunday(0) → mismatch regardless of interval.
+      const pattern: RecurringPattern = { type: 'weekly', interval: 2, daysOfWeek: [0] }
+      expect(
+        matchesRecurringPattern(new Date('2025-06-16T12:00:00Z'), pattern, 'UTC', '2025-06-01')
+      ).toBe(false)
+    })
+
+    it('monthly interval 2 matches every other month from start', () => {
+      const pattern: RecurringPattern = { type: 'monthly', interval: 2 }
+      // start June 2025; August (+2 months) matches, July (+1) does not.
+      expect(
+        matchesRecurringPattern(new Date('2025-08-10T12:00:00Z'), pattern, 'UTC', '2025-06-01')
+      ).toBe(true)
+      expect(
+        matchesRecurringPattern(new Date('2025-07-10T12:00:00Z'), pattern, 'UTC', '2025-06-01')
+      ).toBe(false)
+    })
+
+    it('monthly dayOfMonth mismatch fails before interval check', () => {
+      const pattern: RecurringPattern = { type: 'monthly', interval: 2, dayOfMonth: 15 }
+      // Day 10 != configured 15 → mismatch even on a matching month.
+      expect(
+        matchesRecurringPattern(new Date('2025-08-10T12:00:00Z'), pattern, 'UTC', '2025-06-01')
+      ).toBe(false)
+    })
+
+    it('yearly interval 2 matches every other year from start', () => {
+      const pattern: RecurringPattern = { type: 'yearly', interval: 2 }
+      // start 2025; 2027 (+2 years) matches, 2026 (+1) does not.
+      expect(
+        matchesRecurringPattern(new Date('2027-06-01T12:00:00Z'), pattern, 'UTC', '2025-06-01')
+      ).toBe(true)
+      expect(
+        matchesRecurringPattern(new Date('2026-06-01T12:00:00Z'), pattern, 'UTC', '2025-06-01')
+      ).toBe(false)
+    })
+
+    it('yearly month mismatch fails before day/interval', () => {
+      const pattern: RecurringPattern = { type: 'yearly', month: 6, dayOfMonth: 15 }
+      // July (month 7) != configured June → mismatch.
+      expect(matchesRecurringPattern(new Date('2025-07-15T12:00:00Z'), pattern, 'UTC')).toBe(false)
+    })
+  })
+
   describe('endDate (inclusive, timezone-aware)', () => {
     it('matches throughout the whole end-date day, not just at midnight UTC', () => {
       // Regression: a raw `date > parseDateString(endDate)` rejected any time

--- a/packages/scheduling/src/__tests__/utils/time-of-day.test.ts
+++ b/packages/scheduling/src/__tests__/utils/time-of-day.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import type { TimeRange } from '../../types'
+import {
+  getNextTimeRangeStart,
+  isWithinAnyTimeRange,
+  isWithinTimeRange,
+} from '../../utils/time-of-day'
+
+describe('isWithinTimeRange', () => {
+  const range: TimeRange = { start: '09:00', end: '17:00' }
+
+  it('is true inside the window and false outside', () => {
+    expect(isWithinTimeRange(new Date('2025-06-16T12:00:00Z'), range, 'UTC')).toBe(true)
+    expect(isWithinTimeRange(new Date('2025-06-16T18:00:00Z'), range, 'UTC')).toBe(false)
+    expect(isWithinTimeRange(new Date('2025-06-16T08:00:00Z'), range, 'UTC')).toBe(false)
+  })
+
+  it('is inclusive at both boundaries', () => {
+    expect(isWithinTimeRange(new Date('2025-06-16T09:00:00Z'), range, 'UTC')).toBe(true)
+    expect(isWithinTimeRange(new Date('2025-06-16T17:00:00Z'), range, 'UTC')).toBe(true)
+  })
+
+  it('handles an overnight range that crosses midnight', () => {
+    // 22:00 → 06:00 spans midnight; 23:00 and 02:00 are inside, 12:00 is outside.
+    const overnight: TimeRange = { start: '22:00', end: '06:00' }
+    expect(isWithinTimeRange(new Date('2025-06-16T23:00:00Z'), overnight, 'UTC')).toBe(true)
+    expect(isWithinTimeRange(new Date('2025-06-16T02:00:00Z'), overnight, 'UTC')).toBe(true)
+    expect(isWithinTimeRange(new Date('2025-06-16T12:00:00Z'), overnight, 'UTC')).toBe(false)
+  })
+
+  it('resolves the current time in the supplied timezone', () => {
+    // 14:30 UTC is 10:30 in NY (inside 09–17) but 23:30 in Tokyo (outside).
+    const instant = new Date('2025-06-16T14:30:00Z')
+    expect(isWithinTimeRange(instant, range, 'America/New_York')).toBe(true)
+    expect(isWithinTimeRange(instant, range, 'Asia/Tokyo')).toBe(false)
+  })
+})
+
+describe('isWithinAnyTimeRange', () => {
+  const ranges: TimeRange[] = [
+    { start: '09:00', end: '12:00' },
+    { start: '13:00', end: '17:00' },
+  ]
+
+  it('is true when inside any one range and false in the gap between them', () => {
+    expect(isWithinAnyTimeRange(new Date('2025-06-16T10:00:00Z'), ranges, 'UTC')).toBe(true)
+    expect(isWithinAnyTimeRange(new Date('2025-06-16T14:00:00Z'), ranges, 'UTC')).toBe(true)
+    // 12:30 falls in the lunch gap → outside both windows.
+    expect(isWithinAnyTimeRange(new Date('2025-06-16T12:30:00Z'), ranges, 'UTC')).toBe(false)
+  })
+})
+
+describe('getNextTimeRangeStart', () => {
+  const range: TimeRange = { start: '09:00', end: '17:00' }
+
+  it('returns undefined when already in range', () => {
+    expect(getNextTimeRangeStart(new Date('2025-06-16T10:00:00Z'), range, 'UTC')).toBeUndefined()
+  })
+
+  it('returns today’s start when before the window opens', () => {
+    // 06:00 UTC, next 09:00 is +3h same day.
+    const now = new Date('2025-06-16T06:00:00Z')
+    const next = getNextTimeRangeStart(now, range, 'UTC')
+    expect(next).toBeInstanceOf(Date)
+    expect(next!.getTime() - now.getTime()).toBe(3 * 60 * 60 * 1000)
+  })
+
+  it('rolls to tomorrow’s start when past the window', () => {
+    // 18:00 UTC, next 09:00 is 15h away (tomorrow).
+    const now = new Date('2025-06-16T18:00:00Z')
+    const next = getNextTimeRangeStart(now, range, 'UTC')
+    expect(next).toBeInstanceOf(Date)
+    expect(next!.getTime() - now.getTime()).toBe(15 * 60 * 60 * 1000)
+  })
+})

--- a/packages/scheduling/vitest.config.ts
+++ b/packages/scheduling/vitest.config.ts
@@ -12,15 +12,14 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/', 'src/__tests__/', 'dist/', '**/*.d.ts'],
-      // Thresholds temporarily lowered from 80/75/80/80 — actuals on
-      // chore/code-health-phase-5: stmts 56.60 / branches 44.58 / funcs 70.45 /
-      // lines 56.65. Case-(c): branches <50.
-      // Follow-up: https://github.com/domidex01/tour-kit/issues/13
+      // Slice 7 coverage-truth floor (raised from the phase-5 lows with
+      // business-hours / schedule-status / maxOccurrences behavior tests).
+      // Earned actuals well above these; see CLAUDE.md coverage claim.
       thresholds: {
-        statements: 51,
-        branches: 39,
-        functions: 65,
-        lines: 51,
+        statements: 75,
+        branches: 65,
+        functions: 80,
+        lines: 75,
       },
     },
   },

--- a/packages/surveys/src/__tests__/scheduler.test.ts
+++ b/packages/surveys/src/__tests__/scheduler.test.ts
@@ -115,3 +115,55 @@ describe('SurveyScheduler enqueue/getNext', () => {
     expect(s.canShowMore()).toBe(true)
   })
 })
+
+describe('SurveyScheduler queue introspection & lifecycle', () => {
+  it('peekNext, isQueued, getQueuedIds, queueSize and remove reflect queue contents', () => {
+    const s = new SurveyScheduler(DEFAULT_SURVEY_QUEUE_CONFIG)
+    expect(s.queueSize).toBe(0)
+    expect(s.peekNext()).toBeUndefined()
+
+    s.enqueue(makeConfig({ id: 'a', priority: 'normal' }))
+    s.enqueue(makeConfig({ id: 'b', priority: 'critical' }))
+
+    expect(s.queueSize).toBe(2)
+    expect(s.peekNext()).toBe('b') // critical sits at the head, not dequeued
+    expect(s.queueSize).toBe(2)
+    expect(s.isQueued('a')).toBe(true)
+    expect(s.isQueued('missing')).toBe(false)
+    expect(s.getQueuedIds()).toEqual(['b', 'a'])
+
+    expect(s.remove('a')).toBe(true)
+    expect(s.isQueued('a')).toBe(false)
+    expect(s.remove('a')).toBe(false)
+    expect(s.queueSize).toBe(1)
+  })
+
+  it('currentActiveCount, resetActive and clearQueue reset lifecycle state', () => {
+    const s = new SurveyScheduler(DEFAULT_SURVEY_QUEUE_CONFIG)
+    s.markActive()
+    s.markActive()
+    expect(s.currentActiveCount).toBe(2)
+    s.resetActive()
+    expect(s.currentActiveCount).toBe(0)
+
+    s.enqueue(makeConfig({ id: 'x' }))
+    expect(s.queueSize).toBe(1)
+    s.clearQueue()
+    expect(s.queueSize).toBe(0)
+  })
+
+  it('exposes config getters and updateConfig swaps them', () => {
+    const s = new SurveyScheduler(DEFAULT_SURVEY_QUEUE_CONFIG)
+    expect(s.delayBetween).toBe(DEFAULT_SURVEY_QUEUE_CONFIG.delayBetween)
+    expect(s.autoShow).toBe(DEFAULT_SURVEY_QUEUE_CONFIG.autoShow)
+    expect(s.stackBehavior).toBe(DEFAULT_SURVEY_QUEUE_CONFIG.stackBehavior)
+
+    s.updateConfig({
+      ...DEFAULT_SURVEY_QUEUE_CONFIG,
+      delayBetween: 9999,
+      autoShow: !DEFAULT_SURVEY_QUEUE_CONFIG.autoShow,
+    })
+    expect(s.delayBetween).toBe(9999)
+    expect(s.autoShow).toBe(!DEFAULT_SURVEY_QUEUE_CONFIG.autoShow)
+  })
+})

--- a/packages/surveys/src/__tests__/scoring.test.ts
+++ b/packages/surveys/src/__tests__/scoring.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { calculateCES, calculateCSAT, calculateNPS } from '../core/scoring'
+
+// Real-behavior unit tests for the aggregate scoring math. These exercise the
+// uncovered arms of core/scoring.ts (the per-response classification loops and
+// the empty-array guards) and pin the published result shapes from types/scoring.
+
+describe('calculateNPS', () => {
+  it('returns the zeroed result for an empty array', () => {
+    expect(calculateNPS([])).toEqual({
+      score: 0,
+      promoters: 0,
+      passives: 0,
+      detractors: 0,
+      promoterPct: 0,
+      passivePct: 0,
+      detractorPct: 0,
+      total: 0,
+      responses: [],
+    })
+  })
+
+  it('classifies promoters (9-10), passives (7-8), detractors (0-6)', () => {
+    // 2 promoters (9,10), 2 passives (7,8), 1 detractor (3) of 5 total.
+    const r = calculateNPS([9, 10, 7, 8, 3])
+    expect(r.promoters).toBe(2)
+    expect(r.passives).toBe(2)
+    expect(r.detractors).toBe(1)
+    expect(r.total).toBe(5)
+    expect(r.promoterPct).toBe(40)
+    expect(r.passivePct).toBe(40)
+    expect(r.detractorPct).toBe(20)
+    // score = round(%promoters − %detractors) = round(40 − 20) = 20
+    expect(r.score).toBe(20)
+    expect(r.responses).toEqual([9, 10, 7, 8, 3])
+  })
+
+  it('scores 100 when all promoters and -100 when all detractors', () => {
+    expect(calculateNPS([9, 10, 9]).score).toBe(100)
+    expect(calculateNPS([0, 6, 3]).score).toBe(-100)
+  })
+
+  it('rounds the net percentage to an integer', () => {
+    // 1 promoter, 2 detractors of 3 → 33.33 − 66.66 = -33.33 → round → -33
+    expect(calculateNPS([9, 0, 6]).score).toBe(-33)
+  })
+})
+
+describe('calculateCSAT', () => {
+  it('returns the zeroed result for an empty array', () => {
+    expect(calculateCSAT([])).toEqual({
+      score: 0,
+      positive: 0,
+      negative: 0,
+      total: 0,
+      threshold: 4,
+      responses: [],
+    })
+  })
+
+  it('buckets at-or-above default threshold (4) as positive', () => {
+    const r = calculateCSAT([5, 4, 3, 2]) // 2 positive (5,4), 2 negative (3,2)
+    expect(r.positive).toBe(2)
+    expect(r.negative).toBe(2)
+    expect(r.total).toBe(4)
+    expect(r.threshold).toBe(4)
+    expect(r.score).toBe(50) // round(2/4 * 100)
+  })
+
+  it('honors a custom threshold', () => {
+    const r = calculateCSAT([5, 4, 3], 5) // only 5 is positive
+    expect(r.positive).toBe(1)
+    expect(r.negative).toBe(2)
+    expect(r.threshold).toBe(5)
+    expect(r.score).toBe(33) // round(1/3 * 100)
+  })
+})
+
+describe('calculateCES', () => {
+  it('returns the zeroed result for an empty array', () => {
+    expect(calculateCES([])).toEqual({
+      score: 0,
+      easy: 0,
+      difficult: 0,
+      neutral: 0,
+      total: 0,
+      responses: [],
+    })
+  })
+
+  it('classifies easy (>=5), difficult (<=3), neutral (4) and averages', () => {
+    const r = calculateCES([7, 5, 4, 3, 1]) // easy: 7,5 / neutral: 4 / difficult: 3,1
+    expect(r.easy).toBe(2)
+    expect(r.neutral).toBe(1)
+    expect(r.difficult).toBe(2)
+    expect(r.total).toBe(5)
+    // average = (7+5+4+3+1)/5 = 4.0
+    expect(r.score).toBe(4)
+  })
+
+  it('rounds the average to two decimal places', () => {
+    // (1 + 2) / 2 = 1.5; (1 + 2 + 2) / 3 = 1.666... → 1.67
+    expect(calculateCES([1, 2]).score).toBe(1.5)
+    expect(calculateCES([1, 2, 2]).score).toBe(1.67)
+  })
+})

--- a/packages/surveys/src/__tests__/use-survey-scoring.test.tsx
+++ b/packages/surveys/src/__tests__/use-survey-scoring.test.tsx
@@ -1,0 +1,167 @@
+import { act, renderHook } from '@testing-library/react'
+import type * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { SurveysProvider } from '../context'
+import { useSurvey, useSurveyScoring } from '../hooks'
+import type { CESResult, CSATResult, NPSResult } from '../types'
+import type { SurveyConfig } from '../types'
+
+vi.mock('@tour-kit/license', () => ({
+  LicenseGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ProGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLicenseGate: () => ({ isAllowed: true, isLoading: false }),
+}))
+
+vi.mock('@tour-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tour-kit/core')>()
+  return {
+    ...actual,
+    useTourContext: () => ({ isActive: false }),
+    useTourContextOptional: () => ({ isActive: false }),
+  }
+})
+
+const configs: SurveyConfig[] = [
+  {
+    id: 'nps',
+    type: 'nps',
+    displayMode: 'modal',
+    questions: [{ id: 'q', type: 'rating', text: 'How likely?', scale: { min: 0, max: 10 } }],
+  },
+  {
+    id: 'csat',
+    type: 'csat',
+    displayMode: 'modal',
+    questions: [{ id: 'q', type: 'rating', text: 'Satisfied?', scale: { min: 1, max: 5 } }],
+  },
+  {
+    id: 'ces',
+    type: 'ces',
+    displayMode: 'modal',
+    questions: [{ id: 'q', type: 'rating', text: 'Effort?', scale: { min: 1, max: 7 } }],
+  },
+  {
+    id: 'custom',
+    type: 'custom',
+    displayMode: 'modal',
+    questions: [{ id: 'q', type: 'rating', text: 'Rate', scale: { min: 1, max: 5 } }],
+  },
+  {
+    id: 'textonly',
+    type: 'nps',
+    displayMode: 'modal',
+    questions: [{ id: 'q', type: 'text', text: 'Why?' }],
+  },
+]
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <SurveysProvider surveys={configs} storage={null}>
+      {children}
+    </SurveysProvider>
+  )
+}
+
+// Drive a real survey to completion via the public hooks, then read its score.
+function useScoringHarness() {
+  const scoring = useSurveyScoring()
+  const nps = useSurvey('nps')
+  const csat = useSurvey('csat')
+  const ces = useSurvey('ces')
+  const custom = useSurvey('custom')
+  const textonly = useSurvey('textonly')
+  return { scoring, nps, csat, ces, custom, textonly }
+}
+
+describe('useSurveyScoring', () => {
+  it('exposes the raw scoring calculators', () => {
+    const { result } = renderHook(() => useSurveyScoring(), { wrapper })
+    expect(result.current.calculateNPS([9, 10]).score).toBe(100)
+    expect(result.current.calculateCSAT([5, 4]).score).toBe(100)
+    expect(result.current.calculateCES([7, 7]).score).toBe(7)
+  })
+
+  it('getSurveyScore returns null before the survey is completed', () => {
+    const { result } = renderHook(() => useScoringHarness(), { wrapper })
+    act(() => {
+      result.current.nps.show()
+    })
+    act(() => {
+      result.current.nps.answer('q', 9)
+    })
+    // Answered but not completed → null.
+    expect(result.current.scoring.getSurveyScore('nps')).toBeNull()
+  })
+
+  it('getSurveyScore computes an NPS result once completed', () => {
+    const { result } = renderHook(() => useScoringHarness(), { wrapper })
+    act(() => {
+      result.current.nps.show()
+    })
+    act(() => {
+      result.current.nps.answer('q', 9)
+    })
+    act(() => {
+      result.current.nps.complete()
+    })
+    const score = result.current.scoring.getSurveyScore('nps') as NPSResult
+    expect(score).not.toBeNull()
+    expect(score.promoters).toBe(1)
+    expect(score.score).toBe(100)
+  })
+
+  it('getSurveyScore computes CSAT and CES by config type', () => {
+    const { result } = renderHook(() => useScoringHarness(), { wrapper })
+    act(() => {
+      result.current.csat.show()
+      result.current.ces.show()
+    })
+    act(() => {
+      result.current.csat.answer('q', 5)
+      result.current.ces.answer('q', 6)
+    })
+    act(() => {
+      result.current.csat.complete()
+      result.current.ces.complete()
+    })
+    const csat = result.current.scoring.getSurveyScore('csat') as CSATResult
+    const ces = result.current.scoring.getSurveyScore('ces') as CESResult
+    expect(csat.score).toBe(100) // 5 >= threshold 4
+    expect(csat.positive).toBe(1)
+    expect(ces.score).toBe(6)
+    expect(ces.easy).toBe(1)
+  })
+
+  it('getSurveyScore returns null for a custom type (default arm)', () => {
+    const { result } = renderHook(() => useScoringHarness(), { wrapper })
+    act(() => {
+      result.current.custom.show()
+    })
+    act(() => {
+      result.current.custom.answer('q', 5)
+    })
+    act(() => {
+      result.current.custom.complete()
+    })
+    expect(result.current.scoring.getSurveyScore('custom')).toBeNull()
+  })
+
+  it('getSurveyScore returns null when completed with no numeric responses', () => {
+    const { result } = renderHook(() => useScoringHarness(), { wrapper })
+    act(() => {
+      result.current.textonly.show()
+    })
+    act(() => {
+      result.current.textonly.answer('q', 'a comment')
+    })
+    act(() => {
+      result.current.textonly.complete()
+    })
+    expect(result.current.scoring.getSurveyScore('textonly')).toBeNull()
+  })
+
+  it('getSurveyScore returns null for an unknown survey id', () => {
+    const { result } = renderHook(() => useSurveyScoring(), { wrapper })
+    expect(result.current.getSurveyScore('does-not-exist')).toBeNull()
+  })
+})

--- a/packages/surveys/src/__tests__/use-survey.test.tsx
+++ b/packages/surveys/src/__tests__/use-survey.test.tsx
@@ -1,0 +1,103 @@
+import { act, renderHook } from '@testing-library/react'
+import type * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { SurveysProvider } from '../context'
+import { useSurvey } from '../hooks'
+import type { SurveyConfig } from '../types'
+
+vi.mock('@tour-kit/license', () => ({
+  LicenseGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ProGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLicenseGate: () => ({ isAllowed: true, isLoading: false }),
+}))
+
+vi.mock('@tour-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tour-kit/core')>()
+  return {
+    ...actual,
+    useTourContext: () => ({ isActive: false }),
+    useTourContextOptional: () => ({ isActive: false }),
+  }
+})
+
+const configs: SurveyConfig[] = [
+  {
+    id: 's',
+    type: 'csat',
+    displayMode: 'modal',
+    frequency: 'always',
+    questions: [
+      { id: 'q1', type: 'text', text: 'One' },
+      { id: 'q2', type: 'text', text: 'Two' },
+    ],
+  },
+]
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <SurveysProvider surveys={configs} storage={null}>
+      {children}
+    </SurveysProvider>
+  )
+}
+
+// Each of these drives one of the previously-uncovered useSurvey passthroughs
+// (hide, snooze, prevQuestion, complete, reset) and asserts the observable
+// state transition it produces, not just that the call doesn't throw.
+
+describe('useSurvey passthroughs', () => {
+  it('show then hide toggles visibility', () => {
+    const { result } = renderHook(() => useSurvey('s'), { wrapper })
+    act(() => result.current.show())
+    expect(result.current.state?.isVisible).toBe(true)
+    act(() => result.current.hide())
+    expect(result.current.state?.isVisible).toBe(false)
+  })
+
+  it('snooze marks the survey snoozed and increments the count', () => {
+    const { result } = renderHook(() => useSurvey('s'), { wrapper })
+    act(() => result.current.show())
+    act(() => result.current.snooze())
+    expect(result.current.state?.isSnoozed).toBe(true)
+    expect(result.current.state?.snoozeCount).toBe(1)
+  })
+
+  it('prevQuestion steps back after advancing', () => {
+    const { result } = renderHook(() => useSurvey('s'), { wrapper })
+    act(() => result.current.show())
+    act(() => {
+      result.current.nextQuestion()
+    })
+    expect(result.current.state?.currentStep).toBe(1)
+    act(() => result.current.prevQuestion())
+    expect(result.current.state?.currentStep).toBe(0)
+  })
+
+  it('complete marks the survey completed', () => {
+    const { result } = renderHook(() => useSurvey('s'), { wrapper })
+    act(() => result.current.show())
+    act(() => result.current.complete())
+    expect(result.current.state?.isCompleted).toBe(true)
+  })
+
+  it('reset returns a completed survey to a fresh state', () => {
+    const { result } = renderHook(() => useSurvey('s'), { wrapper })
+    act(() => result.current.show())
+    act(() => result.current.answer('q1', 'hi'))
+    act(() => result.current.complete())
+    expect(result.current.state?.isCompleted).toBe(true)
+
+    act(() => result.current.reset())
+    expect(result.current.state?.isCompleted).toBe(false)
+    expect(result.current.state?.currentStep).toBe(0)
+    expect(result.current.state?.responses.get('q1')).toBeUndefined()
+  })
+
+  it('dismiss records the dismissal reason', () => {
+    const { result } = renderHook(() => useSurvey('s'), { wrapper })
+    act(() => result.current.show())
+    act(() => result.current.dismiss('close_button'))
+    expect(result.current.state?.isDismissed).toBe(true)
+    expect(result.current.state?.dismissalReason).toBe('close_button')
+  })
+})

--- a/packages/surveys/vitest.config.ts
+++ b/packages/surveys/vitest.config.ts
@@ -23,15 +23,15 @@ export default defineConfig({
         'src/components/**/*.{ts,tsx}',
       ],
       exclude: ['src/**/*.test.{ts,tsx}', 'src/types/**', 'src/__tests__/helpers*'],
-      // Thresholds temporarily lowered from 80/75/80/80 — actuals on
-      // chore/code-health-phase-5: stmts 77.23 / branches 69.48 / funcs 72.27 /
-      // lines 79.00. Phase 5 deferred per failure protocol.
-      // Follow-up: https://github.com/domidex01/tour-kit/issues/13
+      // Slice 7 coverage-truth: restored to the canonical 80/75/80/80 with real
+      // behavior tests (validation gate, NPS/CSAT/CES scoring, scoring hook,
+      // scheduler). Note: skipLogic/visitedPath (Slice 1) remain unimplemented,
+      // so this floor is earned from other landed code, not survey branching.
       thresholds: {
-        statements: 72,
-        branches: 64,
-        functions: 67,
-        lines: 74,
+        statements: 80,
+        branches: 75,
+        functions: 80,
+        lines: 80,
       },
     },
   },


### PR DESCRIPTION
Recovers Slice 7 work that was stranded on the merged `fix/slice-5-dead-fields` branch under a commit labelled "chore(docs): update generation dates". It never reached `main`, so `CLAUDE.md` has been describing coverage floors that the repo does not enforce.

## What this does

Writes the missing behavior tests for the five packages whose thresholds were lowered during phase 5, then raises each `vitest.config.ts` to a floor the suite actually earns.

Measured after this change (statements / branches / functions / lines), all verified locally with `pnpm test:coverage` per package:

| package | measured | enforced floor |
|---|---|---|
| core | 90.44 / 84.00 / 92.60 / 92.66 | 80 / 75 / 80 / 80 |
| announcements | 88.04 / 80.32 / 83.52 / 88.43 | 75 / 70 / 80 / 75 |
| media | 85.92 / 86.60 / 77.92 / 86.68 | 70 / 60 / 70 / 70 |
| scheduling | 95.91 / 87.86 / 100 / 96.42 | 75 / 65 / 80 / 75 |
| surveys | 90.59 / 81.84 / 90.86 / 92.18 | 80 / 75 / 80 / 80 |

`packages/core/src/__tests__/coverage-claim-alignment.test.ts` now fails if the `CLAUDE.md` prose and the vitest configs drift apart again.

## Scope

Tests, `vitest.config.ts` files, `CLAUDE.md`, and regenerated docs context exports. No published package source changed, so no changeset.

## Verification

- `pnpm test:coverage` green in all five packages, every threshold satisfied
- `turbo run typecheck` green
- `biome check packages/` — 0 errors

https://claude.ai/code/session_01GTmvN3YseWBrMk4R6TnAWy