### PR TITLE
feat(core): engine parity + the engine handle (v2 §1.4a + §1.4b)

### DIFF
--- a/.changeset/engines-read-the-live-router.md
+++ b/.changeset/engines-read-the-live-router.md
@@ -4,7 +4,7 @@
 
 `createTourEngine` gains `setOptions()` and `setDontShowAgain()`, persists terminal tours by default, defers `boot()` on an empty tour list until `setTours()` supplies one, and re-hydrates from cross-tab route writes when `syncTabs` is on.
 
-These are the places `createTourEngine` behaved differently from `<TourProvider>`, which drives the same reducer through the same port. Nothing changes for React consumers — the provider already did all four — but a direct `@tour-kit/core/engine` consumer gets behaviour it was quietly missing:
+These are the places `createTourEngine` behaved differently from `<TourProvider>`, which drives the same reducer through the same port. Nothing changes for React consumers — the provider already did all of them — but a direct `@tour-kit/core/engine` consumer gets behaviour it was quietly missing:
 
 - **Completed tours are remembered by default.** The engine read `persistence?.enabled ?? false` while the provider merges `defaultPersistenceConfig`, where `enabled` is `true`, and ANDs it with `trackCompleted`. Pass `persistence: { enabled: false }` to keep the old behaviour.
 - **`setOptions({ router, autoNavigate, analytics, onNavigationRequired, onStepError, onTourPaused })`** replaces any of the six props that legitimately change identity after construction. Every router adapter is a memo over its host router's hooks, so an engine that froze `router` at construction navigated through a dead adapter after the first route change.

--- a/.changeset/engines-read-the-live-router.md
+++ b/.changeset/engines-read-the-live-router.md
@@ -4,10 +4,11 @@
 
 `createTourEngine` gains `setOptions()` and `setDontShowAgain()`, persists terminal tours by default, defers `boot()` on an empty tour list until `setTours()` supplies one, and re-hydrates from cross-tab route writes when `syncTabs` is on.
 
-These are the four places `createTourEngine` behaved differently from `<TourProvider>`, which drives the same reducer through the same port. Nothing changes for React consumers — the provider already did all four — but a direct `@tour-kit/core/engine` consumer gets behaviour it was quietly missing:
+These are the places `createTourEngine` behaved differently from `<TourProvider>`, which drives the same reducer through the same port. Nothing changes for React consumers — the provider already did all four — but a direct `@tour-kit/core/engine` consumer gets behaviour it was quietly missing:
 
 - **Completed tours are remembered by default.** The engine read `persistence?.enabled ?? false` while the provider merges `defaultPersistenceConfig`, where `enabled` is `true`, and ANDs it with `trackCompleted`. Pass `persistence: { enabled: false }` to keep the old behaviour.
 - **`setOptions({ router, autoNavigate, analytics, onNavigationRequired, onStepError, onTourPaused })`** replaces any of the six props that legitimately change identity after construction. Every router adapter is a memo over its host router's hooks, so an engine that froze `router` at construction navigated through a dead adapter after the first route change.
 - **`boot()` on an engine with no tours no longer latches.** It defers until `setTours()` supplies some — the shape a declarative registration path produces, where children register after the parent's first pass.
 - **`syncTabs` re-hydrates.** `routeStore.subscribeStorage` was built and never called; the first `boot()` now installs it, so another tab's route write restores the tour at its persisted step.
 - **`setDontShowAgain(tourId, value)`** is present on `TourEngine`, matching `TourActions`. Its body is still a no-op.
+- **The flow session resumes what you actually started.** Its tour id is now kept in sync with engine state rather than set only inside `boot()`, so a tour started from a button, from `startTour()` or by a cross-tour branch writes a resume blob like an autostarted one does. Its storage key is also scoped by `routePersistence.key`, matching the provider — a consumer who set `key` was writing to `tourkit:flow:active` instead of `<key>:flow:active`.

--- a/.changeset/engines-read-the-live-router.md
+++ b/.changeset/engines-read-the-live-router.md
@@ -1,0 +1,13 @@
+---
+'@tour-kit/core': minor
+---
+
+`createTourEngine` gains `setOptions()` and `setDontShowAgain()`, persists terminal tours by default, defers `boot()` on an empty tour list until `setTours()` supplies one, and re-hydrates from cross-tab route writes when `syncTabs` is on.
+
+These are the four places `createTourEngine` behaved differently from `<TourProvider>`, which drives the same reducer through the same port. Nothing changes for React consumers — the provider already did all four — but a direct `@tour-kit/core/engine` consumer gets behaviour it was quietly missing:
+
+- **Completed tours are remembered by default.** The engine read `persistence?.enabled ?? false` while the provider merges `defaultPersistenceConfig`, where `enabled` is `true`, and ANDs it with `trackCompleted`. Pass `persistence: { enabled: false }` to keep the old behaviour.
+- **`setOptions({ router, autoNavigate, analytics, onNavigationRequired, onStepError, onTourPaused })`** replaces any of the six props that legitimately change identity after construction. Every router adapter is a memo over its host router's hooks, so an engine that froze `router` at construction navigated through a dead adapter after the first route change.
+- **`boot()` on an engine with no tours no longer latches.** It defers until `setTours()` supplies some — the shape a declarative registration path produces, where children register after the parent's first pass.
+- **`syncTabs` re-hydrates.** `routeStore.subscribeStorage` was built and never called; the first `boot()` now installs it, so another tab's route write restores the tour at its persisted step.
+- **`setDontShowAgain(tourId, value)`** is present on `TourEngine`, matching `TourActions`. Its body is still a no-op.

--- a/packages/core/src/__tests__/types/engine-handle.test-d.ts
+++ b/packages/core/src/__tests__/types/engine-handle.test-d.ts
@@ -1,0 +1,42 @@
+// v2 §1.4b — the structural claims Decision 2 makes about `EngineHandle`.
+//
+// Vitest never loads `*.test-d.ts` (its include glob is `*.{test,spec}.{ts,tsx}`);
+// these are compiled by `pnpm --filter @tour-kit/core typecheck:types` and by
+// the plain `typecheck`, both of which fail on any error below.
+//
+// Why the first line is the load-bearing one: `attachAdvanceOn` and
+// `attachTestBridge` take hand-written interfaces (`AdvanceOnTarget`,
+// `TestBridgeTarget`), each strictly *looser* than a `Pick<TourEngine, …>`.
+// So passing the handle to them compiles for almost any object and proves
+// little on its own. `Omit<TourEngine, 'destroy'>` is what Decision 2 actually
+// claims — the handle IS a `TourEngine` minus the terminal verb — and it is
+// what lets a future consumer take either.
+
+import { attachAdvanceOn } from '../../lib/advance-on'
+import { attachTestBridge } from '../../lib/test-bridge'
+import type { TourEngine } from '../../lib/tour-engine/create-tour-engine'
+import type { EngineHandle } from '../../lib/tour-engine/engine-handle'
+
+declare const handle: EngineHandle
+
+// ─── The claim: a TourEngine minus the terminal verb ────────────────────────
+const _engineShaped: Omit<TourEngine, 'destroy'> = handle
+void _engineShaped
+
+// `release()` replaces it, because the handle outlives its engines.
+// @ts-expect-error — `destroy` is deliberately not on the handle.
+handle.destroy()
+
+// ─── Both §1.3b attach targets accept it unchanged ──────────────────────────
+const _detachAdvanceOn: () => void = attachAdvanceOn(handle)
+void _detachAdvanceOn
+
+const _detachBridge: () => void = attachTestBridge({
+  start: (tourId) => handle.start(tourId),
+  next: () => handle.next(),
+  prev: () => handle.prev(),
+  goToStep: (stepId) => handle.goToStep(stepId),
+  complete: () => handle.complete(),
+  skip: () => handle.skip(),
+})
+void _detachBridge

--- a/packages/core/src/lib/tour-engine/__tests__/_helpers/counting-factory.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/_helpers/counting-factory.ts
@@ -1,0 +1,20 @@
+/**
+ * v2 §1.4b — a `createTourEngine` factory that records how many engines it built.
+ *
+ * §1.4's whole risk surface is "how many, and when": zero during render, one
+ * per mount, two across a StrictMode remount. Neither "built during render"
+ * nor "built twice" is observable through tour state — both produce a working
+ * tour — so every handle case reads `factory.mock.calls.length` rather than
+ * reaching into the handle.
+ *
+ * Storage is a fresh `createMemoryStorage()` per engine so the persistence
+ * default (ON since §1.4a) cannot leak into jsdom's file-shared
+ * `localStorage`, and so engine 2 does not read what engine 1 wrote.
+ */
+import { vi } from 'vitest'
+import { createMemoryStorage } from '../../../../utils/storage'
+import { type CreateTourEngineOptions, createTourEngine } from '../../create-tour-engine'
+
+export function countingFactory(overrides: Partial<CreateTourEngineOptions> = {}) {
+  return vi.fn(() => createTourEngine({ tours: [], storage: createMemoryStorage(), ...overrides }))
+}

--- a/packages/core/src/lib/tour-engine/__tests__/_helpers/cross-tab.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/_helpers/cross-tab.ts
@@ -1,0 +1,31 @@
+/**
+ * v2 §1.4a — simulate another tab writing our route key.
+ *
+ * BOTH halves are load-bearing:
+ *
+ *  - the *value* must land in the adapter the engine actually reads through
+ *    (`getStorage()` prefers the injected one), and
+ *  - the *event* must be a real `StorageEvent` on `window`, because that is
+ *    the only thing `routeStore.subscribeStorage` listens for.
+ *
+ * Writing only the value changes nothing; firing only the event re-reads the
+ * old value. And `config.storage` must literally be `'localStorage'` with
+ * `syncTabs: true`, or `subscribeStorage` handed back a no-op at boot
+ * (`adapters/route-store.ts:124`).
+ */
+import type { Storage as StorageAdapter } from '../../../../types/config'
+
+export function fireCrossTabWrite(
+  storage: StorageAdapter,
+  key: string,
+  blob: { tourId: string; stepIndex: number }
+): void {
+  const payload = JSON.stringify({
+    completedTours: [],
+    skippedTours: [],
+    timestamp: Date.now(),
+    ...blob,
+  })
+  storage.setItem(key, payload)
+  window.dispatchEvent(new StorageEvent('storage', { key, newValue: payload }))
+}

--- a/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
@@ -1036,3 +1036,49 @@ describe('setDontShowAgain() — v2 §1.4a row 5', () => {
     expect(engine.getState()).toBe(before)
   })
 })
+
+describe('flow session parity — v2 §1.4a rows 6 and 7', () => {
+  const TWO = makeTour('t', [visibleStep('a'), visibleStep('b')])
+  const AUTO = makeTour('auto', [visibleStep('a'), visibleStep('b')], { autoStart: true })
+  const FLOW = {
+    enabled: true,
+    storage: 'localStorage',
+    key: 'myapp',
+    flowSession: { storage: 'localStorage' },
+  } as const
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="x"></div>'
+  })
+
+  it('scopes the flow blob under routePersistence.key, as the provider does', async () => {
+    // Row 6, found while writing the binding and not in the plan: the provider
+    // builds its flow session with `{ ...flowSession, keyPrefix:
+    // routePersistence.key }` (was `tour-provider.tsx:288`); the engine passed
+    // the config straight through. A consumer who namespaced their route state
+    // with `key` had the in-flight resume blob move to `tourkit:flow:active` —
+    // silent data loss for exactly the multi-page tours the key exists for.
+    const { engine, storage } = engineFor({ tours: [AUTO], routePersistence: FLOW })
+
+    await engine.boot()
+    engine.destroy() // flushes the 200 ms throttled save
+
+    expect(storage.getItem('myapp:flow:active')).not.toBeNull()
+    expect(storage.getItem('tourkit:flow:active')).toBeNull()
+  })
+
+  it('writes a resume blob for a tour started by hand, not only a booted one', async () => {
+    // Row 7, and the sharper of the two. `useFlowSession(state.tourId ?? '')`
+    // gave the provider the id REACTIVELY, so any start — a button, a
+    // cross-tour branch, `startTour` — enabled the write. The engine called
+    // `setTourId` only inside `boot()`, so a tour the user started by clicking
+    // wrote nothing and a hard reload resumed nothing. That is the whole
+    // feature.
+    const { engine, storage } = engineFor({ tours: [TWO], routePersistence: FLOW })
+
+    await engine.start('t')
+    engine.destroy()
+
+    expect(storage.getItem('myapp:flow:active')).not.toBeNull()
+  })
+})

--- a/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/create-tour-engine.test.ts
@@ -20,6 +20,7 @@ import type { Storage as TourKitStorage } from '../../../types/config'
 import { TourValidationError } from '../../validate-tour'
 import { createTourEngine } from '../create-tour-engine'
 import type { TourEngine } from '../create-tour-engine'
+import { fireCrossTabWrite } from './_helpers/cross-tab'
 import { makeEngine } from './_helpers/make-engine'
 import { hiddenStep, makeTour, visibleStep } from './_helpers/make-tour'
 import { stageFlow } from './_helpers/stage-storage'
@@ -813,5 +814,225 @@ describe('step lifecycle callbacks — issue #121', () => {
       expect(engine.getState().isActive).toBe(false)
       expect(callOrder).toEqual(['onHide:b'])
     })
+  })
+})
+
+/**
+ * v2 §1.4a — the five adapter-A/B divergences, closed in the engine.
+ *
+ * Each of these is a behaviour `<TourProvider>` has had all along and
+ * `createTourEngine` did not. Shipping the §1.4 swap without them would have
+ * been a silent regression for every React user, so they land first, on their
+ * own PR, with the engine as the only thing under test.
+ */
+describe('persistence default — v2 §1.4a row 1', () => {
+  const ONE = makeTour('t', [visibleStep('a')])
+
+  it('persists a completed tour with NO persistence option at all', async () => {
+    // `defaultPersistenceConfig.enabled` is `true` (types/config.ts:195) and
+    // the provider has always merged it. The engine read
+    // `options.persistence?.enabled ?? false`, so a direct engine consumer
+    // silently lost "don't show me this again" across a reload.
+    const { engine, storage } = engineFor({ tours: [ONE] })
+    await engine.start('t')
+    engine.complete()
+
+    // Prefixed by `createTerminalStore` — `tourkit:` + `completed`.
+    expect(storage.getItem('tourkit:completed')).toBe(JSON.stringify(['t']))
+  })
+
+  it('writes nothing when persistence is explicitly disabled', async () => {
+    const { engine, storage } = engineFor({ tours: [ONE], persistence: { enabled: false } })
+    await engine.start('t')
+    engine.complete()
+
+    expect(storage.getItem('tourkit:completed')).toBeNull()
+  })
+
+  it('writes nothing when trackCompleted is off — the gate is an AND of two merged defaults', async () => {
+    const { engine, storage } = engineFor({
+      tours: [ONE],
+      persistence: { enabled: true, trackCompleted: false },
+    })
+    await engine.start('t')
+    engine.complete()
+
+    expect(storage.getItem('tourkit:completed')).toBeNull()
+  })
+})
+
+describe('setOptions() — v2 §1.4a rows 4', () => {
+  const ROUTED = makeTour('t', [visibleStep('a'), visibleStep('b', { route: '/b' })])
+
+  const makeRouter = (current: string) => ({
+    getCurrentRoute: () => current,
+    navigate: vi.fn(() => undefined),
+    matchRoute: (pattern: string) => pattern === current,
+    onRouteChange: () => () => {},
+  })
+
+  beforeEach(() => {
+    // `visibleStep()` hard-codes `target: '#x'`, and a route hop always awaits
+    // the target before committing.
+    document.body.innerHTML = '<div id="x"></div>'
+  })
+
+  it('routes the next cross-route hop through the NEW router', async () => {
+    // Every built-in adapter's identity changes after a route change
+    // (`createReactRouterAdapter`'s navigate closes over `useNavigate()`), so
+    // an engine that froze the router at construction navigates through a dead
+    // one for the rest of the tour.
+    const router1 = makeRouter('/a')
+    const router2 = makeRouter('/a')
+    const { engine } = engineFor({ tours: [ROUTED], router: router1 })
+    await engine.start('t')
+
+    engine.setOptions({ router: router2 })
+    await engine.next()
+
+    expect(router2.navigate).toHaveBeenCalledWith('/b')
+    expect(router1.navigate).not.toHaveBeenCalled()
+  })
+
+  it('fans out to the NEW analytics sink', async () => {
+    const onStepView1 = vi.fn()
+    const onStepView2 = vi.fn()
+    const { engine } = engineFor({
+      tours: [makeTour('t', [visibleStep('a'), visibleStep('b')])],
+      analytics: { onStepView: onStepView1 },
+    })
+    await engine.start('t')
+    onStepView1.mockClear()
+
+    engine.setOptions({ analytics: { onStepView: onStepView2 } })
+    await engine.next()
+
+    expect(onStepView2).toHaveBeenCalledWith('t', 'b', 1)
+    expect(onStepView1).not.toHaveBeenCalled()
+  })
+
+  it('honours a live autoNavigate flip', async () => {
+    const router = makeRouter('/a')
+    const onNavigationRequired = vi.fn()
+    const { engine } = engineFor({ tours: [ROUTED], router })
+    await engine.start('t')
+
+    engine.setOptions({ autoNavigate: false, onNavigationRequired })
+    await engine.next()
+
+    expect(onNavigationRequired).toHaveBeenCalledWith('/b', 'b')
+    expect(router.navigate).not.toHaveBeenCalled()
+  })
+
+  it('is a silent no-op after destroy()', async () => {
+    const router2 = makeRouter('/a')
+    const { engine } = engineFor({ tours: [ROUTED], router: makeRouter('/a') })
+    await engine.start('t')
+    const before = engine.getState()
+
+    engine.destroy()
+
+    expect(() => engine.setOptions({ router: router2 })).not.toThrow()
+    expect(engine.getState()).toBe(before)
+  })
+})
+
+describe('boot() defers on an empty tour list — v2 §1.4a row 2', () => {
+  const AUTO = makeTour('auto', [visibleStep('a1')], { autoStart: true })
+
+  it('re-arms when setTours() finally supplies tours', async () => {
+    // The `MultiTourKitProvider` + declarative `<Tour>` shape: children
+    // register AFTER the parent's first effect. The provider has always
+    // returned without latching here; the engine latched `ready` in its
+    // `finally` and the late tour never started.
+    const { engine } = engineFor({ tours: [] })
+
+    await engine.boot()
+    expect(engine.getState().isActive).toBe(false)
+
+    engine.setTours([AUTO])
+    await vi.waitFor(() => expect(engine.getState().isActive).toBe(true))
+    expect(engine.getState().tourId).toBe('auto')
+  })
+
+  it('does NOT start anything when setTours() lands on an engine nobody booted', async () => {
+    // Without this pair, "auto-boot on every setTours" — a different and wrong
+    // behaviour — satisfies the case above. `bootRequested` is closure-private,
+    // so the pair is the only way to see it from outside.
+    const { engine } = engineFor({ tours: [] })
+
+    engine.setTours([AUTO])
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(engine.getState().isActive).toBe(false)
+  })
+})
+
+describe('syncTabs re-hydrates from a cross-tab route write — v2 §1.4a row 3', () => {
+  const TWO_PLUS = makeTour('t', [visibleStep('a'), visibleStep('b'), visibleStep('c')])
+  const SYNCED = {
+    enabled: true,
+    storage: 'localStorage',
+    key: 'k',
+    syncTabs: true,
+  } as const
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="x"></div>'
+  })
+
+  it('restores at the step the other tab persisted', async () => {
+    const { engine, storage } = engineFor({ tours: [TWO_PLUS], routePersistence: SYNCED })
+    await engine.boot()
+    expect(engine.getState().isActive).toBe(false)
+
+    fireCrossTabWrite(storage, 'k', { tourId: 't', stepIndex: 2 })
+
+    await vi.waitFor(() => expect(engine.getState().currentStepIndex).toBe(2))
+    expect(engine.getState().tourId).toBe('t')
+  })
+
+  it('ignores the event after destroy()', async () => {
+    const { engine, storage } = engineFor({ tours: [TWO_PLUS], routePersistence: SYNCED })
+    await engine.boot()
+    engine.destroy()
+
+    fireCrossTabWrite(storage, 'k', { tourId: 't', stepIndex: 2 })
+    await Promise.resolve()
+
+    expect(engine.getState().isActive).toBe(false)
+  })
+
+  it('never subscribes when syncTabs is off', async () => {
+    const { engine, storage } = engineFor({
+      tours: [TWO_PLUS],
+      routePersistence: { enabled: true, storage: 'localStorage', key: 'k' },
+    })
+    await engine.boot()
+
+    fireCrossTabWrite(storage, 'k', { tourId: 't', stepIndex: 2 })
+    await Promise.resolve()
+
+    expect(engine.getState().isActive).toBe(false)
+  })
+})
+
+describe('setDontShowAgain() — v2 §1.4a row 5', () => {
+  it('exists, does not throw, and does not notify', async () => {
+    // `TourActions` has it and `TourEngine` did not, so `pickActions(handle)`
+    // in §1.4c could not have type-checked. Still a no-op body by Decision 8 —
+    // wiring it is the first post-1.4 item, not part of a swap.
+    const { engine } = engineFor({ tours: [THREE] })
+    await engine.start('t')
+    const listener = vi.fn()
+    engine.subscribe(listener)
+    const before = engine.getState()
+
+    expect(typeof engine.setDontShowAgain).toBe('function')
+    expect(() => engine.setDontShowAgain('t', true)).not.toThrow()
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(engine.getState()).toBe(before)
   })
 })

--- a/packages/core/src/lib/tour-engine/__tests__/engine-handle.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/engine-handle.test.ts
@@ -1,0 +1,154 @@
+/**
+ * v2 §1.4b — the engine handle.
+ *
+ * The handle exists for three React facts the engine does not share: child
+ * effects run before the parent's, StrictMode double-invokes and discards, and
+ * consumers put actions in dependency arrays. Each maps to a case below, and
+ * each is checked by COUNTING CONSTRUCTIONS rather than by observing tour
+ * state — "built during render" and "built twice" both produce a working tour.
+ *
+ * No React here, deliberately: the handle is a plain object and belongs to the
+ * React-free half of the package.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { tourRegistry } from '../../../registry/tour-registry'
+import { INITIAL_SNAPSHOT, createEngineHandle } from '../engine-handle'
+import type { EngineHandle } from '../engine-handle'
+import { countingFactory } from './_helpers/counting-factory'
+import { makeTour, visibleStep } from './_helpers/make-tour'
+
+const THREE = makeTour('t', [visibleStep('a'), visibleStep('b'), visibleStep('c')])
+
+let handle: EngineHandle
+let factory: ReturnType<typeof countingFactory>
+
+beforeEach(() => {
+  // The engine registers its tours AT CONSTRUCTION, so a leftover 't' from an
+  // earlier case would make the post-release() registry assertion false.
+  // `__reset__` is undefined in production builds — hence the `?.()`.
+  tourRegistry.__reset__?.()
+  factory = countingFactory({ tours: [THREE] })
+  handle = createEngineHandle(factory)
+})
+
+afterEach(() => {
+  handle.release()
+})
+
+describe('render is inert', () => {
+  it('getState() before any verb returns the shared constant and builds nothing', () => {
+    expect(handle.getState()).toBe(INITIAL_SNAPSHOT)
+    expect(handle.getState()).toBe(handle.getState())
+    expect(factory).toHaveBeenCalledTimes(0)
+  })
+
+  it('subscribe() before any verb builds nothing', () => {
+    handle.subscribe(() => {})
+
+    expect(factory).toHaveBeenCalledTimes(0)
+  })
+
+  it('the shared constant is empty and stays empty', () => {
+    // Object.freeze does not freeze the Map inside it, and initialTourState's
+    // stepVisitCount is a module singleton shared by every provider on the
+    // page. If anything ever wrote through the constant, this is where it
+    // shows up.
+    expect(INITIAL_SNAPSHOT.isActive).toBe(false)
+    expect(INITIAL_SNAPSHOT.tour).toBeNull()
+    expect(INITIAL_SNAPSHOT.stepVisitCount.size).toBe(0)
+  })
+})
+
+describe('construction is once, on demand', () => {
+  it('the first verb builds exactly one engine', async () => {
+    await handle.start('t')
+
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect(handle.getState().isActive).toBe(true)
+  })
+
+  it('a second verb reuses it', async () => {
+    await handle.start('t')
+    await handle.next()
+
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect(handle.getState().currentStep?.id).toBe('b')
+  })
+
+  it('ensure() is the explicit form and is idempotent', () => {
+    expect(handle.ensure()).toBe(handle.ensure())
+    expect(factory).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('release() forgets the engine but keeps the listeners', () => {
+  it('destroys the engine and drops its registry membership', async () => {
+    await handle.start('t')
+    expect(tourRegistry.get('t')).not.toBeNull()
+
+    handle.release()
+
+    expect(tourRegistry.get('t')).toBeNull()
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect(handle.getState()).toBe(INITIAL_SNAPSHOT)
+  })
+
+  it('a verb after release() builds a second engine', async () => {
+    await handle.start('t')
+    handle.release()
+    await handle.start('t')
+
+    expect(factory).toHaveBeenCalledTimes(2)
+    expect(handle.getState().isActive).toBe(true)
+  })
+
+  it('the SAME listener, subscribed before any engine existed, fires for both', async () => {
+    // `destroy()` calls `listeners.clear()` on the engine's own set, so this
+    // only holds if the handle owns the set and re-attaches one fan-out per
+    // ensure(). A handle that forwarded subscribe() straight through goes
+    // silent here on the second engine — and under StrictMode that is a
+    // provider that never re-renders again.
+    const calls: number[] = []
+    handle.subscribe(() => calls.push(calls.length))
+
+    await handle.start('t')
+    const afterFirst = calls.length
+    expect(afterFirst).toBeGreaterThan(0)
+
+    handle.release()
+    await handle.start('t')
+
+    expect(calls.length).toBeGreaterThan(afterFirst)
+  })
+
+  it('unsubscribing stops the fan-out across a re-construction', async () => {
+    const calls: number[] = []
+    const off = handle.subscribe(() => calls.push(calls.length))
+    off()
+
+    await handle.start('t')
+    handle.release()
+    await handle.start('t')
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('is idempotent', () => {
+    handle.release()
+
+    expect(() => handle.release()).not.toThrow()
+    expect(factory).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('verb identity is the handle lifetime', () => {
+  it('survives release() and re-construction', async () => {
+    const before = handle.start
+    await handle.start('t')
+    handle.release()
+    await handle.start('t')
+
+    expect(handle.start).toBe(before)
+    expect(handle.next).toBe(handle.next)
+  })
+})

--- a/packages/core/src/lib/tour-engine/create-tour-engine.ts
+++ b/packages/core/src/lib/tour-engine/create-tour-engine.ts
@@ -23,6 +23,7 @@
  */
 import { tourRegistry } from '../../registry/tour-registry'
 import type { PersistenceConfig, Storage as StorageAdapter } from '../../types'
+import { defaultPersistenceConfig } from '../../types/config'
 import type { MultiPagePersistenceConfig, RouterAdapter } from '../../types/router'
 import type { TourCallbackContext } from '../../types/state'
 import type { Tour } from '../../types/tour'
@@ -37,6 +38,7 @@ import {
   nextImpl,
   prevImpl,
   resetImpl,
+  setDontShowAgainImpl,
   skipTourImpl,
   startImpl,
   startTourImpl,
@@ -88,7 +90,13 @@ export interface TourEngine {
   destroy: () => void
 
   // ─── Parity with TourActions, required by §1.4 ──────────────────────────
-  /** Run the restore chain. Idempotent, and a no-op after `destroy()`. */
+  /**
+   * Run the restore chain. Idempotent, and a no-op after `destroy()`.
+   *
+   * A boot on an engine with no tours does NOT latch — it is deferred until
+   * `setTours()` supplies some, because the declarative `<Tour>` path
+   * registers children after the parent's first effect.
+   */
   boot: () => Promise<void>
   goToStep: (stepId: string) => Promise<void>
   startTour: (tourId: string, stepId?: string | number) => Promise<void>
@@ -99,7 +107,37 @@ export interface TourEngine {
   reset: (tourId?: string) => void
   setData: (key: string, value: unknown) => void
   setTours: (tours: Tour[]) => void
+  /**
+   * Still a no-op body (`setDontShowAgainImpl`), and present only so the
+   * engine covers all thirteen `TourActions` keys — the React binding selects
+   * its context value straight off this object. Wiring it is the first
+   * post-1.4 item.
+   */
+  setDontShowAgain: (tourId: string, value: boolean) => void
+  /**
+   * Push the props that legitimately change identity after mount.
+   *
+   * A binding re-runs this every commit: every built-in router adapter is a
+   * `useMemo` over the host router's hook results, so freezing `router` at
+   * construction navigates through a dead adapter after the first route
+   * change. Not live, deliberately: `tours` (that is `setTours`), `storage`,
+   * `persistence` and `routePersistence` — their adapters are built once.
+   *
+   * A no-op after `destroy()`.
+   */
+  setOptions: (patch: Partial<TourEngineLiveOptions>) => void
 }
+
+/**
+ * The options a binding may change after construction.
+ *
+ * Derived from `CreateTourEngineOptions` rather than declared, so it cannot
+ * drift from the options it mirrors.
+ */
+export type TourEngineLiveOptions = Pick<
+  CreateTourEngineOptions,
+  'router' | 'autoNavigate' | 'analytics' | 'onNavigationRequired' | 'onStepError' | 'onTourPaused'
+>
 
 type BootPhase = 'idle' | 'booting' | 'ready'
 
@@ -140,7 +178,13 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
     enabled: false,
     storage: 'localStorage',
   }
-  const persistTerminalTours = options.persistence?.enabled ?? false
+  // The provider's expression, verbatim (was `tour-provider.tsx:164`).
+  // `defaultPersistenceConfig.enabled` is `true`, so terminal-tour memory is
+  // ON unless a consumer turns it off — a bare `?? false` here silently lost
+  // every React user's completed-tour list on reload.
+  const persistTerminalTours =
+    (options.persistence?.enabled ?? defaultPersistenceConfig.enabled) &&
+    (options.persistence?.trackCompleted ?? defaultPersistenceConfig.trackCompleted)
 
   // Adapters. Constructing these reads nothing — the flow session's
   // no-read-on-construct contract is what makes the whole factory SSR-safe.
@@ -158,12 +202,30 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
     { enabled: !!routePersistence.crossTab?.enabled }
   )
 
+  /**
+   * The props a binding may replace after construction (`setOptions`). Read
+   * through accessors on `ctx` below, so every impl's `ctx.router` stays the
+   * plain field read it has always been.
+   */
+  const liveOptions: TourEngineLiveOptions = {
+    router: options.router,
+    autoNavigate: options.autoNavigate ?? true,
+    analytics: options.analytics,
+    onNavigationRequired: options.onNavigationRequired,
+    onStepError: options.onStepError,
+    onTourPaused: options.onTourPaused,
+  }
+
   // ─── Engine state ────────────────────────────────────────────────────────
   let state = initialReducerState(options.tours)
   let data: Record<string, unknown> = {}
   let snapshot: TourCallbackContext = buildCallbackContext(state, null, data)
   let destroyed = false
   let bootPhase: BootPhase = 'idle'
+  /** A `boot()` that found no tours and is waiting for `setTours` to supply some. */
+  let bootRequested = false
+  /** The cross-tab route listener is installed on the first real boot, once. */
+  let storageSubscribed = false
 
   const listeners = new Set<() => void>()
   const abortControllerRef: { current: AbortController | null } = { current: null }
@@ -227,11 +289,23 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
     abortControllerRef,
     completedTourIdRef,
     skippedTourIdRef,
-    router: options.router,
-    autoNavigate: options.autoNavigate ?? true,
+    // Accessors, not fields: `TourEngineContext` is an interface of plain
+    // properties and an object literal with getters satisfies it structurally,
+    // so every `ctx.router` read stays what it was while `setOptions` can move
+    // the value underneath it.
+    get router() {
+      return liveOptions.router
+    },
+    get autoNavigate() {
+      return liveOptions.autoNavigate ?? true
+    },
     maxHiddenChain: MAX_HIDDEN_CHAIN,
-    onNavigationRequired: options.onNavigationRequired,
-    onStepError: options.onStepError,
+    get onNavigationRequired() {
+      return liveOptions.onNavigationRequired
+    },
+    get onStepError() {
+      return liveOptions.onStepError
+    },
     completeTour: () => completeTourImpl(ctx),
     skipTour: () => skipTourImpl(ctx),
     setData: (key, value) => engineSetData(key, value),
@@ -249,8 +323,12 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
     tabId: makeTabId(),
     announce: broadcast.post,
     crossTab,
-    onTourPaused: options.onTourPaused,
-    tourKitContext: options.analytics ?? null,
+    get onTourPaused() {
+      return liveOptions.onTourPaused
+    },
+    get tourKitContext() {
+      return liveOptions.analytics ?? null
+    },
   }
 
   /**
@@ -265,9 +343,55 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
     notify()
   }
 
+  /**
+   * Re-run the precedence rule for a *route* restore only, after another tab
+   * wrote our key.
+   *
+   * Route restore is the one boot source allowed to run more than once — the
+   * provider re-ran its boot effect on `externalVersion` and that is the whole
+   * point of `syncTabs`. Flow restore and autostart stay once per engine.
+   */
+  async function rehydrateFromRoute(): Promise<void> {
+    if (destroyed) return
+
+    const decision = resolveBootStart({
+      flowSession: flowSession.load(),
+      flowIsStale: flowSession.isStale(),
+      routeState: routeStore.load(),
+      tours: [...state.tours.values()],
+      completedTours: persistTerminalTours
+        ? terminalStore.getCompletedTours()
+        : state.completedTours,
+    })
+
+    if (decision?.source !== 'route') return
+
+    // Same-route only, as the provider's was: the blob a sibling tab wrote
+    // carries no route of its own.
+    await runBootStart(ctx, decision, {
+      signal: new AbortController().signal,
+      onClear: flowSession.clear,
+    })
+  }
+
   async function boot(): Promise<void> {
     if (destroyed || bootPhase !== 'idle') return
+
+    // Not a latch: the declarative `<Tour>` path (via `MultiTourKitProvider`)
+    // registers children AFTER the parent's first effect, so an empty engine
+    // is "not yet", not "never". `setTours` re-arms it. The provider has
+    // always returned here without latching (was `tour-provider.tsx:344`).
+    if (state.tours.size === 0) {
+      bootRequested = true
+      return
+    }
+
     bootPhase = 'booting'
+
+    if (routePersistence.syncTabs && !storageSubscribed) {
+      storageSubscribed = true
+      teardown.push(routeStore.subscribeStorage(() => void rehydrateFromRoute()))
+    }
 
     // Boot owns its own controller. `abortControllerRef` is written only by
     // `applyTransitionEffects` on a tour-identity change, so it is null here
@@ -392,6 +516,14 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
     },
     setData: engineSetData,
 
+    setDontShowAgain: (tourId: string, value: boolean) => {
+      if (!destroyed) setDontShowAgainImpl(ctx, tourId, value)
+    },
+
+    setOptions: (patch: Partial<TourEngineLiveOptions>) => {
+      if (!destroyed) Object.assign(liveOptions, patch)
+    },
+
     setTours: (tours: Tour[]) => {
       if (destroyed) return
       for (const tour of tours) validateTour(tour)
@@ -400,6 +532,14 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
       // first mirror write in the same turn instead of the next transition.
       syncRegistry(tours)
       dispatch({ type: 'UPDATE_TOURS', tours })
+
+      // The deferred boot, re-armed. Gated on `bootRequested` and NOT on
+      // "tours arrived": auto-booting every `setTours` would start a tour on
+      // an engine whose owner never asked to boot at all.
+      if (bootRequested && bootPhase === 'idle' && tours.length > 0) {
+        bootRequested = false
+        void boot()
+      }
     },
 
     getState: () => snapshot,

--- a/packages/core/src/lib/tour-engine/create-tour-engine.ts
+++ b/packages/core/src/lib/tour-engine/create-tour-engine.ts
@@ -191,7 +191,14 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
   const terminalStore = createTerminalStore(options.persistence, options.storage)
   const routeStore = createRouteStore(routePersistence, options.storage)
   const flowSession = createFlowSession(
-    routePersistence.flowSession,
+    // `keyPrefix` from the route key, exactly as the provider composed it
+    // (was `tour-provider.tsx:288`). Without it a consumer who namespaced
+    // their route state with `key` had the flow blob written to
+    // `tourkit:flow:active` instead of `<key>:flow:active` — an in-flight
+    // resume silently lost on upgrade.
+    routePersistence.flowSession
+      ? { ...routePersistence.flowSession, keyPrefix: routePersistence.key }
+      : undefined,
     options.storage,
     // The engine has no render pass to mirror into; the factory's own copy is
     // the only one.
@@ -247,6 +254,13 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
 
   function rebuildSnapshot(): void {
     snapshot = buildCallbackContext(state, currentTour(), data)
+    // The flow store stamps this id into every blob it writes, and `''`
+    // disables writes entirely. The provider got it reactively —
+    // `useFlowSession(state.tourId ?? '')` — so ANY start armed the resume,
+    // whether it came from boot, a button, `startTour` or a cross-tour branch.
+    // Setting it only in `boot()` meant a hand-started tour wrote nothing and
+    // a hard reload resumed nothing, which is the entire feature.
+    flowSession.setTourId(state.tourId ?? '')
   }
 
   function notify(): void {

--- a/packages/core/src/lib/tour-engine/engine-handle.ts
+++ b/packages/core/src/lib/tour-engine/engine-handle.ts
@@ -1,0 +1,130 @@
+/**
+ * v2 §1.4b — a lazily-constructing facade over one `TourEngine`.
+ *
+ * React's lifecycle is not the engine's, and three of its rules each kill an
+ * otherwise obvious design:
+ *
+ *  1. **Child effects run before the parent's.** `useEffect(() => start('t'),
+ *     [])` in a child is the documented "start on mount" pattern, and it lands
+ *     before the provider's own boot effect. An engine created in that effect
+ *     would not exist yet.
+ *  2. **React 18/19 double-invoke `useState` initialisers and effects under
+ *     StrictMode and discard one result.** `createTourEngine` registers every
+ *     tour with `tourRegistry` at construction, so building one in render logs
+ *     `Tour "t" registered twice` in dev and leaves a dead `WeakRef` behind.
+ *     Construction in render is therefore out — which is why 1 cannot simply
+ *     be solved by `useState(() => createTourEngine())`.
+ *  3. **Action identities must be stable for the provider's lifetime.**
+ *     Consumers put them in dependency arrays and the tour registry closes
+ *     over them. A remount that swapped in a fresh engine would change all
+ *     thirteen.
+ *
+ * So: nothing is built until the first *verb* or an explicit `ensure()`.
+ * `getState()` and `subscribe()` — the only two members render may touch —
+ * never construct. The listener set lives on the handle rather than on the
+ * engine (whose `destroy()` clears its own), so `release()` can throw an
+ * engine away and the next verb re-attaches a single fan-out to its
+ * replacement without any subscriber noticing.
+ *
+ * Not exported from `@tour-kit/core/engine`: §1.5 names what a binding needs,
+ * and the handle joins the port and the persistence factories on that list.
+ */
+import { initialTourState } from '../../types/state'
+import type { TourCallbackContext } from '../../types/state'
+import type { TourEngine } from './create-tour-engine'
+
+/**
+ * The snapshot every binding reads before its first verb — on the server,
+ * where no effect ever runs, that is the only snapshot it ever reads.
+ *
+ * `useSyncExternalStore` compares with `Object.is`, so this has to be one
+ * module-level constant rather than a fresh object per call. It is only ever
+ * read: the engine builds its own state and never receives this, so sharing it
+ * (including the `stepVisitCount` Map inside it) across every provider on the
+ * page is safe.
+ */
+export const INITIAL_SNAPSHOT: TourCallbackContext = Object.freeze({
+  ...initialTourState,
+  tour: null,
+  data: {},
+})
+
+export interface EngineHandle extends Omit<TourEngine, 'destroy'> {
+  /**
+   * Construct on the first call and return the live engine.
+   *
+   * Never call this from render — that is the `registered twice` hazard. The
+   * provider's own mount effect is the latest it can happen; a child's verb is
+   * the earliest.
+   */
+  ensure: () => TourEngine
+  /** `INITIAL_SNAPSHOT` until the first `ensure()`; then the engine's cached snapshot. */
+  getState: () => TourCallbackContext
+  /**
+   * `destroy()` the current engine, if any, and forget it. Subscribers
+   * survive, so the next verb builds a replacement and re-attaches them.
+   * Idempotent.
+   */
+  release: () => void
+}
+
+export function createEngineHandle(factory: () => TourEngine): EngineHandle {
+  let engine: TourEngine | null = null
+  let off: (() => void) | null = null
+  const listeners = new Set<() => void>()
+
+  const fanOut = (): void => {
+    for (const listener of listeners) listener()
+  }
+
+  const ensure = (): TourEngine => {
+    if (engine) return engine
+    engine = factory()
+    off = engine.subscribe(fanOut)
+    // One fan-out on construction: the snapshot identity just moved from the
+    // module constant to the engine's, so `useSyncExternalStore` has to
+    // re-read even though the values are equal. That extra render is the price
+    // of not constructing during render.
+    fanOut()
+    return engine
+  }
+
+  return {
+    ensure,
+
+    getState: () => engine?.getState() ?? INITIAL_SNAPSHOT,
+
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+
+    release: () => {
+      off?.()
+      off = null
+      engine?.destroy()
+      engine = null
+      // No fan-out: after a release the binding is either unmounting or about
+      // to `ensure()` again, and both re-read on their own.
+    },
+
+    boot: (...a) => ensure().boot(...a),
+    start: (...a) => ensure().start(...a),
+    next: (...a) => ensure().next(...a),
+    prev: (...a) => ensure().prev(...a),
+    goTo: (...a) => ensure().goTo(...a),
+    goToStep: (...a) => ensure().goToStep(...a),
+    startTour: (...a) => ensure().startTour(...a),
+    triggerBranchAction: (...a) => ensure().triggerBranchAction(...a),
+    skip: (...a) => ensure().skip(...a),
+    complete: (...a) => ensure().complete(...a),
+    stop: (...a) => ensure().stop(...a),
+    reset: (...a) => ensure().reset(...a),
+    setData: (...a) => ensure().setData(...a),
+    setTours: (...a) => ensure().setTours(...a),
+    setDontShowAgain: (...a) => ensure().setDontShowAgain(...a),
+    setOptions: (...a) => ensure().setOptions(...a),
+  }
+}


### PR DESCRIPTION
**PR-1 of two for v2 §1.4.** Additive, no React surface touched, mergeable and revertible on its own. PR-2 is the swap that puts `<TourProvider>` on top of this.

## Why this is separate

Reading `<TourProvider>` (adapter A) and `createTourEngine` (adapter B) side by side turned up five places where they disagree. Each one would have shipped as a **silent behaviour change to every React user** the day the provider was swapped, so they land first, alone, with their own changeset and their own revert.

| # | Provider today | Engine before | Now |
|---|---|---|---|
| 1 | merges `defaultPersistenceConfig` (`enabled: true`) **AND** `trackCompleted` | `persistence?.enabled ?? false` | merged, exactly as the provider |
| 2 | boot returns **without latching** on an empty `tours` list, retries on the next change | latched `ready` in its `finally` | defers; `setTours()` re-arms |
| 3 | re-runs route restore on a cross-tab `storage` event when `syncTabs` is on | `routeStore.subscribeStorage` built, never called | subscribed on the first real `boot()` |
| 4 | reads `router` + callbacks fresh every render | captured at construction | six accessors over a `liveOptions` object; `setOptions()` patches it |
| 5 | `TourActions.setDontShowAgain` exists | missing from `TourEngine` | added (body still a no-op, by design) |

Row 4 is the one with teeth in the field: every built-in router adapter is a `useMemo` over the host router's hooks (`createReactRouterAdapter`'s `navigate` closes over `useNavigate()`), so an engine that froze `router` would navigate through a dead adapter after the first route change.

## `createEngineHandle`

`engine-handle.ts` is a new React-free leaf, ~120 lines, not exported from `@tour-kit/core/engine`. It exists because React's lifecycle is not the engine's, and three of its rules each kill an otherwise obvious design:

1. **Child effects run before the parent's** — the documented `useEffect(() => start('t'), [])` pattern lands before the provider's boot effect, so an engine created there does not exist yet.
2. **StrictMode double-invokes `useState` initialisers and discards one** — and `createTourEngine` registers with `tourRegistry` at construction, so building one in render logs `registered twice` and leaks a dead `WeakRef`. That rules out fixing 1 with `useState(() => createTourEngine())`.
3. **Action identities must be stable** — consumers put them in dep arrays; the registry closes over them.

So nothing is built until the first verb or an explicit `ensure()`. `getState()` and `subscribe()` — the only members render may touch — never construct. The listener set lives on the handle, not the engine (whose `destroy()` clears its own), so `release()` can throw an engine away and the next verb re-attaches one fan-out to its replacement.

## Tests

Every engine behaviour was **seen red first** (7 failures, the expected set). The handle's suite was verified against a naive pass-through `subscribe`/`getState`: its four load-bearing cases go red there, which is what makes them an oracle rather than a description.

Construction count is the instrument throughout — "built during render" and "built twice" both still produce a working tour, so neither is visible in tour state.

```
core          114 files, 1561 passed | 3 skipped
react          40 files,  485 passed      hints 295   surveys 299
announcements 377 passed                  checklists 339
turbo run test --concurrency=3 over all six: 16/16 tasks
```

`create-tour-engine.test.ts` scans its own source for React imports, so all thirteen new engine cases are React-free — the `setOptions({ analytics })` case uses a plain literal of spies, not `TourKitProvider`.

Guards: `no-react-in-engine-types` needed no new seed (its walk already covers `lib/tour-engine/`); `no-react-in-engine-dist`, `engine-types-are-portable`, `barrel-exports`, `peer-dep-optional` all pass. `typecheck` and `typecheck:types` clean; biome diagnostic **set** is identical to `main` (line drift only).

## Budgets

```
core         21851 / 22000   unchanged — nothing in the main closure imports the factory yet
core:engine  17688 / 18000   was 17451; +237 B for setOptions, the boot re-arm and the storage subscription
```

## Notes for review

- `boot()` on an empty engine no longer latching is a genuine engine semantic change. No existing test asserted the latch, and `boot.ts`'s own docblock already called empty tours "a *caller* decision".
- The re-arm is gated on `bootRequested`, **not** on "tours arrived" — a pair of tests pins that, because auto-booting on every `setTours` satisfies the happy case and is a different, wrong behaviour.
- The `syncTabs` test injects memory storage and dispatches a synthetic `StorageEvent`. `subscribeStorage` gates on the *config* (`syncTabs` + `storage: 'localStorage'`), never on the adapter, while `load()` reads through the injected adapter — so the plan's "use real `window.localStorage`" instruction would have produced a permanent false red.
- `setDontShowAgain` stays a no-op. Wiring it is the first post-1.4 item; a swap must not change behaviour.

Refs `plan/v2/1-4-react-binding.md` Tasks 1.4a + 1.4b.

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt