### PR TITLE
refactor(core): mirror React's types structurally instead of importing them

### DIFF
--- a/packages/core/src/__tests__/no-react-in-engine-types.test.ts
+++ b/packages/core/src/__tests__/no-react-in-engine-types.test.ts
@@ -1,0 +1,51 @@
+/**
+ * v2 §1.1 — the five type files that task 1.2 will carve into
+ * `@tour-kit/core/engine` must not name `react` at all.
+ *
+ * Today all five use `import type … from 'react'`. That emits zero runtime
+ * code, so the shipped JS is already React-free — what leaks is the emitted
+ * `.d.ts`. A Vue/Svelte consumer with `skipLibCheck: false` gets
+ * `Cannot find module 'react'`; with `skipLibCheck: true` the types quietly
+ * degrade to `any`.
+ *
+ * Source-scan rather than a dist-scan on purpose: the bundled
+ * `dist/index.d.ts` still opens with `import * as React$1 from 'react'`
+ * because hooks and providers legitimately keep it. The consumer-level
+ * guarantee belongs to §1.2, once the engine subpath exists.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** The five files named in the §1.1 acceptance criteria. */
+const ENGINE_TYPE_FILES = [
+  'types/step.ts',
+  'types/hints.ts',
+  'types/target.ts',
+  'lib/tour-engine/context.ts',
+  'lib/segmentation/types.ts',
+] as const
+
+/**
+ * Matches `from 'react'`, `from "react/jsx-runtime"`, and the `import type`
+ * / `export … from` forms alike — the specifier is what matters, not whether
+ * the import is elided at build time.
+ */
+const REACT_MODULE_SPECIFIER = /from\s+["']react(\/[^"']*)?["']/
+const REACT_REQUIRE = /require\(\s*["']react(\/[^"']*)?["']\s*\)/
+
+describe('v2 §1.1 — engine type files are React-free at the source level', () => {
+  it.each(ENGINE_TYPE_FILES)('%s does not import from react', (relPath) => {
+    const lines = readFileSync(join(SRC_ROOT, relPath), 'utf8').split('\n')
+    const offending = lines.filter(
+      (line) => REACT_MODULE_SPECIFIER.test(line) || REACT_REQUIRE.test(line)
+    )
+
+    // Assert on the offending lines, not the file body — a failure should read
+    // as "this import has to go", not as a wall of source.
+    expect(offending).toEqual([])
+  })
+})

--- a/packages/core/src/__tests__/types/tour-node-parity.test-d.ts
+++ b/packages/core/src/__tests__/types/tour-node-parity.test-d.ts
@@ -64,6 +64,13 @@ const _functionContent: VisibleTourStep = { id: 'b2', target: '#x', content: () 
 // @ts-expect-error — `{ key }` is LocalizedText, not renderable content
 const _keyedIsNotANode: TourNode = { key: 'welcome' }
 
+// The promise arm must not launder an excluded type one level down: React's
+// own arm is `Promise<AwaitedReactNode>`, so `PromiseLike<TourNode>` still
+// satisfies the drift guard above while rejecting a promise of a non-node.
+const _promisedNode: TourNode = Promise.resolve('text')
+// @ts-expect-error — a promise of a symbol is not renderable content
+const _promisedSymbol: TourNode = Promise.resolve(Symbol())
+
 // ─── A useRef from React 18 *or* React 19 is still a valid step target ──────
 // React 19's shape, as returned by `useRef<HTMLDivElement | null>(null)`.
 declare const ref19: RefObject<HTMLDivElement | null>
@@ -86,5 +93,7 @@ void _jsxTitle
 void _symbolContent
 void _functionContent
 void _keyedIsNotANode
+void _promisedNode
+void _promisedSymbol
 void _target19
 void _target18

--- a/packages/core/src/__tests__/types/tour-node-parity.test-d.ts
+++ b/packages/core/src/__tests__/types/tour-node-parity.test-d.ts
@@ -1,0 +1,90 @@
+// v2 §1.1 — React-free core types: parity + authoring-safety guards.
+//
+// Vitest doesn't run `*.test-d.ts` files at runtime — they're compiled by
+// `pnpm --filter @tour-kit/core typecheck:types`. The `@ts-expect-error`
+// directives FAIL the build if the offending statement still compiles.
+//
+// Everything here imports through the PUBLIC barrel (`../../index`) on
+// purpose: the acceptance criteria say the four new primitives are exported
+// from `@tour-kit/core`, not merely declared somewhere in `src/types`.
+
+import type { Dispatch, ReactElement, ReactNode, RefObject } from 'react'
+import { expectTypeOf } from 'vitest'
+import type {
+  SegmentationProviderProps,
+  TourDispatch,
+  TourElementLike,
+  TourNode,
+  TourRef,
+  TourTarget,
+  VisibleTourStep,
+} from '../../index'
+
+declare const el: ReactElement
+
+// ─── Drift guard: React's ReactNode must stay inside TourNode ───────────────
+// This is the whole maintenance answer for hand-mirroring React's union. The
+// day React adds a member TourNode doesn't cover, `typecheck:types` fails —
+// same idiom as `_AssertCoversPlacement` in `lib/schemas/step.schema.ts`.
+expectTypeOf<ReactNode>().toExtend<TourNode>()
+
+// A React element satisfies the structural element shape.
+expectTypeOf<ReactElement>().toExtend<TourElementLike>()
+
+// ─── Ref parity: TourRef<T> is structurally React.RefObject<T> ──────────────
+expectTypeOf<RefObject<HTMLElement | null>>().toExtend<TourRef<HTMLElement | null>>()
+expectTypeOf<TourRef<HTMLElement | null>>().toExtend<RefObject<HTMLElement | null>>()
+
+// ─── Dispatch parity: TourDispatch<A> is structurally React.Dispatch<A> ─────
+type TestAction = { type: 'NEXT' }
+expectTypeOf<Dispatch<TestAction>>().toExtend<TourDispatch<TestAction>>()
+expectTypeOf<TourDispatch<TestAction>>().toExtend<Dispatch<TestAction>>()
+
+// ─── Authoring still compiles ───────────────────────────────────────────────
+const _jsxContent: VisibleTourStep = { id: 's1', target: '#x', content: el }
+const _stringContent: VisibleTourStep = { id: 's2', target: '#x', content: 'text' }
+const _mixedArrayContent: VisibleTourStep = { id: 's3', target: '#x', content: [el, 'x'] }
+const _keyedTitle: VisibleTourStep = {
+  id: 's4',
+  target: '#x',
+  content: 'x',
+  title: { key: 'welcome' },
+}
+const _jsxTitle: VisibleTourStep = { id: 's5', target: '#x', content: 'x', title: el }
+
+// ─── Authoring errors survive the widening ──────────────────────────────────
+// @ts-expect-error — a symbol is not renderable content
+const _symbolContent: VisibleTourStep = { id: 'b1', target: '#x', content: Symbol() }
+
+// @ts-expect-error — a bare function is not renderable content
+const _functionContent: VisibleTourStep = { id: 'b2', target: '#x', content: () => {} }
+
+// `{ key }` must NOT be a TourNode, or `TourNode | LocalizedText` stops
+// discriminating and `isI18nKey` narrowing silently breaks.
+// @ts-expect-error — `{ key }` is LocalizedText, not renderable content
+const _keyedIsNotANode: TourNode = { key: 'welcome' }
+
+// ─── A useRef from React 18 *or* React 19 is still a valid step target ──────
+// React 19's shape, as returned by `useRef<HTMLDivElement | null>(null)`.
+declare const ref19: RefObject<HTMLDivElement | null>
+// React 18's shape, written out because no `@types/react@18` is installed in
+// the workspace to import it from.
+declare const ref18: { readonly current: HTMLDivElement | null }
+const _target19: TourTarget = ref19
+const _target18: TourTarget = ref18
+
+// ─── SegmentationProviderProps survives the file move ───────────────────────
+declare const segProps: SegmentationProviderProps
+expectTypeOf(segProps.children).toExtend<ReactNode>()
+
+// Keep references so unused-var noise doesn't drown out the type errors.
+void _jsxContent
+void _stringContent
+void _mixedArrayContent
+void _keyedTitle
+void _jsxTitle
+void _symbolContent
+void _functionContent
+void _keyedIsNotANode
+void _target19
+void _target18

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,11 @@ export type {
   TourTarget,
   TourTargetRef,
   TourTargetGetter,
+  // React-free structural primitives
+  TourNode,
+  TourElementLike,
+  TourRef,
+  TourDispatch,
   Tour,
   TourOptions,
   TourState,

--- a/packages/core/src/lib/i18n/use-resolved-text.ts
+++ b/packages/core/src/lib/i18n/use-resolved-text.ts
@@ -1,20 +1,21 @@
 'use client'
 
 import type * as React from 'react'
+import type { TourNode } from '../../types/primitives'
 import { interpolate } from '../interpolate'
 import { type LocalizedText, isI18nKey } from '../localized-text'
 import { useSegmentationContext } from '../segmentation/segmentation-context'
 import { useT } from './use-t'
 
 /**
- * Resolve a `LocalizedText | ReactNode` value into a `ReactNode`. Drives the
+ * Resolve a `LocalizedText | TourNode` value into a `ReactNode`. Drives the
  * Phase 3a unified text pipeline (promoted to core in Phase 1 of the refactor
  * train — previously duplicated in `@tour-kit/react`, `@tour-kit/hints`, and
  * `@tour-kit/announcements`).
  *
  *   - `string` → `interpolate(value, vars)` (templated literal)
  *   - `{ key }` → `useT()(value.key, vars)` (i18n dictionary)
- *   - any other `ReactNode` → returned as-is
+ *   - any other `TourNode` → returned as-is
  *
  * `vars` defaults to `useSegmentationContext().userContext` so consumers
  * authoring `'Hi {{user.name}}'` get interpolation against the same context
@@ -28,7 +29,7 @@ import { useT } from './use-t'
  * ReactNode pass-through branch.
  */
 export function useResolvedText(
-  value: React.ReactNode | LocalizedText | undefined,
+  value: TourNode | LocalizedText | undefined,
   vars?: Record<string, unknown>
 ): React.ReactNode {
   const t = useT()

--- a/packages/core/src/lib/i18n/use-resolved-text.ts
+++ b/packages/core/src/lib/i18n/use-resolved-text.ts
@@ -15,7 +15,17 @@ import { useT } from './use-t'
  *
  *   - `string` → `interpolate(value, vars)` (templated literal)
  *   - `{ key }` → `useT()(value.key, vars)` (i18n dictionary)
- *   - any other `TourNode` → returned as-is
+ *   - any other `TourNode` → returned as-is, unchecked (see below)
+ *
+ * **This is a boundary, and the pass-through is a widening.** `TourNode` is a
+ * React-free *supertype* of `ReactNode` (v2 §1.1), so the residue left after
+ * the `string` and `{ key }` branches — an element-like, an iterable, a
+ * promise, a number/bigint/boolean — is not provably a `ReactNode`. Authoring
+ * a `TourNode` React cannot render therefore throws at render time instead of
+ * failing `tsc`. That is the accepted cost of a React-free core, and this
+ * function plus `<TourCard>`'s `content` prop are the only two places where
+ * it is paid; both cast once at the boundary, the convention
+ * `lib/schemas/parse.ts` documents.
  *
  * `vars` defaults to `useSegmentationContext().userContext` so consumers
  * authoring `'Hi {{user.name}}'` get interpolation against the same context
@@ -39,5 +49,6 @@ export function useResolvedText(
   if (value === undefined || value === null) return value
   if (typeof value === 'string') return interpolate(value, effectiveVars)
   if (isI18nKey(value)) return t(value.key, effectiveVars)
+  // Boundary cast — see the widening note in the doc comment above.
   return value as React.ReactNode
 }

--- a/packages/core/src/lib/segmentation/index.ts
+++ b/packages/core/src/lib/segmentation/index.ts
@@ -1,4 +1,5 @@
 export { SegmentationProvider, useSegmentationContext } from './segmentation-context'
+export type { SegmentationProviderProps } from './segmentation-context'
 export { useSegment, useSegments } from './use-segment'
 export { parseUserIdsFromCsv } from './csv'
 export type {
@@ -6,5 +7,4 @@ export type {
   StaticSegment,
   SegmentSource,
   SegmentationContextValue,
-  SegmentationProviderProps,
 } from './types'

--- a/packages/core/src/lib/segmentation/segmentation-context.tsx
+++ b/packages/core/src/lib/segmentation/segmentation-context.tsx
@@ -1,6 +1,11 @@
 'use client'
+import type { ReactNode } from 'react'
 import { createContext, useContext, useMemo } from 'react'
-import type { SegmentationContextValue, SegmentationProviderProps } from './types'
+import type { SegmentationContextValue } from './types'
+
+export interface SegmentationProviderProps extends SegmentationContextValue {
+  children: ReactNode
+}
 
 const Ctx = createContext<SegmentationContextValue>({ segments: {} })
 

--- a/packages/core/src/lib/segmentation/types.ts
+++ b/packages/core/src/lib/segmentation/types.ts
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react'
 import type { AudienceCondition } from '../../types/audience'
 
 /**
@@ -44,8 +43,4 @@ export interface SegmentationContextValue {
   segments: Record<string, SegmentSource>
   userContext?: Record<string, unknown>
   currentUserId?: string
-}
-
-export interface SegmentationProviderProps extends SegmentationContextValue {
-  children: ReactNode
 }

--- a/packages/core/src/lib/tour-engine/context.ts
+++ b/packages/core/src/lib/tour-engine/context.ts
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import type { TourDispatch, TourRef } from '../../types/primitives'
 import type { RouterAdapter } from '../../types/router'
 import type { Tour } from '../../types/tour'
 import type { TourAction, TourReducerState } from '../../types/tour-reducer'
@@ -38,10 +38,10 @@ export interface TourEngineContext {
   getStepIdMap: () => Map<string, number>
 
   // ─── Dispatch + refs ─────────────────────────────────────────────────────
-  dispatch: React.Dispatch<TourAction>
-  abortControllerRef: React.RefObject<AbortController | null>
-  completedTourIdRef: React.RefObject<string | null>
-  skippedTourIdRef: React.RefObject<string | null>
+  dispatch: TourDispatch<TourAction>
+  abortControllerRef: TourRef<AbortController | null>
+  completedTourIdRef: TourRef<string | null>
+  skippedTourIdRef: TourRef<string | null>
 
   // ─── Config (static for the provider's lifetime) ─────────────────────────
   router?: RouterAdapter

--- a/packages/core/src/types/hints.ts
+++ b/packages/core/src/types/hints.ts
@@ -1,7 +1,7 @@
-import type React from 'react'
 import type { FrequencyRule } from '../lib/frequency'
 import type { LocalizedText } from '../lib/localized-text'
 import type { Placement } from './config'
+import type { TourNode } from './primitives'
 import type { AudienceProp } from './step'
 import type { TourTarget } from './target'
 
@@ -12,7 +12,7 @@ export interface HintConfig {
   target: TourTarget
   /** Optional title rendered above the content (Phase 3a). */
   title?: LocalizedText
-  content: React.ReactNode | LocalizedText
+  content: TourNode | LocalizedText
   position?: HotspotPosition
   tooltipPlacement?: Placement
   pulse?: boolean

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -38,6 +38,9 @@ export {
   defaultScrollConfig,
 } from './config'
 
+// React-free structural primitives (v2 §1.1)
+export type { TourNode, TourElementLike, TourRef, TourDispatch } from './primitives'
+
 // Step types
 export type {
   TourStep,

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -1,0 +1,55 @@
+/**
+ * React-free structural mirrors of the four React types core's engine surface
+ * used to import. Imports nothing — that is the entire point: task §1.2 carves
+ * `@tour-kit/core/engine` out of these files, and a subpath that names `react`
+ * in its emitted `.d.ts` is not framework-agnostic.
+ *
+ * `TourRef` and `TourDispatch` are exact structural equals of React's
+ * `RefObject` / `Dispatch` (both directions of assignability are pinned in
+ * `__tests__/types/tour-node-parity.test-d.ts`). `TourNode` is a deliberate
+ * *supertype* of `ReactNode` — no React-free type is mutually assignable with
+ * it, so render sites cast once at the boundary, the same convention
+ * `lib/schemas/parse.ts` already documents.
+ */
+
+/**
+ * Structural shape of a rendered element. React's `ReactElement` and Vue's
+ * VNode both satisfy it, so this is not secretly React-only.
+ *
+ * Wider than `ReactElement`: any `{ type, props }` object now type-checks and
+ * fails inside the renderer at runtime instead of at build time. Accepted —
+ * still strictly narrower than the `unknown` that `TourStepDefinition` ships.
+ */
+export interface TourElementLike {
+  readonly type: unknown
+  readonly props: unknown
+}
+
+/**
+ * Renderable content. Mirrors React's `ReactNode` union closely enough that
+ * `ReactNode extends TourNode` holds — enforced by the drift guard in
+ * `__tests__/types/tour-node-parity.test-d.ts`, which fails the build the day
+ * React's union grows a member this one does not cover.
+ *
+ * Deliberately excludes `symbol` and bare functions so authoring errors in
+ * `TourStep.content` stay compile errors, and excludes plain `{ key: string }`
+ * so `TourNode | LocalizedText` keeps discriminating for `isI18nKey`.
+ */
+export type TourNode =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | undefined
+  | TourElementLike
+  | Iterable<TourNode>
+  | PromiseLike<unknown>
+
+/** Structural equal of `React.RefObject<T>`. */
+export interface TourRef<T> {
+  current: T
+}
+
+/** Structural equal of `React.Dispatch<A>`. */
+export type TourDispatch<A> = (value: A) => void

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -33,7 +33,10 @@ export interface TourElementLike {
  *
  * Deliberately excludes `symbol` and bare functions so authoring errors in
  * `TourStep.content` stay compile errors, and excludes plain `{ key: string }`
- * so `TourNode | LocalizedText` keeps discriminating for `isI18nKey`.
+ * so `TourNode | LocalizedText` keeps discriminating for `isI18nKey`. The
+ * promise arm is `PromiseLike<TourNode>` rather than `PromiseLike<unknown>`
+ * for the same reason — otherwise `content: Promise.resolve(Symbol())` would
+ * compile and defeat the exclusions one level down.
  */
 export type TourNode =
   | string
@@ -44,7 +47,7 @@ export type TourNode =
   | undefined
   | TourElementLike
   | Iterable<TourNode>
-  | PromiseLike<unknown>
+  | PromiseLike<TourNode>
 
 /** Structural equal of `React.RefObject<T>`. */
 export interface TourRef<T> {

--- a/packages/core/src/types/step.ts
+++ b/packages/core/src/types/step.ts
@@ -1,8 +1,8 @@
-import type React from 'react'
 import type { LocalizedText } from '../lib/localized-text'
 import type { AudienceCondition } from './audience'
 import type { Branch } from './branch'
 import type { Placement } from './config'
+import type { TourNode } from './primitives'
 import type { TourCallbackContext } from './state'
 import type { TourTarget } from './target'
 
@@ -124,16 +124,16 @@ export interface VisibleTourStep<TId extends string = string> extends BaseTourSt
   /**
    * Step title. Accepts a plain string (interpolated via `interpolate`),
    * a `{ key: string }` dictionary lookup (resolved via `useT()`), or any
-   * `ReactNode` for arbitrary JSX. Strings without `{{var}}` tokens render
+   * `TourNode` for arbitrary JSX. Strings without `{{var}}` tokens render
    * unchanged — the widening is back-compat-safe.
    */
-  title?: React.ReactNode | LocalizedText
+  title?: TourNode | LocalizedText
   /**
    * Optional short description rendered above `content`. i18n-friendly:
    * accepts string (interpolated) or `{ key }` (translated).
    */
   description?: LocalizedText
-  content: React.ReactNode
+  content: TourNode
   /**
    * Optional media (video / GIF / Lottie / image) rendered above the step
    * description by `<TourCard>`. Auto-detects the embed provider via URL

--- a/packages/core/src/types/target.ts
+++ b/packages/core/src/types/target.ts
@@ -1,6 +1,6 @@
-import type * as React from 'react'
+import type { TourRef } from './primitives'
 
-export type TourTargetRef = React.RefObject<HTMLElement | null>
+export type TourTargetRef = TourRef<HTMLElement | null>
 export type TourTargetGetter = () => HTMLElement | null
 
 /**

--- a/packages/hints/src/index.ts
+++ b/packages/hints/src/index.ts
@@ -59,6 +59,9 @@ export {
 // Accessibility hooks (re-exported for ergonomic in-package access)
 export { useReducedMotion } from '@tour-kit/core'
 
+// React-free structural primitives (the type of `HintConfig.content`)
+export type { TourNode, TourElementLike, TourRef, TourDispatch } from '@tour-kit/core'
+
 // ============================================
 // TYPES
 // ============================================

--- a/packages/hints/src/types/index.ts
+++ b/packages/hints/src/types/index.ts
@@ -4,6 +4,7 @@ import type {
   HotspotPosition,
   LocalizedText,
   Placement,
+  TourNode,
 } from '@tour-kit/core'
 import type { MediaSlotProps } from '@tour-kit/media'
 import type * as React from 'react'
@@ -19,10 +20,14 @@ export interface HintConfig {
   title?: LocalizedText
   /**
    * Tooltip body. Accepts a string (interpolated), a `{ key }` dictionary
-   * lookup, or any `ReactNode` for arbitrary JSX. The original
+   * lookup, or any `TourNode` for arbitrary JSX. The original
    * `React.ReactNode`-only contract stays assignable.
+   *
+   * This type is a near-copy of `@tour-kit/core`'s `HintConfig` (they differ
+   * on `target` and `media`); `content` is kept in step with core's so the two
+   * published shapes don't drift further. Reconciling them is its own task.
    */
-  content: React.ReactNode | LocalizedText
+  content: TourNode | LocalizedText
   position?: HotspotPosition
   tooltipPlacement?: Placement
   pulse?: boolean

--- a/packages/react/src/components/card/tour-card.tsx
+++ b/packages/react/src/components/card/tour-card.tsx
@@ -263,7 +263,13 @@ export const TourCard = React.forwardRef<HTMLDivElement, TourCardProps>(
             </div>
           )}
 
-          <TourCardContent content={visibleStep.content} description={resolvedDescription} />
+          {/* `TourNode` is a React-free supertype of `ReactNode`, so nothing
+              assigns back without a cast. Same boundary-cast convention as
+              `@tour-kit/core`'s `lib/schemas/parse.ts`: cast once, here. */}
+          <TourCardContent
+            content={visibleStep.content as React.ReactNode}
+            description={resolvedDescription}
+          />
 
           <TourCardFooter
             currentStep={currentStepIndex + 1}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -196,6 +196,11 @@ export type {
   A11yConfig,
   ScrollConfig,
   Storage,
+  // React-free structural primitives (the type of `TourStep.content`)
+  TourNode,
+  TourElementLike,
+  TourRef,
+  TourDispatch,
   // Step types
   TourStep as TourStepConfig,
   StepOptions,

--- a/tasks/issues/v2-1-1-react-free-core-types.md
+++ b/tasks/issues/v2-1-1-react-free-core-types.md
@@ -2,7 +2,7 @@
 
 issue:  not created
 branch: refactor/v2-1-1-react-free-core-types
-status: tests-red
+status: green
 
 <!-- ============ PLANNER owns below. Everyone else: read only. ============ -->
 
@@ -247,7 +247,7 @@ plus one cast.
 
 ## TEST WRITER
 
-status: tests-red
+status: implementing
 
 ### files
 
@@ -430,3 +430,144 @@ file.
 failures on this machine), repo-wide `pnpm typecheck`, `pnpm --filter
 @tour-kit/core typecheck:types`, the `e2e/next` + `e2e/vite` Playwright specs,
 and `biome check packages/`. Both new files are already biome-clean.
+
+<!-- ============ CODER owns below. Planner + test-writer sections untouched. ============ -->
+
+## CODER
+
+status: green
+
+### what shipped
+
+Exactly the plan's file list, no additions to the source diff. `TourNode` over
+plain `unknown`, as recommended — the drift guard is what made that affordable,
+and it is now proven to bite (see *the guards actually bite*).
+
+- `packages/core/src/types/primitives.ts` — **new, 55 lines, zero imports.**
+  `TourElementLike`, `TourNode`, `TourRef<T>`, `TourDispatch<A>`.
+- `types/step.ts`, `types/hints.ts`, `types/target.ts`,
+  `lib/tour-engine/context.ts` — react import dropped, fields repointed.
+- `lib/segmentation/types.ts` — `SegmentationProviderProps` **moved** to
+  `segmentation-context.tsx` (its only consumer, already React-importing) and
+  `lib/segmentation/index.ts` repointed. No new type. Rung 1, as planned.
+- `types/index.ts` + `src/index.ts` — the four primitives exported (additive).
+- `lib/i18n/use-resolved-text.ts` — param widened to
+  `TourNode | LocalizedText | undefined`; return stays `React.ReactNode` and
+  the file keeps its React import, deliberately.
+- `packages/react/src/components/card/tour-card.tsx:266` — the one boundary
+  cast, commented, pointing at `parse.ts`.
+- `wiki-tech/packages/core.md` — §Types group added, one §Architectural
+  decisions bullet ("React types are structurally mirrored, not imported"),
+  `src/types` added to `sources:`, `updated:` bumped to 2026-09-03.
+
+### acceptance, closed
+
+Every bullet the test-writer mapped is now green, by the test they named.
+Bullets 3, 5 and the runtime half of 4 and 6 were already-green pins and were
+**not** weakened — they still assert what they asserted before.
+
+| # | Bullet | Closed by | Note |
+|---|---|---|---|
+| 1 | Five files import no `react` | `no-react-in-engine-types.test.ts`, 5/5 green | |
+| 2 | Authoring errors survive, valid authoring compiles | `tour-node-parity.test-d.ts` | mutation-tested, below |
+| 3 | JSX `content` renders identically in `<TourCard>` | existing `tour-card-content.test.tsx` | untouched, green |
+| 4 | React 18/19 `useRef` still a valid `target` | type half green; `types/target.test.ts` untouched | 18 shape still hand-written — see *still open* |
+| 5 | `HiddenTourStep` rejects `content`/`title` | existing `hidden-step.test-d.ts` | untouched, green |
+| 6 | `SegmentationProviderProps` still exported, still takes `children` | type half green; `segmentation.test.tsx` untouched | survives the file move |
+| 7 | Build fails if `ReactNode` outgrows `TourNode` | drift guard green | mutation-tested, below |
+| 8 | Five nets | below | 4 fully green, e2e partial — see *e2e* |
+
+`phase-0-harness.test.ts > typecheck:types exits 0` went green on its own the
+moment the type test compiled, exactly as the test-writer's heads-up predicted.
+It was not edited and the new file was not excluded.
+
+### the guards actually bite
+
+The test-writer's honest caveat was that four of the five red type errors were
+`TS2305` module-resolution — proof the names were missing, not proof the guards
+work. Closed by mutation-testing `primitives.ts` against the finished suite:
+
+- Comment out `| TourElementLike` → the drift guard fires (`TS2344` at line 29,
+  `ReactNode` no longer extends `TourNode`) plus `TS2322` at lines 44/46/53
+  where JSX authoring stops compiling.
+- Collapse the union to `unknown` → all three `@ts-expect-error` directives go
+  unused (`TS2578` at 56/59/64): `content: Symbol()`, `content: () => {}` and
+  `{ key: 'welcome' }` all start compiling.
+
+Both mutations restored, suite re-verified clean. The guards are live.
+
+### the finding: runtime output is unchanged, provably
+
+The planner's root-cause claim — *all five imports are `import type`, so nothing
+ships today* — predicts the built JS should not move at all. It doesn't, and
+that is worth more than any assertion in the suite, because it retires the
+entire "did this break something at runtime?" question for every consumer.
+
+Built `dist/index.js` before and after, token-diffed:
+
+- **core** — 26,703 tokens before, 26,703 after. All 50 differing hunks are a
+  single minifier identifier permutation (`M`↔`N` and their suffixed forms
+  `Mt`/`Nt`, `Me`/`Ne`, `Mr`/`Nr`). Zero hunks are anything else.
+- **react** — entry and all 11 chunks token-identical. Two chunk *filenames*
+  moved (`RWECTWZT`→`TDEYCHEY`, `GQLGUUVS`→`VEDES2UF`) and the only in-file
+  differences are those names referring to themselves. The hash moved because
+  the JSX comment changed the sourcemap input, not the code.
+- **hints** — `dist/index.js` byte-identical (same md5).
+
+### nets
+
+| Net | Result |
+|---|---|
+| `npx turbo run test --concurrency=3` | **37 successful, 37 total** (core 87 files / 1013 passed + 3 skipped; react 40 files / 485 passed) |
+| `pnpm typecheck` (repo-wide) | **29 successful, 29 total** |
+| `pnpm --filter @tour-kit/core typecheck:types` | **exit 0** |
+| `npx biome check packages/` | **1028 files, 0 errors**, 16 warnings — all pre-existing, none in this diff |
+| Playwright `e2e/next` + `e2e/vite` | **partial — see below** |
+
+The repo typecheck is the net that earned its place: it caught the single
+`tour-card.tsx:266` `TS2322`, and nothing else anywhere in `react`, `apps/docs`,
+`examples` or `dashboard-next`. The widening's blast radius really is one line.
+
+### e2e — partial, and why
+
+`vite-localhost` + `next-localhost`: **22 passed, 5 failed, 1 flaky.**
+
+The 5 failures are **pre-existing and unrelated**, verified rather than assumed:
+the working tree was stashed, the packages rebuilt from the clean tree, and the
+same two specs re-run — **identical 5 failures, same assertions, same counts.**
+
+- 3 × `next/localhost-bypass.spec.ts` — `[data-tourkit-watermark]` expected 0,
+  got 1, on valid-license / invalid-key / no-provider. Next-only; the four
+  equivalent `vite/localhost-bypass` cases pass, as does Next's own
+  `empty key … shows watermark`. A license-gating issue, no contact with types.
+- 2 × `next/hint-variants` `whats-new-pill` snapshots — 5,178 px (0.05) light,
+  2,116 px (0.02) dark. Playwright browsers were not installed on this machine
+  at all (the first run was 28/28 failures for that reason alone); the
+  committed baselines predate the Chromium 147 that got installed. `badge` and
+  `beacon-with-label` still match, so this is not a blanket rendering shift.
+- 1 flaky — `cross-page-resume-localhost` timed out on the 200 ms throttle poll,
+  passed on retry.
+
+`vite-production` + `next-production` (7 specs) were **not run**: they need
+`127.0.0.1 tourkit-test.dev` in `/etc/hosts`, which is absent on this machine
+and needs sudo. Left for the user rather than edited unasked. They exercise
+license watermarking against a non-localhost origin — no contact with this
+task's surface, but that is reasoning, not a green run.
+
+Also unrelated: `pnpm build` fails at `@tour-kit/docs#build` with exit 137 (OOM
+kill). All 20 package builds succeed. Known local-only WSL2 docs-build break.
+
+### still open
+
+- **React 18 is still a hand-written stand-in.** No `@types/react@18` in the
+  workspace, so the drift guard runs against 19.x only. Unchanged from the
+  test-writer's note; installing 18 and compiling the type tests against both
+  is its own task.
+- **`dist/index.d.ts` still opens with `import * as React$1 from 'react'`.** By
+  design — hooks and providers keep React. That guarantee is §1.2's, and the
+  five files this task freed are exactly the ones §1.2 needs.
+- The three "Seen but out of scope" bugs are untouched.
+- **Not part of this task, do not commit:** `apps/docs/public/context/*.txt`,
+  `apps/docs/public/llms*.txt`, `apps/docs/components/landing/sale-countdown.tsx`
+  and the untracked `apps/docs/components/landing/__tests__/` were already
+  dirty in the working tree when this task started.

--- a/tasks/issues/v2-1-1-react-free-core-types.md
+++ b/tasks/issues/v2-1-1-react-free-core-types.md
@@ -1,0 +1,432 @@
+# v2 §1.1 — Genericise the 5 type-only React imports in core
+
+issue:  not created
+branch: refactor/v2-1-1-react-free-core-types
+status: tests-red
+
+<!-- ============ PLANNER owns below. Everyone else: read only. ============ -->
+
+## Problem
+
+`plan/v2/handoff.md` §1.1 wants five core files to stop importing React so
+task 1.2 can carve `@tour-kit/core/engine`. The symptom is "5 stray imports";
+the root cause is narrower and more useful: **all five imports are
+`import type`, so they already emit zero runtime code.** Nothing ships React
+today. What leaks is the *emitted `.d.ts`* — a Vue/Svelte consumer with
+`skipLibCheck: false` gets `Cannot find module 'react'`, and with
+`skipLibCheck: true` (the common case) the types silently degrade to `any`.
+
+So this is a type-shape problem, not a code-movement problem, and it splits
+cleanly in two:
+
+- **Three files are pure structural aliases** — `React.RefObject<T>` is
+  `{ current: T }` and `React.Dispatch<A>` is `(a: A) => void`. Replacing them
+  is a rename with provably identical assignability (spiked below).
+- **Two files hold `ReactNode`** (`TourStep.title`/`content`,
+  `HintConfig.content`). No React-free type is *mutually* assignable with
+  `ReactNode`, so this one genuinely costs something. It is the whole risk of
+  the task and the handoff's "2 days" hides it.
+
+## Files touched
+
+- `packages/core/src/types/primitives.ts` — **new.** React-free `TourNode`,
+  `TourElementLike`, `TourRef<T>`, `TourDispatch<A>`. ~20 lines, no imports.
+- `packages/core/src/types/step.ts` — drop the react import;
+  `title?: TourNode | LocalizedText`, `content: TourNode`. Update the two
+  doc-comments that say `ReactNode`.
+- `packages/core/src/types/hints.ts` — drop the react import;
+  `content: TourNode | LocalizedText`.
+- `packages/core/src/types/target.ts` — drop the react import;
+  `TourTargetRef = TourRef<HTMLElement | null>`.
+- `packages/core/src/lib/tour-engine/context.ts` — drop the react import;
+  `dispatch: TourDispatch<TourAction>` and the three refs → `TourRef<…>`.
+  Internal type (0 hits in `dist/index.d.ts`) — zero external surface.
+- `packages/core/src/lib/segmentation/types.ts` — drop the react import by
+  **moving** `SegmentationProviderProps` into `segmentation-context.tsx`, its
+  only consumer, which already imports React. No new type. Ladder rung 1.
+- `packages/core/src/lib/segmentation/index.ts` — repoint the
+  `SegmentationProviderProps` re-export at `./segmentation-context`.
+- `packages/core/src/types/index.ts` + `packages/core/src/index.ts` — export
+  `TourNode`, `TourElementLike`, `TourRef`, `TourDispatch` (additive).
+- `packages/core/src/lib/i18n/use-resolved-text.ts` — widen the param to
+  `TourNode | LocalizedText | undefined`. Return stays `React.ReactNode`; this
+  file legitimately keeps its React import (it is a hook calling `useT`).
+- `packages/react/src/components/card/tour-card.tsx` (~line 266) —
+  `content={visibleStep.content as React.ReactNode}`. **The only render-site
+  break in the entire monorepo.** Comment it, pointing at the identical
+  boundary cast already documented in `lib/schemas/parse.ts`.
+- `packages/core/src/__tests__/no-react-in-engine-types.test.ts` — **new.**
+  Source-scan guard over the five files. This is the RED test.
+- `packages/core/src/__tests__/types/tour-node-parity.test-d.ts` — **new.**
+  `ReactNode extends TourNode` drift guard, run by `typecheck:types`. Lives
+  beside the eight existing `.test-d.ts` files, not under `types/__tests__/`.
+- `wiki-tech/packages/core.md` — add the new types to §Types and one
+  §Architectural decisions bullet: React types are structurally mirrored, not
+  imported.
+
+## Unknowns
+
+All resolved by spike (rung 5 — the docs could not answer assignability for
+*this* React version). Probe run under `@types/react@19.2.14`, `strict: true`;
+full source in the session scratchpad, every assertion below compiled clean.
+
+1. **Is `React.RefObject<T>` structurally replaceable?** — Yes.
+   React 19 defines `interface RefObject<T> { current: T }` (index.d.ts:154).
+   `{ current: HTMLElement | null }` and `React.RefObject<HTMLElement | null>`
+   proved assignable **in both directions**, with and without `readonly`, and a
+   subtype ref (`RefObject<HTMLDivElement | null>`, what `useRef` returns)
+   assigns in. Readonly modifiers do not affect object assignability in TS, so
+   the React 18 shape (`{ readonly current: T | null }`) is covered too — which
+   matters, `peerDependencies` is `^18.0.0 || ^19.0.0`. **Caveat:** no
+   `@types/react@18` is installed anywhere in the workspace, so the drift guard
+   in Acceptance runs against 19.x only. React 18 coverage rests on this
+   reasoning (18's `ReactNode` union is a strict subset of 19's; readonly is
+   irrelevant for property assignability), not on a test.
+
+2. **Is `React.Dispatch<A>` replaceable?** — Yes, it is literally
+   `type Dispatch<A> = (value: A) => void` (index.d.ts:1645). Proved
+   bidirectionally assignable.
+
+3. **Does widening `title`/`content` break the `ai` package or `apps/docs`?**
+   — No. `ai` declares its own structural `TourContextLike` with
+   `content?: unknown` (`hooks/use-tour-assistant.ts:44-53`) and never imports
+   core's `TourStep`. The `apps/docs` hits (`features.tsx:17`,
+   `code-preview.tsx:146`) are code samples inside template-literal **strings**,
+   and `how-it-works.tsx` uses its own local objects. Separately confirmed
+   `` `${unknown}` `` is legal in a TS template literal, so
+   `ai/server/system-prompt.ts:105` is safe either way.
+
+4. **Can a React-free type keep authoring safety?** — Yes, and this is the
+   finding the plan turns on. With
+
+   ```ts
+   interface TourElementLike { readonly type: unknown; readonly props: unknown }
+   type TourNode = string | number | bigint | boolean | null | undefined
+                 | TourElementLike | Iterable<TourNode> | PromiseLike<unknown>
+   ```
+
+   the probe proved all of: `ReactNode extends TourNode` ✅ (so the drift guard
+   is satisfiable today); `Symbol()` and `() => {}` still **rejected** ✅;
+   `ReactElement`, `ReactNode[]`, primitives, mixed arrays accepted ✅;
+   `{ key: 'a' }` is **not** a `TourNode` ✅ — so `TourNode | LocalizedText`
+   stays a discriminating union and `isI18nKey` narrowing is unaffected.
+   React's `DO_NOT_USE_…_EXPERIMENTAL_REACT_NODES` arm is an empty interface
+   (index.d.ts:404), so `keyof` it is `never` — that arm contributes nothing.
+
+5. **Does the repo already answer "React-free content type"?** — Partly, and
+   it argues for `unknown`: `types/tour-definition.ts` already ships
+   `TourStepDefinition` with `content: unknown`, and `lib/schemas/parse.ts`
+   already documents casting **once at the boundary**. That is the JSON path
+   though — a deliberately lossier contract (`target` is `string`-only there).
+   Reused as a *convention* (one boundary cast), not as the type. See Approach.
+
+## Approach
+
+**Ladder rung 2 for four of the six files, rung 7 for `TourNode`.**
+
+Rung 2 (reuse what is here): `segmentation/types.ts` needs no new type at all —
+`SegmentationProviderProps` is a React component's props that drifted into a
+types file; moving it to the `.tsx` that consumes it deletes the import. The
+ref/dispatch aliases are mechanical renames proved identical by Unknown 1–2.
+The single render-site cast reuses the `parse.ts` boundary-cast convention.
+
+Rung 7 (write the minimum) applies only to `TourNode`, and only after rejecting
+the cheaper option. **The real decision is `TourNode` vs plain `unknown`,** and
+it is the one thing here worth overriding me on:
+
+- `unknown` is a 6-line diff and zero maintenance, but it deletes type-checking
+  on `content` — the one **required** field of the library's headline type,
+  which today is authored by 100% React users. `content: () => {}` would start
+  compiling and fail at runtime in React instead.
+- `TourNode` keeps every authoring error (Unknown 4) for ~20 lines, at the cost
+  of a hand-maintained mirror that could drift when React's union changes.
+
+I recommend `TourNode`, because the drift risk is neutralised by a compile-time
+guard whose idiom **already exists two files away** — `_AssertCoversPlacement`
+in `lib/schemas/step.schema.ts:29` does exactly this for `Placement`. That turns
+an unbounded maintenance risk into one that fails the build the day it appears.
+Nice accident: Vue VNodes also carry `{ type, props }`, so `TourElementLike` is
+not secretly React-only.
+
+Either way the boundary cast in `tour-card.tsx` is unavoidable — no React-free
+supertype of `ReactNode` is assignable back to it. That is a property of the
+type system, not of this design.
+
+**Not in this task:** routing `visibleStep.content` through `useResolvedText`.
+It would remove the cast, but it also starts interpolating content strings —
+a behaviour change that belongs to i18n §2.2.
+
+## Acceptance
+
+- None of the five named source files imports `react` any more (source-scan
+  test). **Not** "a Vue consumer typechecks with `@types/react` absent": the
+  bundled `dist/index.d.ts` still opens with `import * as React$1 from 'react'`
+  because hooks and providers keep it. That consumer-level guarantee is §1.2's,
+  once the engine subpath exists.
+- Authoring a step with `content: Symbol()` or `content: () => {}` is still a
+  compile error. Authoring `content: <p>hi</p>`, `content: 'text'`,
+  `content: [<a/>, 'x']`, or `title: { key: 'welcome' }` still compiles.
+- A `TourStep` whose `content` is JSX renders identically in `<TourCard>` —
+  same DOM, same `data-slot="tour-card-description"` behaviour.
+- A `useRef` from React 18 *or* React 19 is still accepted as a step `target`,
+  and `resolveTarget` still returns the element.
+- `HiddenTourStep` still rejects `content` / `title` (the `?: never` guard).
+- `<SegmentationProvider>` still accepts `children` and
+  `SegmentationProviderProps` is still exported from `@tour-kit/core`.
+- The build fails loudly if React's `ReactNode` ever gains a member `TourNode`
+  does not cover.
+- Green means all five nets, not just vitest: `turbo run test --concurrency=3`
+  (core 82 files, react 40), repo-wide `pnpm typecheck` (the only net that
+  catches the `tour-card.tsx:266` break and any consumer this widening touches
+  in `react`, `apps/docs`, `examples`), `typecheck:types` in core, the 19
+  Playwright specs under `e2e/next` + `e2e/vite`, and `biome check packages/`.
+
+## Conflicts
+
+**None.** Checked with `gh issue list --state open --json number,title,body` —
+`gh` is installed and authenticated; it returned exactly one open issue, #104
+("uneed upvotes"), which is spam with no Files-touched section and no overlap.
+
+Worth flagging anyway, from `plan/v2/handoff.md` rather than from an issue:
+nothing may touch `context/tour-provider.tsx` while §1.3/§1.4 are open. **This
+task does not touch it** — `lib/tour-engine/context.ts` is a separate file, and
+the provider's own `React.useRef<TourEngineContext | null>` (line 773) is
+unaffected by changing fields *inside* that interface.
+
+## Seen but out of scope
+
+- **`HintConfig` is declared twice and the copies have drifted.**
+  `packages/core/src/types/hints.ts` and `packages/hints/src/types/index.ts`
+  both define it and both are published; `hints` uses its own and ignores
+  core's, so core's `HintConfig` has zero consumers in the monorepo while
+  `@tour-kit/react` re-exports it (`react/src/index.ts:209`). Two different
+  public types with one name. Real bug, its own issue.
+- **`tour-card.tsx:208`** — `` `${stepLabel}: ${resolvedTitle}` `` builds an
+  `aria-label` from a value that may be a JSX element, yielding
+  "[object Object]" for element titles. Pre-existing; an a11y fix, not a types fix.
+- **`isI18nKey` misclassifies keyed React elements.** `lib/localized-text.ts:15`
+  returns true for any non-array object with a string `key`. A React element
+  with a `key` prop (`<p key="x">`) has that shape, so `useResolvedText` calls
+  `t('x')` instead of rendering the element. Pre-existing runtime bug, same
+  family as the aria-label one above; the type change here does not touch it.
+- `wiki-tech/concepts/positioning-engine.md` still documents the engine deleted
+  in refactor phase 3 (already flagged in the handoff).
+- `.mailmap` still absent (handoff §3).
+
+## Three checks
+
+**1. Hyrum's Law — what breaks silently.** The loud breaks are typecheck errors
+and the sweep found exactly one (`tour-card.tsx:266`). The silent ones:
+(a) `TourNode` admits any `{ type, props }` object, so a non-element object in
+`content` now compiles and fails inside React at runtime instead of at build
+time — strictly narrower than `unknown`, strictly wider than today;
+(b) widening `useResolvedText`'s parameter means a symbol passed in now reaches
+the `return value as React.ReactNode` pass-through and throws in React rather
+than being rejected by TS; (c) IDE hover on `content` changes from `ReactNode`
+to `TourNode` — no behaviour change, but every doc example and screenshot
+showing the old signature is now stale. Nothing changes at runtime: these are
+type-only imports today, so the emitted JS is byte-identical apart from the
+`segmentation` file move.
+
+**2. Tesler's Law — where the complexity went.** This is **not** a
+simplification and should not be sold as one. Core gains ~20 lines
+(`primitives.ts`) plus a drift-guard test, and loses one dependency edge in its
+type graph. The complexity React's own types were carrying for free moves to
+`types/primitives.ts` and to whoever must respond when the drift guard fires
+after a React major. That is the price of the `@tour-kit/core/engine` subpath
+in §1.2, paid here.
+
+**3. Inversion — the one assumption that would make this wrong.** That core's
+`content` and `title` should stay type-checked at all: if the intent is instead
+that core's types become genuinely opaque payload — matching the `unknown` that
+`TourStepDefinition` already ships — then `TourNode`, its export surface and its
+drift guard are all wasted, and this whole task collapses to a six-line diff
+plus one cast.
+
+<!-- ============ TEST WRITER owns below. Planner section is untouched. ============ -->
+
+## TEST WRITER
+
+status: tests-red
+
+### files
+
+Two new files. No source file was touched.
+
+- `packages/core/src/__tests__/no-react-in-engine-types.test.ts` — **new.**
+  Runtime source-scan over the five named files (vitest). The primary RED gate.
+- `packages/core/src/__tests__/types/tour-node-parity.test-d.ts` — **new.**
+  Type-level guards compiled by `pnpm --filter @tour-kit/core typecheck:types`.
+  Imports every new primitive through the **public barrel** (`../../index`),
+  not `../../types/primitives`, so it also proves the additive export surface
+  the plan asks for. Where the plan's Acceptance is already pinned by an
+  existing test, I mapped it instead of writing a duplicate.
+
+### acceptance map
+
+| # | Acceptance bullet | Test | State |
+|---|---|---|---|
+| 1 | Five named files no longer import `react` | `no-react-in-engine-types.test.ts` — 5 cases, one per file | **RED** |
+| 2 | `content: Symbol()` / `() => {}` still a compile error; `<p>hi</p>`, `'text'`, `[<a/>,'x']`, `title: {key}` still compile | `tour-node-parity.test-d.ts` § *Authoring still compiles* / § *Authoring errors survive the widening* | **RED** |
+| 3 | JSX `content` renders identically in `<TourCard>`, same `data-slot="tour-card-description"` | **existing** `packages/react/src/components/card/tour-card-content.test.tsx` (`renders ReactNode content`, `renders complex ReactNode content`) + `packages/react/src/__tests__/tour-i18n.test.tsx:83` | green — regression pin, do not weaken |
+| 4 | A React 18 *or* 19 `useRef` is still a valid `target`; `resolveTarget` still returns the element | type half: `tour-node-parity.test-d.ts` (`_target18` / `_target19`); runtime half: **existing** `src/__tests__/types/target.test.ts` | **RED** (type half) |
+| 5 | `HiddenTourStep` still rejects `content` / `title` | **existing** `src/__tests__/types/hidden-step.test-d.ts` (`_bad2`, `_bad3`) | green — pin |
+| 6 | `<SegmentationProvider>` still accepts `children`; `SegmentationProviderProps` still exported from `@tour-kit/core` | type half: `tour-node-parity.test-d.ts` § *SegmentationProviderProps survives the file move*; runtime half: **existing** `src/lib/segmentation/segmentation.test.tsx` | **RED** (type half, via the file) |
+| 7 | Build fails loudly if `ReactNode` gains a member `TourNode` doesn't cover | `tour-node-parity.test-d.ts` — `expectTypeOf<ReactNode>().toExtend<TourNode>()` | **RED** |
+| 8 | "Green means all five nets" | verification protocol, not a test — see *nets* below | — |
+
+Extra guards written beyond the bullets, both cheap and both load-bearing for
+the plan's own Unknowns:
+
+- **Ref/dispatch parity, bidirectional** — Unknown 1 and 2 were proved by a
+  throwaway spike. `tour-node-parity.test-d.ts` makes that proof permanent
+  (`RefObject<T>` ⇄ `TourRef<T>`, `Dispatch<A>` ⇄ `TourDispatch<A>`), so a
+  future React major that changes either shape fails the build instead of
+  silently degrading.
+- **`{ key: 'welcome' }` is NOT a `TourNode`** — Unknown 4's discriminating-union
+  claim. If this ever compiles, `TourNode | LocalizedText` stops discriminating
+  and `isI18nKey` narrowing breaks silently. `@ts-expect-error`-guarded.
+
+### red proof
+
+**Net 1 — vitest, `pnpm --filter @tour-kit/core test`.** Five assertion
+failures, one per file. Each names the exact import line that has to go:
+
+```
+ ❯ src/__tests__/no-react-in-engine-types.test.ts (5 tests | 5 failed) 30ms
+     × types/step.ts does not import from react 16ms
+     × types/hints.ts does not import from react 2ms
+     × types/target.ts does not import from react 2ms
+     × lib/tour-engine/context.ts does not import from react 1ms
+     × lib/segmentation/types.ts does not import from react 2ms
+
+ FAIL  … > types/step.ts does not import from react
+ FAIL  … > types/hints.ts does not import from react
+AssertionError: expected [ 'import type React from \'react\'' ] to deeply equal []
+- Expected
++ Received
+- []
++ [
++   "import type React from 'react'",
++ ]
+ ❯ src/__tests__/no-react-in-engine-types.test.ts:49:23
+
+ FAIL  … > types/target.ts does not import from react
+ FAIL  … > lib/tour-engine/context.ts does not import from react
+AssertionError: expected [ Array(1) ] to deeply equal []
++ [
++   "import type * as React from 'react'",
++ ]
+
+ FAIL  … > lib/segmentation/types.ts does not import from react
+AssertionError: expected [ Array(1) ] to deeply equal []
++ [
++   "import type { ReactNode } from 'react'",
++ ]
+
+ Test Files  1 failed (1)
+      Tests  5 failed (5)
+```
+
+Run twice, byte-identical both times (`Tests 5 failed (5)`).
+
+**Net 2 — `pnpm --filter @tour-kit/core typecheck:types`.** Baseline was clean
+before these files; it now fails with exactly five errors and no unrelated
+noise, which also confirms importing the public barrel from a `.test-d.ts`
+doesn't drag in stray errors:
+
+```
+src/__tests__/types/tour-node-parity.test-d.ts(15,3): error TS2305: Module '"../../index"' has no exported member 'TourDispatch'.
+src/__tests__/types/tour-node-parity.test-d.ts(16,3): error TS2305: Module '"../../index"' has no exported member 'TourElementLike'.
+src/__tests__/types/tour-node-parity.test-d.ts(17,3): error TS2305: Module '"../../index"' has no exported member 'TourNode'.
+src/__tests__/types/tour-node-parity.test-d.ts(18,3): error TS2305: Module '"../../index"' has no exported member 'TourRef'.
+src/__tests__/types/tour-node-parity.test-d.ts(64,1): error TS2578: Unused '@ts-expect-error' directive.
+Exit status 2
+```
+
+**Honest caveat on net 2.** Four of those five are `TS2305` — module-resolution
+errors, not assertion failures. For a type test that *is* the assertion
+mechanism (the type under guard doesn't exist yet), but it is weaker evidence
+than net 1: it proves the names are missing, not yet that the drift guard and
+the `@ts-expect-error` directives actually bite. Two things make it real anyway:
+
+- The fifth error, `TS2578` at line 64, is a genuine assertion failure. It fires
+  because `TourNode` currently resolves to `any`, so `{ key: 'welcome' }`
+  wrongly compiles and the `@ts-expect-error` above it goes unused. It flips to
+  green only when `TourNode` is a real, correctly-narrow type.
+- The two `@ts-expect-error` directives on `content: Symbol()` and
+  `content: () => {}` are **used today** (no `TS2578` reported for them), which
+  proves they bite against the current `React.ReactNode` and will keep biting
+  against `TourNode`. That is Acceptance bullet 2's "still a compile error" half
+  verified as a live guard, not an aspiration.
+
+The drift guard itself (`expectTypeOf<ReactNode>().toExtend<TourNode>()`) can
+only be proved once `TourNode` exists — that is the coder's first green.
+
+### one line per test
+
+- `types/step.ts does not import from react` — guards the `title`/`content`
+  `ReactNode` fields, the widest external surface in the task.
+- `types/hints.ts does not import from react` — guards `HintConfig.content`.
+- `types/target.ts does not import from react` — guards `TourTargetRef`.
+- `lib/tour-engine/context.ts does not import from react` — guards `dispatch`
+  and the three refs; zero external surface, so this one is pure §1.2 setup.
+- `lib/segmentation/types.ts does not import from react` — guards the
+  `SegmentationProviderProps` move; must stay green with the type still
+  exported from the barrel (bullet 6).
+- *drift guard* — fails the build the day React's `ReactNode` union grows a
+  member `TourNode` doesn't mirror.
+- *ref/dispatch parity ⇄* — fails if `TourRef`/`TourDispatch` ever stop being
+  structurally interchangeable with React's.
+- *authoring still compiles* — fails if the widening loses JSX, string, mixed
+  array, or `{ key }` authoring.
+- *authoring errors survive* — fails if `TourNode` gets loose enough to admit a
+  symbol or a bare function.
+- *`{ key }` is not a `TourNode`* — fails if the content union stops
+  discriminating against `LocalizedText`.
+- *React 18/19 useRef is a valid target* — fails if `TourRef` narrows past
+  either ref shape. The 18 shape is written out by hand because no
+  `@types/react@18` exists in the workspace (planner Unknown 1's caveat).
+- *`SegmentationProviderProps` survives the file move* — fails if the type stops
+  being reachable from `@tour-kit/core` or loses `children`.
+
+### heads-up for the coder
+
+`packages/core/__tests__/phase-0/phase-0-harness.test.ts >
+typecheck:types exits 0 on the committed selftest` **also fails right now**, so
+`pnpm --filter @tour-kit/core test` reports `6 failed`, not 5. That harness
+shells out to `typecheck:types` and asserts exit 0, so any red `.test-d.ts`
+cascades into it. It is not broken and needs no edit — it goes green the moment
+`tour-node-parity.test-d.ts` compiles. Do not "fix" it by excluding the new
+file.
+
+### not covered
+
+- **The emitted `dist/index.d.ts` staying React-free.** Deliberate — the planner
+  is right that the bundle still opens with `import * as React$1 from 'react'`
+  because hooks and providers keep it. That guarantee is §1.2's, once the
+  engine subpath exists. Nothing here tests dist.
+- **React 18 for real.** No `@types/react@18` is installed anywhere in the
+  workspace, so the 18 ref shape is a hand-written structural stand-in. If 18
+  support is load-bearing for the release, installing `@types/react@18` as a
+  core devDependency and compiling the type tests against both is its own task.
+- **`use-resolved-text.ts` param widening.** No Acceptance bullet covers it and
+  its runtime behaviour is already pinned by
+  `src/lib/i18n/use-resolved-text.test.tsx`. Note the planner's own Hyrum's-Law
+  item (b): after the widening, a symbol reaching the `return value as
+  React.ReactNode` pass-through throws in React instead of being rejected by
+  TS. That is accepted, not tested.
+- **The `tour-card.tsx:266` cast itself.** Not directly asserted — bullet 3's
+  existing render tests are the net. If the cast is written wrong (e.g.
+  `String(content)` instead of `as React.ReactNode`),
+  `tour-card-content.test.tsx > renders complex ReactNode content` fails.
+- **The three "Seen but out of scope" bugs** (duplicate `HintConfig`, the
+  `aria-label` `[object Object]`, `isI18nKey` misclassifying keyed elements) and
+  the `wiki-tech/packages/core.md` doc update.
+
+### nets to run before calling it green
+
+`turbo run test --concurrency=3` (not bare `pnpm test` — it scatters false
+failures on this machine), repo-wide `pnpm typecheck`, `pnpm --filter
+@tour-kit/core typecheck:types`, the `e2e/next` + `e2e/vite` Playwright specs,
+and `biome check packages/`. Both new files are already biome-clean.

--- a/tasks/issues/v2-1-1-react-free-core-types.md
+++ b/tasks/issues/v2-1-1-react-free-core-types.md
@@ -571,3 +571,65 @@ kill). All 20 package builds succeed. Known local-only WSL2 docs-build break.
   `apps/docs/public/llms*.txt`, `apps/docs/components/landing/sale-countdown.tsx`
   and the untracked `apps/docs/components/landing/__tests__/` were already
   dirty in the working tree when this task started.
+
+### review follow-ups (thermo-nuclear pass)
+
+Five findings from the quality review of PR #117. Four fixed here; one is a
+correction to a claim, which belongs in this section because the planner's is
+read-only.
+
+1. **There were two boundary casts, not one — and the undocumented one was the
+   load-bearing one.** `lib/i18n/use-resolved-text.ts:42`'s
+   `value as React.ReactNode` did not break, so nothing flagged it, but it
+   *changed meaning*: on `main` the residue after the `string` and `{ key }`
+   branches genuinely was a `ReactNode`, so the cast was cosmetic; after the
+   widening the residue is `TourElementLike | Iterable<TourNode> |
+   PromiseLike<TourNode> | number | bigint | boolean`, and the cast launders it.
+   This is the wider surface of the two — `useResolvedText` is core's canonical
+   text pipeline with 17 call sites across `announcements`, `hints` and `react`,
+   and `TourStep.title` reaches React through *this* path, not through
+   `<TourCard>`'s `content` prop. **Fixed:** the invariant is now stated in the
+   function's doc comment and the cast carries the same `parse.ts` boundary note
+   as `tour-card.tsx`. Two casts, both named.
+2. **"A property of the type system, not of this design" (Approach, above) is
+   too strong.** A third option exists that the decision record does not name:
+   parameterise the node type. The repo already uses that idiom on an adjacent
+   axis — `TourStep<TId extends string = string>` is generic over id and
+   `types/tour.ts` threads `Tour<TStep = TourStep>` — so `TourStep<TId, TNode>`
+   is the same move on the content axis, and it would delete the mirror, the
+   drift guard, `TourElementLike` and both casts. **Not taken, deliberately:**
+   with a default of `TourNode` the provider chain still hands back the default
+   instantiation, so the cast returns unless `TourContextValue` and `useTourKit`
+   are parameterised too — which means threading a generic through the
+   1,431-line `context/tour-provider.tsx`. Worse trade. But the claim should
+   read *a property of this design*, not of the type system.
+3. **The new primitives didn't reach the front door.** `TourNode` is in the
+   signature of `TourStep.content`, yet neither `@tour-kit/react` nor
+   `@tour-kit/hints` re-exported it — a consumer of the documented front door
+   could name every type in that signature except the new one. Against the
+   Consumer rule in `CLAUDE.md` / `wiki-tech/packages/core.md`. **Fixed:** all
+   four forwarded from both barrels.
+4. **The duplicate `HintConfig` gap was being widened, not just left alone.**
+   `packages/hints/src/types/index.ts` keeps its own near-copy (it differs on
+   `target` and `media`) and `hint.tsx` renders *that* one, so core's widening
+   bought nothing where hints actually renders while making two same-named
+   published types differ on a new axis. Merging them stays out of scope.
+   **Fixed narrowly:** hints' `content` now tracks core's `TourNode`, so this
+   task leaves the divergence no worse than it found it.
+5. **`PromiseLike<unknown>` was a hole in "authoring errors survive".**
+   `content: Promise.resolve(Symbol())` compiled — the excluded type laundered
+   one level down. **Fixed:** the arm is `PromiseLike<TourNode>`, which still
+   satisfies the drift guard (React's own arm is `Promise<AwaitedReactNode>`),
+   verified rather than assumed. Both directions pinned in the parity test.
+
+Re-verified after the fixes: `turbo run test --concurrency=3` 37/37 (core 1013,
+react 485, hints 295), `pnpm typecheck` 29/29, `typecheck:types` exit 0,
+`biome check packages/` 0 errors, `pnpm dist:size` all green (react +1 gz byte
+from a chunk-hash character; core and hints unchanged).
+
+**Noted, not fixed:** the drift guard reaches CI only transitively — CI runs
+`pnpm test`, core's vitest includes `__tests__/phase-0/phase-0-harness.test.ts`,
+and that shells out to `typecheck:types`. CI never invokes `typecheck:types`
+directly, so the guard goes silent if that harness test is ever moved or
+skipped. Adding it as an explicit CI step is a one-line change that belongs
+with §1.2.


### PR DESCRIPTION
## What

v2 §1.1 — remove the five type-only React imports from `@tour-kit/core`, so §1.2
can carve a framework-agnostic `@tour-kit/core/engine` subpath out of those files.

Plan, test plan, implementation notes and the review follow-ups all live in
[`tasks/issues/v2-1-1-react-free-core-types.md`](tasks/issues/v2-1-1-react-free-core-types.md).

## Why it isn't just deleting five imports

All five are `import type`, so **nothing React ships at runtime today**. What leaks
is the emitted `.d.ts`: a Vue/Svelte consumer with `skipLibCheck: false` gets
`Cannot find module 'react'`, and with `skipLibCheck: true` (the common case) the
types silently degrade to `any`. It's a type-shape problem, and it splits in two:

- **Three files are pure structural aliases.** `React.RefObject<T>` is `{ current: T }`
  and `React.Dispatch<A>` is `(a: A) => void`, so `TourRef`/`TourDispatch` are renames
  with bidirectionally-proved identical assignability.
- **Two hold `ReactNode`** (`TourStep.title`/`content`, `HintConfig.content`). No
  React-free type is *mutually* assignable with `ReactNode`, so this is the real cost.

`packages/core/src/types/primitives.ts` is new, 55 lines, and imports nothing —
that's the whole point.

## The `TourNode` vs `unknown` call

`unknown` would have been a 6-line diff with zero maintenance, but it deletes type
checking on `content`, the one **required** field of the library's headline type.
`content: () => {}` would start compiling and fail at runtime in React instead.

`TourNode` keeps every authoring error for ~20 lines of hand-mirrored union, and the
drift risk it introduces is neutralised by a compile-time guard whose idiom already
exists two files away (`_AssertCoversPlacement` in `lib/schemas/step.schema.ts`).
`expectTypeOf<ReactNode>().toExtend<TourNode>()` fails the build the day React's
union grows an arm the mirror doesn't cover — an unbounded maintenance risk turned
into one that announces itself.

There is a third option the first draft of the plan didn't name: **parameterise the
node type**. The repo already uses that idiom on an adjacent axis — `TourStep<TId>`
is generic over id and `types/tour.ts` threads `Tour<TStep = TourStep>` — and
`TourStep<TId, TNode>` would delete the mirror, the drift guard, `TourElementLike`
and both casts. It's not taken because with a default of `TourNode` the provider
chain still hands back the default instantiation, so the cast returns unless
`TourContextValue` and `useTourKit` are parameterised too, which means threading a
generic through the 1,431-line `context/tour-provider.tsx`. Worse trade — but it's a
property of *this design*, not of the type system.

`segmentation/types.ts` needed no new type at all: `SegmentationProviderProps` is a
component's props that had drifted into a types file, so it moved to
`segmentation-context.tsx`, its only consumer, which already imports React.

## Two boundary casts, both named

No React-free supertype of `ReactNode` assigns back to it, so casting once at the
boundary is unavoidable. There are **two** such boundaries, and the second is the
load-bearing one:

- `tour-card.tsx:270` — the only *compile* break in the monorepo.
- `use-resolved-text.ts:42` — didn't break, because it was already an `as`, but it
  changed meaning. Before the widening the residue after the `string` and `{ key }`
  branches genuinely was a `ReactNode` and the cast was cosmetic; after it, the
  residue is `TourElementLike | Iterable<TourNode> | PromiseLike<TourNode> | number |
  bigint | boolean`. This is the wider surface — `useResolvedText` is core's canonical
  text pipeline with 17 call sites across `announcements`, `hints` and `react`, and
  `TourStep.title` reaches React through *this* path. The invariant is now stated in
  the doc comment and the cast carries the same `parse.ts` note as the other.

## Runtime output is unchanged, and that's verified rather than argued

The root-cause claim predicts the built JS shouldn't move. Token-diffing the dists
before and after the first commit:

- **core** — 26,703 tokens both ways; all 50 differing hunks are one `M`↔`N`
  minifier identifier permutation and nothing else.
- **react** — entry and all 11 chunks token-identical. Two chunk *filenames* moved
  and the only in-file differences are those names referring to themselves; the hash
  shifted because the added JSX comment changed the sourcemap input, not the code.
- **hints** — `dist/index.js` byte-identical.

## Verification

| Net | Result |
|---|---|
| `turbo run test --concurrency=3` | 37/37 (core 1013 passed + 3 skipped, react 485, hints 295) |
| `pnpm typecheck` (repo-wide) | 29/29 |
| `pnpm --filter @tour-kit/core typecheck:types` | exit 0 |
| `biome check packages/` | 1028 files, 0 errors, 16 pre-existing warnings |
| `pnpm dist:size` | all green — core 19,629/20,000, react 3,303/12,000, hints 5,076/5,120 |
| Playwright localhost projects | 22 passed, 5 failed, 1 flaky — **see below** |

The repo-wide typecheck earned its place: it caught the single `tour-card.tsx`
`TS2322` and nothing else anywhere in `react`, `apps/docs`, `examples` or
`dashboard-next`. The widening's blast radius really is one compile break.

**The two type guards were mutation-tested**, because the RED evidence for them was
mostly `TS2305` module-resolution noise (names missing, not guards biting). Commenting
out `| TourElementLike` fires the drift guard at `TS2344` plus three `TS2322`s;
collapsing the union to `unknown` un-uses all three `@ts-expect-error` directives
(`TS2578`). Both mutations reverted, suite re-verified clean.

## Review follow-ups (second commit)

A quality review of the first commit produced five findings; four are fixed here and
the fifth is the claim correction recorded above.

- `use-resolved-text.ts`'s cast is now documented as a boundary, with the invariant
  stated (see above).
- `TourNode`'s promise arm was `PromiseLike<unknown>`, which let
  `content: Promise.resolve(Symbol())` compile — the excluded type laundered one level
  down. Narrowed to `PromiseLike<TourNode>`, which still satisfies the drift guard;
  both directions pinned in the parity test.
- All four primitives are now re-exported from `@tour-kit/react` and `@tour-kit/hints`.
  `TourNode` was in the signature of `TourStep.content` while being unnameable from the
  documented front door, against the Consumer rule in `CLAUDE.md`.
- `packages/hints` keeps its own near-copy of `HintConfig` (differing on `target` and
  `media`) and `hint.tsx` renders *that* one, so widening core's copy alone bought
  nothing where hints renders while making two same-named published types differ on a
  new axis. hints' `content` now tracks core's. Reconciling the copies stays out of scope.

## Known gaps, stated plainly

- **5 e2e failures are pre-existing.** Verified, not assumed: the change was stashed,
  the packages rebuilt from the clean tree and the same specs re-run to *identical*
  failures. Three are Next's `localhost-bypass` watermark appearing when it shouldn't
  (the four equivalent Vite cases pass); two are `whats-new-pill` snapshots drifting
  against baselines that predate the Chromium 147 this machine had to install —
  Playwright had no browsers at all before this run. One further spec was flaky and
  passed on retry.
- **The 7 `*-production` specs were not run.** They need `127.0.0.1 tourkit-test.dev`
  in `/etc/hosts`, which needs sudo.
- **The drift guard reaches CI only transitively.** CI runs `pnpm test`, core's vitest
  includes `__tests__/phase-0/phase-0-harness.test.ts`, and that shells out to
  `typecheck:types`. CI never invokes it directly, so the guard goes silent if that
  harness test is ever moved or skipped. A one-line CI step belongs with §1.2.
- **`dist/index.d.ts` still opens with `import * as React$1 from 'react'`**, by design:
  hooks and providers keep React. That guarantee belongs to §1.2, and the five files
  freed here are exactly the ones §1.2 needs.
- **React 18 coverage rests on reasoning, not a test.** No `@types/react@18` exists in
  the workspace, so the drift guard runs against 19.x only and the 18 ref shape is a
  hand-written structural stand-in.
- **No changeset.** The exports are additive and runtime is unchanged, but versioning
  here cascades a react/hints major, so that call is left to you.

https://claude.ai/code/session_01FNyoFZqAjiW9WrWF9xBYhC
