### PR TITLE
fix(core): implement the step lifecycle callbacks (#121)

### DIFF
--- a/.changeset/step-lifecycle-callbacks.md
+++ b/.changeset/step-lifecycle-callbacks.md
@@ -1,0 +1,28 @@
+---
+'@tour-kit/core': minor
+---
+
+Implement the step lifecycle callbacks (#121)
+
+`onBeforeShow`, `onBeforeHide`, `onHide`, `onEnter`/`onShow` on visible steps
+and `waitForTarget` on same-route steps were declared on `BaseTourStep` and
+documented, but never called. They work now, in this order on every
+app-initiated transition:
+
+`onBeforeHide(prev) → onBeforeShow(next) → onEnter(next) → [commit] → onHide(prev) → onShow(next)`
+
+- **`onBeforeShow` / `onBeforeHide` can cancel a transition.** Return a literal
+  `false` — including from an `async` guard — and the tour stays where it is.
+  Works on `next()`, `prev()` (the reported case), `goTo()`, `start()` and a
+  branch to another tour.
+- **`waitForTarget: true` now waits on the step's own route**, not only after a
+  router hop, for targets rendered after a fetch. Bounded by `waitTimeout`
+  (default 3000); on timeout `onStepError` fires with `TARGET_NOT_FOUND`.
+- **`onHide` also fires when a tour ends** on a step — `stop()`, `skip()`,
+  `complete()`, `reset()`.
+- **A callback that throws is logged and ignored, never a veto**, so a buggy
+  guard cannot trap a user on one step. This also fixes hidden-step
+  `onEnter`/`onShow`, which previously rejected the caller's `next()` promise.
+
+`'restart'` now navigates to step 0 rather than jumping there, so it honours a
+hidden or route-bearing first step.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,14 +123,17 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
   measured that way. `size-limit` (root [`/.size-limit.json`](/.size-limit.json))
   is a secondary smoke signal in a bundled-with-deps + brotli unit, run
   `pnpm bundlesize`. Per-package dist-gzip closure budgets:
-  - core <21.5 KB (target <8 KB; tracked as audit B-1 — neither the §1.2
+  - core <22 KB (target <8 KB; tracked as audit B-1 — neither the §1.2
     subpath nor the §1.3 engine moved the main entry toward it, that is
     §1.4's to earn. §1.3 raised this from 21 KB against a measured 21 271:
     the +446 B is the module-boundary cost of moving 636 lines out of
     `tour-provider.tsx`, not engine runtime leaking in —
     `engine-not-in-main-closure.test.ts` guards that. §1.3b left it at 21.5 KB
-    against a measured 21 457 — 43 bytes. The row is knowingly at the line;
-    §1.4 is expected to trip it and re-baseline with its own measurement)
+    against a measured 21 457 — 43 bytes, knowingly at the line. Issue #121
+    tripped it, exactly as that note predicted: wiring the five dead step
+    lifecycle callbacks measured 21 849, so the row is now 22 KB. The +416 B
+    is the guards in `navigateToStepImpl`, `commitStart` in `actions.ts` and
+    the Group B block in `transition-effects.ts`)
   - core/engine subpath <18 KB (the non-React consumer's worst case: the
     engine — reducer, boot resolver, actions, transition effects, four
     storage adapters — plus the v2 §1.3b DOM behaviours (focus trap,
@@ -140,7 +143,9 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     §1.3 gave it a way to run one but not to show one; a type-only consumer
     still ships zero. §1.3b raised this from 16 KB against a measured 17 033
     — the ~1.6 KB is the code that left the five view hooks, which is why
-    `core` did not move: it lands in the shared chunk both entries read)
+    `core` did not move: it lands in the shared chunk both entries read.
+    Issue #121 took it to 17 446, still inside 18 KB; that +416 B is the same
+    +416 B `core` saw, because both rows read the chunk it landed in)
   - react <12 KB
   - hints <6 KB
   - analytics <4 KB (root; per-plugin <1.5 KB each)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     `engine-not-in-main-closure.test.ts` guards that. §1.3b left it at 21.5 KB
     against a measured 21 457 — 43 bytes, knowingly at the line. Issue #121
     tripped it, exactly as that note predicted: wiring the five dead step
-    lifecycle callbacks measured 21 849, so the row is now 22 KB. The +416 B
+    lifecycle callbacks measured 21 845, so the row is now 22 KB. The +416 B
     is the guards in `navigateToStepImpl`, `commitStart` in `actions.ts` and
     the Group B block in `transition-effects.ts`)
   - core/engine subpath <18 KB (the non-React consumer's worst case: the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     `engine-not-in-main-closure.test.ts` guards that. §1.3b left it at 21.5 KB
     against a measured 21 457 — 43 bytes, knowingly at the line. Issue #121
     tripped it, exactly as that note predicted: wiring the five dead step
-    lifecycle callbacks measured 21 845, so the row is now 22 KB. The +416 B
+    lifecycle callbacks measured 21 851, so the row is now 22 KB. The +416 B
     is the guards in `navigateToStepImpl`, `commitStart` in `actions.ts` and
     the Group B block in `transition-effects.ts`)
   - core/engine subpath <18 KB (the non-React consumer's worst case: the
@@ -144,7 +144,7 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     still ships zero. §1.3b raised this from 16 KB against a measured 17 033
     — the ~1.6 KB is the code that left the five view hooks, which is why
     `core` did not move: it lands in the shared chunk both entries read.
-    Issue #121 took it to 17 446, still inside 18 KB; that +416 B is the same
+    Issue #121 took it to 17 451, still inside 18 KB; that +416 B is the same
     +416 B `core` saw, because both rows read the chunk it landed in)
   - react <12 KB
   - hints <6 KB

--- a/apps/docs/content/compare/tour-kit-vs-driver-js.mdx
+++ b/apps/docs/content/compare/tour-kit-vs-driver-js.mdx
@@ -212,7 +212,7 @@ import { TourKitProvider, Tour, TourCard, TourCardContent,
 
 **Step 3: Replace lifecycle hooks**
 
-Driver.js's `onNextClick` and `onPrevClick` map to userTourKit's step-level `onBeforeShow` and `onNext` callbacks. The `onPopoverRender` DOM manipulation hook has no userTourKit equivalent because you control the rendering directly through JSX.
+Driver.js's `onNextClick` and `onPrevClick` intercept a step you are leaving, so they map to userTourKit's step-level `onBeforeHide` — return `false` to cancel the move, the equivalent of not calling `driverObj.moveNext()`. To redirect rather than cancel, use `onNext` / `onPrev`. The `onPopoverRender` DOM manipulation hook has no userTourKit equivalent because you control the rendering directly through JSX.
 
 **Step 4: Remove Driver.js CSS**
 

--- a/apps/docs/content/docs/api/core.mdx
+++ b/apps/docs/content/docs/api/core.mdx
@@ -481,7 +481,7 @@ interface TourStep {
   offset?: [number, number];
   route?: string;
   routeMatch?: 'exact' | 'startsWith' | 'contains';
-  when?: () => boolean;
+  when?: (context: TourCallbackContext) => boolean | Promise<boolean>;
   advanceOn?: AdvanceOnConfig;
   waitForTarget?: boolean;
   waitTimeout?: number;
@@ -492,10 +492,15 @@ interface TourStep {
   showProgress?: boolean;
   showClose?: boolean;
   className?: string;
-  onBeforeShow?: () => void | Promise<void>;
-  onAfterShow?: () => void;
-  onBeforeHide?: () => void | Promise<void>;
-  onAfterHide?: () => void;
+  onBeforeShow?: (
+    context: TourCallbackContext
+  ) => boolean | undefined | Promise<boolean | undefined>;
+  onEnter?: (context: TourCallbackContext) => void | Promise<void>;
+  onShow?: (context: TourCallbackContext) => void;
+  onBeforeHide?: (
+    context: TourCallbackContext
+  ) => boolean | undefined | Promise<boolean | undefined>;
+  onHide?: (context: TourCallbackContext) => void;
 }
 
 type Placement =
@@ -504,6 +509,78 @@ type Placement =
   | 'left' | 'left-start' | 'left-end' | 'left-center'
   | 'right' | 'right-start' | 'right-end' | 'right-center';
 ```
+
+### Step lifecycle
+
+Every app-initiated transition — `next()`, `prev()`, `goTo()`, `start()` and a
+branch to another tour — runs the step hooks in this order:
+
+```
+onBeforeHide(outgoing) → onBeforeShow(incoming) → onEnter(incoming)
+                       → [the step commits] →
+                         onHide(outgoing) → onShow(incoming)
+```
+
+The two `onBefore*` hooks run **before** the commit and can cancel it. The two
+notifications run after, and cannot.
+
+**Cancelling.** Return a literal `false` from `onBeforeShow` or `onBeforeHide`
+to veto the transition. The tour stays exactly where it is, and the call that
+triggered it resolves having changed nothing. Every other return value —
+including `undefined`, `null`, `0` and `''` — proceeds. Both guards are
+awaited, so an `async` guard that resolves `false` cancels too.
+
+```tsx
+{
+  id: 'confirm-step',
+  target: '#editor',
+  content: 'Save before you continue',
+  onBeforeHide: async ({ data }) => {
+    if (!data.saved) {
+      return false // stay on this step
+    }
+  },
+}
+```
+
+**A throwing callback never cancels anything.** Any hook that throws is logged
+and ignored, and the transition continues. This is deliberate and differs from
+`when`, where a throw skips the step: skipping a step is always safe, while a
+guard that threw on every call would trap the user with no way forward or back.
+No step callback can brick a tour.
+
+**Where the exceptions are:**
+
+- Hidden steps (`kind: 'hidden'`) run `onEnter` and `onShow` only. They never
+  mount, so `onBeforeShow`, `onBeforeHide` and `onHide` are ignored on them.
+- A tour restored from a saved session runs `onEnter` and `onShow`, but never
+  `onBeforeShow` — a veto during a cold restore would strand the user mid-tour.
+- `onHide` also fires when the tour **ends** on a step, through `stop()`,
+  `skip()`, `complete()` or `reset()`. The step did leave the screen.
+- `next()` on the last step completes the tour, so it fires `onHide` and no
+  incoming hooks — there is no step to show.
+
+**Waiting for a late target.** Set `waitForTarget: true` on a step whose target
+is rendered after a fetch or a lazy mount, and the step waits for it to appear
+before committing. It applies on the step's own route; a step with a different
+`route` always waits for its target after the router hop regardless. The flag
+needs a `target` to observe and is ignored without one. `waitTimeout`
+(default `3000`) bounds both waits; on timeout `onStepError` fires with
+`TourRouteError({ code: 'TARGET_NOT_FOUND' })` and the tour stops.
+
+```tsx
+{
+  id: 'chart',
+  target: '#revenue-chart',
+  content: 'Your revenue at a glance',
+  waitForTarget: true,
+  waitTimeout: 5000,
+}
+```
+
+Every hook receives the same `TourCallbackContext` the tour-level callbacks
+get, with `currentStep` and `currentStepIndex` pointing at the step the hook
+belongs to.
 
 ### Router Types
 

--- a/apps/docs/content/docs/guides/hidden-steps.mdx
+++ b/apps/docs/content/docs/guides/hidden-steps.mdx
@@ -226,6 +226,29 @@ class TourValidationError extends Error {
 function validateTour(tour: Tour): void;
 ```
 
+## Waiting for a late target
+
+A hidden step is for a step that should not be *shown*. A step that should be
+shown, just not yet — because its target is rendered after a fetch or a lazy
+mount — wants `waitForTarget: true` instead:
+
+```tsx
+createStep({
+  id: 'revenue',
+  target: '#revenue-chart',
+  content: 'Your revenue at a glance',
+  waitForTarget: true,
+  waitTimeout: 5000, // default 3000
+})
+```
+
+The step waits for the node to appear before it commits, on its own route as
+well as after a router hop. If it never appears, `onStepError` fires with
+`TourRouteError({ code: 'TARGET_NOT_FOUND' })` and the tour stops rather than
+pointing at nothing. The flag needs a `target` to observe and is ignored
+without one. Full semantics, and the rest of the step lifecycle, are in
+[Step lifecycle](/docs/api/core#step-lifecycle).
+
 ## Related
 
 - [Branching tours guide](/docs/guides/branching) — visible decision points, the counterpart to hidden steps.
@@ -233,3 +256,4 @@ function validateTour(tour: Tour): void;
 - [Imperative control guide](/docs/guides/imperative-control) — drive `next()` from `onNext` handlers.
 - [Diagnostic engine](/docs/core/diagnostic) — surfaces `STRUCTURE_INVALID` when hidden-step validation fails.
 - [Step types reference](/docs/core/types/step-types) — every `TourStep` field including `kind` and `onEnter`.
+- [Step lifecycle](/docs/api/core#step-lifecycle) — the order every hook fires in, and how `onBeforeShow` / `onBeforeHide` cancel a transition.

--- a/apps/docs/content/docs/guides/router-integration.mdx
+++ b/apps/docs/content/docs/guides/router-integration.mdx
@@ -376,8 +376,8 @@ createStep({
   id: 'dynamic-step',
   route: '/dashboard',
   target: '#dynamic-widget',
-  waitForTarget: true, // Wait up to 5 seconds for element
-  waitForTargetTimeout: 5000,
+  waitForTarget: true, // Wait for the element to appear
+  waitTimeout: 5000, // ...for up to 5 seconds (default 3000)
 })
 ```
 

--- a/apps/docs/content/docs/guides/troubleshooting.mdx
+++ b/apps/docs/content/docs/guides/troubleshooting.mdx
@@ -81,7 +81,7 @@ For dynamically loaded elements:
 createStep({
   target: '#dynamic-element',
   waitForTarget: true,
-  waitForTargetTimeout: 5000, // Wait up to 5 seconds
+  waitTimeout: 5000, // Wait up to 5 seconds
 })
 ```
 

--- a/apps/docs/content/docs/migration/driver.mdx
+++ b/apps/docs/content/docs/migration/driver.mdx
@@ -204,8 +204,11 @@ to your `<TourOverlay />` slot.
 
 ### on-highlight-started
 
-`Step.onHighlightStarted` and `onHighlighted` fired when the spotlight moved.
-Port to `onShow` on the migrated step.
+`Step.onHighlightStarted` fired as the spotlight began moving to a step.
+Port to `onBeforeShow` (which can also cancel the move by returning `false`)
+or to `onEnter`, which runs after any navigation and just before the step
+mounts. `onHighlighted` — the "spotlight has landed" event — is `onShow`. See
+[Step lifecycle](/docs/api/core#step-lifecycle).
 
 ### on-highlighted
 

--- a/apps/docs/content/docs/migration/shepherd.mdx
+++ b/apps/docs/content/docs/migration/shepherd.mdx
@@ -189,8 +189,10 @@ Wire `useTour().next()` from your own event handler.
 ### before-show-promise
 
 `Step.beforeShowPromise` returned a Promise that resolved before the step
-showed. Await it before calling `useTour().goTo()`, or move the deferred
-logic into a custom `onShow` handler.
+showed. Port it to `onBeforeShow`, which is awaited before the step commits —
+and which can also cancel the transition by returning `false`, something
+`beforeShowPromise` could not do. See
+[Step lifecycle](/docs/api/core#step-lifecycle).
 
 ### show-on
 

--- a/packages/core/src/__tests__/context/tour-provider.test.tsx
+++ b/packages/core/src/__tests__/context/tour-provider.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, renderHook, screen } from '@testing-library/react'
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react'
 import type * as React from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { useTourContext } from '../../context/tour-context'
@@ -563,5 +563,99 @@ describe('useTourContext', () => {
 
     expect(result.current).toBeDefined()
     expect(result.current.isActive).toBe(false)
+  })
+})
+
+/**
+ * Issue #121 — the React seat inherits the step lifecycle without an edit.
+ *
+ * `<TourProvider>` calls `applyTransitionEffects` from a no-deps effect, and
+ * the pre-commit guards live in the shared `navigateToStepImpl`. So the
+ * headless engine and the provider must produce the same order — docs written
+ * once are true twice. If this case ever fails, the effect at
+ * `tour-provider.tsx:607-615` is the first place to look.
+ *
+ * Only the five step hooks are asserted. The tour-level `onStepChange` sits
+ * *before* `onHide`/`onShow` here and *after* them in the engine; pinning it
+ * would pin a divergence this phase is not fixing.
+ */
+describe('TourProvider — step lifecycle order (#121)', () => {
+  const callOrder: string[] = []
+  const note = (name: string, id: string) => () => {
+    callOrder.push(`${name}:${id}`)
+    return undefined
+  }
+
+  const hookedTours: Tour[] = [
+    {
+      id: 'hooked',
+      steps: [
+        {
+          id: 'a',
+          target: '#t1',
+          content: 'Step A',
+          onBeforeHide: note('onBeforeHide', 'a'),
+          onHide: note('onHide', 'a'),
+        },
+        {
+          id: 'b',
+          target: '#t2',
+          content: 'Step B',
+          onBeforeShow: note('onBeforeShow', 'b'),
+          onEnter: note('onEnter', 'b'),
+          onShow: note('onShow', 'b'),
+        },
+      ],
+    },
+  ]
+
+  it('gives the same five-element order as the headless engine', async () => {
+    const wrapper = createWrapper(hookedTours)
+    const { result } = renderHook(() => useTour(), { wrapper })
+
+    await act(async () => {
+      await result.current.start('hooked')
+    })
+    callOrder.length = 0
+
+    await act(async () => {
+      await result.current.next()
+    })
+
+    // Group B lands in a microtask inside a passive effect, so a bare
+    // assertion here reads a short array.
+    await waitFor(() =>
+      expect(callOrder).toEqual([
+        'onBeforeHide:a',
+        'onBeforeShow:b',
+        'onEnter:b',
+        'onHide:a',
+        'onShow:b',
+      ])
+    )
+  })
+
+  it('honours a veto from a step guard', async () => {
+    const vetoTours: Tour[] = [
+      {
+        id: 'vetoed',
+        steps: [
+          { id: 'a', target: '#t1', content: 'A', onBeforeHide: () => false as const },
+          { id: 'b', target: '#t2', content: 'B' },
+        ],
+      },
+    ]
+    const wrapper = createWrapper(vetoTours)
+    const { result } = renderHook(() => useTour(), { wrapper })
+
+    await act(async () => {
+      await result.current.start('vetoed')
+    })
+    await act(async () => {
+      await result.current.next()
+    })
+
+    expect(result.current.currentStepIndex).toBe(0)
+    expect(result.current.isTransitioning).toBe(false)
   })
 })

--- a/packages/core/src/lib/tour-engine/__tests__/actions.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/actions.test.ts
@@ -504,3 +504,83 @@ describe('hidden steps', () => {
     expect(mocks.dispatch).toHaveBeenCalledWith(expect.objectContaining({ stepIndex: 0 }))
   })
 })
+
+/**
+ * Issue #121 — `startImpl` is one of four paths that commit a step without
+ * going through `navigateToStep`, so it needs the incoming guard itself.
+ *
+ * What is real in this unit and what is not: `ctx.navigateToStep` is a
+ * `vi.fn`, so Group A never executes here and nothing in this file can see the
+ * pinned order or a `next()`/`prev()` veto. That lives in
+ * `create-tour-engine.test.ts`, against the real dispatch.
+ */
+describe('start — step lifecycle guards (#121)', () => {
+  const callOrder: string[] = []
+
+  beforeEach(() => {
+    callOrder.length = 0
+  })
+
+  it('a vetoing onBeforeShow never starts the tour', async () => {
+    const onStart = vi.fn()
+    const tour = makeTour('t', [visibleStep('a', { onBeforeShow: () => false as const })], {
+      onStart,
+    })
+    const { ctx, mocks } = on(tour, 0)
+
+    await startImpl(ctx, 't')
+
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'START_TOUR' }))
+    expect(onStart).not.toHaveBeenCalled()
+  })
+
+  it('a veto leaves the terminal-callback guards untouched', async () => {
+    // The re-arm at actions.ts:122-123 happens BEFORE the dispatch. A guard
+    // placed one line too low would leave START_TOUR undispatched (test green)
+    // while having already wiped the terminal state (bug shipped).
+    const tour = makeTour('t', [visibleStep('a', { onBeforeShow: () => false as const })])
+    const { ctx } = on(tour, 0)
+    ctx.completedTourIdRef.current = 'sentinel'
+    ctx.skippedTourIdRef.current = 'sentinel'
+
+    await startImpl(ctx, 't')
+
+    expect(ctx.completedTourIdRef.current).toBe('sentinel')
+    expect(ctx.skippedTourIdRef.current).toBe('sentinel')
+  })
+
+  it('runs onEnter before dispatching START_TOUR', async () => {
+    const tour = makeTour('t', [
+      visibleStep('a', {
+        onEnter: async () => {
+          await Promise.resolve()
+          callOrder.push('onEnter:a')
+        },
+      }),
+    ])
+    const { ctx, mocks } = on(tour, 0)
+    mocks.dispatch.mockImplementation((action: { type: string }) => {
+      callOrder.push(`dispatch:${action.type}`)
+    })
+
+    await startImpl(ctx, 't')
+
+    expect(callOrder).toEqual(['onEnter:a', 'dispatch:START_TOUR'])
+  })
+
+  it('guards the first VISIBLE step, not the requested index', async () => {
+    // `when` filtering resolves the real landing step first; the guard must be
+    // asked about the step the user will actually see.
+    const skipped = vi.fn()
+    const tour = makeTour('t', [
+      visibleStep('a', { when: () => false, onBeforeShow: skipped }),
+      visibleStep('b', { onBeforeShow: () => false as const }),
+    ])
+    const { ctx, mocks } = on(tour, 0)
+
+    await startImpl(ctx, 't')
+
+    expect(skipped).not.toHaveBeenCalled()
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'START_TOUR' }))
+  })
+})

--- a/packages/core/src/lib/tour-engine/__tests__/boot.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/boot.test.ts
@@ -267,3 +267,92 @@ describe('runBootStart', () => {
     expect(timeEndSpy).toHaveBeenCalledExactlyOnceWith('flow-restore')
   })
 })
+
+/**
+ * Issue #121 — session restore fires `onEnter`, and only `onEnter`.
+ *
+ * No `onBeforeShow`: a veto on a cold restore would strand the user mid-tour
+ * with no way to continue, and `boot()` is not cancellable.
+ */
+describe('runBootStart — step lifecycle on restore (#121)', () => {
+  const decision: BootDecision = { tourId: 'r', stepIndex: 0, source: 'flow' }
+  const callOrder: string[] = []
+
+  beforeEach(() => {
+    callOrder.length = 0
+    document.body.innerHTML = '<div id="x"></div>'
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function ctxWith(step: Parameters<typeof visibleStep>[1]) {
+    const handle = createFakeEngineContext()
+    handle.setCurrentTour(makeTour('r', [visibleStep('r1', step)]))
+    return handle
+  }
+
+  it('the no-callback same-route path stays synchronous', async () => {
+    // The existing "dispatches START_TOUR synchronously" case awaits the whole
+    // call before asserting, so it cannot see a lost tick. This one can: the
+    // guard around the await is what keeps the flow-restore timing budget.
+    const { ctx, mocks } = ctxWith({})
+
+    const promise = runBootStart(ctx, decision, { currentRoute: '/', onClear: vi.fn() })
+
+    expect(mocks.dispatch).toHaveBeenCalledWith({
+      type: 'START_TOUR',
+      tourId: 'r',
+      stepIndex: 0,
+    })
+    await promise
+  })
+
+  it('awaits onEnter before dispatching START_TOUR', async () => {
+    const { ctx, mocks } = ctxWith({
+      onEnter: async () => {
+        await Promise.resolve()
+        callOrder.push('onEnter:r1')
+      },
+    })
+    mocks.dispatch.mockImplementation((action: { type: string }) => {
+      callOrder.push(`dispatch:${action.type}`)
+    })
+
+    await runBootStart(ctx, decision, { currentRoute: '/', onClear: vi.fn() })
+
+    expect(callOrder).toEqual(['onEnter:r1', 'dispatch:START_TOUR'])
+  })
+
+  it('never asks onBeforeShow on a restore', async () => {
+    const onBeforeShow = vi.fn()
+    const { ctx, mocks } = ctxWith({ onBeforeShow })
+
+    await runBootStart(ctx, decision, { currentRoute: '/', onClear: vi.fn() })
+
+    expect(onBeforeShow).not.toHaveBeenCalled()
+    expect(mocks.dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'START_TOUR' }))
+  })
+
+  it('runs onEnter on the cross-route path too, after the target resolves', async () => {
+    const { ctx, mocks } = ctxWith({
+      target: '#x',
+      onEnter: () => {
+        callOrder.push('onEnter:r1')
+      },
+    })
+    mocks.router.getCurrentRoute.mockReturnValue('/home')
+    mocks.router.navigate.mockImplementation(async () => {
+      callOrder.push('navigate')
+      return undefined
+    })
+    mocks.dispatch.mockImplementation((action: { type: string }) => {
+      callOrder.push(`dispatch:${action.type}`)
+    })
+
+    await runBootStart(ctx, decision, { currentRoute: '/pricing', onClear: vi.fn() })
+
+    expect(callOrder).toEqual(['navigate', 'onEnter:r1', 'dispatch:START_TOUR'])
+  })
+})

--- a/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
@@ -511,3 +511,304 @@ describe('US-1 guard', () => {
     expect(source).not.toMatch(/from ['"](react|react-dom|@testing-library)/)
   })
 })
+
+/**
+ * Issue #121 — the five typed-but-dead step hooks, wired.
+ *
+ * This is the ORDER ORACLE. `applyTransitionEffects` runs inside the engine's
+ * synchronous `dispatch`, and the microtask carrying `onHide`/`onShow` is
+ * enqueued there — so the pinned order is only observable through a real
+ * engine. An order assertion against `createFakeEngineContext` would be
+ * asserting against a `vi.fn`, i.e. against the test's own arrangement.
+ */
+describe('step lifecycle callbacks — issue #121', () => {
+  const callOrder: string[] = []
+
+  /** Records the call and has no opinion — `undefined` ⇒ proceed. */
+  const note = (name: string, id: string) => () => {
+    callOrder.push(`${name}:${id}`)
+    return undefined
+  }
+
+  /** Records the call and vetoes — a literal `false` ⇒ do not commit. */
+  const veto = (name: string, id: string) => () => {
+    callOrder.push(`${name}:${id}`)
+    return false as const
+  }
+
+  /** Two visible steps with every hook wired. No `waitForTarget` — `visibleStep` hard-codes `target: '#x'`, which never exists here. */
+  const hooked = () =>
+    makeTour('t', [
+      visibleStep('a', {
+        onBeforeShow: note('onBeforeShow', 'a'),
+        onEnter: note('onEnter', 'a'),
+        onShow: note('onShow', 'a'),
+        onBeforeHide: note('onBeforeHide', 'a'),
+        onHide: note('onHide', 'a'),
+      }),
+      visibleStep('b', {
+        onBeforeShow: note('onBeforeShow', 'b'),
+        onEnter: note('onEnter', 'b'),
+        onShow: note('onShow', 'b'),
+        onBeforeHide: note('onBeforeHide', 'b'),
+        onHide: note('onHide', 'b'),
+      }),
+    ])
+
+  beforeEach(() => {
+    callOrder.length = 0
+  })
+
+  describe('the pinned order', () => {
+    it('next() runs beforeHide → beforeShow → enter → [commit] → hide → show', async () => {
+      const { engine } = engineFor({ tours: [hooked()] })
+      await engine.start('t')
+      callOrder.length = 0 // start() fires its own onBeforeShow/onEnter/onShow for `a`
+
+      await engine.next()
+
+      expect(callOrder).toEqual([
+        'onBeforeHide:a',
+        'onBeforeShow:b',
+        'onEnter:b',
+        'onHide:a',
+        'onShow:b',
+      ])
+    })
+
+    it('prev() runs the same order in the other direction', async () => {
+      // prevImpl returns early at currentStepIndex <= 0, so start AT 1 rather
+      // than start() + next() — the arrange must not run the act's hooks.
+      const { engine } = engineFor({ tours: [hooked()] })
+      await engine.start('t', 1)
+      callOrder.length = 0
+
+      await engine.prev()
+
+      expect(callOrder).toEqual([
+        'onBeforeHide:b',
+        'onBeforeShow:a',
+        'onEnter:a',
+        'onHide:b',
+        'onShow:a',
+      ])
+    })
+
+    it('start() runs onBeforeShow → onEnter → [commit] → onShow for the first step', async () => {
+      const { engine } = engineFor({ tours: [hooked()] })
+
+      await engine.start('t')
+
+      expect(callOrder).toEqual(['onBeforeShow:a', 'onEnter:a', 'onShow:a'])
+    })
+  })
+
+  describe('re-entrancy — the reason Group B is deferred', () => {
+    it('an onShow that calls next() advances exactly once more and settles', async () => {
+      // applyTransitionEffects runs INSIDE dispatch and must not dispatch.
+      // Without the queueMicrotask this re-enters the reducer mid-transition.
+      let engine!: TourEngine
+      const tour = makeTour('t', [
+        visibleStep('a'),
+        visibleStep('b', {
+          onShow: () => {
+            callOrder.push('onShow:b')
+            void engine.next()
+          },
+        }),
+        visibleStep('c', { onShow: note('onShow', 'c') }),
+      ])
+      engine = engineFor({ tours: [tour] }).engine
+
+      await engine.start('t')
+      await engine.next()
+      await vi.waitFor(() => expect(engine.getState().currentStep?.id).toBe('c'))
+
+      expect(engine.getState().isTransitioning).toBe(false)
+      expect(callOrder).toEqual(['onShow:b', 'onShow:c'])
+    })
+  })
+
+  describe('fail-safe — a buggy callback is inert', () => {
+    it('a throwing onShow does not reject next() and leaves the tour running', async () => {
+      const tour = makeTour('t', [
+        visibleStep('a'),
+        visibleStep('b', {
+          onShow: () => {
+            throw new Error('consumer bug')
+          },
+        }),
+      ])
+      const { engine } = engineFor({ tours: [tour] })
+      await engine.start('t')
+
+      await expect(engine.next()).resolves.toBeUndefined()
+      await Promise.resolve()
+
+      expect(engine.getState().isActive).toBe(true)
+      expect(engine.getState().currentStep?.id).toBe('b')
+      expect(engine.getState().isTransitioning).toBe(false)
+    })
+
+    it('a throwing onBeforeShow is "no opinion", not a veto', async () => {
+      // Deliberately unlike evaluateStepWhen (throw ⇒ skip): blocking a
+      // transition on a buggy guard is exactly the bricked tour D5 forbids.
+      const tour = makeTour('t', [
+        visibleStep('a'),
+        visibleStep('b', {
+          onBeforeShow: () => {
+            throw new Error('consumer bug')
+          },
+        }),
+      ])
+      const { engine } = engineFor({ tours: [tour] })
+      await engine.start('t')
+
+      await engine.next()
+
+      expect(engine.getState().currentStep?.id).toBe('b')
+    })
+
+    it('a falsy non-false return is not a veto', async () => {
+      // `undefined`, `null`, `0` and `''` all mean "proceed" — only a literal
+      // `false` vetoes.
+      const tour = makeTour('t', [
+        visibleStep('a', { onBeforeHide: () => undefined }),
+        visibleStep('b', { onBeforeShow: () => undefined }),
+      ])
+      const { engine } = engineFor({ tours: [tour] })
+      await engine.start('t')
+
+      await engine.next()
+
+      expect(engine.getState().currentStepIndex).toBe(1)
+    })
+  })
+
+  describe('vetoes unwind through the real dispatch', () => {
+    it('onBeforeHide false on next() changes nothing', async () => {
+      const onStepChange = vi.fn()
+      const tour = makeTour(
+        't',
+        [visibleStep('a', { onBeforeHide: veto('onBeforeHide', 'a') }), visibleStep('b')],
+        { onStepChange }
+      )
+      const { engine } = engineFor({ tours: [tour] })
+      await engine.start('t')
+      callOrder.length = 0
+
+      await engine.next()
+
+      expect(engine.getState().currentStepIndex).toBe(0)
+      expect(engine.getState().isTransitioning).toBe(false) // the free unwind at actions.ts:174
+      expect(onStepChange).not.toHaveBeenCalled()
+      expect(callOrder).toEqual(['onBeforeHide:a'])
+    })
+
+    it('onBeforeHide false on prev() changes nothing — the reporter’s case', async () => {
+      const tour = makeTour('t', [
+        visibleStep('a'),
+        visibleStep('b', { onBeforeHide: veto('onBeforeHide', 'b') }),
+      ])
+      const { engine } = engineFor({ tours: [tour] })
+      await engine.start('t', 1)
+      callOrder.length = 0
+
+      await engine.prev()
+
+      expect(engine.getState().currentStepIndex).toBe(1)
+      expect(engine.getState().isTransitioning).toBe(false)
+    })
+
+    it('onBeforeShow false on goTo() changes nothing', async () => {
+      const tour = makeTour('t', [
+        visibleStep('a'),
+        visibleStep('b'),
+        visibleStep('c', { onBeforeShow: veto('onBeforeShow', 'c') }),
+      ])
+      const { engine } = engineFor({ tours: [tour] })
+      await engine.start('t')
+      callOrder.length = 0
+
+      await engine.goTo(2)
+
+      expect(engine.getState().currentStepIndex).toBe(0)
+      expect(engine.getState().isTransitioning).toBe(false)
+      expect(callOrder).toEqual(['onBeforeShow:c'])
+    })
+
+    it('onBeforeShow false on start() never starts the tour', async () => {
+      const tour = makeTour('t', [
+        visibleStep('a', { onBeforeShow: veto('onBeforeShow', 'a') }),
+        visibleStep('b'),
+      ])
+      const { engine } = engineFor({ tours: [tour] })
+
+      await engine.start('t')
+
+      expect(engine.getState().isActive).toBe(false)
+      expect(callOrder).toEqual(['onBeforeShow:a'])
+    })
+
+    it('an async Promise<false> vetoes too — the guard is awaited', async () => {
+      const tour = makeTour('t', [
+        visibleStep('a', { onBeforeHide: async () => false as const }),
+        visibleStep('b'),
+      ])
+      const { engine } = engineFor({ tours: [tour] })
+      await engine.start('t')
+
+      await engine.next()
+
+      expect(engine.getState().currentStepIndex).toBe(0)
+    })
+  })
+
+  describe('the paths that bypass navigateToStep', () => {
+    it('boot restore fires onEnter and onShow, never onBeforeShow', async () => {
+      // A flow session only exists when `routePersistence.flowSession` is set.
+      const { engine, storage } = engineFor({
+        tours: [hooked()],
+        routePersistence: {
+          enabled: true,
+          storage: 'sessionStorage',
+          flowSession: { storage: 'sessionStorage' },
+        },
+      })
+      stageFlow(storage, { tourId: 't', stepIndex: 1 }) // no currentRoute ⇒ sync path
+
+      await engine.boot()
+      await Promise.resolve()
+
+      expect(engine.getState().currentStep?.id).toBe('b')
+      expect(callOrder).toEqual(['onEnter:b', 'onShow:b'])
+      expect(callOrder).not.toContain('onBeforeShow:b')
+    })
+
+    it('stop() fires onHide for the step that left, and no onShow', async () => {
+      const { engine } = engineFor({ tours: [hooked()] })
+      await engine.start('t')
+      callOrder.length = 0
+
+      engine.stop()
+      await Promise.resolve() // stop() is synchronous; Group B is a microtask away
+
+      expect(callOrder).toEqual(['onHide:a'])
+    })
+
+    it('next() on the last step completes and fires onHide only', async () => {
+      // `next()` at the last step calls completeTour() and returns before any
+      // Group A hook (actions.ts:145-148) — correct, there is no incoming
+      // step, but a silent asymmetry with stop(). Pinned so nobody "fixes" it.
+      const { engine } = engineFor({ tours: [hooked()] })
+      await engine.start('t', 1)
+      callOrder.length = 0
+
+      await engine.next()
+      await Promise.resolve()
+
+      expect(engine.getState().isActive).toBe(false)
+      expect(callOrder).toEqual(['onHide:b'])
+    })
+  })
+})

--- a/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
@@ -607,18 +607,21 @@ describe('step lifecycle callbacks — issue #121', () => {
     it('an onShow that calls next() advances exactly once more and settles', async () => {
       // applyTransitionEffects runs INSIDE dispatch and must not dispatch.
       // Without the queueMicrotask this re-enters the reducer mid-transition.
-      let engine!: TourEngine
+      // The step needs the engine that is built from it, so the callback
+      // reaches it through a holder rather than a forward-declared binding.
+      const live: { current: TourEngine | null } = { current: null }
       const tour = makeTour('t', [
         visibleStep('a'),
         visibleStep('b', {
           onShow: () => {
             callOrder.push('onShow:b')
-            void engine.next()
+            void live.current?.next()
           },
         }),
         visibleStep('c', { onShow: note('onShow', 'c') }),
       ])
-      engine = engineFor({ tours: [tour] }).engine
+      const { engine } = engineFor({ tours: [tour] })
+      live.current = engine
 
       await engine.start('t')
       await engine.next()

--- a/packages/core/src/lib/tour-engine/__tests__/handle-branch-target.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/handle-branch-target.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BranchContext } from '../../../types'
+import type { Tour } from '../../../types/tour'
 import { handleBranchTargetImpl } from '../handle-branch-target'
 import { createFakeEngineContext } from './_helpers/fake-engine-context'
 import { makeTour, visibleStep } from './_helpers/make-tour'
@@ -60,7 +61,7 @@ describe('handleBranchTargetImpl', () => {
       expect(handle.mocks.completeTour).not.toHaveBeenCalled()
     })
 
-    it('"restart" dispatches GO_TO_STEP 0 and tracks step visit', async () => {
+    it('"restart" navigates to step 0 and tracks step visit', async () => {
       const tour = makeTour('t1', [visibleStep('first'), visibleStep('second')])
       const onStepView = vi.fn()
       const handle = createFakeEngineContext({
@@ -72,7 +73,10 @@ describe('handleBranchTargetImpl', () => {
       await handleBranchTargetImpl(handle.ctx, 'restart', noopBranchCtx)
 
       expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'CLEAR_VISIT_TRACKING' })
-      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 0 })
+      // #121: restart routes through navigateToStep so step 0's `when`,
+      // `route` and lifecycle guards are honoured like any other landing.
+      // The mocked navigateToStep resolves true without dispatching.
+      expect(handle.mocks.navigateToStep).toHaveBeenCalledWith(0)
       expect(handle.mocks.dispatch).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'TRACK_STEP_VISIT', stepId: 'first' })
       )
@@ -379,6 +383,108 @@ describe('handleBranchTargetImpl', () => {
       const capturedCtx = handle.ctx
       handle.setState({ currentStepIndex: 1 })
       expect(capturedCtx.getState().currentStepIndex).toBe(1)
+    })
+  })
+})
+
+/**
+ * Issue #121 — the two branch paths that commit a step without going through
+ * `navigateToStep`, and the one that now does.
+ */
+describe('handleBranchTargetImpl — step lifecycle guards (#121)', () => {
+  const callOrder: string[] = []
+
+  beforeEach(() => {
+    callOrder.length = 0
+  })
+
+  describe('"restart"', () => {
+    it('unwinds when navigateToStep declines', async () => {
+      const tour = makeTour('t1', [visibleStep('first'), visibleStep('second')])
+      const onStepView = vi.fn()
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[1] ?? null, currentStepIndex: 1 },
+        navigateToStep: () => Promise.resolve(false),
+        tourKitContext: { onStepView },
+      })
+
+      await handleBranchTargetImpl(handle.ctx, 'restart', noopBranchCtx)
+
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'SET_TRANSITIONING',
+        isTransitioning: false,
+      })
+      expect(handle.mocks.dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'TRACK_STEP_VISIT' })
+      )
+      expect(onStepView).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('BranchToTour', () => {
+    /** Two tours registered, sitting on `t1` step 0. */
+    function crossTour(target: Tour, extras: Parameters<typeof createFakeEngineContext>[0] = {}) {
+      const source = makeTour('t1', [visibleStep('a')])
+      return createFakeEngineContext({
+        currentTour: source,
+        state: {
+          currentStep: source.steps[0] ?? null,
+          tours: new Map([
+            ['t1', source],
+            [target.id, target],
+          ]),
+        },
+        ...extras,
+      })
+    }
+
+    it('a vetoing first step leaves the current tour running', async () => {
+      // The only observable proof that `newStepIndex` is resolved BEFORE the
+      // STOP_TOUR dispatch: without that hoist the index is unknown at guard
+      // time, so the guard could only run after the stop — and a veto then
+      // strands the user with no tour at all.
+      const target = makeTour('t2', [
+        visibleStep('x'),
+        visibleStep('y', { onBeforeShow: () => false as const }),
+      ])
+      const handle = crossTour(target)
+
+      await handleBranchTargetImpl(handle.ctx, { tour: 't2', step: 'y' }, noopBranchCtx)
+
+      expect(handle.mocks.dispatch).not.toHaveBeenCalledWith({ type: 'STOP_TOUR' })
+      expect(handle.mocks.dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'START_TOUR' })
+      )
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({
+        type: 'SET_TRANSITIONING',
+        isTransitioning: false,
+      })
+    })
+
+    it('runs onEnter on the destination step before START_TOUR', async () => {
+      const onStart = vi.fn()
+      const target = makeTour(
+        't2',
+        [
+          visibleStep('x', {
+            onEnter: async () => {
+              await Promise.resolve()
+              callOrder.push('onEnter:x')
+            },
+          }),
+        ],
+        { onStart }
+      )
+      const handle = crossTour(target)
+      handle.mocks.dispatch.mockImplementation((action: { type: string }) => {
+        callOrder.push(`dispatch:${action.type}`)
+      })
+
+      await handleBranchTargetImpl(handle.ctx, { tour: 't2' }, noopBranchCtx)
+
+      expect(callOrder).toEqual(['onEnter:x', 'dispatch:STOP_TOUR', 'dispatch:START_TOUR'])
+      expect(onStart).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/core/src/lib/tour-engine/__tests__/handle-branch-target.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/handle-branch-target.test.ts
@@ -462,6 +462,52 @@ describe('handleBranchTargetImpl — step lifecycle guards (#121)', () => {
       })
     })
 
+    it('a vetoing first step announces nothing', async () => {
+      // Absence-of-dispatch is NOT proof that nothing happened. `onTourBranch`
+      // fires above the dispatches, so the case above passed while a cancelled
+      // branch still emitted a "branched from t1 to t2" analytics event and
+      // called the author's own callback for a branch that never occurred.
+      const onTourBranch = vi.fn()
+      const tourOnBranch = vi.fn()
+      const target = makeTour('t2', [visibleStep('x', { onBeforeShow: () => false as const })])
+      const handle = crossTour(target, { tourKitContext: { onTourBranch } })
+      const source = handle.ctx.getCurrentTour()
+      if (source) source.onTourBranch = tourOnBranch
+
+      await handleBranchTargetImpl(handle.ctx, { tour: 't2' }, noopBranchCtx)
+
+      expect(onTourBranch).not.toHaveBeenCalled()
+      expect(tourOnBranch).not.toHaveBeenCalled()
+    })
+
+    it('announces the branch once it actually happens', async () => {
+      const onTourBranch = vi.fn()
+      const target = makeTour('t2', [visibleStep('x')])
+      const handle = crossTour(target, { tourKitContext: { onTourBranch } })
+
+      await handleBranchTargetImpl(handle.ctx, { tour: 't2' }, noopBranchCtx)
+
+      expect(onTourBranch).toHaveBeenCalledWith('t1', 't2', 'a')
+    })
+
+    it('a throwing onTourBranch does not reject the caller', async () => {
+      const target = makeTour('t2', [visibleStep('x')])
+      const handle = crossTour(target)
+      const source = handle.ctx.getCurrentTour()
+      if (source) {
+        source.onTourBranch = () => {
+          throw new Error('consumer bug')
+        }
+      }
+
+      await expect(
+        handleBranchTargetImpl(handle.ctx, { tour: 't2' }, noopBranchCtx)
+      ).resolves.toBeUndefined()
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'START_TOUR' })
+      )
+    })
+
     it('runs onEnter on the destination step before START_TOUR', async () => {
       const onStart = vi.fn()
       const target = makeTour(

--- a/packages/core/src/lib/tour-engine/__tests__/navigate-to-step.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/navigate-to-step.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TourValidationError } from '../../validate-tour'
 import { TourRouteError } from '../../wait-for-step-target'
 import { navigateToStepImpl } from '../navigate-to-step'
@@ -190,6 +190,360 @@ describe('navigateToStepImpl', () => {
       const handle = createFakeEngineContext({ currentTour: tour, maxHiddenChain: max })
 
       await expect(navigateToStepImpl(handle.ctx, 0)).rejects.toBeInstanceOf(TourValidationError)
+    })
+  })
+})
+
+/**
+ * Issue #121 — Group A: the pre-commit guards, and where they sit.
+ *
+ * This is the PLACEMENT unit, not the order oracle. `dispatch` here is a
+ * `vi.fn`, so nothing observable happens after the commit — Group B
+ * (`onHide`/`onShow`) lives in `applyTransitionEffects` and is tested through
+ * the real engine instead. What this file owns is *which* side effects have
+ * and have not happened by the time a guard vetoes.
+ *
+ * Every `onBeforeHide` case passes `state.currentStep` explicitly:
+ * `createFakeEngineContext` defaults it to `null`, and the impl reads the
+ * outgoing step from `ctx.getState().currentStep`. Without it the case would
+ * assert `false` against a callback that never ran — green for the wrong
+ * reason. (That default is also why the 17 route/strategy cases above are
+ * unchanged by this phase: they are the regression oracle for the restructure.)
+ */
+describe('navigateToStepImpl — step lifecycle guards (#121)', () => {
+  const callOrder: string[] = []
+
+  const note = (name: string, id: string) => () => {
+    callOrder.push(`${name}:${id}`)
+    return undefined
+  }
+  const veto = (name: string, id: string) => () => {
+    callOrder.push(`${name}:${id}`)
+    return false as const
+  }
+
+  /** A handle whose dispatch mock records into the shared order array. */
+  function orderingHandle(...args: Parameters<typeof createFakeEngineContext>) {
+    const handle = createFakeEngineContext(...args)
+    handle.mocks.dispatch.mockImplementation((action: { type: string }) => {
+      callOrder.push(`dispatch:${action.type}`)
+    })
+    return handle
+  }
+
+  beforeEach(() => {
+    callOrder.length = 0
+  })
+
+  afterEach(() => {
+    // The in-tree idiom from `__tests__/lib/wait-for-step-target.test.ts` — a
+    // bare `useRealTimers()` leaves queued timers behind, and most cases in
+    // this file never enable fake timers at all.
+    if (vi.isFakeTimers?.()) {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+    document.body.innerHTML = ''
+  })
+
+  describe('onBeforeHide (the outgoing step)', () => {
+    it('a literal false returns false and never dispatches', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a', { onBeforeHide: veto('onBeforeHide', 'a') }),
+        visibleStep('b'),
+      ])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+      })
+
+      const result = await navigateToStepImpl(handle.ctx, 1)
+
+      expect(result).toBe(false)
+      expect(handle.mocks.dispatch).not.toHaveBeenCalled()
+      expect(callOrder).toEqual(['onBeforeHide:a'])
+    })
+
+    it('a veto walks no hidden steps — it runs before the traversal', async () => {
+      // The guard sits at entry, before the hidden walk, so a vetoed
+      // transition must not have run any hidden step's onEnter along the way.
+      const hiddenEnter = vi.fn()
+      const tour = makeTour('t1', [
+        visibleStep('a', { onBeforeHide: veto('onBeforeHide', 'a') }),
+        hiddenStep('h', { onEnter: hiddenEnter }),
+        visibleStep('b'),
+      ])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+      })
+
+      const result = await navigateToStepImpl(handle.ctx, 1)
+
+      expect(result).toBe(false)
+      expect(hiddenEnter).not.toHaveBeenCalled()
+    })
+
+    it('an async Promise<false> vetoes — the guard is awaited', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a', { onBeforeHide: async () => false as const }),
+        visibleStep('b'),
+      ])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+      })
+
+      expect(await navigateToStepImpl(handle.ctx, 1)).toBe(false)
+      expect(handle.mocks.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('a throwing guard is "no opinion" — the step still commits', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a', {
+          onBeforeHide: () => {
+            throw new Error('consumer bug')
+          },
+        }),
+        visibleStep('b'),
+      ])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+      })
+
+      expect(await navigateToStepImpl(handle.ctx, 1)).toBe(true)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 1 })
+    })
+  })
+
+  describe('onBeforeShow (the incoming step)', () => {
+    it('a veto on a route-change step never calls router.navigate', async () => {
+      // This is what proves the guard sits BEFORE the router, not after: a
+      // veto must leave the user on the page they are already on.
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        visibleStep('b', { route: '/about', onBeforeShow: veto('onBeforeShow', 'b') }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+
+      const result = await navigateToStepImpl(handle.ctx, 1)
+
+      expect(result).toBe(false)
+      expect(handle.mocks.router.navigate).not.toHaveBeenCalled()
+      expect(handle.mocks.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('a veto on a same-route step returns false without dispatching', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        visibleStep('b', { onBeforeShow: veto('onBeforeShow', 'b') }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      expect(await navigateToStepImpl(handle.ctx, 1)).toBe(false)
+      expect(handle.mocks.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('is not reached on a "prompt" step — the consumer drives that navigation', async () => {
+      // The prompt/manual early returns come first: the transition is deferred,
+      // not decided, so asking the incoming step's guard would be premature.
+      const onBeforeShow = vi.fn()
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        visibleStep('b', { route: '/about', routeChangeStrategy: 'prompt', onBeforeShow }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+
+      expect(await navigateToStepImpl(handle.ctx, 1)).toBe(false)
+      expect(onBeforeShow).not.toHaveBeenCalled()
+      expect(handle.mocks.onNavigationRequired).toHaveBeenCalledWith('/about', 'b')
+    })
+
+    it('a throwing guard logs and proceeds', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        visibleStep('b', {
+          onBeforeShow: () => {
+            throw new Error('consumer bug')
+          },
+        }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      expect(await navigateToStepImpl(handle.ctx, 1)).toBe(true)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 1 })
+    })
+  })
+
+  describe('onEnter runs before the commit', () => {
+    it('is awaited before GO_TO_STEP is dispatched', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a', { onBeforeHide: note('onBeforeHide', 'a') }),
+        visibleStep('b', {
+          onBeforeShow: note('onBeforeShow', 'b'),
+          onEnter: async () => {
+            await Promise.resolve()
+            callOrder.push('onEnter:b')
+          },
+        }),
+      ])
+      const handle = orderingHandle({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+      })
+
+      await navigateToStepImpl(handle.ctx, 1)
+
+      expect(callOrder).toEqual([
+        'onBeforeHide:a',
+        'onBeforeShow:b',
+        'onEnter:b',
+        'dispatch:GO_TO_STEP',
+      ])
+    })
+
+    it('runs after the router navigates, so it sees the page the step mounts on', async () => {
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        visibleStep('b', { route: '/about', target: '#about-x', onEnter: note('onEnter', 'b') }),
+      ])
+      const handle = orderingHandle({ currentTour: tour })
+      handle.mocks.router.matchRoute.mockReturnValue(false)
+      handle.mocks.router.navigate.mockImplementation(async () => {
+        callOrder.push('navigate')
+        const el = document.createElement('div')
+        el.id = 'about-x'
+        document.body.appendChild(el)
+        return undefined
+      })
+
+      await navigateToStepImpl(handle.ctx, 1)
+
+      expect(callOrder).toEqual(['navigate', 'onEnter:b', 'dispatch:GO_TO_STEP'])
+    })
+  })
+
+  describe('waitForTarget on the step’s own route', () => {
+    it('commits once a late target appears', async () => {
+      vi.useFakeTimers()
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        visibleStep('b', { target: '#late', waitForTarget: true, waitTimeout: 1000 }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      const promise = navigateToStepImpl(handle.ctx, 1)
+      setTimeout(() => {
+        const el = document.createElement('div')
+        el.id = 'late'
+        document.body.appendChild(el)
+      }, 200)
+      await vi.advanceTimersByTimeAsync(250)
+
+      expect(await promise).toBe(true)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 1 })
+    })
+
+    it('stops the tour with TARGET_NOT_FOUND when the target never appears', async () => {
+      vi.useFakeTimers()
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        visibleStep('b', { target: '#never', waitForTarget: true, waitTimeout: 1000 }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      const promise = navigateToStepImpl(handle.ctx, 1)
+      await vi.advanceTimersByTimeAsync(1100)
+
+      expect(await promise).toBe(false)
+      expect(handle.mocks.onStepError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'TARGET_NOT_FOUND' })
+      )
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'STOP_TOUR' })
+      expect(handle.mocks.dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'GO_TO_STEP' })
+      )
+    })
+
+    it('is ignored on a targetless step — there is nothing to observe', async () => {
+      // `waitForStepTarget` throws TARGET_NOT_FOUND *synchronously* for a null
+      // resolve, so without the `&& step.target` gate every targetless modal
+      // step carrying this flag would stop the tour instantly.
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        visibleStep('b', { target: undefined, waitForTarget: true }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      expect(await navigateToStepImpl(handle.ctx, 1)).toBe(true)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 1 })
+      expect(handle.mocks.onStepError).not.toHaveBeenCalled()
+    })
+
+    it('a step without the flag does not wait, even when its target is missing', async () => {
+      // The regression net under the restructure: `visibleStep` hard-codes
+      // `target: '#x'`, which exists in no test document.
+      const tour = makeTour('t1', [visibleStep('a'), visibleStep('b')])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      expect(await navigateToStepImpl(handle.ctx, 1)).toBe(true)
+    })
+  })
+
+  describe('hidden steps keep their own lifecycle', () => {
+    it('fires onEnter and onShow exactly once each on the way past', async () => {
+      const onEnter = vi.fn()
+      const onShow = vi.fn()
+      const successorShow = vi.fn()
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        hiddenStep('h', { onEnter, onShow }),
+        visibleStep('b', { onShow: successorShow }),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      expect(await navigateToStepImpl(handle.ctx, 1)).toBe(true)
+
+      expect(onEnter).toHaveBeenCalledTimes(1)
+      expect(onShow).toHaveBeenCalledTimes(1)
+      // Group B lives in applyTransitionEffects, which this unit does not run.
+      expect(successorShow).not.toHaveBeenCalled()
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 2 })
+    })
+
+    it('a throwing hidden onEnter is logged, not rethrown', async () => {
+      // Before #121 these two were awaited directly rather than through
+      // `invokeAsyncCallback`, so a throw here rejected the consumer's next()
+      // and left isTransitioning stuck true — the bricked tour the callback
+      // contract forbids.
+      const tour = makeTour('t1', [
+        visibleStep('a'),
+        hiddenStep('h', {
+          onEnter: () => {
+            throw new Error('consumer bug')
+          },
+        }),
+        visibleStep('b'),
+      ])
+      const handle = createFakeEngineContext({ currentTour: tour })
+
+      await expect(navigateToStepImpl(handle.ctx, 1)).resolves.toBe(true)
+      expect(handle.mocks.dispatch).toHaveBeenCalledWith({ type: 'GO_TO_STEP', stepIndex: 2 })
+    })
+
+    it('onBeforeHide is ignored on a hidden outgoing step', async () => {
+      const onBeforeHide = vi.fn()
+      const tour = makeTour('t1', [hiddenStep('h', { onBeforeHide }), visibleStep('b')])
+      const handle = createFakeEngineContext({
+        currentTour: tour,
+        state: { currentStep: tour.steps[0] ?? null, currentStepIndex: 0 },
+      })
+
+      expect(await navigateToStepImpl(handle.ctx, 1)).toBe(true)
+      expect(onBeforeHide).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/core/src/lib/tour-engine/__tests__/step-callbacks-wired.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/step-callbacks-wired.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Issue #121 — the meta-guard: a declared step hook cannot go unwired.
+ *
+ * `BaseTourStep` declared seven lifecycle fields and the engine read two of
+ * them. They were typed, documented on ten docs pages and twelve compare
+ * pages, and dead — for long enough that a user filed a bug. That is a shape
+ * of failure no behaviour test catches, because there is no behaviour to test:
+ * the code that would have been wrong was never written.
+ *
+ * So this reads the source. Every lifecycle key on the interface must appear
+ * as a `.key` property access somewhere in the non-test engine, and the
+ * extractor self-checks first: a regex that silently stops matching would turn
+ * the guard into a no-op that passes forever — the exact failure mode that let
+ * #121 exist.
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SRC = resolve(__dirname, '..', '..', '..')
+const ENGINE_DIR = resolve(SRC, 'lib', 'tour-engine')
+
+/**
+ * The seven lifecycle fields. `onNext`, `onPrev` and `onAction` match the same
+ * regex but are branch targets, not lifecycle hooks; `waitTimeout` is a number
+ * read alongside `waitForTarget` and does not match at all.
+ */
+const LIFECYCLE_KEYS = [
+  'onBeforeHide',
+  'onBeforeShow',
+  'onEnter',
+  'onHide',
+  'onShow',
+  'waitForTarget',
+  'when',
+] as const
+
+const BRANCH_KEYS = new Set(['onNext', 'onPrev', 'onAction'])
+
+function declaredLifecycleKeys(): string[] {
+  const source = readFileSync(resolve(SRC, 'types', 'step.ts'), 'utf8')
+  const start = source.indexOf('interface BaseTourStep')
+  expect(start, 'BaseTourStep interface not found in types/step.ts').toBeGreaterThan(-1)
+  const end = source.indexOf('\n}', start)
+  const body = source.slice(start, end)
+
+  const keys = new Set<string>()
+  for (const match of body.matchAll(/^\s+(on[A-Z]\w+|when|waitForTarget)\??:/gm)) {
+    const key = match[1]
+    if (key && !BRANCH_KEYS.has(key)) keys.add(key)
+  }
+  return [...keys].sort()
+}
+
+/** Every non-test `.ts` under `lib/tour-engine/`, recursively. */
+function engineSources(dir = ENGINE_DIR): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '__tests__') continue
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...engineSources(path))
+    else if (entry.name.endsWith('.ts')) out.push(path)
+  }
+  return out
+}
+
+describe('every declared step hook has a call site (#121)', () => {
+  it('self-check: the extractor finds exactly the seven lifecycle keys', () => {
+    // Without this, a renamed interface or a changed field style would make
+    // the guard below iterate an empty list and pass on anything.
+    expect(declaredLifecycleKeys()).toEqual([...LIFECYCLE_KEYS])
+  })
+
+  it.each(LIFECYCLE_KEYS)('`%s` is read somewhere in lib/tour-engine/', (key) => {
+    const wired = engineSources().filter((file) => readFileSync(file, 'utf8').includes(`.${key}`))
+
+    expect(wired, `no non-test file under lib/tour-engine/ reads \`.${key}\``).not.toHaveLength(0)
+  })
+})

--- a/packages/core/src/lib/tour-engine/__tests__/transition-effects.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/transition-effects.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tourRegistry } from '../../../registry/tour-registry'
 import type { TourCallbackContext } from '../../../types/state'
 import type { Tour } from '../../../types/tour'
+import { logger } from '../../../utils/logger'
 import { createBroadcast } from '../adapters/broadcast'
 import type { CrossTabActiveMessage } from '../context'
 import { applyTransitionEffects, subscribeCrossTabPause } from '../transition-effects'
@@ -408,5 +409,98 @@ describe('cross-tab pause', () => {
     await drain()
 
     expect(us.mocks.dispatch).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * Issue #121 — Group B: the post-commit notifications.
+ *
+ * `onHide`/`onShow` are deferred by a `queueMicrotask` because this function
+ * runs inside `dispatch` and a consumer's `onShow` may call `next()`. Every
+ * assertion therefore comes after an explicit `await Promise.resolve()` —
+ * a synchronous call here does not cross the microtask boundary on its own.
+ */
+describe('step lifecycle notifications (#121)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fires onHide(prev) and onShow(next) on a position change', async () => {
+    const onHide = vi.fn()
+    const onShow = vi.fn()
+    const tour = makeTour('t', [visibleStep('a', { onHide }), visibleStep('b', { onShow })])
+    const { ctx } = createFakeEngineContext({ currentTour: tour })
+
+    applyTransitionEffects(ctx, active(0, tour), active(1, tour))
+    await Promise.resolve()
+
+    // Each receives its OWN snapshot — the one it is leaving / arriving in.
+    expect(onHide).toHaveBeenCalledTimes(1)
+    expect(onHide.mock.calls[0]?.[0]).toMatchObject({ currentStepIndex: 0 })
+    expect(onShow).toHaveBeenCalledTimes(1)
+    expect(onShow.mock.calls[0]?.[0]).toMatchObject({ currentStepIndex: 1 })
+  })
+
+  it('is silent on an inert re-apply — adapter A calls this on every commit', async () => {
+    const onHide = vi.fn()
+    const onShow = vi.fn()
+    const tour = makeTour('t', [visibleStep('a', { onHide, onShow })])
+    const { ctx } = createFakeEngineContext({ currentTour: tour })
+    const same = active(0, tour)
+
+    applyTransitionEffects(ctx, same, same)
+    await Promise.resolve()
+
+    expect(onHide).not.toHaveBeenCalled()
+    expect(onShow).not.toHaveBeenCalled()
+  })
+
+  it('fires only onHide when the tour ends', async () => {
+    const onHide = vi.fn()
+    const tour = makeTour('t', [visibleStep('a'), visibleStep('b', { onHide })])
+    const { ctx } = createFakeEngineContext({ currentTour: tour })
+
+    applyTransitionEffects(ctx, active(1, tour), snap())
+    await Promise.resolve()
+
+    expect(onHide).toHaveBeenCalledTimes(1)
+  })
+
+  it('never fires onShow into an inactive snapshot', async () => {
+    // The only case that can see the `next.isActive` gate. Through the real
+    // engine it is unobservable: `createStoppedState` nulls `currentStep` as
+    // well as clearing `isActive`, so the gate would hold with it deleted.
+    const onShow = vi.fn()
+    const tour = makeTour('t', [visibleStep('a'), visibleStep('b', { onShow })])
+    const { ctx } = createFakeEngineContext({ currentTour: tour })
+
+    applyTransitionEffects(
+      ctx,
+      active(0, tour),
+      snap({ isActive: false, currentStep: tour.steps[1] ?? null })
+    )
+    await Promise.resolve()
+
+    expect(onShow).not.toHaveBeenCalled()
+  })
+
+  it('a throwing onHide is logged and does not prevent onShow', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const onShow = vi.fn()
+    const tour = makeTour('t', [
+      visibleStep('a', {
+        onHide: () => {
+          throw new Error('consumer bug')
+        },
+      }),
+      visibleStep('b', { onShow }),
+    ])
+    const { ctx } = createFakeEngineContext({ currentTour: tour })
+
+    applyTransitionEffects(ctx, active(0, tour), active(1, tour))
+    await Promise.resolve()
+
+    expect(warn).toHaveBeenCalled()
+    expect(onShow).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/lib/tour-engine/actions.ts
+++ b/packages/core/src/lib/tour-engine/actions.ts
@@ -139,14 +139,19 @@ export async function startImpl(
  * dispatch, so a guard placed below it would leave START_TOUR undispatched
  * while having already wiped the terminal state.
  *
+ * `opts.beforeDispatch` runs after the guard has passed and before
+ * `START_TOUR` — the cross-tour branch uses it to stop the outgoing tour,
+ * which must not happen if the destination step vetoes.
+ *
  * @returns `false` when the step's `onBeforeShow` vetoed; the caller unwinds.
  */
-async function commitStart(
+export async function commitStart(
   ctx: TourEngineContext,
   tour: Tour,
   stepIndex: number,
   state: TourCallbackContext | TourReducerState,
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
+  opts?: { beforeDispatch?: () => void }
 ): Promise<boolean> {
   const step = tour.steps[stepIndex]
   if (step) {
@@ -163,6 +168,8 @@ async function commitStart(
     }
     await invokeAsyncCallback('onEnter', () => step.onEnter?.(stepCtx))
   }
+
+  opts?.beforeDispatch?.()
 
   // Re-arm terminal-callback guards for the (re)started tour.
   ctx.completedTourIdRef.current = null

--- a/packages/core/src/lib/tour-engine/actions.ts
+++ b/packages/core/src/lib/tour-engine/actions.ts
@@ -10,6 +10,8 @@
  */
 import type { BranchContext } from '../../types/branch'
 import type { TourCallbackContext } from '../../types/state'
+import type { Tour } from '../../types/tour'
+import type { TourReducerState } from '../../types/tour-reducer'
 import { resolveBranch } from '../../utils/branch'
 import { logger } from '../../utils/logger'
 import type { TourEngineContext } from './context'
@@ -19,6 +21,7 @@ import {
   evaluateStepWhen,
   findNearestVisibleStepIndex,
   findNextVisibleStepIndex,
+  invokeAsyncCallback,
   invokeCallback,
 } from './helpers'
 
@@ -118,13 +121,57 @@ export async function startImpl(
     return
   }
 
+  await commitStart(ctx, tour, visibleIndex, state, data)
+}
+
+/**
+ * The commit tail shared by `startImpl` and the cross-tour branch: ask the
+ * landing step's guard, run its `onEnter`, re-arm the terminal-callback
+ * guards, dispatch `START_TOUR`, fire the start callbacks.
+ *
+ * It exists because both callers commit a step *without* going through
+ * `navigateToStep`, so both owe the incoming half of the step lifecycle
+ * (#121) — and the re-arm/dispatch/analytics/onStart block was already
+ * duplicated verbatim between them. One copy, one place to get the ordering
+ * right.
+ *
+ * The re-arm happens only after the guard has passed. It runs before the
+ * dispatch, so a guard placed below it would leave START_TOUR undispatched
+ * while having already wiped the terminal state.
+ *
+ * @returns `false` when the step's `onBeforeShow` vetoed; the caller unwinds.
+ */
+async function commitStart(
+  ctx: TourEngineContext,
+  tour: Tour,
+  stepIndex: number,
+  state: TourCallbackContext | TourReducerState,
+  data: Record<string, unknown>
+): Promise<boolean> {
+  const step = tour.steps[stepIndex]
+  if (step) {
+    const stepCtx: TourCallbackContext = {
+      ...buildCallbackContext(ctx.getState(), tour, data),
+      tourId: tour.id,
+      isActive: true,
+      totalSteps: tour.steps.length,
+      currentStepIndex: stepIndex,
+      currentStep: step,
+    }
+    if ((await invokeAsyncCallback('onBeforeShow', () => step.onBeforeShow?.(stepCtx))) === false) {
+      return false
+    }
+    await invokeAsyncCallback('onEnter', () => step.onEnter?.(stepCtx))
+  }
+
   // Re-arm terminal-callback guards for the (re)started tour.
   ctx.completedTourIdRef.current = null
   ctx.skippedTourIdRef.current = null
 
-  ctx.dispatch({ type: 'START_TOUR', tourId: id, stepIndex: visibleIndex })
-  ctx.tourKitContext?.onTourStart?.(id)
+  ctx.dispatch({ type: 'START_TOUR', tourId: tour.id, stepIndex })
+  ctx.tourKitContext?.onTourStart?.(tour.id)
   invokeCallback('onStart', () => tour.onStart?.({ ...state, tour, data }))
+  return true
 }
 
 export async function nextImpl(ctx: TourEngineContext): Promise<void> {

--- a/packages/core/src/lib/tour-engine/actions.ts
+++ b/packages/core/src/lib/tour-engine/actions.ts
@@ -10,8 +10,6 @@
  */
 import type { BranchContext } from '../../types/branch'
 import type { TourCallbackContext } from '../../types/state'
-import type { Tour } from '../../types/tour'
-import type { TourReducerState } from '../../types/tour-reducer'
 import { resolveBranch } from '../../utils/branch'
 import { logger } from '../../utils/logger'
 import type { TourEngineContext } from './context'
@@ -21,9 +19,9 @@ import {
   evaluateStepWhen,
   findNearestVisibleStepIndex,
   findNextVisibleStepIndex,
-  invokeAsyncCallback,
   invokeCallback,
 } from './helpers'
+import { askStepGuards, commitStart } from './start-tour'
 
 /** The `{ ...state, tour, data }` shape every tour-level callback receives. */
 function snapshot(ctx: TourEngineContext): TourCallbackContext {
@@ -121,64 +119,8 @@ export async function startImpl(
     return
   }
 
-  await commitStart(ctx, tour, visibleIndex, state, data)
-}
-
-/**
- * The commit tail shared by `startImpl` and the cross-tour branch: ask the
- * landing step's guard, run its `onEnter`, re-arm the terminal-callback
- * guards, dispatch `START_TOUR`, fire the start callbacks.
- *
- * It exists because both callers commit a step *without* going through
- * `navigateToStep`, so both owe the incoming half of the step lifecycle
- * (#121) — and the re-arm/dispatch/analytics/onStart block was already
- * duplicated verbatim between them. One copy, one place to get the ordering
- * right.
- *
- * The re-arm happens only after the guard has passed. It runs before the
- * dispatch, so a guard placed below it would leave START_TOUR undispatched
- * while having already wiped the terminal state.
- *
- * `opts.beforeDispatch` runs after the guard has passed and before
- * `START_TOUR` — the cross-tour branch uses it to stop the outgoing tour,
- * which must not happen if the destination step vetoes.
- *
- * @returns `false` when the step's `onBeforeShow` vetoed; the caller unwinds.
- */
-export async function commitStart(
-  ctx: TourEngineContext,
-  tour: Tour,
-  stepIndex: number,
-  state: TourCallbackContext | TourReducerState,
-  data: Record<string, unknown>,
-  opts?: { beforeDispatch?: () => void }
-): Promise<boolean> {
-  const step = tour.steps[stepIndex]
-  if (step) {
-    const stepCtx: TourCallbackContext = {
-      ...buildCallbackContext(ctx.getState(), tour, data),
-      tourId: tour.id,
-      isActive: true,
-      totalSteps: tour.steps.length,
-      currentStepIndex: stepIndex,
-      currentStep: step,
-    }
-    if ((await invokeAsyncCallback('onBeforeShow', () => step.onBeforeShow?.(stepCtx))) === false) {
-      return false
-    }
-    await invokeAsyncCallback('onEnter', () => step.onEnter?.(stepCtx))
-  }
-
-  opts?.beforeDispatch?.()
-
-  // Re-arm terminal-callback guards for the (re)started tour.
-  ctx.completedTourIdRef.current = null
-  ctx.skippedTourIdRef.current = null
-
-  ctx.dispatch({ type: 'START_TOUR', tourId: tour.id, stepIndex })
-  ctx.tourKitContext?.onTourStart?.(tour.id)
-  invokeCallback('onStart', () => tour.onStart?.({ ...state, tour, data }))
-  return true
+  if (!(await askStepGuards(ctx, tour, visibleIndex, data))) return
+  commitStart(ctx, tour, visibleIndex, state, data)
 }
 
 export async function nextImpl(ctx: TourEngineContext): Promise<void> {

--- a/packages/core/src/lib/tour-engine/boot.ts
+++ b/packages/core/src/lib/tour-engine/boot.ts
@@ -17,6 +17,7 @@ import type { FlowSessionV2 } from '../flow-session'
 import { waitForStepTarget } from '../wait-for-step-target'
 import type { PersistedRouteState } from './adapters/route-store'
 import type { TourEngineContext } from './context'
+import { buildCallbackContext, invokeAsyncCallback } from './helpers'
 import { findAutoStartTour } from './reducer'
 
 export type BootSource = 'flow' | 'route' | 'auto'
@@ -129,14 +130,39 @@ export async function runBootStart(
   const { router } = ctx
 
   const endTimer = createRestoreTimer(decision.source)
-  const dispatchStart = () => {
+  const targetTour = ctx.getState().tours.get(decision.tourId) ?? null
+  const targetStep = targetTour?.steps[decision.stepIndex]
+
+  /**
+   * A restore runs the step's `onEnter` but never its `onBeforeShow` (#121):
+   * a veto on a cold restore would strand the user mid-tour, and `boot()` is
+   * not cancellable. `onShow` arrives on its own through the transition
+   * effects once START_TOUR lands.
+   *
+   * The `onEnter` guard keeps the no-callback path synchronous. That is the
+   * common case and it has a timing budget — awaiting unconditionally would
+   * cost every restore a tick for a callback almost no tour defines.
+   */
+  const dispatchStart = async () => {
+    if (targetStep?.onEnter) {
+      await invokeAsyncCallback('onEnter', () =>
+        targetStep.onEnter?.({
+          ...buildCallbackContext(ctx.getState(), targetTour, ctx.getData()),
+          tourId: decision.tourId,
+          isActive: true,
+          currentStepIndex: decision.stepIndex,
+          currentStep: targetStep,
+          totalSteps: targetTour?.steps.length ?? 0,
+        })
+      )
+    }
     ctx.dispatch({ type: 'START_TOUR', tourId: decision.tourId, stepIndex: decision.stepIndex })
   }
 
   const needsRouteRestore = !!currentRoute && !!router && currentRoute !== router.getCurrentRoute()
 
   if (!needsRouteRestore) {
-    dispatchStart()
+    await dispatchStart()
     endTimer()
     return
   }
@@ -144,8 +170,6 @@ export async function runBootStart(
   // Narrowing: `needsRouteRestore` proved both of these.
   const route = currentRoute as string
   const nav = router as NonNullable<typeof router>
-
-  const targetStep = ctx.getState().tours.get(decision.tourId)?.steps[decision.stepIndex]
 
   try {
     await nav.navigate(route)
@@ -158,7 +182,7 @@ export async function runBootStart(
       if (signal?.aborted) return endTimer()
     }
 
-    dispatchStart()
+    await dispatchStart()
     endTimer()
   } catch {
     endTimer()

--- a/packages/core/src/lib/tour-engine/handle-branch-target.ts
+++ b/packages/core/src/lib/tour-engine/handle-branch-target.ts
@@ -64,7 +64,16 @@ export async function handleBranchTargetImpl(
 
       case 'restart': {
         ctx.dispatch({ type: 'CLEAR_VISIT_TRACKING' })
-        ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: 0 })
+        // Through navigateToStep, not a raw GO_TO_STEP: landing on step 0 is
+        // a landing like any other, so it owes the same hidden-step walk,
+        // route navigation and lifecycle guards. The raw dispatch also put
+        // the tour on step 0 unconditionally — including when step 0 is
+        // hidden or lives on another route (#121).
+        const navigated = await ctx.navigateToStep(0)
+        if (!navigated) {
+          ctx.dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
+          return
+        }
         const firstStep = currentTour.steps[0]
         if (firstStep) {
           ctx.dispatch({

--- a/packages/core/src/lib/tour-engine/handle-branch-target.ts
+++ b/packages/core/src/lib/tour-engine/handle-branch-target.ts
@@ -7,7 +7,6 @@ import {
   resolveTargetToIndex,
 } from '../../utils/branch'
 import { logger } from '../../utils/logger'
-import { commitStart } from './actions'
 import type { TourEngineContext } from './context'
 import {
   buildCallbackContext,
@@ -15,6 +14,7 @@ import {
   findNextVisibleStepIndex,
   invokeCallback,
 } from './helpers'
+import { askStepGuards, commitStart } from './start-tour'
 
 /**
  * Resolve a `BranchTarget` to its effect on the active tour. Mirrors the
@@ -102,14 +102,10 @@ export async function handleBranchTargetImpl(
       return
     }
 
-    ctx.tourKitContext?.onTourBranch?.(currentTour.id, target.tour, currentStepId)
-    currentTour.onTourBranch?.(target.tour, currentStepId)
-
-    // Resolved BEFORE the stop: `commitStart` needs the landing index to ask
-    // the destination step's guard, and a veto has to leave the current tour
-    // running. Asking after STOP_TOUR would strand the user with no tour at
-    // all (#121). The move is a pure reorder — nothing here reads state the
-    // stop would have changed.
+    // Resolved BEFORE anything is announced or stopped: the guard needs the
+    // landing index, and a veto has to leave the current tour running and
+    // silent. Asking after STOP_TOUR would strand the user with no tour at
+    // all (#121).
     let newStepIndex = 0
     if (target.step !== undefined) {
       if (typeof target.step === 'number') {
@@ -121,12 +117,20 @@ export async function handleBranchTargetImpl(
       }
     }
 
-    const started = await commitStart(ctx, toTour, newStepIndex, state, data, {
-      beforeDispatch: () => ctx.dispatch({ type: 'STOP_TOUR' }),
-    })
-    if (!started) {
+    if (!(await askStepGuards(ctx, toTour, newStepIndex, data))) {
       ctx.dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
+      return
     }
+
+    // Only now has the branch actually happened. Announcing above the guard
+    // emitted a "branched from A to B" event for a branch a veto then
+    // cancelled — a false analytics event and a consumer callback for
+    // something that did not occur.
+    ctx.tourKitContext?.onTourBranch?.(currentTour.id, target.tour, currentStepId)
+    invokeCallback('onTourBranch', () => currentTour.onTourBranch?.(target.tour, currentStepId))
+
+    ctx.dispatch({ type: 'STOP_TOUR' })
+    commitStart(ctx, toTour, newStepIndex, state, data)
     return
   }
 

--- a/packages/core/src/lib/tour-engine/handle-branch-target.ts
+++ b/packages/core/src/lib/tour-engine/handle-branch-target.ts
@@ -7,6 +7,7 @@ import {
   resolveTargetToIndex,
 } from '../../utils/branch'
 import { logger } from '../../utils/logger'
+import { commitStart } from './actions'
 import type { TourEngineContext } from './context'
 import {
   buildCallbackContext,
@@ -95,8 +96,11 @@ export async function handleBranchTargetImpl(
     ctx.tourKitContext?.onTourBranch?.(currentTour.id, target.tour, currentStepId)
     currentTour.onTourBranch?.(target.tour, currentStepId)
 
-    ctx.dispatch({ type: 'STOP_TOUR' })
-
+    // Resolved BEFORE the stop: `commitStart` needs the landing index to ask
+    // the destination step's guard, and a veto has to leave the current tour
+    // running. Asking after STOP_TOUR would strand the user with no tour at
+    // all (#121). The move is a pure reorder — nothing here reads state the
+    // stop would have changed.
     let newStepIndex = 0
     if (target.step !== undefined) {
       if (typeof target.step === 'number') {
@@ -108,13 +112,12 @@ export async function handleBranchTargetImpl(
       }
     }
 
-    // Re-arm terminal-callback guards for the new tour
-    ctx.completedTourIdRef.current = null
-    ctx.skippedTourIdRef.current = null
-
-    ctx.dispatch({ type: 'START_TOUR', tourId: target.tour, stepIndex: newStepIndex })
-    ctx.tourKitContext?.onTourStart?.(target.tour)
-    invokeCallback('onStart', () => toTour.onStart?.({ ...state, tour: toTour, data }))
+    const started = await commitStart(ctx, toTour, newStepIndex, state, data, {
+      beforeDispatch: () => ctx.dispatch({ type: 'STOP_TOUR' }),
+    })
+    if (!started) {
+      ctx.dispatch({ type: 'SET_TRANSITIONING', isTransitioning: false })
+    }
     return
   }
 

--- a/packages/core/src/lib/tour-engine/helpers.ts
+++ b/packages/core/src/lib/tour-engine/helpers.ts
@@ -80,6 +80,29 @@ export function invokeCallback(name: string, fn: () => void): void {
 }
 
 /**
+ * Async sibling of `invokeCallback` for the step guards (`onBeforeShow`,
+ * `onBeforeHide`) and `onEnter`.
+ *
+ * Resolves to the callback's value, or `undefined` when it throws (logged).
+ * A guard vetoes a transition only with a **literal `false`**; a throw is
+ * "no opinion" and the transition proceeds.
+ *
+ * Deliberately unlike `evaluateStepWhen`, which treats a throw as `false`:
+ * skipping a step is always safe, blocking a transition is not. An
+ * `onBeforeHide` that throws on every call would otherwise block both
+ * `next()` and `prev()` — the bricked tour the `invokeCallback` contract
+ * exists to prevent (issue #121, D5).
+ */
+export async function invokeAsyncCallback(name: string, fn: () => unknown): Promise<unknown> {
+  try {
+    return await fn()
+  } catch (error) {
+    logger.warn(`Error in ${name} callback:`, error)
+    return undefined
+  }
+}
+
+/**
  * Walk steps in `direction` from `startIndex` (inclusive) until a step's
  * `when` predicate returns true or the array boundary is reached.
  *

--- a/packages/core/src/lib/tour-engine/navigate-to-step.ts
+++ b/packages/core/src/lib/tour-engine/navigate-to-step.ts
@@ -1,5 +1,5 @@
 import type { BranchContext, TourCallbackContext } from '../../types'
-import type { TourStep, VisibleTourStep } from '../../types/step'
+import { type TourStep, type VisibleTourStep, isVisibleStep } from '../../types/step'
 import type { Tour } from '../../types/tour'
 import { resolveBranch, resolveTargetToIndex } from '../../utils/branch'
 import { TourValidationError } from '../validate-tour'
@@ -46,6 +46,122 @@ async function advancePastHiddenStep(
 
   const idx = resolveTargetToIndex(target, cursor, stepIdLookup, tour.steps.length)
   return idx ?? cursor + 1
+}
+
+/**
+ * The route hop a step needs before it can mount, or `null` when the step
+ * mounts on the route the user is already on.
+ *
+ * Deliberately a nullable pair rather than a `sameRoute` boolean: a flag
+ * answers the question but discards the two values that answered it, and every
+ * later use then has to assert them back with `as`.
+ */
+type RouteHop = { route: string; router: NonNullable<TourEngineContext['router']> }
+
+function resolveRouteHop(ctx: TourEngineContext, step: VisibleTourStep): RouteHop | null {
+  const { needed } = isNavigationNeeded(step, ctx.router)
+  if (!needed || !step.route || !ctx.router) return null
+  return { route: step.route, router: ctx.router }
+}
+
+/**
+ * Drive the router to the step's route. `NAVIGATION_REJECTED` and an abort are
+ * the only outcomes that are not a throw.
+ *
+ * @returns `false` when the caller should unwind.
+ */
+async function runRouteHop(
+  ctx: TourEngineContext,
+  hop: RouteHop,
+  step: VisibleTourStep
+): Promise<boolean> {
+  try {
+    const navResult = await hop.router.navigate(hop.route)
+    if (navResult === false) {
+      throw new TourRouteError({
+        code: 'NAVIGATION_REJECTED',
+        route: hop.route,
+        message: `Router rejected navigation to "${hop.route}".`,
+      })
+    }
+
+    if (step.routeDelay && step.routeDelay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, step.routeDelay))
+    }
+    return true
+  } catch (err) {
+    if (ctx.abortControllerRef.current?.signal.aborted) return false
+    if (err instanceof TourRouteError) {
+      ctx.onStepError?.(err)
+      ctx.dispatch({ type: 'STOP_TOUR' })
+      return false
+    }
+    throw err
+  }
+}
+
+/**
+ * Everything between "the hidden walk found a mountable step" and
+ * `GO_TO_STEP`: the navigation strategy, the incoming guard, the route hop,
+ * the target wait and `onEnter`.
+ *
+ * It lives outside the hidden-walk loop because it is that loop's *exit* —
+ * every path here returns, so it runs at most once per navigation.
+ *
+ * @returns `true` when the step was committed.
+ */
+async function commitVisibleStep(
+  ctx: TourEngineContext,
+  step: VisibleTourStep,
+  cursor: number,
+  tour: Tour
+): Promise<boolean> {
+  const hop = resolveRouteHop(ctx, step)
+
+  // The deferred strategies come first: the transition is postponed, not
+  // decided, so asking the incoming step's guard would be premature.
+  //
+  // ponytail: a prompt/manual step therefore runs `onBeforeHide` once on the
+  // deferred attempt and again when the consumer re-drives it — visible to a
+  // guard that shows a confirm dialog. Ceiling: the landing step is only known
+  // after the hidden walk, so the outgoing guard cannot be deferred past this
+  // check without letting hidden side effects run ahead of a veto, which is
+  // worse. Upgrade path: have the prompt/manual return carry the resolved
+  // cursor so the consumer's re-drive resumes here instead of re-entering at
+  // the top.
+  if (hop) {
+    if (!ctx.autoNavigate || step.routeChangeStrategy === 'prompt') {
+      ctx.onNavigationRequired?.(hop.route, step.id)
+      return false
+    }
+    if (step.routeChangeStrategy === 'manual') return false
+  }
+
+  const stepCtx: TourCallbackContext = {
+    ...buildCallbackContext(ctx.getState(), tour, ctx.getData()),
+    currentStepIndex: cursor,
+    currentStep: step,
+  }
+
+  if ((await invokeAsyncCallback('onBeforeShow', () => step.onBeforeShow?.(stepCtx))) === false) {
+    return false
+  }
+
+  if (hop && !(await runRouteHop(ctx, hop, step))) return false
+
+  // A route change always waits — the target cannot exist before the
+  // navigation. On the step's own route the author opts in, and only with a
+  // target to observe: `waitForStepTarget` fails synchronously on a null
+  // resolve, so a targetless modal step carrying the flag would otherwise stop
+  // the tour instantly.
+  if (hop || (step.waitForTarget && step.target)) {
+    const route = hop?.route ?? ctx.router?.getCurrentRoute() ?? ''
+    if (!(await awaitTarget(ctx, step, route))) return false
+  }
+
+  await invokeAsyncCallback('onEnter', () => step.onEnter?.(stepCtx))
+  ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
+  return true
 }
 
 /**
@@ -109,7 +225,6 @@ async function awaitTarget(
  *   when navigation is deferred to the consumer or aborted, throws on a
  *   hidden-step loop.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: hidden-traversal + route navigation in one orchestrator
 export async function navigateToStepImpl(
   ctx: TourEngineContext,
   stepIndex: number
@@ -123,7 +238,7 @@ export async function navigateToStepImpl(
   // The outgoing guard runs first, before the hidden walk and before any
   // navigation, so a veto is genuinely a no-op rather than a half-transition.
   const outgoing = ctx.getState().currentStep
-  if (outgoing && outgoing.kind !== 'hidden') {
+  if (outgoing && isVisibleStep(outgoing)) {
     const outgoingCtx = buildCallbackContext(ctx.getState(), currentTour, ctx.getData())
     const vetoed = await invokeAsyncCallback('onBeforeHide', () =>
       outgoing.onBeforeHide?.(outgoingCtx)
@@ -142,76 +257,7 @@ export async function navigateToStepImpl(
       return false
     }
 
-    if (step.kind !== 'hidden') {
-      const { needed } = isNavigationNeeded(step, ctx.router)
-      const sameRoute = !needed || !step.route || !ctx.router
-
-      // The deferred strategies come first: the transition is postponed, not
-      // decided, so asking the incoming step's guard would be premature.
-      // ponytail: a prompt/manual step therefore runs `onBeforeHide` once on
-      // the deferred attempt and again when the consumer re-drives it. The
-      // alternative — deferring the outgoing guard past the strategy check —
-      // would let a hidden walk run ahead of a veto, which is worse.
-      if (!sameRoute) {
-        if (!ctx.autoNavigate || step.routeChangeStrategy === 'prompt') {
-          ctx.onNavigationRequired?.(step.route as string, step.id)
-          return false
-        }
-        if (step.routeChangeStrategy === 'manual') return false
-      }
-
-      const stepCtx: TourCallbackContext = {
-        ...buildCallbackContext(ctx.getState(), currentTour, ctx.getData()),
-        currentStepIndex: cursor,
-        currentStep: step,
-      }
-
-      if (
-        (await invokeAsyncCallback('onBeforeShow', () => step.onBeforeShow?.(stepCtx))) === false
-      ) {
-        return false
-      }
-
-      if (!sameRoute) {
-        const route = step.route as string
-        try {
-          const navResult = await (ctx.router as NonNullable<typeof ctx.router>).navigate(route)
-          if (navResult === false) {
-            throw new TourRouteError({
-              code: 'NAVIGATION_REJECTED',
-              route,
-              message: `Router rejected navigation to "${route}".`,
-            })
-          }
-
-          if (step.routeDelay && step.routeDelay > 0) {
-            await new Promise((resolve) => setTimeout(resolve, step.routeDelay))
-          }
-        } catch (err) {
-          if (ctx.abortControllerRef.current?.signal.aborted) return false
-          if (err instanceof TourRouteError) {
-            ctx.onStepError?.(err)
-            ctx.dispatch({ type: 'STOP_TOUR' })
-            return false
-          }
-          throw err
-        }
-      }
-
-      // A route change always waits — the target cannot exist before the
-      // navigation. On the step's own route the author opts in, and only with
-      // a target to observe: `waitForStepTarget` fails synchronously on a null
-      // resolve, so a targetless modal step carrying the flag would otherwise
-      // stop the tour instantly.
-      if (!sameRoute || (step.waitForTarget && step.target)) {
-        const route = sameRoute ? (ctx.router?.getCurrentRoute() ?? '') : (step.route as string)
-        if (!(await awaitTarget(ctx, step, route))) return false
-      }
-
-      await invokeAsyncCallback('onEnter', () => step.onEnter?.(stepCtx))
-      ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
-      return true
-    }
+    if (isVisibleStep(step)) return commitVisibleStep(ctx, step, cursor, currentTour)
 
     const next = await advancePastHiddenStep(ctx, step, cursor, currentTour, localStepIdMap)
     if (next === 'terminate') {

--- a/packages/core/src/lib/tour-engine/navigate-to-step.ts
+++ b/packages/core/src/lib/tour-engine/navigate-to-step.ts
@@ -1,11 +1,11 @@
 import type { BranchContext, TourCallbackContext } from '../../types'
-import type { TourStep } from '../../types/step'
+import type { TourStep, VisibleTourStep } from '../../types/step'
 import type { Tour } from '../../types/tour'
 import { resolveBranch, resolveTargetToIndex } from '../../utils/branch'
 import { TourValidationError } from '../validate-tour'
 import { TourRouteError, waitForStepTarget } from '../wait-for-step-target'
 import type { TourEngineContext } from './context'
-import { buildCallbackContext, isNavigationNeeded } from './helpers'
+import { buildCallbackContext, invokeAsyncCallback, isNavigationNeeded } from './helpers'
 
 /**
  * Run a hidden step's lifecycle and return either the next cursor or
@@ -26,8 +26,12 @@ async function advancePastHiddenStep(
     currentStepIndex: cursor,
     currentStep: step,
   }
-  await step.onEnter?.(stepCtx)
-  await step.onShow?.(stepCtx)
+  // Through the fail-safe helper, not awaited directly: a throwing hidden
+  // callback used to reject navigateToStepImpl and, through nextImpl, the
+  // consumer's next() promise — leaving isTransitioning stuck true. No step
+  // callback may brick the tour (#121).
+  await invokeAsyncCallback('onEnter', () => step.onEnter?.(stepCtx))
+  await invokeAsyncCallback('onShow', () => step.onShow?.(stepCtx))
 
   if (step.onNext === undefined || step.onNext === null) {
     return cursor + 1
@@ -45,12 +49,53 @@ async function advancePastHiddenStep(
 }
 
 /**
+ * Wait for a visible step's target, with the single copy of the failure
+ * matrix both wait sites share.
+ *
+ * @returns `true` when the target resolved, `false` when the caller should
+ *   unwind (aborted, or stopped with `TARGET_NOT_FOUND`). Rethrows anything
+ *   that is not a `TourRouteError`.
+ */
+async function awaitTarget(
+  ctx: TourEngineContext,
+  step: VisibleTourStep,
+  route: string
+): Promise<boolean> {
+  try {
+    await waitForStepTarget(step, {
+      route,
+      timeoutMs: step.waitTimeout ?? 3000,
+      signal: ctx.abortControllerRef.current?.signal,
+    })
+    return true
+  } catch (err) {
+    if (ctx.abortControllerRef.current?.signal.aborted) return false
+    if (err instanceof TourRouteError) {
+      ctx.onStepError?.(err)
+      ctx.dispatch({ type: 'STOP_TOUR' })
+      return false
+    }
+    throw err
+  }
+}
+
+/**
  * Route-aware step navigation.
  *
  * Walks past hidden steps (firing their `onEnter` / `onShow` lifecycle) until
  * a mountable step is reached, then dispatches `GO_TO_STEP`. Throws
  * `TourValidationError({ code: 'HIDDEN_STEP_LOOP' })` when the hidden chain
  * exceeds `ctx.maxHiddenChain`.
+ *
+ * Step lifecycle (#121) — the pre-commit half. `onBeforeHide(outgoing)` runs
+ * at entry, so a veto walks no hidden steps and navigates nowhere;
+ * `onBeforeShow(incoming)` runs once the visible step is resolved but before
+ * the router moves, so a veto leaves the user on the page they are on; and
+ * `onEnter(incoming)` runs last, after any navigation and target wait, so it
+ * sees the page the step will mount on. Either guard returning a literal
+ * `false` returns `false` from here, which every caller already unwinds. The
+ * post-commit half (`onHide` / `onShow`) lives in `applyTransitionEffects`,
+ * where all four commit paths pass.
  *
  * Per-step `routeChangeStrategy`:
  * - `'auto'` (default): navigate, await target via `waitForStepTarget`,
@@ -75,6 +120,17 @@ export async function navigateToStepImpl(
     return true
   }
 
+  // The outgoing guard runs first, before the hidden walk and before any
+  // navigation, so a veto is genuinely a no-op rather than a half-transition.
+  const outgoing = ctx.getState().currentStep
+  if (outgoing && outgoing.kind !== 'hidden') {
+    const outgoingCtx = buildCallbackContext(ctx.getState(), currentTour, ctx.getData())
+    const vetoed = await invokeAsyncCallback('onBeforeHide', () =>
+      outgoing.onBeforeHide?.(outgoingCtx)
+    )
+    if (vetoed === false) return false
+  }
+
   const localStepIdMap = new Map<string, number>()
   currentTour.steps.forEach((s, i) => localStepIdMap.set(s.id, i))
 
@@ -88,57 +144,71 @@ export async function navigateToStepImpl(
 
     if (step.kind !== 'hidden') {
       const { needed } = isNavigationNeeded(step, ctx.router)
-      if (!needed || !step.route || !ctx.router) {
-        ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
-        return true
-      }
+      const sameRoute = !needed || !step.route || !ctx.router
 
-      if (!ctx.autoNavigate) {
-        ctx.onNavigationRequired?.(step.route, step.id)
-        return false
-      }
-
-      const strategy = step.routeChangeStrategy ?? 'auto'
-
-      if (strategy === 'manual') {
-        return false
-      }
-
-      if (strategy === 'prompt') {
-        ctx.onNavigationRequired?.(step.route, step.id)
-        return false
-      }
-
-      // strategy === 'auto'
-      try {
-        const navResult = await ctx.router.navigate(step.route)
-        if (navResult === false) {
-          throw new TourRouteError({
-            code: 'NAVIGATION_REJECTED',
-            route: step.route,
-            message: `Router rejected navigation to "${step.route}".`,
-          })
-        }
-
-        if (step.routeDelay && step.routeDelay > 0) {
-          await new Promise((resolve) => setTimeout(resolve, step.routeDelay))
-        }
-
-        await waitForStepTarget(step, {
-          route: step.route,
-          timeoutMs: step.waitTimeout ?? 3000,
-          signal: ctx.abortControllerRef.current?.signal,
-        })
-      } catch (err) {
-        if (ctx.abortControllerRef.current?.signal.aborted) return false
-        if (err instanceof TourRouteError) {
-          ctx.onStepError?.(err)
-          ctx.dispatch({ type: 'STOP_TOUR' })
+      // The deferred strategies come first: the transition is postponed, not
+      // decided, so asking the incoming step's guard would be premature.
+      // ponytail: a prompt/manual step therefore runs `onBeforeHide` once on
+      // the deferred attempt and again when the consumer re-drives it. The
+      // alternative — deferring the outgoing guard past the strategy check —
+      // would let a hidden walk run ahead of a veto, which is worse.
+      if (!sameRoute) {
+        if (!ctx.autoNavigate || step.routeChangeStrategy === 'prompt') {
+          ctx.onNavigationRequired?.(step.route as string, step.id)
           return false
         }
-        throw err
+        if (step.routeChangeStrategy === 'manual') return false
       }
 
+      const stepCtx: TourCallbackContext = {
+        ...buildCallbackContext(ctx.getState(), currentTour, ctx.getData()),
+        currentStepIndex: cursor,
+        currentStep: step,
+      }
+
+      if (
+        (await invokeAsyncCallback('onBeforeShow', () => step.onBeforeShow?.(stepCtx))) === false
+      ) {
+        return false
+      }
+
+      if (!sameRoute) {
+        const route = step.route as string
+        try {
+          const navResult = await (ctx.router as NonNullable<typeof ctx.router>).navigate(route)
+          if (navResult === false) {
+            throw new TourRouteError({
+              code: 'NAVIGATION_REJECTED',
+              route,
+              message: `Router rejected navigation to "${route}".`,
+            })
+          }
+
+          if (step.routeDelay && step.routeDelay > 0) {
+            await new Promise((resolve) => setTimeout(resolve, step.routeDelay))
+          }
+        } catch (err) {
+          if (ctx.abortControllerRef.current?.signal.aborted) return false
+          if (err instanceof TourRouteError) {
+            ctx.onStepError?.(err)
+            ctx.dispatch({ type: 'STOP_TOUR' })
+            return false
+          }
+          throw err
+        }
+      }
+
+      // A route change always waits — the target cannot exist before the
+      // navigation. On the step's own route the author opts in, and only with
+      // a target to observe: `waitForStepTarget` fails synchronously on a null
+      // resolve, so a targetless modal step carrying the flag would otherwise
+      // stop the tour instantly.
+      if (!sameRoute || (step.waitForTarget && step.target)) {
+        const route = sameRoute ? (ctx.router?.getCurrentRoute() ?? '') : (step.route as string)
+        if (!(await awaitTarget(ctx, step, route))) return false
+      }
+
+      await invokeAsyncCallback('onEnter', () => step.onEnter?.(stepCtx))
       ctx.dispatch({ type: 'GO_TO_STEP', stepIndex: cursor })
       return true
     }

--- a/packages/core/src/lib/tour-engine/start-tour.ts
+++ b/packages/core/src/lib/tour-engine/start-tour.ts
@@ -1,0 +1,79 @@
+/**
+ * Issue #121 — the two halves of "a tour starts on this step", shared by
+ * `startImpl` and the cross-tour branch.
+ *
+ * Both commit a step *without* going through `navigateToStep`, so both owe the
+ * incoming half of the step lifecycle; and the re-arm / dispatch / analytics /
+ * `onStart` tail was already duplicated verbatim between them.
+ *
+ * They live here rather than in `actions.ts` because `handle-branch-target.ts`
+ * needs them and `actions.ts` already imports `handleBranchTargetImpl` — a
+ * direct import would close a cycle between the two, which
+ * `handle-branch-target.ts` documents that it avoids.
+ *
+ * The split is deliberate: the *guards* are shared, the *response to a veto* is
+ * not. `startImpl` returns silently; the branch clears its transitioning flag
+ * and leaves the current tour running. Injecting that difference into one
+ * function as a callback would hide each caller's control flow from its own
+ * reader, so each caller asks, then decides, then commits.
+ */
+import type { TourCallbackContext } from '../../types/state'
+import type { Tour } from '../../types/tour'
+import type { TourReducerState } from '../../types/tour-reducer'
+import type { TourEngineContext } from './context'
+import { buildCallbackContext, invokeAsyncCallback, invokeCallback } from './helpers'
+
+/**
+ * Ask the landing step's pre-commit hooks: `onBeforeShow` (which may veto) and
+ * then `onEnter`. Nothing is dispatched and nothing is announced, so a `false`
+ * here leaves the world exactly as it was.
+ *
+ * @returns `false` when `onBeforeShow` returned a literal `false`.
+ */
+export async function askStepGuards(
+  ctx: TourEngineContext,
+  tour: Tour,
+  stepIndex: number,
+  data: Record<string, unknown>
+): Promise<boolean> {
+  const step = tour.steps[stepIndex]
+  if (!step) return true
+
+  // Shaped as if the tour had already started — the step's own hooks should
+  // see where they are about to be, not the pre-start state.
+  const stepCtx: TourCallbackContext = {
+    ...buildCallbackContext(ctx.getState(), tour, data),
+    tourId: tour.id,
+    isActive: true,
+    totalSteps: tour.steps.length,
+    currentStepIndex: stepIndex,
+    currentStep: step,
+  }
+
+  if ((await invokeAsyncCallback('onBeforeShow', () => step.onBeforeShow?.(stepCtx))) === false) {
+    return false
+  }
+  await invokeAsyncCallback('onEnter', () => step.onEnter?.(stepCtx))
+  return true
+}
+
+/**
+ * Commit the start: re-arm the terminal-callback guards, dispatch `START_TOUR`,
+ * fire the start callbacks. Synchronous, and only ever called once
+ * {@link askStepGuards} has passed — the re-arm wipes terminal state, so a
+ * vetoed start must not reach this.
+ */
+export function commitStart(
+  ctx: TourEngineContext,
+  tour: Tour,
+  stepIndex: number,
+  state: TourReducerState,
+  data: Record<string, unknown>
+): void {
+  ctx.completedTourIdRef.current = null
+  ctx.skippedTourIdRef.current = null
+
+  ctx.dispatch({ type: 'START_TOUR', tourId: tour.id, stepIndex })
+  ctx.tourKitContext?.onTourStart?.(tour.id)
+  invokeCallback('onStart', () => tour.onStart?.({ ...state, tour, data }))
+}

--- a/packages/core/src/lib/tour-engine/transition-effects.ts
+++ b/packages/core/src/lib/tour-engine/transition-effects.ts
@@ -91,31 +91,40 @@ export function applyTransitionEffects(
   // walk and no subscriber renders.
   mirrorToRegistry(ctx, next)
 
-  // ─── Step lifecycle notifications (#121) ────────────────────────────────
-  // Post-commit by definition, and this is the one place every commit passes
-  // — including the four paths that bypass `navigateToStep` (start, boot
-  // restore, 'restart', a cross-tour branch) and every way a tour ends.
-  //
-  // Deferred by a microtask because this function runs inside `dispatch` and
-  // may not dispatch: a consumer's `onShow` calling `next()` is ordinary
-  // usage. The microtask is enqueued before `navigateToStepImpl` returns, so
-  // it still runs ahead of the caller's continuation — `onShow` precedes
-  // TRACK_STEP_VISIT and the tour-level `onStepChange` in the engine. One
-  // firing after `destroy()` is harmless: both snapshots are already captured
-  // and nothing here dispatches.
-  //
-  // The `isActive` reads are what make tour end fire `onHide` and never a
-  // phantom `onShow`, whatever `createStoppedState` chooses to retain.
-  if (positionChanged) {
-    const hide = prev.isActive ? prev.currentStep : null
-    const show = next.isActive ? next.currentStep : null
-    if (hide?.onHide || show?.onShow) {
-      queueMicrotask(() => {
-        if (hide?.onHide) invokeCallback('onHide', () => hide.onHide?.(prev))
-        if (show?.onShow) invokeCallback('onShow', () => show.onShow?.(next))
-      })
-    }
-  }
+  notifyStepChange(prev, next, positionChanged)
+}
+
+/**
+ * The two consumer step notifications (#121) — post-commit by definition, and
+ * this is the one place every commit passes, including the four paths that
+ * bypass `navigateToStep` and every way a tour ends.
+ *
+ * Deferred by a microtask because `applyTransitionEffects` runs inside
+ * `dispatch` and may not dispatch: a consumer's `onShow` calling `next()` is
+ * ordinary usage. The microtask is enqueued before `navigateToStepImpl`
+ * returns, so it still runs ahead of the caller's continuation — `onShow`
+ * precedes `TRACK_STEP_VISIT` and the tour-level `onStepChange` in the engine.
+ * One firing after `destroy()` is harmless: both snapshots are captured and
+ * nothing here dispatches.
+ *
+ * The `isActive` reads are what make a tour end fire `onHide` and never a
+ * phantom `onShow`, whatever `createStoppedState` chooses to retain.
+ */
+function notifyStepChange(
+  prev: TourCallbackContext,
+  next: TourCallbackContext,
+  positionChanged: boolean
+): void {
+  if (!positionChanged) return
+
+  const hide = prev.isActive ? prev.currentStep : null
+  const show = next.isActive ? next.currentStep : null
+  if (!(hide?.onHide || show?.onShow)) return
+
+  queueMicrotask(() => {
+    if (hide?.onHide) invokeCallback('onHide', () => hide.onHide?.(prev))
+    if (show?.onShow) invokeCallback('onShow', () => show.onShow?.(next))
+  })
 }
 
 function mirrorToRegistry(ctx: TourEngineContext, next: TourCallbackContext): void {

--- a/packages/core/src/lib/tour-engine/transition-effects.ts
+++ b/packages/core/src/lib/tour-engine/transition-effects.ts
@@ -12,9 +12,14 @@ import { tourRegistry } from '../../registry/tour-registry'
  * may write storage, post to a channel or update the registry. It may NOT
  * dispatch. Anything needing a second transition — the cross-tab pause — comes
  * back on a later tick through `subscribeCrossTabPause`.
+ *
+ * That constraint is also why the two consumer notifications added for #121
+ * (`onHide` / `onShow`) are deferred by a microtask: a consumer's `onShow`
+ * calling `next()` would otherwise re-enter the reducer mid-transition.
  */
 import type { TourCallbackContext } from '../../types/state'
 import type { CrossTabActiveMessage, TourEngineContext } from './context'
+import { invokeCallback } from './helpers'
 
 /**
  * @param prev - Snapshot before the transition.
@@ -85,6 +90,32 @@ export function applyTransitionEffects(
   // field and notifies only on a real change, so an inert commit costs a Map
   // walk and no subscriber renders.
   mirrorToRegistry(ctx, next)
+
+  // ─── Step lifecycle notifications (#121) ────────────────────────────────
+  // Post-commit by definition, and this is the one place every commit passes
+  // — including the four paths that bypass `navigateToStep` (start, boot
+  // restore, 'restart', a cross-tour branch) and every way a tour ends.
+  //
+  // Deferred by a microtask because this function runs inside `dispatch` and
+  // may not dispatch: a consumer's `onShow` calling `next()` is ordinary
+  // usage. The microtask is enqueued before `navigateToStepImpl` returns, so
+  // it still runs ahead of the caller's continuation — `onShow` precedes
+  // TRACK_STEP_VISIT and the tour-level `onStepChange` in the engine. One
+  // firing after `destroy()` is harmless: both snapshots are already captured
+  // and nothing here dispatches.
+  //
+  // The `isActive` reads are what make tour end fire `onHide` and never a
+  // phantom `onShow`, whatever `createStoppedState` chooses to retain.
+  if (positionChanged) {
+    const hide = prev.isActive ? prev.currentStep : null
+    const show = next.isActive ? next.currentStep : null
+    if (hide?.onHide || show?.onShow) {
+      queueMicrotask(() => {
+        if (hide?.onHide) invokeCallback('onHide', () => hide.onHide?.(prev))
+        if (show?.onShow) invokeCallback('onShow', () => show.onShow?.(next))
+      })
+    }
+  }
 }
 
 function mirrorToRegistry(ctx: TourEngineContext, next: TourCallbackContext): void {

--- a/packages/core/src/types/step.ts
+++ b/packages/core/src/types/step.ts
@@ -71,18 +71,92 @@ interface BaseTourStep<TId extends string = string> {
    * @default 'auto'
    */
   routeChangeStrategy?: 'auto' | 'prompt' | 'manual'
+  /**
+   * Filter this step out when the predicate resolves false — the step is
+   * walked past, not shown.
+   *
+   * Unlike the guards below, a **throw is treated as `false`** (skip): passing
+   * over a step is always safe, so a buggy predicate hides the step rather
+   * than bricking the tour.
+   */
   when?: (context: TourCallbackContext) => boolean | Promise<boolean>
+  /**
+   * Wait for `target` to exist in the DOM before the step commits, for a
+   * target rendered after a fetch or a lazy mount.
+   *
+   * Applies on the step's **own** route; a step with a different `route`
+   * always waits for its target after the router hop regardless of this flag.
+   * Requires a `target` — the flag is ignored on a targetless step, because
+   * there would be nothing to observe and the wait would fail instantly.
+   *
+   * On timeout, `onStepError` fires with
+   * `TourRouteError({ code: 'TARGET_NOT_FOUND' })` and the tour stops.
+   *
+   * @default false
+   */
   waitForTarget?: boolean
+  /**
+   * Milliseconds to wait for `target` before giving up, used by both
+   * `waitForTarget` and the route-change wait.
+   *
+   * @default 3000
+   */
   waitTimeout?: number
+  /**
+   * Guard: runs **before** the step commits, and can cancel the transition.
+   *
+   * Return a **literal `false`** to veto — the tour stays where it is and the
+   * verb that fired it (`next()`, `prev()`, `goTo()`, `start()`) resolves
+   * having changed nothing. Every other return value (including `undefined`,
+   * `null`, `0` and `''`) proceeds. Awaited, so a `Promise<false>` vetoes too.
+   *
+   * A **throw is "no opinion"**: it is logged and the transition proceeds. A
+   * guard that always throws must not be able to trap the user on one step.
+   *
+   * Runs before the router navigates, so a veto leaves the user on the page
+   * they are on. Not called on a hidden step, and not called when a tour is
+   * restored from a saved session (a veto on a cold restore would strand the
+   * user mid-tour with no way to continue).
+   */
   onBeforeShow?: (
     context: TourCallbackContext
   ) => boolean | undefined | Promise<boolean | undefined>
-  /** Runs before the step mounts (visible) or auto-advances (hidden). */
+  /**
+   * Runs after the transition is committed to but before the step mounts —
+   * after any route navigation and target wait, so it sees the page the step
+   * is about to mount on. Awaited; a throw is logged and ignored.
+   *
+   * Fires on hidden steps (which never mount) and on session restore.
+   */
   onEnter?: (context: TourCallbackContext) => void | Promise<void>
+  /**
+   * Notification: the step is now the current step. Post-commit, so it cannot
+   * cancel anything, and deferred by a microtask — calling `next()` from here
+   * is safe.
+   *
+   * Fires on hidden steps and on session restore. A throw is logged and
+   * ignored.
+   */
   onShow?: (context: TourCallbackContext) => void
+  /**
+   * Guard: runs **before** the current step is left, and can cancel the
+   * transition. Same contract as {@link BaseTourStep.onBeforeShow}: only a
+   * literal `false` vetoes and a throw is "no opinion". It runs first, so a
+   * veto walks no hidden steps and navigates nowhere.
+   *
+   * Ignored on hidden steps.
+   */
   onBeforeHide?: (
     context: TourCallbackContext
   ) => boolean | undefined | Promise<boolean | undefined>
+  /**
+   * Notification: the step has left the screen. Post-commit and
+   * microtask-deferred, like {@link BaseTourStep.onShow}.
+   *
+   * Also fires when the **tour ends** on this step — `stop()`, `skip()`,
+   * `complete()` and `reset()` — because the step did leave. Ignored on hidden
+   * steps. A throw is logged and ignored.
+   */
   onHide?: (context: TourCallbackContext) => void
   /**
    * Override the next navigation behavior

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -39,13 +39,20 @@
  *     the identifier because `minify: true` renames the function and the
  *     obvious grep passes either way.
  *
- *     KNOWINGLY AT THE LINE. v2 §1.3b measured 21 457 against this 21 500 —
- *     43 bytes, 0.2%. The ceiling was deliberately NOT re-baselined (§1.3b's
- *     plan pre-authorised <=22 000 and the breach never came), so the next
- *     change to touch the main entry — §1.4, which wires the provider to the
- *     engine — will trip this row. That is the intended behaviour: §1.4 raises
- *     it with its own measurement, or earns the B-1 target back down. A red
- *     row here is not a mystery, it is this note coming due.
+ *     That note came due. §1.3b left this row 43 bytes under 21 500 and said
+ *     the next change to touch the main entry would trip it. Issue #121 —
+ *     wiring the five dead step lifecycle callbacks — did, at a measured
+ *     21 849, so the ceiling is now 22 000.
+ *
+ *     The +416 B is Group A in `navigateToStepImpl` (three guard call sites
+ *     plus the `awaitTarget` helper), `commitStart` in `actions.ts`, and the
+ *     five-line Group B block in `transition-effects.ts`. `core:engine` moved
+ *     by the SAME 416 B (17 030 -> 17 446) because every file involved lives
+ *     in the chunk both entries read — a delta that appeared on only one of
+ *     the two rows would mean something else happened.
+ *
+ *     Still not engine runtime leaking in: `engine-not-in-main-closure.test.ts`
+ *     is green. The <8 KB B-1 target remains §1.4's to earn.
  *   - core:engine: 18 KB against a measured 17.0 KB, up from 8.1 KB when this
  *     was a types-and-predicates door and 15.3 KB after §1.3. The difference
  *     is first a working tour engine (reducer, boot resolver, actions,
@@ -81,7 +88,7 @@
  * @type {Array<[name: string, relPath: string, budgetBytes: number]>}
  */
 export const budgets = [
-  ['core', 'packages/core/dist/index.js', 21500],
+  ['core', 'packages/core/dist/index.js', 22000],
   ['core:engine', 'packages/core/dist/engine/index.js', 18000],
   ['react', 'packages/react/dist/index.js', 12000],
   ['hints', 'packages/hints/dist/index.js', 6000],

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -42,7 +42,7 @@
  *     That note came due. §1.3b left this row 43 bytes under 21 500 and said
  *     the next change to touch the main entry would trip it. Issue #121 —
  *     wiring the five dead step lifecycle callbacks — did, at a measured
- *     21 849, so the ceiling is now 22 000.
+ *     21 845, so the ceiling is now 22 000.
  *
  *     The +416 B is Group A in `navigateToStepImpl` (three guard call sites
  *     plus the `awaitTarget` helper), `commitStart` in `actions.ts`, and the

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -42,12 +42,12 @@
  *     That note came due. §1.3b left this row 43 bytes under 21 500 and said
  *     the next change to touch the main entry would trip it. Issue #121 —
  *     wiring the five dead step lifecycle callbacks — did, at a measured
- *     21 845, so the ceiling is now 22 000.
+ *     21 851, so the ceiling is now 22 000.
  *
  *     The +416 B is Group A in `navigateToStepImpl` (three guard call sites
  *     plus the `awaitTarget` helper), `commitStart` in `actions.ts`, and the
  *     five-line Group B block in `transition-effects.ts`. `core:engine` moved
- *     by the SAME 416 B (17 030 -> 17 446) because every file involved lives
+ *     by the SAME 416 B (17 030 -> 17 451) because every file involved lives
  *     in the chunk both entries read — a delta that appeared on only one of
  *     the two rows would mean something else happened.
  *


### PR DESCRIPTION
Closes #121. Executes `plan/step-lifecycle-callbacks.md` and `plan/step-lifecycle-callbacks-tests.md`.

## The bug

`BaseTourStep` declares seven step hooks. `when` worked, and `onEnter`/`onShow` worked for *hidden* steps only. `onBeforeShow`, `onBeforeHide`, `onHide` and `waitForTarget` were read nowhere — typed, documented across ten docs pages and twelve compare pages, and dead. The reporter read the `.d.ts` and reasonably expected them to fire.

## The order this pins

```
onBeforeHide(prev) → onBeforeShow(next) → onEnter(next) → [commit] → onHide(prev) → onShow(next)
```

The handoff spec pinned a different order (`onHide` before `onBeforeShow`) that is unreachable under its own design — a post-commit event cannot precede a pre-commit one — and would tell the consumer the outgoing step hid, then leave it on screen when the veto landed. Both "before" hooks are pre-commit and can veto; both "hide/show" hooks are post-commit notifications.

## Two homes, and why

**Group A** (pre-commit, async, vetoing) lives in `navigateToStepImpl`, where the commit is decided, so a veto is a `return false` — which the five callers already unwind. Nothing was added to any of them.

**Group B** (post-commit, sync, notifying) lives in `applyTransitionEffects`, the one place *every* commit passes. That is why the four paths bypassing `navigateToStep` get their notifications for free, and why `<TourProvider>` inherits the whole feature — the React seat parity test went green with no provider edit and no change under `packages/react/`.

Group B is deferred by `queueMicrotask` because `applyTransitionEffects` runs inside `dispatch` and may not dispatch: a consumer's `onShow` calling `next()` is ordinary usage.

## Beyond the ticket

Three changes go past the literal report. Each is its own commit and can be reverted alone:

- **`'restart'` routes through `navigateToStep(0)`** instead of dispatching `GO_TO_STEP 0`. It was landing on step 0 unconditionally, skipping the hidden-step walk and any route — broken independently of #121.
- **Hidden-step `onEnter`/`onShow` now go through `invokeAsyncCallback`.** They were awaited directly, so a throwing hidden callback rejected the consumer's `next()` promise and left `isTransitioning` stuck `true` — contradicting the fail-safe contract this PR writes into the `.d.ts`. Same file, same root cause, two lines.
- **`BranchToTour` hoists `newStepIndex` above the `STOP_TOUR` dispatch.** A pure reorder, but without it the guard could only run after the current tour was already stopped, and a veto would strand the user with no tour at all.

## Verification

- 40 new cases across eight files; `@tour-kit/core` **1531 passing / 3 skipped**. `react` 485, `hints` 295.
- Order and Group B are asserted only against the **real** `createTourEngine` dispatch — an order assertion against a `vi.fn` would be asserting against the test's own arrangement.
- Coverage 93.2 / 88.5 / 92.7 / 94.6, above the 80/75/80/80 floors.
- `pnpm dist:size` green. `core` re-baselined to **22 000 against a measured 21 849**; `core:engine` 17 446 inside its existing 18 000. Both rows moved by the same +416 B, because everything added lives in the chunk they share — a delta on one row alone would have meant something else happened. Mirrored into `budgets.mjs`, `CLAUDE.md` and the wiki; `bundle-budget-claim-alignment` green.
- `pnpm typecheck` clean across 29 tasks; Biome at the unchanged 20-finding `main` baseline.
- `git diff --stat main -- packages/react` is empty.

## Three tests worth naming

They were each rewritten because the obvious version could not fail:

- **The `onBeforeHide` veto cases pass `state.currentStep` explicitly.** `createFakeEngineContext` defaults it to `null`, so the natural spelling asserts `false` against a callback that never ran.
- **The `next.isActive` gate is proven against a hand-built snapshot only.** `createStoppedState` nulls `currentStep` too, so through the real engine the gate holds with it deleted.
- **`step-callbacks-wired.test.ts` self-checks its own extractor** before using it. A regex that silently stopped matching would reproduce #121 rather than catch it. Sanity-checked by renaming `.onHide` and confirming it goes red.

The last one is the guard against this class of bug recurring: every lifecycle key declared on `BaseTourStep` must have a call site in the non-test engine.

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt