### PR TITLE
refactor(core): DOM behaviours as plain functions (v2 §1.3b)

### DIFF
--- a/.changeset/dom-behaviours-engine.md
+++ b/.changeset/dom-behaviours-engine.md
@@ -1,0 +1,9 @@
+---
+'@tour-kit/core': minor
+---
+
+Publish the DOM behaviours from `@tour-kit/core/engine`: `createFocusTrap`, `attachKeyboard`, `trackRect`, `computeSpotlight`, `bindStepAdvance` / `attachAdvanceOn` / `dispatchAdvanceEvent`, and `attachTestBridge`.
+
+`@tour-kit/core/engine` could already *run* a tour without React; it can now *show* one. A Vue, Svelte or vanilla binding gets focus trapping, keyboard navigation, target tracking through scroll and resize, the spotlight geometry and auto-advance as plain functions it attaches around its own rendering.
+
+Nothing changes for React consumers. `useFocusTrap`, `useKeyboardNavigation`, `useSpotlight`, `useElementPosition` and `useAdvanceOn` keep their exact signatures and behaviour — they are now thin wrappers over the same functions, and all 82 of their existing tests pass unmodified.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -15,7 +15,7 @@
   {
     "name": "@tour-kit/core/engine",
     "path": "packages/core/dist/engine/index.js",
-    "limit": "8 KB"
+    "limit": "15 KB"
   },
   {
     "name": "@tour-kit/react",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,11 +129,16 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     the +446 B is the module-boundary cost of moving 636 lines out of
     `tour-provider.tsx`, not engine runtime leaking in —
     `engine-not-in-main-closure.test.ts` guards that)
-  - core/engine subpath <16 KB (the non-React consumer's worst case: the
+  - core/engine subpath <18 KB (the non-React consumer's worst case: the
     engine — reducer, boot resolver, actions, transition effects, four
-    storage adapters — plus the chunk it and the main entry both read. Was
-    <9 KB while this was a types-and-predicates door with no way to run a
-    tour; a type-only consumer still ships zero)
+    storage adapters — plus the v2 §1.3b DOM behaviours (focus trap,
+    keyboard, rect tracker, spotlight, advance-on, test bridge) and the chunk
+    it and the main entry both read. Was <9 KB while this was a
+    types-and-predicates door with no way to run a tour, and <16 KB after
+    §1.3 gave it a way to run one but not to show one; a type-only consumer
+    still ships zero. §1.3b raised this from 16 KB against a measured 17 033
+    — the ~1.6 KB is the code that left the five view hooks, which is why
+    `core` did not move: it lands in the shared chunk both entries read)
   - react <12 KB
   - hints <6 KB
   - analytics <4 KB (root; per-plugin <1.5 KB each)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,9 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     §1.4's to earn. §1.3 raised this from 21 KB against a measured 21 271:
     the +446 B is the module-boundary cost of moving 636 lines out of
     `tour-provider.tsx`, not engine runtime leaking in —
-    `engine-not-in-main-closure.test.ts` guards that)
+    `engine-not-in-main-closure.test.ts` guards that. §1.3b left it at 21.5 KB
+    against a measured 21 457 — 43 bytes. The row is knowingly at the line;
+    §1.4 is expected to trip it and re-baseline with its own measurement)
   - core/engine subpath <18 KB (the non-React consumer's worst case: the
     engine — reducer, boot resolver, actions, transition effects, four
     storage adapters — plus the v2 §1.3b DOM behaviours (focus trap,

--- a/packages/core/src/__tests__/biome-noConsole.integration.test.ts
+++ b/packages/core/src/__tests__/biome-noConsole.integration.test.ts
@@ -52,6 +52,11 @@ describe('Biome noConsole rule + overrides (integration)', () => {
     // the boot resolver. Playwright's console listener reads it for the
     // <200 ms hard-refresh resume budget, so it is loud by design.
     expect(config).toMatch(/packages\/core\/src\/lib\/tour-engine\/boot\.ts/)
+    // v2 §1.3b — the test bridge's "disable for production" nudge moved here
+    // out of tour-provider.tsx. Routing it through `logger` would prefix the
+    // message and break the exact-string assertion in
+    // `context/__tests__/test-bridge.test.tsx`.
+    expect(config).toMatch(/packages\/core\/src\/lib\/test-bridge\.ts/)
     expect(config).toMatch(/packages\/analytics\/src\/plugins\/console\.ts/)
     expect(config).toMatch(/packages\/license\/src\/components\/license-test-mode\.tsx/)
     expect(config).toMatch(/packages\/license\/src\/components\/license-warning\.tsx/)

--- a/packages/core/src/__tests__/hooks/spotlight-retarget.test.tsx
+++ b/packages/core/src/__tests__/hooks/spotlight-retarget.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * v2 §1.3b-3 regression — `show(a)` then `show(b)` with no `hide()` between.
+ *
+ * `TourOverlay` (both variants) advances a step by calling `show(newTarget)`
+ * directly; `isVisible` never goes false in between. Before §1.3b the
+ * scroll/resize handler read `targetRef.current` at call time, so it followed
+ * the swap for free. `trackRect` takes a concrete element, so the wrapper's
+ * effect has to re-run on a retarget or the spotlight silently keeps tracking
+ * the previous step's element.
+ *
+ * None of the 15 `use-spotlight` oracle cases exercises a retarget, which is
+ * why this lives in its own file rather than being caught there.
+ */
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSpotlight } from '../../hooks/use-spotlight'
+
+function targetAt(top: number): HTMLElement {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    top,
+    left: 0,
+    width: 10,
+    height: 10,
+    bottom: top + 10,
+    right: 10,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect)
+  return el
+}
+
+beforeEach(() => {
+  // Synchronous frames, the idiom the hook suites already use.
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    cb(0)
+    return 0
+  })
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('useSpotlight retargeting', () => {
+  it('tracks the NEW target after show() is called again while visible', () => {
+    const first = targetAt(100)
+    const second = targetAt(500)
+    const { result } = renderHook(() => useSpotlight())
+
+    act(() => result.current.show(first))
+    act(() => result.current.show(second))
+
+    // A scroll must now report the second target's rect, not the first's.
+    act(() => {
+      window.dispatchEvent(new Event('scroll'))
+    })
+
+    expect(result.current.targetRect?.top).toBe(500)
+  })
+
+  it('stops tracking the old target entirely', () => {
+    const first = targetAt(100)
+    const second = targetAt(500)
+    const { result } = renderHook(() => useSpotlight())
+
+    act(() => result.current.show(first))
+    ;(first.getBoundingClientRect as ReturnType<typeof vi.fn>).mockClear()
+
+    act(() => result.current.show(second))
+    act(() => {
+      window.dispatchEvent(new Event('scroll'))
+    })
+
+    expect(first.getBoundingClientRect).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/__tests__/lib/_helpers/frames.ts
+++ b/packages/core/src/__tests__/lib/_helpers/frames.ts
@@ -1,0 +1,49 @@
+/**
+ * Manual `requestAnimationFrame` control.
+ *
+ * The five hook suites stub rAF as `mockImplementation((cb) => { cb(0); return 0 })`
+ * — SYNCHRONOUS. Under that, `throttleRAF` clears its `rafId` before returning,
+ * so two scrolls produce two `onRect` calls and the coalescing that is the
+ * whole point of the throttle is unobservable. A deferred queue is the only way
+ * to assert "one call per frame".
+ */
+import { vi } from 'vitest'
+
+export interface FrameHarness {
+  /** Run every frame queued since the last flush, as one animation frame. */
+  flush(): void
+  /** Frames requested and not yet flushed. */
+  pending(): number
+  restore(): void
+}
+
+export function deferredFrames(): FrameHarness {
+  let nextId = 1
+  const queue = new Map<number, FrameRequestCallback>()
+
+  const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    const id = nextId++
+    queue.set(id, cb)
+    return id
+  })
+  // Spied too: `trackRect().stop()` calls `throttled.cancel()`, which calls
+  // cancelAnimationFrame. Without this, `pending()` would still report a queued
+  // frame after stop() and "stop then scroll calls nothing" would be untestable.
+  const caf = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+    queue.delete(id)
+  })
+
+  return {
+    flush() {
+      const due = [...queue.values()]
+      queue.clear()
+      for (const cb of due) cb(performance.now())
+    },
+    pending: () => queue.size,
+    restore() {
+      queue.clear()
+      raf.mockRestore()
+      caf.mockRestore()
+    },
+  }
+}

--- a/packages/core/src/__tests__/lib/_helpers/rect.ts
+++ b/packages/core/src/__tests__/lib/_helpers/rect.ts
@@ -1,0 +1,13 @@
+/** jsdom returns all-zero rects for detached nodes, so pin values explicitly. */
+export const rectOf = (top: number, left: number, width: number, height: number): DOMRect =>
+  ({
+    top,
+    left,
+    width,
+    height,
+    bottom: top + height,
+    right: left + width,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect

--- a/packages/core/src/__tests__/lib/_helpers/resize-observer.ts
+++ b/packages/core/src/__tests__/lib/_helpers/resize-observer.ts
@@ -1,0 +1,48 @@
+/**
+ * jsdom has no `ResizeObserver`. Same shape as the stub at
+ * `__tests__/hooks/use-element-position.test.ts:62`, plus the ability to read
+ * back what was observed and to drive a resize.
+ *
+ * Deliberately no existence guard on the production side: `trackRect` must
+ * construct one unconditionally when `observeResize` is set, exactly as
+ * `use-element-position.ts` does today.
+ */
+import { vi } from 'vitest'
+
+export interface ResizeObserverStub {
+  observe: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+  /** Every element passed to observe(), across all instances. */
+  observed(): Element[]
+  /** Invoke every constructed observer's callback, as a resize would. */
+  trigger(): void
+  restore(): void
+}
+
+export function stubResizeObserver(): ResizeObserverStub {
+  const observe = vi.fn()
+  const disconnect = vi.fn()
+  const callbacks: ResizeObserverCallback[] = []
+
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(cb: ResizeObserverCallback) {
+        callbacks.push(cb)
+      }
+      observe = observe
+      unobserve = vi.fn()
+      disconnect = disconnect
+    }
+  )
+
+  return {
+    observe,
+    disconnect,
+    observed: () => observe.mock.calls.map((c) => c[0] as Element),
+    trigger() {
+      for (const cb of callbacks) cb([], {} as ResizeObserver)
+    },
+    restore: () => vi.unstubAllGlobals(),
+  }
+}

--- a/packages/core/src/__tests__/lib/advance-on.test.ts
+++ b/packages/core/src/__tests__/lib/advance-on.test.ts
@@ -1,0 +1,299 @@
+/**
+ * v2 §1.3b-4 — `bindStepAdvance` / `attachAdvanceOn`, the body of
+ * `use-advance-on.ts` as plain functions.
+ *
+ * The 15 oracle cases in `__tests__/hooks/use-advance-on.test.tsx` never touch
+ * the 100 ms debounce — the hook's only timing behaviour has been shipping
+ * untested. Two cases here are therefore first coverage, not a port:
+ *
+ *  - the debounce window itself, and
+ *  - that a FALSY handler does not consume it. `use-advance-on.ts:58` returns
+ *    before `isAdvancing = true`; hoisting the flag above the handler call
+ *    would pass every oracle case and every naive debounce test while
+ *    swallowing the first real advance after a rejection.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { attachAdvanceOn, bindStepAdvance, dispatchAdvanceEvent } from '../../lib/advance-on'
+import { createTourEngine } from '../../lib/tour-engine/create-tour-engine'
+import type { TourStep, VisibleTourStep } from '../../types/step'
+import { logger } from '../../utils/logger'
+import { createMemoryStorage } from '../../utils/storage'
+
+const step = (extras: Partial<VisibleTourStep> = {}): TourStep =>
+  ({ id: 's', target: '#target', content: 'hi', ...extras }) as TourStep
+
+function target(id = 'target'): HTMLButtonElement {
+  const el = document.createElement('button')
+  el.type = 'button'
+  el.id = id
+  document.body.appendChild(el)
+  return el
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('bindStepAdvance', () => {
+  it('advances on a click on the resolved target', () => {
+    const el = target()
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(
+      step({ advanceOn: { event: 'click', selector: '#target' } }),
+      next
+    )
+
+    el.click()
+
+    expect(next).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('returns a no-op cleanup for a step with no advanceOn', () => {
+    const next = vi.fn()
+
+    const cleanup = bindStepAdvance(step(), next)
+
+    expect(() => cleanup()).not.toThrow()
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('removes the listener on cleanup', () => {
+    const el = target()
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(
+      step({ advanceOn: { event: 'click', selector: '#target' } }),
+      next
+    )
+
+    cleanup()
+    el.click()
+
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('warns and falls back to document when the selector resolves nothing', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(
+      step({ advanceOn: { event: 'click', selector: '#nope' } }),
+      next
+    )
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('#nope'))
+
+    document.dispatchEvent(new Event('click'))
+    expect(next).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('binds tourkit:advance for the custom event, which dispatchAdvanceEvent fires', () => {
+    const el = target()
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(
+      step({ advanceOn: { event: 'custom', selector: '#target' } }),
+      next
+    )
+
+    dispatchAdvanceEvent('#target')
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(el.isConnected).toBe(true)
+    cleanup()
+  })
+
+  it('dispatchAdvanceEvent with no selector targets document', () => {
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(step({ advanceOn: { event: 'custom' } }), next)
+
+    dispatchAdvanceEvent()
+
+    expect(next).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('passes an unmapped event name straight through', () => {
+    const el = target()
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(
+      // `event` is a string-literal union today; a wider authored value must
+      // still reach addEventListener unchanged rather than silently binding
+      // nothing.
+      step({ advanceOn: { event: 'input', selector: '#target' } }),
+      next
+    )
+
+    el.dispatchEvent(new Event('input'))
+
+    expect(next).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+})
+
+describe('the handler contract', () => {
+  it('does not advance when the handler returns falsy', () => {
+    const el = target()
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(
+      step({ advanceOn: { event: 'click', selector: '#target', handler: () => false } }),
+      next
+    )
+
+    el.click()
+
+    expect(next).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('warns and does not advance when the handler throws', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const el = target()
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(
+      step({
+        advanceOn: {
+          event: 'click',
+          selector: '#target',
+          handler: () => {
+            throw new Error('boom')
+          },
+        },
+      }),
+      next
+    )
+
+    el.click()
+
+    expect(next).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('handler error'), expect.any(Error))
+    cleanup()
+  })
+})
+
+describe('the 100 ms debounce — no oracle case covers this', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('collapses two rapid clicks into one advance, then re-arms', () => {
+    const el = target()
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(
+      step({ advanceOn: { event: 'click', selector: '#target' } }),
+      next
+    )
+
+    el.click()
+    el.click()
+    expect(next).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(100)
+    el.click()
+
+    expect(next).toHaveBeenCalledTimes(2)
+    cleanup()
+  })
+
+  it('a falsy handler does not consume the window', () => {
+    // The guard against hoisting `isAdvancing = true` above the handler call:
+    // a rejected click must leave the very next accepted one free to advance.
+    const el = target()
+    const next = vi.fn()
+    let accept = false
+    const cleanup = bindStepAdvance(
+      step({ advanceOn: { event: 'click', selector: '#target', handler: () => accept } }),
+      next
+    )
+
+    el.click()
+    expect(next).not.toHaveBeenCalled()
+
+    accept = true
+    el.click()
+
+    expect(next).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('cleanup clears the pending timeout', () => {
+    // DELIBERATE DIVERGENCE from the hook, not pinned legacy behaviour.
+    // `use-advance-on.ts:85-87` removes only the listener and lets the 100 ms
+    // timer fire on a dead closure. `bindStepAdvance` clears it.
+    const el = target()
+    const next = vi.fn()
+    const cleanup = bindStepAdvance(
+      step({ advanceOn: { event: 'click', selector: '#target' } }),
+      next
+    )
+
+    el.click()
+    cleanup()
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('attachAdvanceOn — the engine-level watcher', () => {
+  function engineWithTwoTargets() {
+    const a = target('a')
+    const b = target('b')
+    const engine = createTourEngine({
+      storage: createMemoryStorage(),
+      tours: [
+        {
+          id: 't',
+          steps: [
+            { id: 'a', target: '#a', content: 'a', advanceOn: { event: 'click', selector: '#a' } },
+            { id: 'b', target: '#b', content: 'b', advanceOn: { event: 'click', selector: '#b' } },
+          ],
+        },
+      ],
+    })
+    return { engine, a, b }
+  }
+
+  it('rebinds as the current step changes', async () => {
+    // No fake engine: Decision 1's claim is that the REAL TourEngine satisfies
+    // Pick<TourEngine, 'subscribe' | 'getState' | 'next'> structurally.
+    const { engine, a, b } = engineWithTwoTargets()
+    const detach = attachAdvanceOn(engine)
+    await engine.start('t')
+
+    a.click()
+    await vi.waitFor(() => expect(engine.getState().currentStep?.id).toBe('b'))
+
+    // Step a's binding is gone; only b's target advances now.
+    a.click()
+    expect(engine.getState().currentStep?.id).toBe('b')
+
+    b.click()
+    await vi.waitFor(() => expect(engine.getState().isActive).toBe(false))
+
+    detach()
+    engine.destroy()
+  })
+
+  it('stops advancing after detach', async () => {
+    const { engine, a } = engineWithTwoTargets()
+    const detach = attachAdvanceOn(engine)
+    await engine.start('t')
+
+    detach()
+    a.click()
+
+    expect(engine.getState().currentStep?.id).toBe('a')
+    engine.destroy()
+  })
+
+  it('detach is idempotent', () => {
+    const { engine } = engineWithTwoTargets()
+    const detach = attachAdvanceOn(engine)
+
+    expect(() => {
+      detach()
+      detach()
+    }).not.toThrow()
+    engine.destroy()
+  })
+})

--- a/packages/core/src/__tests__/lib/behaviours-headless.test.ts
+++ b/packages/core/src/__tests__/lib/behaviours-headless.test.ts
@@ -1,0 +1,137 @@
+/**
+ * v2 §1.3b-6 — THE PHASE PROOF.
+ *
+ * §1.3 made `@tour-kit/core/engine` able to *run* a tour with no React. This
+ * file proves §1.3b made it able to *show* one: a real `createTourEngine()`
+ * driven through `attachKeyboard`, `attachAdvanceOn` and `createFocusTrap`,
+ * with neither `react` nor `@testing-library` anywhere in the module graph.
+ *
+ * The self-read guard at the bottom is what makes that a proof rather than a
+ * claim — copied from `lib/tour-engine/__tests__/create-tour-engine.test.ts`,
+ * which does the same for the engine itself.
+ */
+import { readFileSync } from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as engineEntry from '../../engine'
+import { attachAdvanceOn } from '../../lib/advance-on'
+import { createFocusTrap } from '../../lib/focus-trap'
+import { attachKeyboard } from '../../lib/keyboard'
+import { type TourEngine, createTourEngine } from '../../lib/tour-engine/create-tour-engine'
+import { createMemoryStorage } from '../../utils/storage'
+
+let engine: TourEngine
+const detachers: Array<() => void> = []
+
+function button(id: string): HTMLButtonElement {
+  const el = document.createElement('button')
+  el.type = 'button'
+  el.id = id
+  document.body.appendChild(el)
+  return el
+}
+
+beforeEach(() => {
+  button('a')
+  button('b')
+  engine = createTourEngine({
+    storage: createMemoryStorage(),
+    tours: [
+      {
+        id: 't',
+        steps: [
+          {
+            id: 'a',
+            target: '#a',
+            content: 'step a',
+            advanceOn: { event: 'click', selector: '#a' },
+          },
+          { id: 'b', target: '#b', content: 'step b' },
+        ],
+      },
+    ],
+  })
+})
+
+afterEach(() => {
+  for (const detach of detachers.splice(0)) detach()
+  engine.destroy()
+  document.body.innerHTML = ''
+})
+
+function press(key: string): void {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }))
+}
+
+describe('a binding drives the engine with no React', () => {
+  it('ArrowRight advances and Escape ends the tour', async () => {
+    // `engine` satisfies KeyboardActions structurally — next/prev/skip all
+    // return Promise<void> or void, both assignable to unknown.
+    detachers.push(attachKeyboard(engine))
+    await engine.start('t')
+    expect(engine.getState().currentStep?.id).toBe('a')
+
+    press('ArrowRight')
+    await vi.waitFor(() => expect(engine.getState().currentStep?.id).toBe('b'))
+
+    press('Escape')
+    expect(engine.getState().isActive).toBe(false)
+  })
+
+  it('a click on the step target advances through attachAdvanceOn', async () => {
+    detachers.push(attachAdvanceOn(engine))
+    await engine.start('t')
+
+    document.querySelector<HTMLButtonElement>('#a')?.click()
+
+    await vi.waitFor(() => expect(engine.getState().currentStep?.id).toBe('b'))
+  })
+
+  it('createFocusTrap wraps Tab and restores focus on deactivate', () => {
+    const trigger = button('trigger')
+    const card = document.createElement('div')
+    const first = document.createElement('button')
+    const last = document.createElement('button')
+    card.append(first, last)
+    document.body.appendChild(card)
+
+    const trap = createFocusTrap(() => card)
+    trigger.focus()
+    trap.capture()
+    trap.activate()
+
+    expect(document.activeElement).toBe(first)
+
+    last.focus()
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
+    )
+    expect(document.activeElement).toBe(first)
+
+    trap.deactivate()
+    expect(document.activeElement).toBe(trigger)
+  })
+})
+
+describe('the /engine barrel publishes all eight behaviours', () => {
+  it.each([
+    'createFocusTrap',
+    'attachKeyboard',
+    'trackRect',
+    'computeSpotlight',
+    'bindStepAdvance',
+    'attachAdvanceOn',
+    'dispatchAdvanceEvent',
+    'attachTestBridge',
+  ] as const)('%s is a module export of @tour-kit/core/engine', (name) => {
+    // Module exports of the barrel, NOT methods on a TourEngine instance.
+    expect(typeof engineEntry[name]).toBe('function')
+  })
+})
+
+describe('US-1 guard', () => {
+  it('this file imports no react and no testing-library', () => {
+    const source = readFileSync(new URL(import.meta.url), 'utf8')
+
+    expect(source).not.toMatch(/from ['"](react|react-dom|@testing-library)/)
+  })
+})

--- a/packages/core/src/__tests__/lib/focus-trap.ssr.test.ts
+++ b/packages/core/src/__tests__/lib/focus-trap.ssr.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+/**
+ * v2 §1.3b-1 — `createFocusTrap` on the server.
+ *
+ * `useFocusTrap` builds its trap in a `useMemo`, which runs during a server
+ * render. The pragma is file-scoped, which is why this cannot live inside
+ * `focus-trap.test.ts` — the same reason §1.3 split `create-tour-engine.ssr.test.ts`.
+ */
+import { describe, expect, it } from 'vitest'
+import { createFocusTrap } from '../../lib/focus-trap'
+
+describe('createFocusTrap with no document', () => {
+  it('constructs and every method is a no-op', () => {
+    expect(typeof document).toBe('undefined')
+
+    const trap = createFocusTrap(() => null, { inertBackground: true })
+
+    expect(() => {
+      trap.capture()
+      trap.activate()
+      trap.forget()
+      trap.deactivate()
+      trap.release()
+    }).not.toThrow()
+  })
+})

--- a/packages/core/src/__tests__/lib/focus-trap.test.ts
+++ b/packages/core/src/__tests__/lib/focus-trap.test.ts
@@ -1,0 +1,399 @@
+/**
+ * v2 §1.3b-1 — `createFocusTrap`, the plain function behind `useFocusTrap`.
+ *
+ * The 20 cases in `__tests__/hooks/use-focus-trap.test.tsx` are the read-only
+ * oracle for the React surface; this file covers what that oracle structurally
+ * cannot see, plus the two-phase contract the factory makes explicit:
+ *
+ *  - `capture()` and `activate()` are separate phases, because `TourPortal` and
+ *    `FloatingPortal` mount their node AFTER the render in which the trap
+ *    becomes enabled. By the time `activate()` runs, `document.activeElement`
+ *    has already drifted to `<body>`.
+ *  - the empty-container branch focuses the container ITSELF — the oracle case
+ *    (`use-focus-trap.test.tsx:177`) only asserts "does not throw".
+ *  - nested `inert` releases in BOTH orders — the oracle covers A-then-B only.
+ *  - `release()` must NOT move focus. That is the only thing distinguishing it
+ *    from `deactivate()`, and the oracle's unmount case never checks it.
+ *
+ * No React and no @testing-library anywhere in this directory.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createFocusTrap } from '../../lib/focus-trap'
+
+/** A container with `n` buttons, appended to `document.body`. */
+function makeContainer(n = 2): { container: HTMLDivElement; buttons: HTMLButtonElement[] } {
+  const container = document.createElement('div')
+  container.tabIndex = -1
+  const buttons = Array.from({ length: n }, (_, i) => {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.textContent = `b${i}`
+    container.appendChild(button)
+    return button
+  })
+  document.body.appendChild(container)
+  return { container, buttons }
+}
+
+function tab(options: { shift?: boolean } = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: !!options.shift,
+    bubbles: true,
+    cancelable: true,
+  })
+  document.dispatchEvent(event)
+  return event
+}
+
+let trigger: HTMLButtonElement
+
+beforeEach(() => {
+  trigger = document.createElement('button')
+  trigger.type = 'button'
+  trigger.textContent = 'open'
+  document.body.appendChild(trigger)
+})
+
+afterEach(() => {
+  // `applyBackgroundInert` walks document.body.children — one stranded node from
+  // an earlier case turns the inert assertions into order-dependent flakes.
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('the two-phase contract', () => {
+  it('restores focus to the element captured at enable, not the one active at activate', () => {
+    const { container } = makeContainer()
+    const trap = createFocusTrap(() => container)
+
+    trigger.focus()
+    trap.capture()
+    // The lazy portal mounts here; focus drifts to <body> in between.
+    document.body.focus()
+    ;(document.activeElement as HTMLElement | null)?.blur()
+
+    trap.activate()
+    trap.deactivate()
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('activate() alone still captures, as a last resort', () => {
+    const { container } = makeContainer()
+    const trap = createFocusTrap(() => container)
+
+    trigger.focus()
+    trap.activate()
+    trap.deactivate()
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('capture() twice keeps the first element', () => {
+    const { container } = makeContainer()
+    const second = document.createElement('button')
+    document.body.appendChild(second)
+    const trap = createFocusTrap(() => container)
+
+    trigger.focus()
+    trap.capture()
+    second.focus()
+    trap.capture()
+
+    trap.activate()
+    trap.deactivate()
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('activate() twice does not re-capture', () => {
+    const { container, buttons } = makeContainer()
+    const trap = createFocusTrap(() => container)
+
+    trigger.focus()
+    trap.activate()
+    expect(document.activeElement).toBe(buttons[0])
+
+    // A StrictMode double-effect: the second activate() must not record the
+    // first focusable as the thing to restore to.
+    trap.activate()
+    trap.deactivate()
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('activate() is a no-op when the container getter returns null', () => {
+    const trap = createFocusTrap(() => null)
+
+    trigger.focus()
+
+    expect(() => trap.activate()).not.toThrow()
+    expect(document.activeElement).toBe(trigger)
+  })
+})
+
+describe('forget()', () => {
+  it('clears the captured element when not trapping', () => {
+    const { container, buttons } = makeContainer()
+    const trap = createFocusTrap(() => container)
+
+    trigger.focus()
+    trap.capture()
+    trap.forget()
+
+    // Nothing recorded, so deactivate() has nowhere to send focus back to and
+    // the first focusable keeps it.
+    trap.activate()
+    buttons[0].focus()
+    trap.deactivate()
+
+    expect(document.activeElement).toBe(buttons[0])
+  })
+
+  it('is a no-op while trapping', () => {
+    const { container } = makeContainer()
+    const trap = createFocusTrap(() => container)
+
+    trigger.focus()
+    trap.capture()
+    trap.activate()
+    trap.forget()
+    trap.deactivate()
+
+    expect(document.activeElement).toBe(trigger)
+  })
+})
+
+describe('Tab handling', () => {
+  it('wraps Tab on the last focusable back to the first', () => {
+    const { container, buttons } = makeContainer(3)
+    const trap = createFocusTrap(() => container)
+    trap.activate()
+
+    buttons[2].focus()
+    const event = tab()
+
+    expect(document.activeElement).toBe(buttons[0])
+    expect(event.defaultPrevented).toBe(true)
+    trap.release()
+  })
+
+  it('wraps Shift+Tab on the first focusable back to the last', () => {
+    const { container, buttons } = makeContainer(3)
+    const trap = createFocusTrap(() => container)
+    trap.activate()
+
+    buttons[0].focus()
+    const event = tab({ shift: true })
+
+    expect(document.activeElement).toBe(buttons[2])
+    expect(event.defaultPrevented).toBe(true)
+    trap.release()
+  })
+
+  it('leaves an interior Tab alone', () => {
+    const { container, buttons } = makeContainer(3)
+    const trap = createFocusTrap(() => container)
+    trap.activate()
+
+    buttons[1].focus()
+    const event = tab()
+
+    expect(document.activeElement).toBe(buttons[1])
+    expect(event.defaultPrevented).toBe(false)
+    trap.release()
+  })
+
+  it('pulls drifted focus back to the first focusable', () => {
+    const { container, buttons } = makeContainer(2)
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    const trap = createFocusTrap(() => container)
+    trap.activate()
+
+    outside.focus()
+    const event = tab()
+
+    expect(document.activeElement).toBe(buttons[0])
+    expect(event.defaultPrevented).toBe(true)
+    trap.release()
+  })
+
+  it('focuses the container itself when nothing inside is focusable', () => {
+    const { container } = makeContainer(0)
+    const focusSpy = vi.spyOn(container, 'focus')
+    const trap = createFocusTrap(() => container)
+    trap.activate()
+    focusSpy.mockClear()
+
+    const event = tab()
+
+    // The oracle case asserts only "does not throw"; the branch that keeps Tab
+    // from escaping an empty dialog is otherwise untested.
+    expect(focusSpy).toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
+    trap.release()
+  })
+
+  it('ignores keys other than Tab', () => {
+    const { container, buttons } = makeContainer(2)
+    const trap = createFocusTrap(() => container)
+    trap.activate()
+
+    buttons[1].focus()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+
+    expect(document.activeElement).toBe(buttons[1])
+    trap.release()
+  })
+})
+
+describe('inertBackground', () => {
+  function background(): { plain: HTMLElement; preset: HTMLElement } {
+    const plain = document.createElement('section')
+    const preset = document.createElement('section')
+    preset.setAttribute('aria-hidden', 'false')
+    document.body.append(plain, preset)
+    return { plain, preset }
+  }
+
+  it('marks body siblings and restores their ORIGINAL attributes', () => {
+    const { plain, preset } = background()
+    const { container } = makeContainer()
+    const trap = createFocusTrap(() => container, { inertBackground: true })
+
+    trap.activate()
+
+    expect(plain.hasAttribute('inert')).toBe(true)
+    expect(plain.getAttribute('aria-hidden')).toBe('true')
+    expect(preset.getAttribute('aria-hidden')).toBe('true')
+
+    trap.deactivate()
+
+    expect(plain.hasAttribute('inert')).toBe(false)
+    expect(plain.hasAttribute('aria-hidden')).toBe(false)
+    // Restored, not removed.
+    expect(preset.getAttribute('aria-hidden')).toBe('false')
+  })
+
+  it('leaves the subtree containing the container interactive', () => {
+    const portal = document.createElement('div')
+    document.body.appendChild(portal)
+    const container = document.createElement('div')
+    portal.appendChild(container)
+    const trap = createFocusTrap(() => container, { inertBackground: true })
+
+    trap.activate()
+
+    expect(portal.hasAttribute('inert')).toBe(false)
+    trap.release()
+  })
+
+  it('does not touch the background when the option is off', () => {
+    const { plain } = background()
+    const { container } = makeContainer()
+    const trap = createFocusTrap(() => container)
+
+    trap.activate()
+
+    expect(plain.hasAttribute('inert')).toBe(false)
+    trap.release()
+  })
+
+  it.each([
+    ['A then B', 0],
+    ['B then A', 1],
+  ])('ref-counts nested traps released %s', (_label, releaseSecondFirst) => {
+    const { plain, preset } = background()
+    const a = makeContainer().container
+    const b = makeContainer().container
+    const trapA = createFocusTrap(() => a, { inertBackground: true })
+    const trapB = createFocusTrap(() => b, { inertBackground: true })
+
+    trapA.activate()
+    trapB.activate()
+
+    // Both traps hold the background; releasing one must not restore it.
+    const [first, second] = releaseSecondFirst ? [trapB, trapA] : [trapA, trapB]
+    first.deactivate()
+
+    expect(plain.hasAttribute('inert')).toBe(true)
+    expect(preset.getAttribute('aria-hidden')).toBe('true')
+
+    second.deactivate()
+
+    expect(plain.hasAttribute('inert')).toBe(false)
+    expect(plain.hasAttribute('aria-hidden')).toBe(false)
+    expect(preset.getAttribute('aria-hidden')).toBe('false')
+  })
+})
+
+describe('release()', () => {
+  it('removes the Tab handler and restores inert WITHOUT moving focus', () => {
+    const plain = document.createElement('section')
+    document.body.appendChild(plain)
+    const { container, buttons } = makeContainer(2)
+    const trap = createFocusTrap(() => container, { inertBackground: true })
+
+    trigger.focus()
+    trap.capture()
+    trap.activate()
+    buttons[1].focus()
+
+    trap.release()
+
+    // deactivate() would have sent focus back to `trigger`. release() is the
+    // unmount path and must leave it exactly where it was.
+    expect(document.activeElement).toBe(buttons[1])
+    expect(plain.hasAttribute('inert')).toBe(false)
+
+    buttons[1].focus()
+    tab()
+    expect(document.activeElement).toBe(buttons[1])
+  })
+
+  it('is idempotent', () => {
+    const { container } = makeContainer()
+    const trap = createFocusTrap(() => container)
+    trap.activate()
+
+    expect(() => {
+      trap.release()
+      trap.release()
+    }).not.toThrow()
+  })
+})
+
+describe('deactivate()', () => {
+  it('is idempotent and removes the listener', () => {
+    const { container, buttons } = makeContainer(2)
+    const trap = createFocusTrap(() => container)
+
+    trigger.focus()
+    trap.activate()
+    trap.deactivate()
+    expect(() => trap.deactivate()).not.toThrow()
+
+    buttons[1].focus()
+    const event = tab()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('re-activating after deactivate re-captures the current trigger', () => {
+    const { container } = makeContainer()
+    const other = document.createElement('button')
+    document.body.appendChild(other)
+    const trap = createFocusTrap(() => container)
+
+    trigger.focus()
+    trap.activate()
+    trap.deactivate()
+
+    other.focus()
+    trap.activate()
+    trap.deactivate()
+
+    expect(document.activeElement).toBe(other)
+  })
+})

--- a/packages/core/src/__tests__/lib/focus-trap.test.ts
+++ b/packages/core/src/__tests__/lib/focus-trap.test.ts
@@ -384,6 +384,31 @@ describe('release()', () => {
       trap.release()
     }).not.toThrow()
   })
+
+  it('leaves the trap re-armable — activate() after release() engages again', () => {
+    // A binding that wires close -> release() and open -> activate() must get a
+    // live trap the second time. `activate()` bails on its own idempotence
+    // guard, so release() has to clear the trapping flag or the reopened card
+    // has no focus move, no Tab handler and no inert — failing silently.
+    const { container, buttons } = makeContainer(2)
+    const trap = createFocusTrap(() => container)
+
+    trap.activate()
+    trap.release()
+    trigger.focus()
+
+    trap.activate()
+    expect(document.activeElement).toBe(buttons[0])
+
+    // The Tab handler is live again, not just the focus move.
+    buttons[1].focus()
+    tab()
+    expect(document.activeElement).toBe(buttons[0])
+
+    // afterEach clears the body but not document-level listeners — a trap left
+    // armed here would preventDefault the next case's Tab.
+    trap.release()
+  })
 })
 
 describe('deactivate()', () => {

--- a/packages/core/src/__tests__/lib/focus-trap.test.ts
+++ b/packages/core/src/__tests__/lib/focus-trap.test.ts
@@ -134,21 +134,42 @@ describe('the two-phase contract', () => {
 })
 
 describe('forget()', () => {
-  it('clears the captured element when not trapping', () => {
-    const { container, buttons } = makeContainer()
+  it('clears the record so the next capture() takes the CURRENT trigger', () => {
+    // enabled -> false with no activate() in between: a lazy portal that never
+    // mounted. Without forget(), the next enable would restore focus to a
+    // trigger that is no longer the one the user came from.
+    const { container } = makeContainer()
+    const other = document.createElement('button')
+    document.body.appendChild(other)
     const trap = createFocusTrap(() => container)
 
     trigger.focus()
     trap.capture()
     trap.forget()
 
-    // Nothing recorded, so deactivate() has nowhere to send focus back to and
-    // the first focusable keeps it.
+    other.focus()
+    trap.capture()
     trap.activate()
-    buttons[0].focus()
     trap.deactivate()
 
-    expect(document.activeElement).toBe(buttons[0])
+    expect(document.activeElement).toBe(other)
+  })
+
+  it('without forget(), the first captured trigger still wins', () => {
+    const { container } = makeContainer()
+    const other = document.createElement('button')
+    document.body.appendChild(other)
+    const trap = createFocusTrap(() => container)
+
+    trigger.focus()
+    trap.capture()
+
+    other.focus()
+    trap.capture()
+    trap.activate()
+    trap.deactivate()
+
+    expect(document.activeElement).toBe(trigger)
   })
 
   it('is a no-op while trapping', () => {

--- a/packages/core/src/__tests__/lib/keyboard.test.ts
+++ b/packages/core/src/__tests__/lib/keyboard.test.ts
@@ -1,0 +1,186 @@
+/**
+ * v2 §1.3b-2 — `attachKeyboard`, the plain function behind
+ * `useKeyboardNavigation`.
+ *
+ * The 20 cases in `__tests__/hooks/use-keyboard.test.tsx` are the read-only
+ * oracle. What they cannot see is the gating seam this phase introduces:
+ * `isEnabled` is a PREDICATE evaluated per event, not a subscription
+ * (Decision 2), so a binding attaches once at mount and lets the predicate
+ * decide. Flipping it must take effect without re-attaching.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { attachKeyboard } from '../../lib/keyboard'
+
+function press(key: string, options: KeyboardEventInit = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...options })
+  document.dispatchEvent(event)
+  return event
+}
+
+function actions() {
+  return { next: vi.fn(), prev: vi.fn(), skip: vi.fn() }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('the three key lists', () => {
+  it.each([
+    ['ArrowRight', 'next'],
+    ['Enter', 'next'],
+    ['ArrowLeft', 'prev'],
+    ['Escape', 'skip'],
+  ] as const)('%s calls %s and preventDefaults', (key, verb) => {
+    const a = actions()
+    const detach = attachKeyboard(a)
+
+    const event = press(key)
+
+    expect(a[verb]).toHaveBeenCalledTimes(1)
+    expect(event.defaultPrevented).toBe(true)
+    detach()
+  })
+
+  it('ignores an unmapped key', () => {
+    const a = actions()
+    const detach = attachKeyboard(a)
+
+    const event = press('a')
+
+    expect(a.next).not.toHaveBeenCalled()
+    expect(a.prev).not.toHaveBeenCalled()
+    expect(a.skip).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+    detach()
+  })
+
+  it('honours custom key lists over the defaults', () => {
+    const a = actions()
+    const detach = attachKeyboard(a, { nextKeys: ['n'], prevKeys: ['p'], exitKeys: ['q'] })
+
+    press('n')
+    press('p')
+    press('q')
+    press('ArrowRight')
+
+    expect(a.next).toHaveBeenCalledTimes(1)
+    expect(a.prev).toHaveBeenCalledTimes(1)
+    expect(a.skip).toHaveBeenCalledTimes(1)
+    detach()
+  })
+})
+
+describe('the editable-target guard', () => {
+  function focusable(build: () => HTMLElement): HTMLElement {
+    const el = build()
+    document.body.appendChild(el)
+    el.focus()
+    return el
+  }
+
+  it.each([
+    ['input', () => document.createElement('input')],
+    ['textarea', () => document.createElement('textarea')],
+    ['select', () => document.createElement('select')],
+    [
+      'contentEditable',
+      () => {
+        const el = document.createElement('div')
+        el.tabIndex = 0
+        // jsdom does not derive isContentEditable from the attribute.
+        Object.defineProperty(el, 'isContentEditable', { value: true })
+        return el
+      },
+    ],
+    [
+      'role="textbox"',
+      () => {
+        const el = document.createElement('div')
+        el.tabIndex = 0
+        el.setAttribute('role', 'textbox')
+        return el
+      },
+    ],
+  ])('stays silent while focus is in a %s', (_label, build) => {
+    const a = actions()
+    const detach = attachKeyboard(a)
+    focusable(build)
+
+    press('ArrowRight')
+    press('ArrowLeft')
+    press('Escape')
+
+    expect(a.next).not.toHaveBeenCalled()
+    expect(a.prev).not.toHaveBeenCalled()
+    expect(a.skip).not.toHaveBeenCalled()
+    detach()
+  })
+})
+
+describe('isEnabled is a per-event predicate, not a subscription', () => {
+  it('suppresses every verb while it returns false', () => {
+    const a = actions()
+    const detach = attachKeyboard(a, undefined, { isEnabled: () => false })
+
+    press('ArrowRight')
+    press('ArrowLeft')
+    press('Escape')
+
+    expect(a.next).not.toHaveBeenCalled()
+    expect(a.prev).not.toHaveBeenCalled()
+    expect(a.skip).not.toHaveBeenCalled()
+    detach()
+  })
+
+  it('re-enables mid-flight with no re-attach', () => {
+    // A Vue binding attaches once at mount and passes
+    // `() => engine.getState().isActive`. If the predicate were read at attach
+    // time, the tour could never become drivable without a re-attach.
+    const a = actions()
+    let live = false
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const detach = attachKeyboard(a, undefined, { isEnabled: () => live })
+    const attachCount = addSpy.mock.calls.length
+
+    press('ArrowRight')
+    expect(a.next).not.toHaveBeenCalled()
+
+    live = true
+    press('ArrowRight')
+
+    expect(a.next).toHaveBeenCalledTimes(1)
+    expect(addSpy.mock.calls.length).toBe(attachCount)
+    detach()
+  })
+})
+
+describe('enabled: false', () => {
+  it('installs no listener at all', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const a = actions()
+
+    const detach = attachKeyboard(a, { enabled: false })
+
+    expect(addSpy).not.toHaveBeenCalled()
+    press('ArrowRight')
+    expect(a.next).not.toHaveBeenCalled()
+    expect(() => detach()).not.toThrow()
+  })
+})
+
+describe('detach', () => {
+  it('is idempotent and silences later keys', () => {
+    const a = actions()
+    const detach = attachKeyboard(a)
+
+    expect(() => {
+      detach()
+      detach()
+    }).not.toThrow()
+
+    press('ArrowRight')
+    expect(a.next).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/__tests__/lib/spotlight.test.ts
+++ b/packages/core/src/__tests__/lib/spotlight.test.ts
@@ -1,0 +1,81 @@
+/**
+ * v2 §1.3b-3 — `computeSpotlight`, the two `useMemo`s from `use-spotlight.ts`
+ * as one pure function.
+ *
+ * The trap for a "verbatim move" is `overlayStyle.backgroundColor`: it is the
+ * literal `'transparent'`, and the configured colour reaches the DOM only
+ * through the cutout's `boxShadow`. Wiring `config.color` into the overlay
+ * passes a careless test and changes rendering.
+ */
+import { describe, expect, it } from 'vitest'
+import { computeSpotlight } from '../../lib/spotlight'
+import { rectOf } from './_helpers/rect'
+
+const RECT = rectOf(100, 100, 200, 100)
+
+describe('computeSpotlight', () => {
+  it('returns an overlay and a null cutout with no rect', () => {
+    const { overlayStyle, cutoutStyle } = computeSpotlight(null)
+
+    // The hook maps null -> {} for React; the factory returns null so a binding
+    // can tell "no target yet" from "an empty style object".
+    expect(cutoutStyle).toBeNull()
+    expect(overlayStyle.position).toBe('fixed')
+    expect(overlayStyle.inset).toBe(0)
+    expect(overlayStyle.pointerEvents).toBe('auto')
+  })
+
+  it('keeps the overlay transparent and puts the colour in the cutout shadow', () => {
+    const { overlayStyle, cutoutStyle } = computeSpotlight(RECT, { color: 'rgba(1, 2, 3, 0.9)' })
+
+    expect(overlayStyle.backgroundColor).toBe('transparent')
+    expect(cutoutStyle?.boxShadow).toBe('0 0 0 9999px rgba(1, 2, 3, 0.9)')
+  })
+
+  it('insets the cutout by the configured padding', () => {
+    const { cutoutStyle } = computeSpotlight(RECT, { padding: 10, borderRadius: 12 })
+
+    expect(cutoutStyle).toMatchObject({
+      position: 'absolute',
+      top: 90,
+      left: 90,
+      width: 220,
+      height: 120,
+      borderRadius: 12,
+      pointerEvents: 'none',
+    })
+  })
+
+  it('falls back to the default padding and radius', () => {
+    const { cutoutStyle } = computeSpotlight(RECT, {})
+
+    expect(cutoutStyle?.top).toBe(92)
+    expect(cutoutStyle?.width).toBe(216)
+    expect(cutoutStyle?.borderRadius).toBe(4)
+  })
+
+  it('merges a partial config over the defaults', () => {
+    const { cutoutStyle } = computeSpotlight(RECT, { padding: 0 })
+
+    // padding overridden, colour still the default.
+    expect(cutoutStyle?.top).toBe(100)
+    expect(cutoutStyle?.boxShadow).toBe('0 0 0 9999px rgba(0, 0, 0, 0.5)')
+  })
+
+  it('sets transition on BOTH styles when animate is on', () => {
+    const { overlayStyle, cutoutStyle } = computeSpotlight(RECT, {
+      animate: true,
+      animationDuration: 120,
+    })
+
+    expect(overlayStyle.transition).toBe('all 120ms ease-out')
+    expect(cutoutStyle?.transition).toBe('all 120ms ease-out')
+  })
+
+  it('sets transition on NEITHER style when animate is off', () => {
+    const { overlayStyle, cutoutStyle } = computeSpotlight(RECT, { animate: false })
+
+    expect(overlayStyle.transition).toBeUndefined()
+    expect(cutoutStyle?.transition).toBeUndefined()
+  })
+})

--- a/packages/core/src/__tests__/lib/test-bridge.ssr.test.ts
+++ b/packages/core/src/__tests__/lib/test-bridge.ssr.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+/**
+ * v2 §1.3b-5 — `attachTestBridge` on the server. The provider's effect body is
+ * where this is called, and an effect setup path must not throw during a
+ * server render. The pragma is file-scoped, hence the separate file.
+ */
+import { describe, expect, it } from 'vitest'
+import { attachTestBridge } from '../../lib/test-bridge'
+
+describe('attachTestBridge with no window', () => {
+  it('installs nothing and returns a callable detach', () => {
+    expect(typeof window).toBe('undefined')
+
+    const detach = attachTestBridge({
+      start: () => {},
+      next: () => {},
+      prev: () => {},
+      goToStep: () => {},
+      complete: () => {},
+      skip: () => {},
+    })
+
+    expect(typeof detach).toBe('function')
+    expect(() => detach()).not.toThrow()
+  })
+})

--- a/packages/core/src/__tests__/lib/test-bridge.test.ts
+++ b/packages/core/src/__tests__/lib/test-bridge.test.ts
@@ -1,0 +1,159 @@
+/**
+ * v2 §1.3b-5 — `attachTestBridge`, the provider's `window.__tourKit__` effect
+ * as a plain function.
+ *
+ * `context/__tests__/test-bridge.test.tsx` stays the read-only oracle for the
+ * provider's once-per-mount warning guard. What this file pins is the shape
+ * `@tour-kit/playwright` and `@tour-kit/testing-library` drive out of process:
+ *
+ *  - the installed verb is `previous`, while the structural target names it
+ *    `prev`. That mapping is easy to lose in a "verbatim move".
+ *  - detach `delete`s the property outright, because consumers use
+ *    `'__tourKit__' in window` and `= undefined` would leave an own property.
+ *  - detach after a foreign reassignment leaves the foreign value alone.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { type TestBridgeTarget, attachTestBridge } from '../../lib/test-bridge'
+
+function makeTarget(extras: Partial<TestBridgeTarget> = {}): TestBridgeTarget & {
+  calls: Record<string, unknown[]>
+} {
+  const calls: Record<string, unknown[]> = {}
+  const record =
+    (name: string) =>
+    (...args: unknown[]) => {
+      ;(calls[name] ??= []).push(args)
+    }
+  return {
+    calls,
+    start: record('start'),
+    next: record('next'),
+    prev: record('prev'),
+    goToStep: record('goToStep'),
+    complete: record('complete'),
+    skip: record('skip'),
+    ...extras,
+  }
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  delete window.__tourKit__
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('the installed global', () => {
+  it('exposes every verb and routes them to the target', () => {
+    const target = makeTarget()
+
+    const detach = attachTestBridge(target)
+
+    const bridge = window.__tourKit__
+    expect(bridge).toBeDefined()
+    bridge?.start('t')
+    bridge?.next()
+    // `previous` on the bridge maps to `prev` on the target.
+    bridge?.previous()
+    bridge?.goToStep('s')
+    bridge?.complete()
+    bridge?.skip()
+
+    expect(target.calls.start).toEqual([['t']])
+    expect(target.calls.next).toHaveLength(1)
+    expect(target.calls.prev).toHaveLength(1)
+    expect(target.calls.goToStep).toEqual([['s']])
+    expect(target.calls.complete).toHaveLength(1)
+    expect(target.calls.skip).toHaveLength(1)
+    detach()
+  })
+
+  it('delegates getDiagnostic when the target has one', () => {
+    const report = { tourId: 't' } as never
+    const detach = attachTestBridge(makeTarget({ getDiagnostic: () => report }))
+
+    expect(window.__tourKit__?.getDiagnostic('t')).toBe(report)
+    detach()
+  })
+
+  it('returns null from getDiagnostic when the target has none', () => {
+    const detach = attachTestBridge(makeTarget())
+
+    expect(window.__tourKit__?.getDiagnostic('t')).toBeNull()
+    detach()
+  })
+})
+
+describe('detach', () => {
+  it('removes the property outright, not just its value', () => {
+    const detach = attachTestBridge(makeTarget())
+
+    detach()
+
+    // Consumers use `in`. Assigning undefined would leave an own property.
+    expect('__tourKit__' in window).toBe(false)
+  })
+
+  it('leaves a foreign global alone', () => {
+    const detach = attachTestBridge(makeTarget())
+    const foreign = { next: () => {} } as never
+    window.__tourKit__ = foreign
+
+    detach()
+
+    expect(window.__tourKit__).toBe(foreign)
+  })
+
+  it('is idempotent', () => {
+    const detach = attachTestBridge(makeTarget())
+
+    expect(() => {
+      detach()
+      detach()
+    }).not.toThrow()
+  })
+})
+
+describe('the non-production warning', () => {
+  it('warns by default', () => {
+    const detach = attachTestBridge(makeTarget())
+
+    expect(warnSpy).toHaveBeenCalledWith('[Tour Kit] Test bridge enabled. Disable for production.')
+    detach()
+  })
+
+  it('is suppressed by warn: false', () => {
+    // The once-guard stays in the provider (`testBridgeWarnedRef`); a
+    // module-level flag here would leak across tests in test-bridge.test.tsx
+    // and make that file order-dependent.
+    const detach = attachTestBridge(makeTarget(), { warn: false })
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    detach()
+  })
+
+  it('still warns when `process` is absent', () => {
+    // The provider's condition is `typeof process === 'undefined' ||
+    // NODE_ENV !== 'production'` — a browser bundle has no `process`.
+    vi.stubGlobal('process', undefined)
+
+    const detach = attachTestBridge(makeTarget())
+
+    expect(warnSpy).toHaveBeenCalled()
+    detach()
+  })
+
+  it('stays silent in production', () => {
+    vi.stubGlobal('process', { env: { NODE_ENV: 'production' } })
+
+    const detach = attachTestBridge(makeTarget())
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    detach()
+  })
+})

--- a/packages/core/src/__tests__/lib/test-bridge.test.ts
+++ b/packages/core/src/__tests__/lib/test-bridge.test.ts
@@ -22,7 +22,9 @@ function makeTarget(extras: Partial<TestBridgeTarget> = {}): TestBridgeTarget & 
   const record =
     (name: string) =>
     (...args: unknown[]) => {
-      ;(calls[name] ??= []).push(args)
+      const bucket = calls[name] ?? []
+      bucket.push(args)
+      calls[name] = bucket
     }
   return {
     calls,
@@ -43,7 +45,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  delete window.__tourKit__
+  Reflect.deleteProperty(window, '__tourKit__')
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })

--- a/packages/core/src/__tests__/lib/track-rect.test.ts
+++ b/packages/core/src/__tests__/lib/track-rect.test.ts
@@ -1,0 +1,165 @@
+/**
+ * v2 §1.3b-3 — `trackRect`, the one scroll/resize tracker behind both
+ * `useSpotlight` and `useElementPosition`.
+ *
+ * The load-bearing case here is **construction reads nothing** (US-4).
+ * `useSpotlight.show()` seeds `targetRect` itself before its effect runs; an
+ * attach-time read would `setTargetRect` a fresh `DOMRect` and cost one extra
+ * render per `show()` in a real DOM. Neither hook oracle counts
+ * `getBoundingClientRect` calls — both only assert `toHaveBeenCalled()` after a
+ * scroll or an explicit `update()` — so an auto-reading tracker passes all 27
+ * of their cases silently. This file is the only net.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { trackRect } from '../../lib/track-rect'
+import { type FrameHarness, deferredFrames } from './_helpers/frames'
+import { rectOf } from './_helpers/rect'
+import { type ResizeObserverStub, stubResizeObserver } from './_helpers/resize-observer'
+
+describe('trackRect', () => {
+  let el: HTMLDivElement
+  let onRect: ReturnType<typeof vi.fn>
+  let frames: FrameHarness
+
+  beforeEach(() => {
+    el = document.createElement('div')
+    document.body.appendChild(el)
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue(rectOf(100, 100, 200, 100))
+    onRect = vi.fn()
+    frames = deferredFrames()
+  })
+
+  afterEach(() => {
+    frames.restore()
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  describe('construction reads nothing', () => {
+    it('calls neither onRect nor getBoundingClientRect on construction', () => {
+      const tracker = trackRect(el, onRect)
+
+      expect(onRect).not.toHaveBeenCalled()
+      expect(el.getBoundingClientRect).not.toHaveBeenCalled()
+
+      tracker.stop()
+    })
+
+    it('update() reads once, synchronously', () => {
+      const tracker = trackRect(el, onRect)
+
+      tracker.update()
+
+      expect(onRect).toHaveBeenCalledTimes(1)
+      expect(onRect).toHaveBeenCalledWith(expect.objectContaining({ top: 100, width: 200 }))
+      expect(frames.pending()).toBe(0)
+
+      tracker.stop()
+    })
+  })
+
+  describe('throttled scroll/resize', () => {
+    it.each([
+      ['scroll', () => window.dispatchEvent(new Event('scroll'))],
+      ['resize', () => window.dispatchEvent(new Event('resize'))],
+    ])('coalesces repeated %s events into one call per frame', (_label, fire) => {
+      const tracker = trackRect(el, onRect)
+
+      fire()
+      fire()
+      expect(onRect).not.toHaveBeenCalled()
+      expect(frames.pending()).toBe(1)
+
+      frames.flush()
+
+      expect(onRect).toHaveBeenCalledTimes(1)
+      tracker.stop()
+    })
+  })
+
+  describe('observeResize', () => {
+    let ro: ResizeObserverStub
+
+    beforeEach(() => {
+      ro = stubResizeObserver()
+    })
+
+    it('observes the element and its HTMLElement scroll parent', () => {
+      const scroller = document.createElement('div')
+      scroller.style.overflow = 'auto'
+      document.body.appendChild(scroller)
+      scroller.appendChild(el)
+
+      const tracker = trackRect(el, onRect, { observeResize: true })
+
+      expect(ro.observed()).toContain(el)
+      expect(ro.observed()).toContain(scroller)
+      tracker.stop()
+    })
+
+    it('observes only the element when the scroll parent is the window', () => {
+      const tracker = trackRect(el, onRect, { observeResize: true })
+
+      expect(ro.observed()).toEqual([el])
+      tracker.stop()
+    })
+
+    it('a resize goes through the same frame throttle', () => {
+      const tracker = trackRect(el, onRect, { observeResize: true })
+
+      ro.trigger()
+      ro.trigger()
+      expect(onRect).not.toHaveBeenCalled()
+
+      frames.flush()
+
+      expect(onRect).toHaveBeenCalledTimes(1)
+      tracker.stop()
+    })
+
+    it('disconnects on stop()', () => {
+      const tracker = trackRect(el, onRect, { observeResize: true })
+
+      tracker.stop()
+
+      expect(ro.disconnect).toHaveBeenCalled()
+    })
+
+    it('does not construct a ResizeObserver without the option', () => {
+      const tracker = trackRect(el, onRect)
+
+      expect(ro.observe).not.toHaveBeenCalled()
+      tracker.stop()
+    })
+  })
+
+  describe('stop()', () => {
+    it('is idempotent and silences later events', () => {
+      const tracker = trackRect(el, onRect)
+
+      expect(() => {
+        tracker.stop()
+        tracker.stop()
+      }).not.toThrow()
+
+      window.dispatchEvent(new Event('scroll'))
+      frames.flush()
+
+      expect(onRect).not.toHaveBeenCalled()
+    })
+
+    it('cancels a frame already queued', () => {
+      const tracker = trackRect(el, onRect)
+
+      window.dispatchEvent(new Event('scroll'))
+      expect(frames.pending()).toBe(1)
+
+      tracker.stop()
+      expect(frames.pending()).toBe(0)
+
+      frames.flush()
+      expect(onRect).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/__tests__/no-react-in-engine-types.test.ts
+++ b/packages/core/src/__tests__/no-react-in-engine-types.test.ts
@@ -20,13 +20,28 @@ import { describe, expect, it } from 'vitest'
 
 const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 
-/** The five files named in the §1.1 acceptance criteria. */
+/**
+ * The five files named in the §1.1 acceptance criteria, plus the six flat
+ * `lib/` leaves v2 §1.3b published from `/engine`.
+ *
+ * The leaves have to be seeded by hand: `engineSourceFiles()` walks only
+ * `lib/tour-engine/`, so a flat `lib/` file is invisible to it. They are DOM
+ * behaviours a binding attaches, not engine state, which is why they are not
+ * in that directory.
+ */
 const ENGINE_TYPE_SEEDS = [
   'types/step.ts',
   'types/hints.ts',
   'types/target.ts',
   'lib/tour-engine/context.ts',
   'lib/segmentation/types.ts',
+  // v2 §1.3b — DOM behaviours
+  'lib/focus-trap.ts',
+  'lib/keyboard.ts',
+  'lib/track-rect.ts',
+  'lib/spotlight.ts',
+  'lib/advance-on.ts',
+  'lib/test-bridge.ts',
 ] as const
 
 /**

--- a/packages/core/src/__tests__/types/spotlight-styles.test-d.ts
+++ b/packages/core/src/__tests__/types/spotlight-styles.test-d.ts
@@ -1,0 +1,19 @@
+/**
+ * v2 §1.3b-3 — the two spotlight style shapes must assign to
+ * `React.CSSProperties` without a cast, so `UseSpotlightReturn` can keep
+ * declaring `React.CSSProperties` while the factory that builds them never
+ * names React.
+ *
+ * This lives under `__tests__/types/` because core's vitest config has no
+ * `typecheck` block — an `expectTypeOf` inside a `.test.ts` would run as a
+ * silent no-op. `pnpm typecheck:types` compiles this file; vitest's include
+ * glob never matches `*.test-d.ts`.
+ */
+import type { CSSProperties } from 'react'
+import type { SpotlightCutoutStyle, SpotlightOverlayStyle } from '../../lib/spotlight'
+
+declare const overlay: SpotlightOverlayStyle
+declare const cutout: SpotlightCutoutStyle
+
+export const overlayAsCss: CSSProperties = overlay
+export const cutoutAsCss: CSSProperties = cutout

--- a/packages/core/src/context/tour-provider.tsx
+++ b/packages/core/src/context/tour-provider.tsx
@@ -5,6 +5,7 @@ import { useFlowSession } from '../hooks/use-flow-session'
 import { usePersistence } from '../hooks/use-persistence'
 import { useRoutePersistence } from '../hooks/use-route-persistence'
 import { explainTour } from '../lib/diagnostic'
+import { attachTestBridge } from '../lib/test-bridge'
 import {
   completeTourImpl,
   goToImpl,
@@ -35,7 +36,6 @@ import type { Tour, TourCallbackContext, TourContextValue } from '../types'
 import { defaultPersistenceConfig } from '../types/config'
 import type { DiagnosticContext, DiagnosticGate, EligibilityReport } from '../types/diagnostic'
 import type { MultiPagePersistenceConfig, RouterAdapter } from '../types/router'
-import type { TestBridge } from '../types/test-bridge'
 import type { TourReducerState } from '../types/tour-reducer'
 import { logger } from '../utils/logger'
 import { TourContext } from './tour-context'
@@ -649,46 +649,24 @@ export function TourProvider({
 
   React.useEffect(() => {
     if (!enableTestBridge) return
-    if (typeof window === 'undefined') return
+    const methods = bridgeMethodsRef
+    // The once-per-mount guard stays here, not in `attachTestBridge`: a
+    // module-level flag in the plain function would leak across tests.
+    const warn = !testBridgeWarnedRef.current
+    testBridgeWarnedRef.current = true
 
-    if (typeof process === 'undefined' || process.env?.NODE_ENV !== 'production') {
-      if (!testBridgeWarnedRef.current) {
-        testBridgeWarnedRef.current = true
-        console.warn('[Tour Kit] Test bridge enabled. Disable for production.')
-      }
-    }
-
-    const bridge: TestBridge = {
-      start: (tourId) => {
-        void bridgeMethodsRef.current.start(tourId)
+    return attachTestBridge(
+      {
+        start: (tourId) => methods.current.start(tourId),
+        next: () => methods.current.next(),
+        prev: () => methods.current.previous(),
+        goToStep: (stepId) => methods.current.goToStep(stepId),
+        complete: () => methods.current.complete(),
+        skip: () => methods.current.skip(),
+        getDiagnostic: (tourId) => methods.current.diagnostics[tourId] ?? null,
       },
-      next: () => {
-        void bridgeMethodsRef.current.next()
-      },
-      previous: () => {
-        void bridgeMethodsRef.current.previous()
-      },
-      goToStep: (stepId) => {
-        void bridgeMethodsRef.current.goToStep(stepId)
-      },
-      complete: () => {
-        bridgeMethodsRef.current.complete()
-      },
-      skip: () => {
-        bridgeMethodsRef.current.skip()
-      },
-      getDiagnostic: (tourId) => bridgeMethodsRef.current.diagnostics[tourId] ?? null,
-    }
-    window.__tourKit__ = bridge
-
-    return () => {
-      // Identity check defends against another library reassigning the global
-      // between our mount and unmount — see the cleanup-safety unit test.
-      if (window.__tourKit__ === bridge) {
-        // biome-ignore lint/performance/noDelete: full removal mirrors the absent-by-default invariant — `= undefined` would leave an own property and break consumer `'__tourKit__' in window` checks
-        delete window.__tourKit__
-      }
-    }
+      { warn }
+    )
   }, [enableTestBridge])
 
   const contextValue = React.useMemo<TourContextValue>(

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -262,5 +262,6 @@ export type {
   SpotlightStyles,
 } from '../lib/spotlight'
 export { attachAdvanceOn, bindStepAdvance, dispatchAdvanceEvent } from '../lib/advance-on'
+export type { AdvanceOnTarget } from '../lib/advance-on'
 export { attachTestBridge } from '../lib/test-bridge'
 export type { AttachTestBridgeOptions, TestBridgeTarget } from '../lib/test-bridge'

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -24,7 +24,10 @@
  * Since v2 §1.3 this entry can *run* a tour: `createTourEngine()` returns a
  * plain-JavaScript engine with no React, no DOM and no bundler required.
  * §1.2 shipped the door; §1.3 is what made it a capability rather than
- * infrastructure.
+ * infrastructure. §1.3b added what a binding needs to *show* one — trap focus
+ * in a card, wire the keys, follow the target through scroll and resize, cut
+ * the spotlight hole and auto-advance on a click — as plain functions a Vue,
+ * Svelte or vanilla binding attaches around its own rendering.
  *
  * Still deliberately absent, and not an oversight: the port itself
  * (`TourEngineContext`), the four persistence/broadcast factories, and the
@@ -239,3 +242,25 @@ export type {
   BootSource,
   ResolveBootStartInput,
 } from '../lib/tour-engine/boot'
+
+// ── DOM behaviours (v2 §1.3b) ───────────────────────────────────────────────
+// LEAF imports. These are view behaviours a binding ATTACHES, not engine
+// state, which is why they live as flat `lib/` leaves rather than under
+// `lib/tour-engine/`. Every one is React-free and DOM-only; each returns a
+// detach/stop/release that is safe to call twice, and none subscribes to
+// anything except `attachAdvanceOn`, which returns its own unsubscribe.
+export { createFocusTrap } from '../lib/focus-trap'
+export type { FocusTrap, FocusTrapOptions } from '../lib/focus-trap'
+export { attachKeyboard } from '../lib/keyboard'
+export type { AttachKeyboardOptions, KeyboardActions } from '../lib/keyboard'
+export { trackRect } from '../lib/track-rect'
+export type { RectTracker, TrackRectOptions } from '../lib/track-rect'
+export { computeSpotlight } from '../lib/spotlight'
+export type {
+  SpotlightCutoutStyle,
+  SpotlightOverlayStyle,
+  SpotlightStyles,
+} from '../lib/spotlight'
+export { attachAdvanceOn, bindStepAdvance, dispatchAdvanceEvent } from '../lib/advance-on'
+export { attachTestBridge } from '../lib/test-bridge'
+export type { AttachTestBridgeOptions, TestBridgeTarget } from '../lib/test-bridge'

--- a/packages/core/src/hooks/use-advance-on.ts
+++ b/packages/core/src/hooks/use-advance-on.ts
@@ -1,7 +1,8 @@
-import { useContext, useEffect, useRef } from 'react'
+import { useContext, useEffect } from 'react'
 import { TourContext } from '../context/tour-context'
-import { getElement } from '../utils/dom'
-import { logger } from '../utils/logger'
+import { bindStepAdvance } from '../lib/advance-on'
+
+export { dispatchAdvanceEvent } from '../lib/advance-on'
 
 export interface UseAdvanceOnOptions {
   /** Enable/disable the advanceOn behavior (default: true) */
@@ -10,12 +11,14 @@ export interface UseAdvanceOnOptions {
 
 /**
  * Hook to handle advanceOn behavior - automatically advances tour when
- * user performs specified action on target element
+ * user performs specified action on target element.
+ *
+ * A React wrapper over `bindStepAdvance` (`lib/advance-on.ts`). The engine-level
+ * equivalent for a non-React binding is `attachAdvanceOn(engine)`.
  */
 export function useAdvanceOn(options: UseAdvanceOnOptions = {}): void {
   const { enabled = true } = options
   const context = useContext(TourContext)
-  const cleanupRef = useRef<(() => void) | null>(null)
 
   if (!context) {
     throw new Error('useAdvanceOn must be used within a TourProvider')
@@ -24,86 +27,7 @@ export function useAdvanceOn(options: UseAdvanceOnOptions = {}): void {
   const { isActive, currentStep, next } = context
 
   useEffect(() => {
-    // Clean up previous listeners
-    if (cleanupRef.current) {
-      cleanupRef.current()
-      cleanupRef.current = null
-    }
-
-    if (!enabled || !isActive || !currentStep?.advanceOn) {
-      return
-    }
-
-    const { event, selector, handler } = currentStep.advanceOn
-
-    // Get target element (defaults to document)
-    const targetElement: Element | Document = selector
-      ? (getElement(selector) ?? document)
-      : document
-
-    if (selector && targetElement === document) {
-      logger.warn(`advanceOn: Element "${selector}" not found for step "${currentStep.id}"`)
-    }
-
-    // Debounce flag to prevent multiple rapid advances
-    let isAdvancing = false
-
-    const handleEvent = () => {
-      if (isAdvancing) return
-
-      // If handler is provided, it must return true to advance
-      if (handler) {
-        try {
-          const shouldAdvance = handler()
-          if (!shouldAdvance) return
-        } catch (error) {
-          logger.warn(`advanceOn handler error for step "${currentStep.id}":`, error)
-          return
-        }
-      }
-
-      isAdvancing = true
-      next()
-
-      // Reset after a short delay to handle race conditions
-      setTimeout(() => {
-        isAdvancing = false
-      }, 100)
-    }
-
-    // Map event types to actual DOM events
-    const eventMap: Record<string, string> = {
-      click: 'click',
-      input: 'input',
-      custom: 'tourkit:advance', // Custom event for programmatic advance
-    }
-
-    const domEvent = eventMap[event] || event
-
-    targetElement.addEventListener(domEvent, handleEvent)
-
-    cleanupRef.current = () => {
-      targetElement.removeEventListener(domEvent, handleEvent)
-    }
-
-    return () => {
-      if (cleanupRef.current) {
-        cleanupRef.current()
-        cleanupRef.current = null
-      }
-    }
+    if (!enabled || !isActive || !currentStep) return
+    return bindStepAdvance(currentStep, next)
   }, [enabled, isActive, currentStep, next])
-}
-
-/**
- * Dispatch a custom advance event (for 'custom' event type)
- * This allows programmatic advancement when the step has advanceOn: { event: 'custom' }
- *
- * @param selector - Optional CSS selector for the target element (defaults to document)
- */
-export function dispatchAdvanceEvent(selector?: string): void {
-  const target = selector ? getElement(selector) : document
-  if (target) {
-    target.dispatchEvent(new CustomEvent('tourkit:advance', { bubbles: true }))
-  }
 }

--- a/packages/core/src/hooks/use-element-position.ts
+++ b/packages/core/src/hooks/use-element-position.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { trackRect } from '../lib/track-rect'
 import type { TourTarget } from '../types/target'
 import { getElement, getScrollParent } from '../utils/dom'
-import { throttleRAF } from '../utils/throttle'
 
 export interface ElementPositionResult {
   element: HTMLElement | null
@@ -15,12 +15,15 @@ export interface ElementPositionResult {
  * selector, `RefObject`, getter) plus a direct `HTMLElement` for callers that
  * already hold the resolved node. Resolution flows through `getElement`, which
  * delegates the union branches to `resolveTarget`.
+ *
+ * A React wrapper over `trackRect` (`lib/track-rect.ts`). `update` stays a
+ * hook-owned callback because it must no-op on a null element, before any
+ * tracker exists.
  */
 export function useElementPosition(target: TourTarget | HTMLElement | null): ElementPositionResult {
   const [element, setElement] = useState<HTMLElement | null>(null)
   const [rect, setRect] = useState<DOMRect | null>(null)
   const [scrollParent, setScrollParent] = useState<HTMLElement | Window | null>(null)
-  const observerRef = useRef<ResizeObserver | null>(null)
 
   // Resolve target to element
   useEffect(() => {
@@ -35,37 +38,18 @@ export function useElementPosition(target: TourTarget | HTMLElement | null): Ele
     }
   }, [element])
 
-  // Throttle updates to RAF for smooth 60fps during scroll/resize
-  const throttledUpdate = useMemo(() => throttleRAF(update), [update])
-
   useEffect(() => {
     if (!element) {
       setRect(null)
       return
     }
 
-    update()
-
-    // Observe element resize
-    observerRef.current = new ResizeObserver(throttledUpdate)
-    observerRef.current.observe(element)
-
-    // Listen for window scroll/resize with passive listeners for better performance
-    window.addEventListener('scroll', throttledUpdate, { passive: true, capture: true })
-    window.addEventListener('resize', throttledUpdate, { passive: true })
-
-    // Also observe scrollable parent's resize if it's not window
-    if (scrollParent && scrollParent !== window && scrollParent instanceof HTMLElement) {
-      observerRef.current.observe(scrollParent)
-    }
-
-    return () => {
-      throttledUpdate.cancel()
-      observerRef.current?.disconnect()
-      window.removeEventListener('scroll', throttledUpdate, true)
-      window.removeEventListener('resize', throttledUpdate)
-    }
-  }, [element, scrollParent, update, throttledUpdate])
+    const tracker = trackRect(element, setRect, { observeResize: true })
+    // The synchronous first read this hook has always done on attach — unlike
+    // `useSpotlight`, nothing has seeded the rect here.
+    tracker.update()
+    return tracker.stop
+  }, [element])
 
   return { element, rect, scrollParent, update }
 }

--- a/packages/core/src/hooks/use-focus-trap.ts
+++ b/packages/core/src/hooks/use-focus-trap.ts
@@ -1,19 +1,7 @@
-import { useCallback, useEffect, useRef } from 'react'
-import { getFocusableElements } from '../utils/dom'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { type FocusTrapOptions, createFocusTrap } from '../lib/focus-trap'
 
-export interface UseFocusTrapOptions {
-  /**
-   * When `true`, sibling content outside the trapped container is marked
-   * `inert` + `aria-hidden="true"` while the trap is active, giving true modal
-   * semantics (`aria-modal="true"`). The subtree containing the trapped
-   * container (e.g. its portal root) is left interactive. Attributes are
-   * restored to their previous values on deactivate/unmount.
-   *
-   * Default: `false` (focus is trapped, but the background stays perceivable —
-   * appropriate for non-modal dialogs).
-   */
-  inertBackground?: boolean
-}
+export type UseFocusTrapOptions = FocusTrapOptions
 
 export interface UseFocusTrapReturn {
   containerRef: React.RefObject<HTMLElement | null>
@@ -22,70 +10,13 @@ export interface UseFocusTrapReturn {
 }
 
 /**
- * Module-level ref-count of the `inert` + `aria-hidden` applied to background
- * elements. Concurrent/nested inert-background traps may touch the same element;
- * each records the ORIGINAL (pre-any-trap) state once and increments a count,
- * and the original is only restored when the last trap releases. Without this,
- * the later trap's restore could re-apply `aria-hidden` after the first removed
- * it, stranding the background hidden from assistive tech.
+ * React wrapper over `createFocusTrap` (`lib/focus-trap.ts`). The signature is
+ * unchanged; every behaviour lives in the factory, which a Vue/Svelte/vanilla
+ * binding can drive directly from `@tour-kit/core/engine`.
+ *
+ * The `enabled` gate is the wrapper's, not the factory's: `activate()` on a
+ * disabled hook must stay a no-op, and the factory has no notion of enabled.
  */
-interface InertRecord {
-  count: number
-  originalInert: boolean
-  originalAriaHidden: string | null
-}
-const inertRegistry = new WeakMap<HTMLElement, InertRecord>()
-
-/**
- * Marks every direct child of `document.body` that does not contain `container`
- * as `inert` + `aria-hidden`, returning a function that releases this trap's
- * hold (restoring the original state once no trap needs the element hidden).
- * `container` is typically inside a portal appended to `body`, so its own portal
- * root is skipped and stays interactive.
- */
-function applyBackgroundInert(container: HTMLElement): () => void {
-  if (typeof document === 'undefined' || !document.body) return () => {}
-
-  const affected: HTMLElement[] = []
-
-  for (const child of Array.from(document.body.children)) {
-    if (!(child instanceof HTMLElement)) continue
-    // Leave the subtree that owns the trapped container interactive.
-    if (child === container || child.contains(container)) continue
-
-    affected.push(child)
-    const existing = inertRegistry.get(child)
-    if (existing) {
-      existing.count += 1
-    } else {
-      inertRegistry.set(child, {
-        count: 1,
-        originalInert: child.hasAttribute('inert'),
-        originalAriaHidden: child.getAttribute('aria-hidden'),
-      })
-      child.setAttribute('inert', '')
-      child.setAttribute('aria-hidden', 'true')
-    }
-  }
-
-  return () => {
-    for (const el of affected) {
-      const record = inertRegistry.get(el)
-      if (!record) continue
-      record.count -= 1
-      if (record.count > 0) continue
-      // Last trap released — restore the original (pre-trap) state.
-      inertRegistry.delete(el)
-      if (!record.originalInert) el.removeAttribute('inert')
-      if (record.originalAriaHidden === null) {
-        el.removeAttribute('aria-hidden')
-      } else {
-        el.setAttribute('aria-hidden', record.originalAriaHidden)
-      }
-    }
-  }
-}
-
 export function useFocusTrap(
   enabled = true,
   options: UseFocusTrapOptions = {}
@@ -93,121 +24,26 @@ export function useFocusTrap(
   const { inertBackground = false } = options
 
   const containerRef = useRef<HTMLElement | null>(null)
-  const previousActiveElement = useRef<HTMLElement | null>(null)
-  const isTrapping = useRef(false)
-  const restoreInert = useRef<(() => void) | null>(null)
-
-  const handleKeyDown = useCallback((event: KeyboardEvent) => {
-    if (!isTrapping.current || event.key !== 'Tab' || !containerRef.current) {
-      return
-    }
-
-    const container = containerRef.current
-    const focusable = getFocusableElements(container)
-
-    if (focusable.length === 0) {
-      // Nothing focusable inside — keep focus on the container itself rather
-      // than letting Tab escape to the background.
-      event.preventDefault()
-      container.focus()
-      return
-    }
-
-    const first = focusable[0]
-    const last = focusable[focusable.length - 1]
-    const active = document.activeElement
-
-    // If focus has drifted outside the container, pull it back in. Guards the
-    // case where focus is on neither the first nor last focusable (so the
-    // boundary checks below would miss it) yet has left the dialog.
-    if (!(active instanceof Node) || !container.contains(active)) {
-      event.preventDefault()
-      first.focus()
-      return
-    }
-
-    if (event.shiftKey && active === first) {
-      event.preventDefault()
-      last.focus()
-    } else if (!event.shiftKey && active === last) {
-      event.preventDefault()
-      first.focus()
-    }
-  }, [])
-
-  const activate = useCallback(() => {
-    if (!enabled || !containerRef.current) return
-    // Idempotent: don't re-capture the previously-focused element if already
-    // trapping (e.g. an effect firing twice under React Strict Mode).
-    if (isTrapping.current) return
-
-    // Prefer the element captured when the trap was enabled (see effect below).
-    // Falling back to `document.activeElement` here is a last resort — by the
-    // time activate() runs (often several renders later, once a lazy portal has
-    // mounted), focus may already have drifted to <body>.
-    if (!previousActiveElement.current) {
-      const active = document.activeElement as HTMLElement | null
-      if (active && active !== document.body) {
-        previousActiveElement.current = active
-      }
-    }
-    isTrapping.current = true
-
-    if (inertBackground) {
-      restoreInert.current = applyBackgroundInert(containerRef.current)
-    }
-
-    const focusable = getFocusableElements(containerRef.current)
-    if (focusable.length > 0) {
-      focusable[0].focus()
-    } else {
-      containerRef.current.focus?.()
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-  }, [enabled, inertBackground, handleKeyDown])
-
-  const deactivate = useCallback(() => {
-    document.removeEventListener('keydown', handleKeyDown)
-
-    restoreInert.current?.()
-    restoreInert.current = null
-
-    if (isTrapping.current && previousActiveElement.current) {
-      previousActiveElement.current.focus()
-    }
-    previousActiveElement.current = null
-    isTrapping.current = false
-  }, [handleKeyDown])
+  const trap = useMemo(
+    () => createFocusTrap(() => containerRef.current, { inertBackground }),
+    [inertBackground]
+  )
 
   // Capture the element to restore focus to as soon as the trap becomes
   // enabled — before the portal mounts or `inert`/focus moves shift
   // `document.activeElement` to <body>. activate() can run several renders
   // later (once a lazy portal node exists), by which point the trigger is no
-  // longer the active element. Capturing here makes focus restoration reliable.
+  // longer the active element.
   useEffect(() => {
-    if (!enabled) {
-      // Enabled→false without a deactivate() (e.g. the trap was enabled but its
-      // consumer never activated because a lazy portal never mounted). Clear the
-      // captured element so the next enable re-captures the correct trigger
-      // instead of restoring focus to a stale one.
-      if (!isTrapping.current) previousActiveElement.current = null
-      return
-    }
-    if (previousActiveElement.current) return
-    const active = document.activeElement as HTMLElement | null
-    if (active && active !== document.body) {
-      previousActiveElement.current = active
-    }
-  }, [enabled])
+    if (enabled) trap.capture()
+    else trap.forget()
+  }, [enabled, trap])
 
-  useEffect(() => {
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-      restoreInert.current?.()
-      restoreInert.current = null
-    }
-  }, [handleKeyDown])
+  useEffect(() => () => trap.release(), [trap])
 
-  return { containerRef, activate, deactivate }
+  const activate = useCallback(() => {
+    if (enabled) trap.activate()
+  }, [enabled, trap])
+
+  return { containerRef, activate, deactivate: trap.deactivate }
 }

--- a/packages/core/src/hooks/use-keyboard.ts
+++ b/packages/core/src/hooks/use-keyboard.ts
@@ -1,8 +1,14 @@
 import { useContext, useEffect, useMemo } from 'react'
 import { TourContext } from '../context/tour-context'
+import { attachKeyboard } from '../lib/keyboard'
 import type { KeyboardConfig } from '../types'
 import { defaultKeyboardConfig } from '../types/config'
 
+/**
+ * React wrapper over `attachKeyboard` (`lib/keyboard.ts`). The effect's
+ * `isActive` dep is the gate — the factory's `isEnabled` predicate exists for
+ * bindings that attach once and never re-run.
+ */
 export function useKeyboardNavigation(config?: KeyboardConfig): void {
   const context = useContext(TourContext)
 
@@ -15,35 +21,6 @@ export function useKeyboardNavigation(config?: KeyboardConfig): void {
 
   useEffect(() => {
     if (!isActive || !mergedConfig.enabled) return
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const { key } = event
-
-      // Ignore if user is typing in an input, select, or editable region
-      const active = document.activeElement as HTMLElement | null
-      if (
-        active instanceof HTMLInputElement ||
-        active instanceof HTMLTextAreaElement ||
-        active instanceof HTMLSelectElement ||
-        active?.isContentEditable ||
-        active?.getAttribute('role') === 'textbox'
-      ) {
-        return
-      }
-
-      if (mergedConfig.nextKeys?.includes(key)) {
-        event.preventDefault()
-        next()
-      } else if (mergedConfig.prevKeys?.includes(key)) {
-        event.preventDefault()
-        prev()
-      } else if (mergedConfig.exitKeys?.includes(key)) {
-        event.preventDefault()
-        skip()
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+    return attachKeyboard({ next, prev, skip }, mergedConfig)
   }, [isActive, mergedConfig, next, prev, skip])
 }

--- a/packages/core/src/hooks/use-spotlight.ts
+++ b/packages/core/src/hooks/use-spotlight.ts
@@ -24,7 +24,11 @@ export function useSpotlight(): UseSpotlightReturn {
   const [isVisible, setIsVisible] = useState(false)
   const [targetRect, setTargetRect] = useState<DOMRect | null>(null)
   const [config, setConfig] = useState<SpotlightConfig>(defaultSpotlightConfig)
+  // The same node twice, on purpose. The ref is what `updateRect` reads, so
+  // that callback can stay identity-stable across renders; the state slot is
+  // what keys the tracking effect, so a retarget re-runs it.
   const targetRef = useRef<HTMLElement | null>(null)
+  const [target, setTarget] = useState<HTMLElement | null>(null)
 
   const updateRect = useCallback(() => {
     if (targetRef.current) {
@@ -33,24 +37,31 @@ export function useSpotlight(): UseSpotlightReturn {
   }, [])
 
   useEffect(() => {
-    const el = targetRef.current
-    // The null check is for the type (`trackRect` takes a non-null element) and
-    // for `hide()`, which nulls the ref. No attach-time read: `show()` has
-    // already seeded the rect, and reading again would cost a render.
-    if (!isVisible || !el) return
-    return trackRect(el, setTargetRect).stop
-  }, [isVisible])
+    // Keyed on `target`, not just `isVisible`: `TourOverlay` advances a step by
+    // calling `show(newTarget)` with no `hide()` in between, so `isVisible`
+    // never flips and an effect keyed on it alone would keep tracking the
+    // previous step's element. (Before §1.3b the handler re-read the ref on
+    // every scroll and followed the swap for free; `trackRect` takes a concrete
+    // element, so the re-run has to be explicit.)
+    //
+    // No attach-time read: `show()` has already seeded the rect, and reading
+    // again would cost a render.
+    if (!isVisible || !target) return
+    return trackRect(target, setTargetRect).stop
+  }, [isVisible, target])
 
-  const show = useCallback((target: HTMLElement, spotlightConfig?: SpotlightConfig) => {
-    targetRef.current = target
+  const show = useCallback((next: HTMLElement, spotlightConfig?: SpotlightConfig) => {
+    targetRef.current = next
+    setTarget(next)
     setConfig({ ...defaultSpotlightConfig, ...spotlightConfig })
-    setTargetRect(target.getBoundingClientRect())
+    setTargetRect(next.getBoundingClientRect())
     setIsVisible(true)
   }, [])
 
   const hide = useCallback(() => {
     setIsVisible(false)
     targetRef.current = null
+    setTarget(null)
     setTargetRect(null)
   }, [])
 

--- a/packages/core/src/hooks/use-spotlight.ts
+++ b/packages/core/src/hooks/use-spotlight.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { computeSpotlight } from '../lib/spotlight'
 import { trackRect } from '../lib/track-rect'
 import type { SpotlightConfig } from '../types'
@@ -15,26 +15,26 @@ export interface UseSpotlightReturn {
 }
 
 /**
- * React wrapper over `trackRect` + `computeSpotlight` (`lib/`). The state, the
- * target ref and the returned `update` stay here: `update` must work while the
- * spotlight is hidden (no tracker exists then), which a tracker handle created
- * inside an effect cannot provide.
+ * React wrapper over `trackRect` + `computeSpotlight` (`lib/`). The state and
+ * the returned `update` stay here: `update` must work while the spotlight is
+ * hidden (no tracker exists then), which a tracker handle created inside an
+ * effect cannot provide.
  */
 export function useSpotlight(): UseSpotlightReturn {
   const [isVisible, setIsVisible] = useState(false)
   const [targetRect, setTargetRect] = useState<DOMRect | null>(null)
   const [config, setConfig] = useState<SpotlightConfig>(defaultSpotlightConfig)
-  // The same node twice, on purpose. The ref is what `updateRect` reads, so
-  // that callback can stay identity-stable across renders; the state slot is
-  // what keys the tracking effect, so a retarget re-runs it.
-  const targetRef = useRef<HTMLElement | null>(null)
+  // ONE source of truth for the current target. `show(a)` then `show(b)` with
+  // no `hide()` between is a real flow (`TourOverlay` advances that way), and
+  // holding the node in two places is what let the tracker keep following the
+  // previous step's element.
   const [target, setTarget] = useState<HTMLElement | null>(null)
 
   const updateRect = useCallback(() => {
-    if (targetRef.current) {
-      setTargetRect(targetRef.current.getBoundingClientRect())
+    if (target) {
+      setTargetRect(target.getBoundingClientRect())
     }
-  }, [])
+  }, [target])
 
   useEffect(() => {
     // Keyed on `target`, not just `isVisible`: `TourOverlay` advances a step by
@@ -51,7 +51,6 @@ export function useSpotlight(): UseSpotlightReturn {
   }, [isVisible, target])
 
   const show = useCallback((next: HTMLElement, spotlightConfig?: SpotlightConfig) => {
-    targetRef.current = next
     setTarget(next)
     setConfig({ ...defaultSpotlightConfig, ...spotlightConfig })
     setTargetRect(next.getBoundingClientRect())
@@ -60,7 +59,6 @@ export function useSpotlight(): UseSpotlightReturn {
 
   const hide = useCallback(() => {
     setIsVisible(false)
-    targetRef.current = null
     setTarget(null)
     setTargetRect(null)
   }, [])

--- a/packages/core/src/hooks/use-spotlight.ts
+++ b/packages/core/src/hooks/use-spotlight.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { computeSpotlight } from '../lib/spotlight'
+import { trackRect } from '../lib/track-rect'
 import type { SpotlightConfig } from '../types'
 import { defaultSpotlightConfig } from '../types/config'
-import { throttleRAF } from '../utils/throttle'
 
 export interface UseSpotlightReturn {
   isVisible: boolean
@@ -13,6 +14,12 @@ export interface UseSpotlightReturn {
   update: () => void
 }
 
+/**
+ * React wrapper over `trackRect` + `computeSpotlight` (`lib/`). The state, the
+ * target ref and the returned `update` stay here: `update` must work while the
+ * spotlight is hidden (no tracker exists then), which a tracker handle created
+ * inside an effect cannot provide.
+ */
 export function useSpotlight(): UseSpotlightReturn {
   const [isVisible, setIsVisible] = useState(false)
   const [targetRect, setTargetRect] = useState<DOMRect | null>(null)
@@ -25,21 +32,14 @@ export function useSpotlight(): UseSpotlightReturn {
     }
   }, [])
 
-  // Throttle updates to RAF for smooth 60fps during scroll/resize
-  const throttledUpdateRect = useMemo(() => throttleRAF(updateRect), [updateRect])
-
   useEffect(() => {
-    if (!isVisible) return
-
-    window.addEventListener('scroll', throttledUpdateRect, { passive: true, capture: true })
-    window.addEventListener('resize', throttledUpdateRect, { passive: true })
-
-    return () => {
-      throttledUpdateRect.cancel()
-      window.removeEventListener('scroll', throttledUpdateRect, true)
-      window.removeEventListener('resize', throttledUpdateRect)
-    }
-  }, [isVisible, throttledUpdateRect])
+    const el = targetRef.current
+    // The null check is for the type (`trackRect` takes a non-null element) and
+    // for `hide()`, which nulls the ref. No attach-time read: `show()` has
+    // already seeded the rect, and reading again would cost a render.
+    if (!isVisible || !el) return
+    return trackRect(el, setTargetRect).stop
+  }, [isVisible])
 
   const show = useCallback((target: HTMLElement, spotlightConfig?: SpotlightConfig) => {
     targetRef.current = target
@@ -54,42 +54,17 @@ export function useSpotlight(): UseSpotlightReturn {
     setTargetRect(null)
   }, [])
 
-  const overlayStyle = useMemo<React.CSSProperties>(
-    () => ({
-      position: 'fixed',
-      inset: 0,
-      backgroundColor: 'transparent',
-      transition: config.animate ? `all ${config.animationDuration ?? 300}ms ease-out` : undefined,
-      pointerEvents: 'auto',
-    }),
-    [config]
+  const { overlayStyle, cutoutStyle } = useMemo(
+    () => computeSpotlight(targetRect, config),
+    [targetRect, config]
   )
-
-  const cutoutStyle = useMemo<React.CSSProperties>(() => {
-    if (!targetRect) return {}
-
-    const padding = config.padding ?? 8
-    const borderRadius = config.borderRadius ?? 4
-
-    return {
-      position: 'absolute',
-      top: targetRect.top - padding,
-      left: targetRect.left - padding,
-      width: targetRect.width + padding * 2,
-      height: targetRect.height + padding * 2,
-      borderRadius,
-      boxShadow: `0 0 0 9999px ${config.color ?? 'rgba(0, 0, 0, 0.5)'}`,
-      transition: config.animate ? `all ${config.animationDuration ?? 300}ms ease-out` : undefined,
-      pointerEvents: 'none',
-    }
-  }, [targetRect, config])
 
   return useMemo(
     () => ({
       isVisible,
       targetRect,
       overlayStyle,
-      cutoutStyle,
+      cutoutStyle: cutoutStyle ?? {},
       show,
       hide,
       update: updateRect,

--- a/packages/core/src/lib/advance-on.ts
+++ b/packages/core/src/lib/advance-on.ts
@@ -13,7 +13,6 @@
 import type { TourStep } from '../types/step'
 import { getElement } from '../utils/dom'
 import { logger } from '../utils/logger'
-import type { TourEngine } from './tour-engine/create-tour-engine'
 
 /** Reset delay for the re-entrancy flag, in ms. */
 const ADVANCE_DEBOUNCE_MS = 100
@@ -88,13 +87,25 @@ export function bindStepAdvance(step: TourStep, next: () => unknown): () => void
 }
 
 /**
- * Keep one step binding in sync with an engine's current step.
+ * What this needs from whoever owns the tour. Structural, like
+ * `KeyboardActions` and `TestBridgeTarget` — a `TourEngine` satisfies it, and
+ * so does anything else that can report a current step and advance. Declared
+ * here rather than `Pick<TourEngine, ...>` so this leaf keeps no edge into
+ * `lib/tour-engine/`.
+ */
+export interface AdvanceOnTarget {
+  /** Listeners take no arguments and read `getState()` themselves. */
+  subscribe(listener: () => void): () => void
+  getState(): { isActive: boolean; currentStep: TourStep | null }
+  next(): unknown
+}
+
+/**
+ * Keep one step binding in sync with a target's current step.
  *
  * @returns Detach — unsubscribes and cleans up the live binding. Idempotent.
  */
-export function attachAdvanceOn(
-  engine: Pick<TourEngine, 'subscribe' | 'getState' | 'next'>
-): () => void {
+export function attachAdvanceOn(engine: AdvanceOnTarget): () => void {
   let cleanup = noop
   let bound: TourStep | null = null
 

--- a/packages/core/src/lib/advance-on.ts
+++ b/packages/core/src/lib/advance-on.ts
@@ -1,0 +1,27 @@
+/** v2 §1.3b — RED STUB for the advance-on binder. */
+import type { TourStep } from '../types/step'
+import { getElement } from '../utils/dom'
+import type { TourEngine } from './tour-engine/create-tour-engine'
+
+export function bindStepAdvance(_step: TourStep, _next: () => unknown): () => void {
+  throw new Error('bindStepAdvance: not implemented')
+}
+
+export function attachAdvanceOn(
+  _engine: Pick<TourEngine, 'subscribe' | 'getState' | 'next'>
+): () => void {
+  throw new Error('attachAdvanceOn: not implemented')
+}
+
+/**
+ * Dispatch a custom advance event (for 'custom' event type)
+ * This allows programmatic advancement when the step has advanceOn: { event: 'custom' }
+ *
+ * @param selector - Optional CSS selector for the target element (defaults to document)
+ */
+export function dispatchAdvanceEvent(selector?: string): void {
+  const target = selector ? getElement(selector) : document
+  if (target) {
+    target.dispatchEvent(new CustomEvent('tourkit:advance', { bubbles: true }))
+  }
+}

--- a/packages/core/src/lib/advance-on.ts
+++ b/packages/core/src/lib/advance-on.ts
@@ -1,16 +1,125 @@
-/** v2 §1.3b — RED STUB for the advance-on binder. */
+/**
+ * v2 §1.3b — `use-advance-on.ts`'s body as plain functions.
+ *
+ * Two layers, because two consumers want different things. `bindStepAdvance`
+ * binds ONE step and returns its cleanup — that is all the React hook needs,
+ * and it makes the hook's `cleanupRef` dance disappear, because the effect
+ * cleanup IS the cleanup. `attachAdvanceOn` is the engine-level sugar a
+ * non-React binding wants: subscribe once, rebind whenever the current step
+ * changes identity.
+ *
+ * @module advance-on
+ */
 import type { TourStep } from '../types/step'
 import { getElement } from '../utils/dom'
+import { logger } from '../utils/logger'
 import type { TourEngine } from './tour-engine/create-tour-engine'
 
-export function bindStepAdvance(_step: TourStep, _next: () => unknown): () => void {
-  throw new Error('bindStepAdvance: not implemented')
+/** Reset delay for the re-entrancy flag, in ms. */
+const ADVANCE_DEBOUNCE_MS = 100
+
+/** Authored event names that do not match their DOM event name. */
+const EVENT_MAP: Record<string, string> = {
+  click: 'click',
+  input: 'input',
+  custom: 'tourkit:advance',
 }
 
+const noop = () => {}
+
+/**
+ * Bind one step's `advanceOn` rule.
+ *
+ * @returns Cleanup. A no-op when the step has no `advanceOn` or there is no
+ *   `document`.
+ */
+export function bindStepAdvance(step: TourStep, next: () => unknown): () => void {
+  if (!step.advanceOn || typeof document === 'undefined') return noop
+
+  const { event, selector, handler } = step.advanceOn
+
+  // Get target element (defaults to document)
+  const targetElement: Element | Document = selector ? (getElement(selector) ?? document) : document
+
+  if (selector && targetElement === document) {
+    logger.warn(`advanceOn: Element "${selector}" not found for step "${step.id}"`)
+  }
+
+  // Debounce flag to prevent multiple rapid advances.
+  let isAdvancing = false
+  let resetTimer: ReturnType<typeof setTimeout> | null = null
+
+  const handleEvent = () => {
+    if (isAdvancing) return
+
+    // If handler is provided, it must return true to advance. Note it runs
+    // BEFORE the flag is set: a rejected event must leave the window open, or
+    // the first accepted event after a rejection is swallowed.
+    if (handler) {
+      try {
+        if (!handler()) return
+      } catch (error) {
+        logger.warn(`advanceOn handler error for step "${step.id}":`, error)
+        return
+      }
+    }
+
+    isAdvancing = true
+    next()
+
+    // Reset after a short delay to handle race conditions.
+    resetTimer = setTimeout(() => {
+      isAdvancing = false
+      resetTimer = null
+    }, ADVANCE_DEBOUNCE_MS)
+  }
+
+  const domEvent = EVENT_MAP[event] || event
+  targetElement.addEventListener(domEvent, handleEvent)
+
+  return () => {
+    targetElement.removeEventListener(domEvent, handleEvent)
+    // The hook left this timer to fire on a dead closure. Harmless, but a leak.
+    if (resetTimer !== null) {
+      clearTimeout(resetTimer)
+      resetTimer = null
+    }
+  }
+}
+
+/**
+ * Keep one step binding in sync with an engine's current step.
+ *
+ * @returns Detach — unsubscribes and cleans up the live binding. Idempotent.
+ */
 export function attachAdvanceOn(
-  _engine: Pick<TourEngine, 'subscribe' | 'getState' | 'next'>
+  engine: Pick<TourEngine, 'subscribe' | 'getState' | 'next'>
 ): () => void {
-  throw new Error('attachAdvanceOn: not implemented')
+  let cleanup = noop
+  let bound: TourStep | null = null
+
+  const sync = () => {
+    const { isActive, currentStep } = engine.getState()
+    const wanted = isActive ? (currentStep ?? null) : null
+    // Identity, not id: an author can swap a step's `advanceOn` under the same
+    // id via setTours, and the binding has to follow.
+    if (wanted === bound) return
+
+    cleanup()
+    cleanup = noop
+    bound = wanted
+    if (wanted) cleanup = bindStepAdvance(wanted, () => engine.next())
+  }
+
+  sync()
+  const unsubscribe = engine.subscribe(sync)
+
+  return () => {
+    unsubscribe()
+    cleanup()
+    cleanup = noop
+    bound = null
+  }
 }
 
 /**

--- a/packages/core/src/lib/focus-trap.ts
+++ b/packages/core/src/lib/focus-trap.ts
@@ -1,0 +1,26 @@
+/**
+ * v2 §1.3b — `use-focus-trap.ts`'s body as a plain factory.
+ *
+ * RED STUB. The real implementation lands in the next commit.
+ */
+export interface FocusTrapOptions {
+  inertBackground?: boolean
+}
+
+export interface FocusTrap {
+  capture(): void
+  forget(): void
+  activate(): void
+  deactivate(): void
+  release(): void
+}
+
+export function createFocusTrap(
+  _getContainer: () => HTMLElement | null,
+  _options: FocusTrapOptions = {}
+): FocusTrap {
+  const notYet = () => {
+    throw new Error('createFocusTrap: not implemented')
+  }
+  return { capture: notYet, forget: notYet, activate: notYet, deactivate: notYet, release: notYet }
+}

--- a/packages/core/src/lib/focus-trap.ts
+++ b/packages/core/src/lib/focus-trap.ts
@@ -45,7 +45,10 @@ export interface FocusTrap {
   activate(): void
   /** Remove the handler, restore inert, restore focus to the captured element. */
   deactivate(): void
-  /** Teardown without focus restore — the unmount path. Idempotent. */
+  /**
+   * Teardown without focus restore — the unmount path. Idempotent, and
+   * re-armable: a later `activate()` engages the trap again.
+   */
   release(): void
 }
 
@@ -230,6 +233,13 @@ export function createFocusTrap(
       isTrapping = false
     },
 
-    release: teardown,
+    release: () => {
+      teardown()
+      // Reset the flag, or `activate()` bails on its idempotence guard and
+      // the trap is silently dead. Harmless while this was a hook (unmount
+      // threw the closure away); not harmless now that a binding drives
+      // release/re-activate cycles through `/engine`.
+      isTrapping = false
+    },
   }
 }

--- a/packages/core/src/lib/focus-trap.ts
+++ b/packages/core/src/lib/focus-trap.ts
@@ -1,26 +1,235 @@
 /**
- * v2 §1.3b — `use-focus-trap.ts`'s body as a plain factory.
+ * v2 §1.3b — `use-focus-trap.ts`'s body as a plain, React-free factory.
  *
- * RED STUB. The real implementation lands in the next commit.
+ * **Two phases, deliberately.** Both `TourCard` (`TourPortal`) and
+ * `SurveyPopover` (`FloatingPortal`) mount their node AFTER the render in
+ * which the trap becomes enabled, so by the time a consumer can call
+ * `activate()` the trigger is no longer `document.activeElement` — focus has
+ * drifted to `<body>`. `capture()` records the return target the moment the
+ * trap is enabled; `activate()` engages once the node exists. The container is
+ * a getter for the same reason: it arrives late.
+ *
+ * @module focus-trap
  */
+import { getFocusableElements } from '../utils/dom'
+
 export interface FocusTrapOptions {
+  /**
+   * When `true`, sibling content outside the trapped container is marked
+   * `inert` + `aria-hidden="true"` while the trap is active, giving true modal
+   * semantics (`aria-modal="true"`). The subtree containing the trapped
+   * container (e.g. its portal root) is left interactive. Attributes are
+   * restored to their previous values on `deactivate()` / `release()`.
+   *
+   * Default: `false` (focus is trapped, but the background stays perceivable —
+   * appropriate for non-modal dialogs).
+   */
   inertBackground?: boolean
 }
 
 export interface FocusTrap {
+  /**
+   * Record `document.activeElement` as the return target, once. Call when the
+   * trap becomes enabled — before any portal mounts.
+   */
   capture(): void
+  /**
+   * Drop the recorded target without restoring focus. For enabled → false with
+   * no `activate()` in between. A no-op while trapping.
+   */
   forget(): void
+  /**
+   * Focus the first focusable (or the container), install the Tab handler,
+   * inert the background. Idempotent; bails when the getter returns `null`.
+   */
   activate(): void
+  /** Remove the handler, restore inert, restore focus to the captured element. */
   deactivate(): void
+  /** Teardown without focus restore — the unmount path. Idempotent. */
   release(): void
 }
 
-export function createFocusTrap(
-  _getContainer: () => HTMLElement | null,
-  _options: FocusTrapOptions = {}
-): FocusTrap {
-  const notYet = () => {
-    throw new Error('createFocusTrap: not implemented')
+/**
+ * Module-level ref-count of the `inert` + `aria-hidden` applied to background
+ * elements. Concurrent/nested inert-background traps may touch the same element;
+ * each records the ORIGINAL (pre-any-trap) state once and increments a count,
+ * and the original is only restored when the last trap releases. Without this,
+ * the later trap's restore could re-apply `aria-hidden` after the first removed
+ * it, stranding the background hidden from assistive tech.
+ */
+interface InertRecord {
+  count: number
+  originalInert: boolean
+  originalAriaHidden: string | null
+}
+const inertRegistry = new WeakMap<HTMLElement, InertRecord>()
+
+/**
+ * Marks every direct child of `document.body` that does not contain `container`
+ * as `inert` + `aria-hidden`, returning a function that releases this trap's
+ * hold (restoring the original state once no trap needs the element hidden).
+ * `container` is typically inside a portal appended to `body`, so its own portal
+ * root is skipped and stays interactive.
+ */
+function applyBackgroundInert(container: HTMLElement): () => void {
+  if (typeof document === 'undefined' || !document.body) return () => {}
+
+  const affected: HTMLElement[] = []
+
+  for (const child of Array.from(document.body.children)) {
+    if (!(child instanceof HTMLElement)) continue
+    // Leave the subtree that owns the trapped container interactive.
+    if (child === container || child.contains(container)) continue
+
+    affected.push(child)
+    const existing = inertRegistry.get(child)
+    if (existing) {
+      existing.count += 1
+    } else {
+      inertRegistry.set(child, {
+        count: 1,
+        originalInert: child.hasAttribute('inert'),
+        originalAriaHidden: child.getAttribute('aria-hidden'),
+      })
+      child.setAttribute('inert', '')
+      child.setAttribute('aria-hidden', 'true')
+    }
   }
-  return { capture: notYet, forget: notYet, activate: notYet, deactivate: notYet, release: notYet }
+
+  return () => {
+    for (const el of affected) {
+      const record = inertRegistry.get(el)
+      if (!record) continue
+      record.count -= 1
+      if (record.count > 0) continue
+      // Last trap released — restore the original (pre-trap) state.
+      inertRegistry.delete(el)
+      if (!record.originalInert) el.removeAttribute('inert')
+      if (record.originalAriaHidden === null) {
+        el.removeAttribute('aria-hidden')
+      } else {
+        el.setAttribute('aria-hidden', record.originalAriaHidden)
+      }
+    }
+  }
+}
+
+/** Every method is a no-op on the server; a `useMemo` may build one there. */
+const NOOP_TRAP: FocusTrap = {
+  capture: () => {},
+  forget: () => {},
+  activate: () => {},
+  deactivate: () => {},
+  release: () => {},
+}
+
+export function createFocusTrap(
+  getContainer: () => HTMLElement | null,
+  options: FocusTrapOptions = {}
+): FocusTrap {
+  if (typeof document === 'undefined') return NOOP_TRAP
+
+  const { inertBackground = false } = options
+
+  // Closure variables where the hook had refs.
+  let previousActiveElement: HTMLElement | null = null
+  let isTrapping = false
+  let restoreInert: (() => void) | null = null
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    const container = getContainer()
+    if (!isTrapping || event.key !== 'Tab' || !container) return
+
+    const focusable = getFocusableElements(container)
+
+    if (focusable.length === 0) {
+      // Nothing focusable inside — keep focus on the container itself rather
+      // than letting Tab escape to the background.
+      event.preventDefault()
+      container.focus()
+      return
+    }
+
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const active = document.activeElement
+
+    // If focus has drifted outside the container, pull it back in. Guards the
+    // case where focus is on neither the first nor last focusable (so the
+    // boundary checks below would miss it) yet has left the dialog.
+    if (!(active instanceof Node) || !container.contains(active)) {
+      event.preventDefault()
+      first.focus()
+      return
+    }
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  const capture = (): void => {
+    if (previousActiveElement) return
+    const active = document.activeElement as HTMLElement | null
+    if (active && active !== document.body) previousActiveElement = active
+  }
+
+  /** Drop the handler + inert hold. Shared by `deactivate()` and `release()`. */
+  const teardown = (): void => {
+    document.removeEventListener('keydown', handleKeyDown)
+    restoreInert?.()
+    restoreInert = null
+  }
+
+  return {
+    capture,
+
+    forget: () => {
+      // Enabled→false without a deactivate() (e.g. the trap was enabled but its
+      // consumer never activated because a lazy portal never mounted). Clear the
+      // captured element so the next enable re-captures the correct trigger
+      // instead of restoring focus to a stale one.
+      if (!isTrapping) previousActiveElement = null
+    },
+
+    activate: () => {
+      const container = getContainer()
+      if (!container) return
+      // Idempotent: don't re-capture the previously-focused element if already
+      // trapping (e.g. an effect firing twice under React Strict Mode).
+      if (isTrapping) return
+
+      // Prefer the element captured when the trap was enabled. Falling back to
+      // `document.activeElement` here is a last resort — by the time activate()
+      // runs (often several renders later, once a lazy portal has mounted),
+      // focus may already have drifted to <body>.
+      capture()
+      isTrapping = true
+
+      if (inertBackground) restoreInert = applyBackgroundInert(container)
+
+      const focusable = getFocusableElements(container)
+      if (focusable.length > 0) {
+        focusable[0].focus()
+      } else {
+        container.focus?.()
+      }
+
+      document.addEventListener('keydown', handleKeyDown)
+    },
+
+    deactivate: () => {
+      teardown()
+
+      if (isTrapping && previousActiveElement) previousActiveElement.focus()
+      previousActiveElement = null
+      isTrapping = false
+    },
+
+    release: teardown,
+  }
 }

--- a/packages/core/src/lib/keyboard.ts
+++ b/packages/core/src/lib/keyboard.ts
@@ -1,12 +1,18 @@
 /**
  * v2 §1.3b — `use-keyboard.ts`'s body as a plain, React-free function.
  *
- * **Gating is a predicate, not a subscription** (§1.3b Decision 2). The hook
- * attaches inside an effect keyed on `isActive`, so it simply does not listen
- * while a tour is idle. A plain function has no idea when a tour is active, and
- * subscribing here would give `lib/` something to leak and an ordering to
- * state. Instead `isEnabled?.()` is read inside the handler: a binding attaches
- * once at mount and passes `() => engine.getState().isActive`.
+ * **Gating is a predicate, not a subscription** (§1.3b Decision 2), because
+ * nothing here has to be rebuilt when the tour changes: the listener sits on
+ * `document` and the three actions are stable, so knowing whether a tour is
+ * live is the only per-event question. `isEnabled?.()` answers it inside the
+ * handler — a binding attaches once at mount and passes
+ * `() => engine.getState().isActive`. Contrast `attachAdvanceOn`, which DOES
+ * subscribe: its listener hangs off the current step's target element, so a
+ * step change forces a genuine rebind and there is nothing a predicate could
+ * do about it.
+ *
+ * The React wrapper uses neither, because an effect keyed on `isActive`
+ * already detaches while the tour is idle.
  *
  * @module keyboard
  */

--- a/packages/core/src/lib/keyboard.ts
+++ b/packages/core/src/lib/keyboard.ts
@@ -1,0 +1,23 @@
+/**
+ * v2 §1.3b — RED STUB for `attachKeyboard`.
+ */
+import type { KeyboardConfig } from '../types'
+
+export interface KeyboardActions {
+  next(): unknown
+  prev(): unknown
+  skip(): unknown
+}
+
+export interface AttachKeyboardOptions {
+  /** Checked inside the handler, per event. Not a subscription. */
+  isEnabled?: () => boolean
+}
+
+export function attachKeyboard(
+  _actions: KeyboardActions,
+  _config?: KeyboardConfig,
+  _options?: AttachKeyboardOptions
+): () => void {
+  throw new Error('attachKeyboard: not implemented')
+}

--- a/packages/core/src/lib/keyboard.ts
+++ b/packages/core/src/lib/keyboard.ts
@@ -1,7 +1,17 @@
 /**
- * v2 §1.3b — RED STUB for `attachKeyboard`.
+ * v2 §1.3b — `use-keyboard.ts`'s body as a plain, React-free function.
+ *
+ * **Gating is a predicate, not a subscription** (§1.3b Decision 2). The hook
+ * attaches inside an effect keyed on `isActive`, so it simply does not listen
+ * while a tour is idle. A plain function has no idea when a tour is active, and
+ * subscribing here would give `lib/` something to leak and an ordering to
+ * state. Instead `isEnabled?.()` is read inside the handler: a binding attaches
+ * once at mount and passes `() => engine.getState().isActive`.
+ *
+ * @module keyboard
  */
 import type { KeyboardConfig } from '../types'
+import { defaultKeyboardConfig } from '../types/config'
 
 export interface KeyboardActions {
   next(): unknown
@@ -10,14 +20,54 @@ export interface KeyboardActions {
 }
 
 export interface AttachKeyboardOptions {
-  /** Checked inside the handler, per event. Not a subscription. */
+  /** Evaluated inside every keydown. Returning `false` suppresses the event. */
   isEnabled?: () => boolean
 }
 
+/** Typing in a field must never advance the tour. */
+function isEditable(el: HTMLElement | null): boolean {
+  return (
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement ||
+    !!el?.isContentEditable ||
+    el?.getAttribute('role') === 'textbox'
+  )
+}
+
+const noop = () => {}
+
+/**
+ * Wire arrow/exit keys on `document` to three actions.
+ *
+ * @returns Detach. Idempotent.
+ */
 export function attachKeyboard(
-  _actions: KeyboardActions,
-  _config?: KeyboardConfig,
-  _options?: AttachKeyboardOptions
+  actions: KeyboardActions,
+  config?: KeyboardConfig,
+  options?: AttachKeyboardOptions
 ): () => void {
-  throw new Error('attachKeyboard: not implemented')
+  const merged = { ...defaultKeyboardConfig, ...config }
+  if (!merged.enabled || typeof document === 'undefined') return noop
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (options?.isEnabled && !options.isEnabled()) return
+
+    if (isEditable(document.activeElement as HTMLElement | null)) return
+
+    const { key } = event
+    if (merged.nextKeys?.includes(key)) {
+      event.preventDefault()
+      actions.next()
+    } else if (merged.prevKeys?.includes(key)) {
+      event.preventDefault()
+      actions.prev()
+    } else if (merged.exitKeys?.includes(key)) {
+      event.preventDefault()
+      actions.skip()
+    }
+  }
+
+  document.addEventListener('keydown', handleKeyDown)
+  return () => document.removeEventListener('keydown', handleKeyDown)
 }

--- a/packages/core/src/lib/spotlight.ts
+++ b/packages/core/src/lib/spotlight.ts
@@ -1,0 +1,29 @@
+/** v2 §1.3b — RED STUB for `computeSpotlight`. */
+import type { SpotlightConfig } from '../types'
+
+export interface SpotlightOverlayStyle {
+  position: 'fixed'
+  inset: 0
+  backgroundColor: string
+  transition?: string
+  pointerEvents: 'auto'
+}
+
+export interface SpotlightCutoutStyle {
+  position: 'absolute'
+  top: number
+  left: number
+  width: number
+  height: number
+  borderRadius: number
+  boxShadow: string
+  transition?: string
+  pointerEvents: 'none'
+}
+
+export function computeSpotlight(
+  _rect: DOMRect | null,
+  _config?: SpotlightConfig
+): { overlayStyle: SpotlightOverlayStyle; cutoutStyle: SpotlightCutoutStyle | null } {
+  throw new Error('computeSpotlight: not implemented')
+}

--- a/packages/core/src/lib/spotlight.ts
+++ b/packages/core/src/lib/spotlight.ts
@@ -1,9 +1,20 @@
-/** v2 §1.3b — RED STUB for `computeSpotlight`. */
+/**
+ * v2 §1.3b — `use-spotlight.ts`'s two `useMemo`s as one pure function.
+ *
+ * The returned shapes are React-free interfaces with literal-typed `position`
+ * and `pointerEvents`, which is what makes them assignable to
+ * `React.CSSProperties` without this file ever naming React.
+ * `__tests__/types/spotlight-styles.test-d.ts` holds that check.
+ *
+ * @module spotlight
+ */
 import type { SpotlightConfig } from '../types'
+import { defaultSpotlightConfig } from '../types/config'
 
 export interface SpotlightOverlayStyle {
   position: 'fixed'
   inset: 0
+  /** Always `'transparent'`. The colour is the cutout's `boxShadow`. */
   backgroundColor: string
   transition?: string
   pointerEvents: 'auto'
@@ -16,14 +27,49 @@ export interface SpotlightCutoutStyle {
   width: number
   height: number
   borderRadius: number
+  /** `0 0 0 9999px <color>` — the ring that darkens everything but the hole. */
   boxShadow: string
   transition?: string
   pointerEvents: 'none'
 }
 
-export function computeSpotlight(
-  _rect: DOMRect | null,
-  _config?: SpotlightConfig
-): { overlayStyle: SpotlightOverlayStyle; cutoutStyle: SpotlightCutoutStyle | null } {
-  throw new Error('computeSpotlight: not implemented')
+export interface SpotlightStyles {
+  overlayStyle: SpotlightOverlayStyle
+  /** `null` when there is no target rect. The hook maps that to `{}`. */
+  cutoutStyle: SpotlightCutoutStyle | null
+}
+
+export function computeSpotlight(rect: DOMRect | null, config?: SpotlightConfig): SpotlightStyles {
+  const merged = { ...defaultSpotlightConfig, ...config }
+  const transition = merged.animate
+    ? `all ${merged.animationDuration ?? 300}ms ease-out`
+    : undefined
+
+  const overlayStyle: SpotlightOverlayStyle = {
+    position: 'fixed',
+    inset: 0,
+    backgroundColor: 'transparent',
+    transition,
+    pointerEvents: 'auto',
+  }
+
+  if (!rect) return { overlayStyle, cutoutStyle: null }
+
+  const padding = merged.padding ?? 8
+  const borderRadius = merged.borderRadius ?? 4
+
+  return {
+    overlayStyle,
+    cutoutStyle: {
+      position: 'absolute',
+      top: rect.top - padding,
+      left: rect.left - padding,
+      width: rect.width + padding * 2,
+      height: rect.height + padding * 2,
+      borderRadius,
+      boxShadow: `0 0 0 9999px ${merged.color ?? 'rgba(0, 0, 0, 0.5)'}`,
+      transition,
+      pointerEvents: 'none',
+    },
+  }
 }

--- a/packages/core/src/lib/test-bridge.ts
+++ b/packages/core/src/lib/test-bridge.ts
@@ -1,0 +1,24 @@
+/** v2 §1.3b — RED STUB for `attachTestBridge`. */
+import type { EligibilityReport } from '../types/diagnostic'
+
+export interface TestBridgeTarget {
+  start(tourId: string): unknown
+  next(): unknown
+  prev(): unknown
+  goToStep(stepId: string): unknown
+  complete(): void
+  skip(): void
+  getDiagnostic?(tourId: string): EligibilityReport | null
+}
+
+export interface AttachTestBridgeOptions {
+  /** `false` suppresses the non-production console warning. */
+  warn?: boolean
+}
+
+export function attachTestBridge(
+  _target: TestBridgeTarget,
+  _options?: AttachTestBridgeOptions
+): () => void {
+  throw new Error('attachTestBridge: not implemented')
+}

--- a/packages/core/src/lib/test-bridge.ts
+++ b/packages/core/src/lib/test-bridge.ts
@@ -1,6 +1,25 @@
-/** v2 §1.3b — RED STUB for `attachTestBridge`. */
+/**
+ * v2 §1.3b — the provider's `window.__tourKit__` effect as a plain function.
+ *
+ * `TestBridge` (`types/test-bridge.ts`) is unchanged, so `@tour-kit/playwright`
+ * and `@tour-kit/testing-library` — the two out-of-process consumers of the
+ * global — are untouched by the move.
+ *
+ * The once-per-mount warning guard deliberately stays in the provider:
+ * `context/__tests__/test-bridge.test.tsx` asserts exactly one warning across
+ * an `enableTestBridge` toggle cycle, and a module-level flag here would leak
+ * across tests in that file and make it order-dependent. Hence `{ warn }`.
+ *
+ * @module test-bridge
+ */
 import type { EligibilityReport } from '../types/diagnostic'
+import type { TestBridge } from '../types/test-bridge'
 
+/**
+ * What the bridge needs from whoever owns the tour. Structural, so both the
+ * provider's context value and a `TourEngine` satisfy it — note `prev`, which
+ * the bridge exposes to the outside world as `previous`.
+ */
 export interface TestBridgeTarget {
   start(tourId: string): unknown
   next(): unknown
@@ -12,13 +31,58 @@ export interface TestBridgeTarget {
 }
 
 export interface AttachTestBridgeOptions {
-  /** `false` suppresses the non-production console warning. */
+  /** `false` suppresses the non-production console warning. Default `true`. */
   warn?: boolean
 }
 
+/**
+ * Publish `window.__tourKit__`.
+ *
+ * @returns Detach — an identity-checked `delete`. Idempotent, and a no-op
+ *   without a `window`.
+ */
 export function attachTestBridge(
-  _target: TestBridgeTarget,
-  _options?: AttachTestBridgeOptions
+  target: TestBridgeTarget,
+  options: AttachTestBridgeOptions = {}
 ): () => void {
-  throw new Error('attachTestBridge: not implemented')
+  if (typeof window === 'undefined') return () => {}
+
+  if (options.warn !== false) {
+    // No `process` at all is a browser bundle, which is never production here.
+    if (typeof process === 'undefined' || process.env?.NODE_ENV !== 'production') {
+      console.warn('[Tour Kit] Test bridge enabled. Disable for production.')
+    }
+  }
+
+  const bridge: TestBridge = {
+    start: (tourId) => {
+      void target.start(tourId)
+    },
+    next: () => {
+      void target.next()
+    },
+    previous: () => {
+      void target.prev()
+    },
+    goToStep: (stepId) => {
+      void target.goToStep(stepId)
+    },
+    complete: () => {
+      target.complete()
+    },
+    skip: () => {
+      target.skip()
+    },
+    getDiagnostic: (tourId) => target.getDiagnostic?.(tourId) ?? null,
+  }
+  window.__tourKit__ = bridge
+
+  return () => {
+    // Identity check defends against another library reassigning the global
+    // between attach and detach — see the cleanup-safety unit test.
+    if (window.__tourKit__ === bridge) {
+      // biome-ignore lint/performance/noDelete: full removal mirrors the absent-by-default invariant — `= undefined` would leave an own property and break consumer `'__tourKit__' in window` checks
+      delete window.__tourKit__
+    }
+  }
 }

--- a/packages/core/src/lib/tour-engine/__tests__/boot.parity.test.tsx
+++ b/packages/core/src/lib/tour-engine/__tests__/boot.parity.test.tsx
@@ -1,15 +1,20 @@
 /**
- * v2 §1.3c — boot parity: the mounted provider is the oracle.
+ * v2 §1.3c — boot wiring, end to end through a mounted provider.
  *
- * This file must be GREEN before any of the three boot effects
- * (`tour-provider.tsx:524`, `:620`, `:642`) is touched. It stages each row of
- * the truth table into real jsdom storage, mounts the *current* `<TourProvider>`
- * and asserts the settled tour matches what `resolveBootStart` claims the rule
- * is. A disagreeing row is the React-timing coupling the handoff warned about,
- * and is a finding to report — not a row to edit.
+ * **This is a regression test, not a parity proof.** It was written as one: the
+ * mounted `<TourProvider>` was an independent second implementation of the boot
+ * precedence rule, and every row here cross-checked it against
+ * `resolveBootStart`. Since `b0019461` the provider calls `resolveBootStart`
+ * itself, so both sides of the comparison are now the same implementation and
+ * a row can no longer disagree on the *rule* — only on the *wiring* that gets
+ * storage into it and its decision back out into React state.
  *
- * It is allowed to be slower and uglier than `boot.test.ts`. Its only job is to
- * make a row-by-row disagreement impossible to miss.
+ * That wiring is still worth a net, which is why the file stays: it stages each
+ * row of the truth table into real jsdom storage, mounts the provider, and
+ * asserts the settled tour. A red row means the effects, the storage adapters
+ * or the dispatch path broke — not that the precedence rule drifted.
+ *
+ * It is allowed to be slower and uglier than `boot.test.ts`.
  */
 import { render, waitFor } from '@testing-library/react'
 import type * as React from 'react'

--- a/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
@@ -22,6 +22,7 @@ import { createTourEngine } from '../create-tour-engine'
 import type { TourEngine } from '../create-tour-engine'
 import { makeEngine } from './_helpers/make-engine'
 import { hiddenStep, makeTour, visibleStep } from './_helpers/make-tour'
+import { stageFlow } from './_helpers/stage-storage'
 
 const THREE = makeTour('t', [visibleStep('a'), visibleStep('b'), visibleStep('c')])
 
@@ -253,6 +254,89 @@ describe('destroy is terminal, not a pause', () => {
     engine.destroy()
 
     expect(tourRegistry.get('t')).toBeNull()
+  })
+})
+
+describe('boot() is cancellable — v2 §1.3b-0', () => {
+  it('destroy() during an in-flight boot leaves the staged flow session alone', async () => {
+    // The discriminator is rejecting AFTER destroy(). A `navigate` left pending
+    // hangs the await inside runBootStart, so its catch — and the onClear()
+    // that wipes the session — is never reached, and the assertion would pass
+    // against the very bug it exists to catch.
+    let rejectNavigation: (reason: Error) => void = () => {}
+    const navigate = vi.fn(
+      () =>
+        new Promise<boolean | undefined>((_resolve, reject) => {
+          rejectNavigation = reject
+        })
+    )
+
+    const { engine, storage } = engineFor({
+      tours: [makeTour('t', [visibleStep('a')])],
+      router: {
+        getCurrentRoute: () => '/home',
+        navigate,
+        matchRoute: () => false,
+        onRouteChange: () => () => {},
+      },
+      routePersistence: {
+        enabled: true,
+        storage: 'sessionStorage',
+        flowSession: { storage: 'sessionStorage' },
+      },
+    })
+    stageFlow(storage, { tourId: 't', currentRoute: '/pricing' })
+
+    const booting = engine.boot()
+    engine.destroy()
+    rejectNavigation(new Error('route 404'))
+    await booting
+
+    expect(storage.getItem('tourkit:flow:active')).not.toBeNull()
+  })
+})
+
+describe('setTours() keeps the tour registry in sync — v2 §1.3b-0', () => {
+  const extra = makeTour('extra', [visibleStep('x')])
+
+  it('registers a tour added after construction', () => {
+    const { engine } = engineFor({ tours: [THREE] })
+    expect(tourRegistry.get('extra')).toBeNull()
+
+    engine.setTours([THREE, extra])
+
+    expect(tourRegistry.get('extra')).not.toBeNull()
+  })
+
+  it('unregisters a tour that setTours dropped', () => {
+    const { engine } = engineFor({ tours: [THREE, extra] })
+
+    engine.setTours([THREE])
+
+    expect(tourRegistry.get('extra')).toBeNull()
+    expect(tourRegistry.get('t')).not.toBeNull()
+  })
+
+  it('leaves the running tour registry mirror intact', async () => {
+    // Id-diff, not unregister-all-and-re-register: `register()` seeds
+    // `isActive: false` and `mirrorToRegistry` writes only on a transition, so
+    // re-registering the running tour would zero its mirror until the next one.
+    const { engine } = engineFor({ tours: [THREE] })
+    await engine.start('t')
+    expect(tourRegistry.get('t')?.state.isActive).toBe(true)
+
+    engine.setTours([THREE, extra])
+
+    expect(tourRegistry.get('t')?.state.isActive).toBe(true)
+  })
+
+  it('unregisters setTours-added tours on destroy()', () => {
+    const { engine } = engineFor({ tours: [THREE] })
+    engine.setTours([THREE, extra])
+
+    engine.destroy()
+
+    expect(tourRegistry.get('extra')).toBeNull()
   })
 })
 

--- a/packages/core/src/lib/tour-engine/create-tour-engine.ts
+++ b/packages/core/src/lib/tour-engine/create-tour-engine.ts
@@ -167,10 +167,13 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
 
   const listeners = new Set<() => void>()
   const abortControllerRef: { current: AbortController | null } = { current: null }
+  const bootAbortRef: { current: AbortController | null } = { current: null }
   const completedTourIdRef: { current: string | null } = { current: null }
   const skippedTourIdRef: { current: string | null } = { current: null }
   const crossTab: { lastAnnounceTs: number | null } = { lastAnnounceTs: null }
   const teardown: Array<() => void> = []
+  /** Registry id -> the unregister fn `tourRegistry.register` handed back. */
+  const registered = new Map<string, () => void>()
 
   const currentTour = () => (state.tourId ? (state.tours.get(state.tourId) ?? null) : null)
 
@@ -266,6 +269,14 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
     if (destroyed || bootPhase !== 'idle') return
     bootPhase = 'booting'
 
+    // Boot owns its own controller. `abortControllerRef` is written only by
+    // `applyTransitionEffects` on a tour-identity change, so it is null here
+    // and every `signal?.aborted` check inside `runBootStart` would be dead —
+    // a `destroy()` mid-restore would still fall into the catch and clear a
+    // flow session the user is in the middle of.
+    const bootAbort = new AbortController()
+    bootAbortRef.current = bootAbort
+
     try {
       // Terminal tours first: the autostart rule reads completedTours.
       if (persistTerminalTours) {
@@ -292,35 +303,58 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
       flowSession.setTourId(decision.tourId)
       await runBootStart(ctx, decision, {
         currentRoute: decision.source === 'flow' ? flowBlob?.currentRoute : undefined,
-        signal: abortControllerRef.current?.signal,
+        signal: bootAbort.signal,
         onClear: flowSession.clear,
       })
     } finally {
       bootPhase = 'ready'
+      if (bootAbortRef.current === bootAbort) bootAbortRef.current = null
     }
   }
 
   // Cross-tab pause and registry membership are lifecycle, not transition.
   teardown.push(subscribeCrossTabPause(ctx, broadcast.subscribe))
-  teardown.push(registerTours(options.tours))
+  syncRegistry(options.tours)
+  teardown.push(() => {
+    for (const unregister of registered.values()) unregister()
+    registered.clear()
+  })
 
-  function registerTours(tours: Tour[]): () => void {
-    const unregisters = tours.map((tour) =>
-      tourRegistry.register({
-        id: tour.id,
-        state: { isActive: false, currentStepId: null, progress: 0 },
-        actions: {
-          start: () => void engine.start(tour.id),
-          stop: () => engine.stop(),
-          restart: () => void engine.start(tour.id, 0),
-          next: () => void engine.next(),
-          prev: () => void engine.prev(),
-          goToStep: (stepId) => void engine.goToStep(stepId),
-        },
-      })
-    )
-    return () => {
-      for (const unregister of unregisters) unregister()
+  /**
+   * Bring registry membership in line with `tours`, by id.
+   *
+   * An id-diff and NOT unregister-all-and-re-register, even though that is the
+   * shorter patch: `transition-effects.ts` mirrors `isActive` /
+   * `currentStepId` / `progress` into the registry on every transition and
+   * `register()` seeds `isActive: false`, so re-registering the running tour
+   * would zero its mirror until the next transition moved it.
+   */
+  function syncRegistry(tours: Tour[]): void {
+    const nextIds = new Set(tours.map((tour) => tour.id))
+
+    for (const [id, unregister] of registered) {
+      if (nextIds.has(id)) continue
+      unregister()
+      registered.delete(id)
+    }
+
+    for (const tour of tours) {
+      if (registered.has(tour.id)) continue
+      registered.set(
+        tour.id,
+        tourRegistry.register({
+          id: tour.id,
+          state: { isActive: false, currentStepId: null, progress: 0 },
+          actions: {
+            start: () => void engine.start(tour.id),
+            stop: () => engine.stop(),
+            restart: () => void engine.start(tour.id, 0),
+            next: () => void engine.next(),
+            prev: () => void engine.prev(),
+            goToStep: (stepId) => void engine.goToStep(stepId),
+          },
+        })
+      )
     }
   }
 
@@ -361,6 +395,10 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
     setTours: (tours: Tour[]) => {
       if (destroyed) return
       for (const tour of tours) validateTour(tour)
+      // Registry first: `dispatch` runs `applyTransitionEffects`, whose
+      // registry mirror walks the NEW tour set, so a tour added here gets its
+      // first mirror write in the same turn instead of the next transition.
+      syncRegistry(tours)
       dispatch({ type: 'UPDATE_TOURS', tours })
     },
 
@@ -384,6 +422,8 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
       destroyed = true
       abortControllerRef.current?.abort()
       abortControllerRef.current = null
+      bootAbortRef.current?.abort()
+      bootAbortRef.current = null
       flowSession.flush()
       broadcast.close()
       for (const off of teardown.splice(0)) off()

--- a/packages/core/src/lib/track-rect.ts
+++ b/packages/core/src/lib/track-rect.ts
@@ -1,17 +1,81 @@
-/** v2 §1.3b — RED STUB for `trackRect`. */
+/**
+ * v2 §1.3b — one rect tracker for `useSpotlight` and `useElementPosition`.
+ *
+ * Both hooks carried the same scroll + resize + `throttleRAF` block; this is
+ * that block, once. `useElementPosition` additionally wants a `ResizeObserver`
+ * on the element and on its scroll parent, which is what `observeResize` adds.
+ *
+ * **Construction reads nothing, deliberately.** `useSpotlight.show()` seeds the
+ * first rect itself before its effect runs, so an attach-time read would push a
+ * fresh `DOMRect` through `setTargetRect` and buy one extra render per
+ * `show()`. `useElementPosition` DOES read synchronously on attach
+ * (`use-element-position.ts:47`), so its wrapper calls `update()` once right
+ * after constructing the tracker. Neither hook suite counts
+ * `getBoundingClientRect` calls, so this asymmetry is pinned in
+ * `__tests__/lib/track-rect.test.ts` and nowhere else.
+ *
+ * @module track-rect
+ */
+import { getScrollParent } from '../utils/dom'
+import { throttleRAF } from '../utils/throttle'
+
 export interface RectTracker {
+  /** Read the rect now and hand it to `onRect`. Synchronous. */
   update(): void
+  /** Cancel the pending frame, disconnect, remove listeners. Idempotent. */
   stop(): void
 }
 
 export interface TrackRectOptions {
+  /**
+   * Also observe the element (and its `HTMLElement` scroll parent) with a
+   * `ResizeObserver`. `useElementPosition` sets this; `useSpotlight` does not.
+   */
   observeResize?: boolean
 }
 
+/**
+ * Follow an element's bounding rect through scroll and resize.
+ *
+ * @param element - The node to measure. Non-null: the caller has already
+ *   resolved it, and a null-tolerant signature would hide a resolution bug.
+ */
 export function trackRect(
-  _element: HTMLElement,
-  _onRect: (rect: DOMRect) => void,
-  _options?: TrackRectOptions
+  element: HTMLElement,
+  onRect: (rect: DOMRect) => void,
+  options: TrackRectOptions = {}
 ): RectTracker {
-  throw new Error('trackRect: not implemented')
+  const update = () => onRect(element.getBoundingClientRect())
+  const throttled = throttleRAF(update)
+
+  window.addEventListener('scroll', throttled, { passive: true, capture: true })
+  window.addEventListener('resize', throttled, { passive: true })
+
+  let observer: ResizeObserver | null = null
+  if (options.observeResize) {
+    // No existence guard, matching `use-element-position.ts:50` — its suite
+    // stubs the global, and adding a guard the hook does not have would change
+    // behaviour the oracle pins.
+    observer = new ResizeObserver(throttled)
+    observer.observe(element)
+    const scrollParent = getScrollParent(element)
+    if (scrollParent !== window && scrollParent instanceof HTMLElement) {
+      observer.observe(scrollParent)
+    }
+  }
+
+  let stopped = false
+
+  return {
+    update,
+    stop: () => {
+      if (stopped) return
+      stopped = true
+      throttled.cancel()
+      observer?.disconnect()
+      observer = null
+      window.removeEventListener('scroll', throttled, true)
+      window.removeEventListener('resize', throttled)
+    },
+  }
 }

--- a/packages/core/src/lib/track-rect.ts
+++ b/packages/core/src/lib/track-rect.ts
@@ -1,0 +1,17 @@
+/** v2 §1.3b — RED STUB for `trackRect`. */
+export interface RectTracker {
+  update(): void
+  stop(): void
+}
+
+export interface TrackRectOptions {
+  observeResize?: boolean
+}
+
+export function trackRect(
+  _element: HTMLElement,
+  _onRect: (rect: DOMRect) => void,
+  _options?: TrackRectOptions
+): RectTracker {
+  throw new Error('trackRect: not implemented')
+}

--- a/packages/core/src/lib/track-rect.ts
+++ b/packages/core/src/lib/track-rect.ts
@@ -14,6 +14,11 @@
  * `getBoundingClientRect` calls, so this asymmetry is pinned in
  * `__tests__/lib/track-rect.test.ts` and nowhere else.
  *
+ * **No `typeof window` guard, unlike the other leaves.** The `element`
+ * parameter is the guard: a caller that holds a live `HTMLElement` is in a
+ * document by definition, so a server-side call is a resolution bug worth
+ * throwing on rather than swallowing into a silent no-op tracker.
+ *
  * @module track-rect
  */
 import { getScrollParent } from '../utils/dom'

--- a/tooling/biome/biome.json
+++ b/tooling/biome/biome.json
@@ -75,6 +75,7 @@
         "packages/core/src/lib/interpolate.ts",
         "packages/core/src/context/tour-provider.tsx",
         "packages/core/src/lib/tour-engine/boot.ts",
+        "packages/core/src/lib/test-bridge.ts",
         "packages/analytics/src/plugins/console.ts",
         "packages/license/src/components/license-test-mode.tsx",
         "packages/license/src/components/license-warning.tsx",

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -38,6 +38,14 @@
  *     `createTourEngine` stays out, matching on a string literal rather than
  *     the identifier because `minify: true` renames the function and the
  *     obvious grep passes either way.
+ *
+ *     KNOWINGLY AT THE LINE. v2 §1.3b measured 21 457 against this 21 500 —
+ *     43 bytes, 0.2%. The ceiling was deliberately NOT re-baselined (§1.3b's
+ *     plan pre-authorised <=22 000 and the breach never came), so the next
+ *     change to touch the main entry — §1.4, which wires the provider to the
+ *     engine — will trip this row. That is the intended behaviour: §1.4 raises
+ *     it with its own measurement, or earns the B-1 target back down. A red
+ *     row here is not a mystery, it is this note coming due.
  *   - core:engine: 18 KB against a measured 17.0 KB, up from 8.1 KB when this
  *     was a types-and-predicates door and 15.3 KB after §1.3. The difference
  *     is first a working tour engine (reducer, boot resolver, actions,

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -38,14 +38,20 @@
  *     `createTourEngine` stays out, matching on a string literal rather than
  *     the identifier because `minify: true` renames the function and the
  *     obvious grep passes either way.
- *   - core:engine: 16 KB against a measured 15.3 KB (2.5 KB entry + the same
- *     12.8 KB chunk), up from 8.1 KB when this was a types-and-predicates door.
- *     The difference is a working tour engine: reducer, boot resolver, actions,
- *     transition effects and four storage adapters. §1.3's plan expected
- *     13–14 KB; the measured number is the number. A type-only consumer still
- *     ships zero (types erase, the barrel is re-exports-only and
- *     `sideEffects: false`), so this row is the worst case — import everything
- *     — not the common one.
+ *   - core:engine: 18 KB against a measured 17.0 KB, up from 8.1 KB when this
+ *     was a types-and-predicates door and 15.3 KB after §1.3. The difference
+ *     is first a working tour engine (reducer, boot resolver, actions,
+ *     transition effects, four storage adapters) and then, in v2 §1.3b, the
+ *     DOM behaviours: focus trap, keyboard, rect tracker, spotlight,
+ *     advance-on and the test bridge. Those ~1.6 KB are exactly the code that
+ *     left the five view hooks, which is why `core` did NOT move — it lands in
+ *     the shared chunk both entries already read.
+ *
+ *     Do NOT split a `/engine/dom` entry to keep this number flat: the row
+ *     measures the import-everything worst case, a bundler tree-shakes the
+ *     rest (`sideEffects: false`), and the only consumer who pays all of it is
+ *     the §1.6 IIFE — where shipping focus/keyboard/spotlight is the point. A
+ *     type-only consumer still ships zero.
  *   - hints, announcements, surveys, media, ai:client: re-baselined in v2 §1.2
  *     WITHOUT a byte being added. All five ship a `headless` entry alongside
  *     `index`, so they have been split since long before core was, and the
@@ -68,7 +74,7 @@
  */
 export const budgets = [
   ['core', 'packages/core/dist/index.js', 21500],
-  ['core:engine', 'packages/core/dist/engine/index.js', 16000],
+  ['core:engine', 'packages/core/dist/engine/index.js', 18000],
   ['react', 'packages/react/dist/index.js', 12000],
   ['hints', 'packages/hints/dist/index.js', 6000],
   ['analytics:main', 'packages/analytics/dist/index.js', 4000],


### PR DESCRIPTION
Implements [`plan/v2/1-3b-dom-behaviours.md`](plan/v2/1-3b-dom-behaviours.md) and its test plan.

After §1.3, `@tour-kit/core/engine` could **run** a tour with no React. It could not **show** one — the five things a binding needs to render a card existed only as React hooks. This moves each hook's body into a plain function under `packages/core/src/lib/` and publishes them from `/engine`. Every hook keeps its exact signature and becomes a wrapper.

One commit per slice, red test first, so each slice stays revertible.

## What a binding gets

```ts
import {
  createFocusTrap, attachKeyboard, trackRect, computeSpotlight,
  bindStepAdvance, attachAdvanceOn, dispatchAdvanceEvent, attachTestBridge,
} from '@tour-kit/core/engine'
```

`__tests__/lib/behaviours-headless.test.ts` is the proof: a real `createTourEngine()` driven through `attachKeyboard` (ArrowRight `a`→`b`, Escape ends it), `attachAdvanceOn` (click the target) and `createFocusTrap` (Tab wraps, deactivate restores) — in a file that reads its own source back to assert it names neither `react` nor `@testing-library`.

## Read this part before approving

**The plan's own prescribed `useSpotlight` effect body shipped a regression, and the green oracle did not catch it** (`13c7f025`).

`TourOverlay` — both the styled and headless variants — advances a step by calling `show(newTarget)` directly. It never calls `hide()` in between, so `isVisible` stays `true`. Before this PR the scroll handler re-read `targetRef.current` on every event and followed that swap for free. `trackRect` takes a concrete element, so an effect keyed on `[isVisible]` alone keeps a tracker pointed at the **previous** step's node: the spotlight stops following the real target on scroll and starts following the old one.

Fixed by keying the tracking effect on a state slot that `show()`/`hide()` write. The ref stays because `updateRect` — the returned `update`, which must work while hidden — reads it and needs a stable identity.

`__tests__/hooks/spotlight-retarget.test.tsx` is the net. It is a **new file, not an oracle edit**; none of the 15 `use-spotlight` cases exercises a retarget. Verified red on this branch and green against `main`'s hook, so the direction of the bug is not in doubt.

## Slice 0 — two §1.3 defects fixed on the way

Not DOM behaviour, done here so §1.4 does not hit both on day one and attribute them to itself.

- **`boot()` was uncancellable.** It passed `abortControllerRef.current?.signal`, but that ref is only written by `applyTransitionEffects` on a tour-identity change, so it is `null` at boot and every `signal?.aborted` check inside the restore was dead code. A `destroy()` during a cross-page restore still fell into the catch and called `onClear()`, wiping a flow session the user was in the middle of.
- **`setTours()` never touched `tourRegistry`.** Registration ran once at construction, so a tour added later was invisible to `useTourActions` and one removed later outlived `destroy()`. The fix diffs by id rather than re-registering everything, because `transition-effects.ts` mirrors state into the registry and `register()` seeds `isActive: false` — re-registering the running tour would zero its mirror until the next transition.

The red test for the first one rejects a **held** navigate promise *after* `destroy()`. A never-settling `navigate` hangs the `await` before the catch that calls `onClear()`, so the assertion would pass against the very bug it exists to catch.

## What the new tests cover that the oracle cannot

The 82 hook cases are the read-only spec and all pass unmodified. The new `__tests__/lib/` files exist for the structural blind spots:

- **`trackRect` construction reads nothing.** `useSpotlight.show()` seeds the rect itself, so an auto-reading tracker costs a render per `show()` — and passes all 27 spotlight + element-position cases silently, because neither suite counts `getBoundingClientRect` calls.
- **The 100 ms advance debounce**, which no oracle case exercises. Including that a *falsy* handler must not consume the window: `use-advance-on.ts:58` returns before `isAdvancing = true`, so hoisting the flag would pass every existing test while swallowing the first real advance after a rejection.
- **The empty-container focus branch** (the oracle asserts only "does not throw"), **nested `inert` release in both orders** (the oracle covers one), and **`release()` not moving focus** — the only thing distinguishing it from `deactivate()`.
- `_helpers/frames.ts` defers rAF rather than running the callback inline the way the hook suites do; under a synchronous spy `throttleRAF` clears its `rafId` before returning and coalescing is unobservable.

## Budgets — the opposite of what the plan predicted

| Entry | Before | After | Budget |
|---|---|---|---|
| `core` | 21 194 | 21 457 | 21 500 (unchanged) |
| `core:engine` | 15 323 | 17 033 | 16 000 → **18 000** |

The plan pre-authorised a `core` re-baseline to ≤22 000 expecting a breach. It did not happen, and both rows follow from the same fact: code leaving the hooks lands in the shared chunk **both** entries already read, so the engine row grows by exactly what moved and the main row barely shifts. Mirrored into `budgets.mjs`, `.size-limit.json` and `CLAUDE.md`, which `bundle-budget-claim-alignment.test.ts` enforces.

The root `.size-limit.json` engine row went 8 KB → 15 KB. That informational check had been failing since §1.3 and was simply never updated.

## One success criterion missed, deliberately

`wc -l` of the five hooks is **237**, not the plan's `<200` (from 541). Non-comment code is 162 lines. The gap is the two exported return interfaces (21 lines, mandatory) plus the docblocks explaining the two `trackRect` asymmetries. Deleting those to hit an estimate seemed the wrong trade — say so and I will trim.

## Verification

- 1 472 core tests green; `turbo run test --concurrency=3` across core / react / hints / surveys exits 0 (12/12 tasks).
- `git diff --stat main -- packages/core/src/__tests__/hooks/ packages/core/src/context/__tests__/test-bridge.test.tsx` is **empty**.
- No `react` or `@testing-library` import anywhere under `__tests__/lib/`.
- Coverage 92.9 / 88.3 / 92.4 / 94.3 against the 80/75/80/80 floors.
- `pnpm dist:size` exits 0; `biome check packages/ tooling/` clean; `typecheck` and `typecheck:types` pass.
- `@tour-kit/playwright` and `@tour-kit/testing-library` smokes pass — `TestBridge` is unchanged, so `window.__tourKit__` consumers are untouched.
- **Browser-verified** in `examples/next-app` (it uses `workspace:*`, so it picks up `dist/` directly — no tarball dance, unlike `qa-next` which pins npm versions): Escape closes the card, Tab and Shift+Tab wrap both ways, focus returns to the trigger, and the cutout tracked step 2's target through a 300 px scroll (357 → 57) rather than step 1's. No console errors.

`changeset status` will cascade a react/hints major — that is `linked` config, not a signal.

## Wiki (gitignored, so not in this diff)

`packages/core.md` hooks table, entry points, unexported list and budget row. `concepts/focus-trap.md` **rewritten** — its API section documented a `useFocusTrap(options)` returning `isActive` that has never existed. `concepts/positioning-engine.md` **rewritten** — it documented `calculatePosition()` and a collision solver deleted in refactor phase 3; filename kept so its seven inbound links still resolve. `concepts/tour-engine.md` gains a Behaviours section. Index and log updated.

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt
