### PR TITLE
feat(vue): @tour-kit/vue — the first non-React binding (v2 §1.5b)

### DIFF
--- a/.changeset/vue-binding.md
+++ b/.changeset/vue-binding.md
@@ -1,0 +1,14 @@
+---
+"@tour-kit/vue": minor
+---
+
+Initial Vue 3 binding over `@tour-kit/core/engine`.
+
+`provideTourKit` / `useTour` / `<TourProvider>` give a Vue app the whole engine —
+state, navigation, branching, persistence, routing, audience and frequency,
+cross-tab sync, focus, keyboard and advance-on — with no React installed. The
+package imports only `@tour-kit/core/engine`; `useSpotlight`, `useFocusTrap` and
+`createVueRouterAdapter` are the framework glue. It ships no card: the consumer
+renders their own.
+
+Private until the v2 licence lands (§3.2).

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,9 @@
 [
-  { "name": "@tour-kit/core", "path": "packages/core/dist/index.js", "limit": "28 KB" },
+  {
+    "name": "@tour-kit/core",
+    "path": "packages/core/dist/index.js",
+    "limit": "28 KB"
+  },
   {
     "name": "@tour-kit/core (useTour-only consumer)",
     "path": "packages/core/dist/index.js",
@@ -29,7 +33,11 @@
     "limit": "175 KB",
     "ignore": ["@tour-kit/analytics"]
   },
-  { "name": "@tour-kit/adoption", "path": "packages/adoption/dist/index.js", "limit": "90 KB" },
+  {
+    "name": "@tour-kit/adoption",
+    "path": "packages/adoption/dist/index.js",
+    "limit": "90 KB"
+  },
   {
     "name": "@tour-kit/checklists",
     "path": "packages/checklists/dist/index.js",
@@ -42,9 +50,21 @@
     "limit": "185 KB",
     "ignore": ["@tour-kit/analytics"]
   },
-  { "name": "@tour-kit/media", "path": "packages/media/dist/index.js", "limit": "160 KB" },
-  { "name": "@tour-kit/surveys", "path": "packages/surveys/dist/index.js", "limit": "190 KB" },
-  { "name": "@tour-kit/analytics", "path": "packages/analytics/dist/index.js", "limit": "260 KB" },
+  {
+    "name": "@tour-kit/media",
+    "path": "packages/media/dist/index.js",
+    "limit": "160 KB"
+  },
+  {
+    "name": "@tour-kit/surveys",
+    "path": "packages/surveys/dist/index.js",
+    "limit": "190 KB"
+  },
+  {
+    "name": "@tour-kit/analytics",
+    "path": "packages/analytics/dist/index.js",
+    "limit": "260 KB"
+  },
   {
     "name": "@tour-kit/analytics/posthog",
     "path": "packages/analytics/dist/plugins/posthog.js",
@@ -81,7 +101,25 @@
     "limit": "70 KB",
     "ignore": ["@tour-kit/analytics"]
   },
-  { "name": "@tour-kit/license", "path": "packages/license/dist/index.js", "limit": "70 KB" },
-  { "name": "@tour-kit/ai (client)", "path": "packages/ai/dist/index.js", "limit": "110 KB" },
-  { "name": "@tour-kit/ai/server", "path": "packages/ai/dist/server/index.js", "limit": "120 KB" }
+  {
+    "name": "@tour-kit/license",
+    "path": "packages/license/dist/index.js",
+    "limit": "70 KB"
+  },
+  {
+    "name": "@tour-kit/ai (client)",
+    "path": "packages/ai/dist/index.js",
+    "limit": "110 KB"
+  },
+  {
+    "name": "@tour-kit/ai/server",
+    "path": "packages/ai/dist/server/index.js",
+    "limit": "120 KB"
+  },
+  {
+    "name": "@tour-kit/vue",
+    "path": "packages/vue/dist/index.js",
+    "limit": "3 KB",
+    "ignore": ["@tour-kit/core", "vue"]
+  }
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,9 +159,10 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     closure for the first time, because `/engine` now publishes the binding
     contract two non-React bindings sit on. §1.5f raised the ceiling from 18 KB
     to 18.5 KB at a measured 18 098 (+366 B) for `createSpotlight()`, the
-    spotlight state machine that §1.5 had shipped in three copies. Those bytes
-    MOVED rather than appeared — a Vue consumer ships engine + binding, and
-    that total went 19 187 → 19 191)
+    spotlight state machine that §1.5 had shipped in three copies. Most of
+    those bytes MOVED rather than appeared — a Vue consumer ships engine +
+    binding, and that total went 19 187 → 19 341, so +154 B net for deleting
+    two of the three implementations)
   - react <12 KB
   - hints <6 KB
   - analytics <4 KB (root; per-plugin <1.5 KB each)
@@ -170,7 +171,7 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
   - media <9 KB
   - ai <7 KB (client), <8 KB (server)
   - scheduling <4 KB
-  - vue <1.8 KB
+  - vue <1.5 KB
 
   The hints / announcements / surveys / media / ai numbers rose in v2 §1.2
   **without a byte being added**: they all ship a `headless` entry, so the gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,9 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
 
 - TypeScript strict mode enabled
 - Test coverage: thresholds are enforced **per-package** in each `packages/*/vitest.config.ts`,
-  not as a blanket repo number. Eight packages hold the canonical floor — ≥80% statements,
+  not as a blanket repo number. Nine packages hold the canonical floor — ≥80% statements,
   functions, and lines with ≥75% branches: `core`, `react`, `hints`, `adoption`, `checklists`,
-  `analytics`, `license`, and `surveys`. Three feature packages enforce honest, earned floors
+  `analytics`, `license`, `surveys`, and `vue`. Three feature packages enforce honest, earned floors
   below canonical (statements/branches/functions/lines): `announcements` 75/70/80/75,
   `scheduling` 75/65/80/75, and `media` 70/60/70/70. `ai` has no per-key threshold yet. Slice 7
   raised these from the temporary phase-5 lows with real behavior tests, and measured coverage
@@ -167,6 +167,7 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
   - media <9 KB
   - ai <7 KB (client), <8 KB (server)
   - scheduling <4 KB
+  - vue <1.8 KB
 
   The hints / announcements / surveys / media / ai numbers rose in v2 §1.2
   **without a byte being added**: they all ship a `headless` entry, so the gate
@@ -258,8 +259,13 @@ When adding new animations, prefix with `motion-safe:` if it's a `tailwindcss-an
 @tour-kit/license ──────┤
 @tour-kit/media ────────┤
 @tour-kit/scheduling ───┤
-@tour-kit/surveys ──────┘
+@tour-kit/surveys ──────┤
+@tour-kit/vue ──────────┘
 ```
+
+`@tour-kit/vue` is the odd one out on that arrow: it imports the
+`@tour-kit/core/engine` subpath only, never the main entry, so no React reaches
+its `.d.ts` chain. A per-package `no-react-in-dist.test.ts` enforces it.
 
 Note: `@tour-kit/scheduling` is an optional peer dependency for `@tour-kit/announcements`. `@tour-kit/license` is the runtime validator the other Pro packages consult.
 
@@ -279,6 +285,7 @@ Each package has its own CLAUDE.md with domain-specific guidance:
 | `packages/media/CLAUDE.md` | Embed components, URL parsing, accessibility |
 | `packages/scheduling/CLAUDE.md` | Schedule evaluation, timezone handling, recurring patterns |
 | `packages/surveys/CLAUDE.md` | Survey types, scoring engine, fatigue prevention, context awareness |
+| `packages/vue/CLAUDE.md` | Vue binding: `watch` not `watchEffect`, SSR rule, lazy `ensure()` |
 | `apps/docs/CLAUDE.md` | MDX conventions, Fumadocs patterns |
 
 ## Documentation Site

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,9 @@
       "**/__tests__/fixtures/**",
       "**/scripts/**",
       "**/test-results/**",
-      "**/playwright-report/**"
+      "**/playwright-report/**",
+      "**/*.vue",
+      "**/*.svelte"
     ]
   }
 }

--- a/e2e/_shared/binding-tour-flow.ts
+++ b/e2e/_shared/binding-tour-flow.ts
@@ -1,0 +1,145 @@
+import { type Page, expect, test } from '@playwright/test'
+
+/**
+ * v2 §1.5 — the eight cases that prove a non-React binding runs a real tour.
+ *
+ * Shared by the Vue and Svelte lanes because they run the SAME three-step tour
+ * against the same `data-testid` map — the whole point of §1.5 is that the two
+ * bindings behave identically over one engine, so a divergence should show up
+ * as one lane failing a case the other passes, not as two drifting files.
+ *
+ * Every case is its own `test()`, which matters for more than isolation:
+ * `Escape` maps to `skip()`, not `stop()`, and a skip is PERSISTED. Sharing a
+ * browser context between the Escape case and the reload-resume case would let
+ * the skipped mark decide the resume.
+ */
+
+/** The tour, for reference — see `src/tours.ts` in either example. */
+const STEP_1 = 'Step one'
+const STEP_2 = 'Step two'
+const STEP_3 = 'Step three'
+
+const title = (page: Page) => page.getByTestId('tour-card-title')
+
+async function startTour(page: Page) {
+  await page.goto('/')
+  await page.waitForSelector('#start-here')
+  await page.getByTestId('start-tour').click()
+  await expect(title(page)).toHaveText(STEP_1)
+}
+
+export function describeBindingTourFlow(binding: 'Vue' | 'Svelte') {
+  test.describe(`${binding} binding — tour flow`, () => {
+    test('a click on Start opens the card on step 1', async ({ page }) => {
+      await startTour(page)
+      await expect(page.getByTestId('tour-card')).toBeVisible()
+    })
+
+    test('ArrowRight advances', async ({ page }) => {
+      await startTour(page)
+
+      // `attachKeyboard` is wired by the binding, not by a card: a headless
+      // consumer would otherwise have to find it themselves.
+      await page.keyboard.press('ArrowRight')
+
+      await expect(title(page)).toHaveText(STEP_2)
+    })
+
+    test('a cross-route step navigates and the card resumes on the target', async ({ page }) => {
+      await startTour(page)
+      await page.keyboard.press('ArrowRight')
+
+      await expect(page).toHaveURL(/\/settings$/)
+      await expect(title(page)).toHaveText(STEP_2)
+      await expect(page.getByTestId('tour-card')).toBeVisible()
+    })
+
+    test('a real click on step 1s target lands on step 2, not step 3', async ({ page }) => {
+      await startTour(page)
+
+      // `page.click()`, never `dispatchEvent`. A real click dispatches with an
+      // empty JS stack, so the microtask checkpoint between listeners runs and
+      // the transition completes before the event bubbles to `document` — the
+      // exact window in which the unfixed `attachAdvanceOn` bound step 2's
+      // document-fallback listener and ate the same click.
+      await page.click('#start-here')
+
+      await expect(title(page)).toHaveText(STEP_2)
+      await expect(title(page)).not.toHaveText(STEP_3)
+    })
+
+    test('a real click on the page during step 2 advances exactly one step', async ({ page }) => {
+      await startTour(page)
+      await page.click('#start-here')
+      await expect(title(page)).toHaveText(STEP_2)
+
+      // Step 2 is document-bound (no `selector`), so any click advances it.
+      await page.click('body', { position: { x: 5, y: 5 } })
+
+      await expect(title(page)).toHaveText(STEP_3)
+    })
+
+    test('the cards Back on step 2 goes back, it does not advance', async ({ page }) => {
+      await startTour(page)
+      await page.click('#start-here')
+      await expect(title(page)).toHaveText(STEP_2)
+
+      // The card's button row stops propagation. Without it the document-bound
+      // step would swallow Back's own click and advance instead —
+      // `bindStepAdvance` has no card guard.
+      await page.getByTestId('tour-back').click()
+
+      await expect(title(page)).toHaveText(STEP_1)
+    })
+
+    test('a hard reload mid-tour resumes on the same step in under 200ms', async ({ page }) => {
+      // Inline, not `e2e/fixtures/console.ts`: that fixture collects
+      // `msg.type() === 'error'` only and never sees `console.timeEnd`.
+      // Runtimes disagree about which type `timeEnd` logs as, so match the
+      // text prefix.
+      let flowRestoreMs: number | null = null
+      page.on('console', (msg) => {
+        const text = msg.text()
+        if (text.startsWith('flow-restore:')) {
+          const match = text.match(/([\d.]+)\s*ms/)
+          if (match) flowRestoreMs = Number.parseFloat(match[1] ?? '0')
+        }
+      })
+
+      await startTour(page)
+      await page.keyboard.press('ArrowRight')
+      await expect(page).toHaveURL(/\/settings$/)
+      await expect(title(page)).toHaveText(STEP_2)
+
+      // The flow-session write is TRAILING-EDGE throttled at 200 ms
+      // (`adapters/flow-session-store.ts`, `SAVE_THROTTLE_MS`), and a hard
+      // browser reload runs no teardown, so it never gets the `flush()` that
+      // an unmount would give it. Reloading inside that window resumes on the
+      // PREVIOUS step — measured here, and true of the React provider too; the
+      // existing React resume spec only avoids it because its assertions
+      // happen to take longer than 200 ms. Waiting explicitly is the honest
+      // version of what that spec does by accident. (A `pagehide` flush in the
+      // engine would close the gap for all three bindings; out of scope here.)
+      await page.waitForTimeout(300)
+
+      await page.reload()
+
+      await expect(page).toHaveURL(/\/settings$/)
+      await expect(title(page)).toHaveText(STEP_2)
+
+      // Assert the timer was SEEN before comparing: a `null` satisfies no
+      // comparison, so a broken restore would otherwise pass as "fast".
+      expect(flowRestoreMs, 'no flow-restore console timer was emitted').not.toBeNull()
+      expect(flowRestoreMs as unknown as number).toBeLessThan(200)
+    })
+
+    test('Escape ends the tour and focus returns to the Start button', async ({ page }) => {
+      await startTour(page)
+
+      await page.keyboard.press('Escape')
+
+      await expect(page.getByTestId('tour-card')).toHaveCount(0)
+      await expect(page.getByTestId('start-tour')).toBeFocused()
+    })
+  })
+}

--- a/e2e/vue/tour-flow.localhost.spec.ts
+++ b/e2e/vue/tour-flow.localhost.spec.ts
@@ -1,0 +1,3 @@
+import { describeBindingTourFlow } from '../_shared/binding-tour-flow'
+
+describeBindingTourFlow('Vue')

--- a/examples/vue-app/README.md
+++ b/examples/vue-app/README.md
@@ -1,0 +1,23 @@
+# vue-tour-kit-demo
+
+What it proves: a Vue 3 app runs a two-page tour — start, keyboard, cross-route
+navigation, advance-on, reload-resume, focus restore — with **no React
+installed**. Everything comes from `@tour-kit/vue`, which imports only
+`@tour-kit/core/engine`. The card and its positioning live here, not in the
+package.
+
+```bash
+pnpm --filter vue-tour-kit-demo dev   # http://localhost:5175
+```
+
+`data-testid` map used by `e2e/vue/tour-flow.localhost.spec.ts`:
+
+| testid | what |
+|---|---|
+| `start-tour` | starts the tour (also `#start-tour`) |
+| `start-here` | step 1's target (`#start-here`) |
+| `theme-toggle` | step 2's target (`#theme-toggle`), document-bound step |
+| `save-button` | step 3's target (`#save-button`) |
+| `tour-card` | the card itself |
+| `tour-card-title` / `tour-card-content` | step text |
+| `tour-back` / `tour-next` / `tour-skip` | the card's button row |

--- a/examples/vue-app/index.html
+++ b/examples/vue-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tour Kit — Vue binding demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/vue-app/package.json
+++ b/examples/vue-app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "vue-tour-kit-demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 5175 --strictPort",
+    "build": "vite build",
+    "preview": "vite preview --port 5175",
+    "typecheck": "vue-tsc --noEmit"
+  },
+  "dependencies": {
+    "@floating-ui/dom": "^1.7.6",
+    "@tour-kit/vue": "workspace:*",
+    "vue": "^3.5.13",
+    "vue-router": "^4.5.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.1",
+    "typescript": "catalog:",
+    "vite": "^6.3.5",
+    "vue-tsc": "^2.2.10"
+  }
+}

--- a/examples/vue-app/src/App.vue
+++ b/examples/vue-app/src/App.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { createVueRouterAdapter, provideTourKit } from '@tour-kit/vue'
+import { useRouter } from 'vue-router'
+import TourCard from './components/TourCard.vue'
+import { tours } from './tours'
+
+const router = useRouter()
+
+// A Vue Router instance is an app-level singleton, so this adapter's identity is
+// stable — unlike every React adapter, which is a `useMemo` over hook results.
+const kit = provideTourKit({
+  tours,
+  router: createVueRouterAdapter(router),
+  // `flowSession` takes a `storage`, not an `enabled` — it is what makes a
+  // hard reload resume the active tour at its persisted step, and what makes
+  // the `flow-restore` console timer fire at all.
+  routePersistence: { enabled: true, flowSession: { storage: 'sessionStorage' } },
+  enableTestBridge: true,
+})
+
+const start = () => {
+  void kit.start('proof')
+}
+</script>
+
+<template>
+  <header>
+    <h1>Tour Kit — Vue binding</h1>
+    <p>
+      Nothing on this page imports React. The tour engine, routing, persistence,
+      focus and keyboard all come from <code>@tour-kit/core/engine</code>.
+    </p>
+    <nav>
+      <RouterLink to="/">Home</RouterLink>
+      <RouterLink to="/settings">Settings</RouterLink>
+    </nav>
+    <button id="start-tour" data-testid="start-tour" type="button" @click="start">
+      Start tour
+    </button>
+  </header>
+
+  <main>
+    <RouterView />
+  </main>
+
+  <TourCard />
+</template>

--- a/examples/vue-app/src/components/TourCard.vue
+++ b/examples/vue-app/src/components/TourCard.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+/**
+ * The consumer's own card — the headless half of the proof. `@tour-kit/vue`
+ * ships no component and no `@floating-ui/*`; positioning lives here, with the
+ * exact middleware stack `packages/react/src/components/card/tour-card.tsx`
+ * uses, so the two cards position identically.
+ */
+import {
+  type Placement as FloatingPlacement,
+  arrow,
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  shift,
+} from '@floating-ui/dom'
+import {
+  getDocumentDirection,
+  mirrorPlacementForRTL,
+  useFocusTrap,
+  useSpotlight,
+  useTour,
+} from '@tour-kit/vue'
+import { computed, nextTick, onScopeDispose, shallowRef, watch } from 'vue'
+
+/**
+ * Core's `Placement` has a `-center` alignment; floating-ui's does not (it
+ * spells the same thing as the bare side). Strip it on the way out.
+ */
+function toFloatingPlacement(placement: string): FloatingPlacement {
+  return placement.replace(/-center$/, '') as FloatingPlacement
+}
+
+const tour = useTour()
+const spotlight = useSpotlight()
+
+const isActive = computed(() => tour.state.value.isActive)
+const step = computed(() => tour.state.value.currentStep)
+const isFirst = computed(() => tour.state.value.currentStepIndex === 0)
+
+const { containerRef, activate, deactivate } = useFocusTrap(isActive)
+const arrowRef = shallowRef<HTMLElement | null>(null)
+
+let cleanupPosition: (() => void) | null = null
+
+const stopPositioning = () => {
+  cleanupPosition?.()
+  cleanupPosition = null
+}
+
+function position(reference: HTMLElement, floating: HTMLElement) {
+  stopPositioning()
+  const placement = toFloatingPlacement(
+    mirrorPlacementForRTL(step.value?.placement ?? 'bottom', getDocumentDirection() === 'rtl')
+  )
+  cleanupPosition = autoUpdate(reference, floating, () => {
+    void computePosition(reference, floating, {
+      placement,
+      middleware: [
+        offset(12),
+        flip({ fallbackAxisSideDirection: 'start' }),
+        shift({ padding: 8 }),
+        ...(arrowRef.value ? [arrow({ element: arrowRef.value })] : []),
+      ],
+    }).then(({ x, y, middlewareData }) => {
+      Object.assign(floating.style, { left: `${x}px`, top: `${y}px` })
+      const a = middlewareData.arrow
+      if (arrowRef.value && a) {
+        Object.assign(arrowRef.value.style, {
+          left: a.x != null ? `${a.x}px` : '',
+          top: a.y != null ? `${a.y}px` : '',
+        })
+      }
+    })
+  })
+}
+
+watch(
+  [isActive, step],
+  async ([active, current]) => {
+    if (!active || !current || !('target' in current)) {
+      stopPositioning()
+      spotlight.hide()
+      // The CARD owns the focus restore, not the binding — `useFocusTrap`'s
+      // `enabled` gate only decides whether `activate()` does anything, exactly
+      // like the React hook. `<TourCard>` (React) calls `deactivate()` from its
+      // effect cleanup; this is the same call at the same moment.
+      deactivate()
+      return
+    }
+    await nextTick()
+    const reference = document.querySelector<HTMLElement>(String(current.target))
+    const floating = containerRef.value
+    if (!reference || !floating) return
+    spotlight.show(reference)
+    position(reference, floating)
+    activate()
+  },
+  { immediate: true }
+)
+
+onScopeDispose(stopPositioning)
+</script>
+
+<template>
+  <div
+    v-if="isActive && step"
+    ref="containerRef"
+    class="tk-card"
+    data-testid="tour-card"
+    role="dialog"
+    aria-modal="true"
+    :aria-label="String(step.title ?? 'Tour step')"
+  >
+    <h2 data-testid="tour-card-title">{{ step.title }}</h2>
+    <p data-testid="tour-card-content">{{ step.content }}</p>
+
+    <!--
+      `@click.stop` on the row is load-bearing, not cosmetic. Step 2 is
+      document-bound, and `bindStepAdvance` has no card guard: without this,
+      clicking Back would ALSO advance the tour.
+    -->
+    <div class="tk-actions" @click.stop>
+      <button
+        v-if="!isFirst"
+        data-testid="tour-back"
+        type="button"
+        @click="tour.prev()"
+      >
+        Back
+      </button>
+      <button data-testid="tour-next" type="button" @click="tour.next()">Next</button>
+      <button data-testid="tour-skip" type="button" @click="tour.skip()">Skip</button>
+    </div>
+
+    <div ref="arrowRef" class="tk-arrow" />
+  </div>
+</template>

--- a/examples/vue-app/src/main.ts
+++ b/examples/vue-app/src/main.ts
@@ -1,0 +1,16 @@
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import App from './App.vue'
+import Home from './pages/Home.vue'
+import Settings from './pages/Settings.vue'
+import './style.css'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/', component: Home },
+    { path: '/settings', component: Settings },
+  ],
+})
+
+createApp(App).use(router).mount('#app')

--- a/examples/vue-app/src/pages/Home.vue
+++ b/examples/vue-app/src/pages/Home.vue
@@ -1,0 +1,7 @@
+<template>
+  <section>
+    <h2>Home</h2>
+    <p>Step one of the tour points at the button below.</p>
+    <button id="start-here" data-testid="start-here" type="button">Start here</button>
+  </section>
+</template>

--- a/examples/vue-app/src/pages/Settings.vue
+++ b/examples/vue-app/src/pages/Settings.vue
@@ -1,0 +1,8 @@
+<template>
+  <section>
+    <h2>Settings</h2>
+    <p>Steps two and three live on this route, which the tour navigates to.</p>
+    <button id="theme-toggle" data-testid="theme-toggle" type="button">Toggle theme</button>
+    <button id="save-button" data-testid="save-button" type="button">Save</button>
+  </section>
+</template>

--- a/examples/vue-app/src/style.css
+++ b/examples/vue-app/src/style.css
@@ -1,0 +1,77 @@
+/* Plain CSS on purpose. A Tailwind purge config once made embeds invisible in
+   this repo's QA; the proof must not depend on one. */
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  background: #fbfbfd;
+  color: #16161a;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+nav a {
+  color: #3730a3;
+}
+
+button {
+  font: inherit;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid #c7c7d1;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.tk-card {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  width: max-content;
+  max-width: 20rem;
+  padding: 1rem;
+  border: 1px solid #d4d4dd;
+  border-radius: 10px;
+  background: #fff;
+  box-shadow: 0 10px 30px rgb(0 0 0 / 12%);
+}
+
+.tk-card h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.tk-card p {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+}
+
+.tk-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tk-arrow {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: #fff;
+  border: 1px solid #d4d4dd;
+  transform: rotate(45deg);
+}
+
+.tk-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  pointer-events: none;
+}

--- a/examples/vue-app/src/tours.ts
+++ b/examples/vue-app/src/tours.ts
@@ -1,0 +1,48 @@
+/**
+ * The shared proof tour — identical in the Svelte example.
+ *
+ * Designed so the Playwright lane exercises every advance-on case:
+ *
+ * | # | route       | target          | advanceOn                            | why                                              |
+ * |---|-------------|-----------------|--------------------------------------|--------------------------------------------------|
+ * | 1 | `/`         | `#start-here`   | click on `#start-here`               | the original hazard: one real click lands on 2   |
+ * | 2 | `/settings` | `#theme-toggle` | click, NO selector — document-bound   | the mirror hazard + the card-button swallow      |
+ * | 3 | `/settings` | `#save-button`  | none                                 | terminal                                          |
+ *
+ * Step 2 is deliberately in the MIDDLE: a document-bound step at the end makes
+ * "advanced past it" unobservable. It is also deliberately a VISIBLE step —
+ * `HiddenTourStep` declares `advanceOn?: never`.
+ */
+import type { Tour } from '@tour-kit/vue'
+
+export const tours: Tour[] = [
+  {
+    id: 'proof',
+    steps: [
+      {
+        id: 'start-here',
+        target: '#start-here',
+        title: 'Step one',
+        content: 'Click this button and you should land on step two, not step three.',
+        route: '/',
+        advanceOn: { event: 'click', selector: '#start-here' },
+      },
+      {
+        id: 'theme',
+        target: '#theme-toggle',
+        title: 'Step two',
+        content: 'This step advances on a click anywhere. One click, one step.',
+        route: '/settings',
+        // No `selector`: `bindStepAdvance` falls back to `document`.
+        advanceOn: { event: 'click' },
+      },
+      {
+        id: 'save',
+        target: '#save-button',
+        title: 'Step three',
+        content: 'Last step. Finish to complete the tour.',
+        route: '/settings',
+      },
+    ],
+  },
+]

--- a/examples/vue-app/tsconfig.json
+++ b/examples/vue-app/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "vite.config.ts"]
+}

--- a/examples/vue-app/vite.config.ts
+++ b/examples/vue-app/vite.config.ts
@@ -1,0 +1,7 @@
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: { port: 5175, strictPort: true },
+})

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "e2e": "playwright test",
     "e2e:vite": "playwright test --project=vite-localhost --project=vite-production",
     "e2e:next": "playwright test --project=next-localhost --project=next-production",
+    "e2e:vue": "playwright test --project=vue-localhost",
+    "e2e:svelte": "playwright test --project=svelte-localhost",
     "e2e:report": "playwright show-report",
     "phase-0-doctest": "bash tasks/v2-package-polish/phase-0-doctest.sh"
   },

--- a/packages/__tests__/free-package-isolation.test.ts
+++ b/packages/__tests__/free-package-isolation.test.ts
@@ -3,7 +3,9 @@ import * as path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const PACKAGES_ROOT = path.resolve(__dirname, '..')
-const FREE_PACKAGES = ['core', 'react', 'hints']
+// v2 §1.5 — `vue` and `svelte` join the free tier: the handoff's "do not
+// runtime-gate the AGPL packages" applies to a binding as much as to core.
+const FREE_PACKAGES = ['core', 'react', 'hints', 'vue']
 
 function getAllFiles(dir: string, extensions: string[]): string[] {
   const results: string[] = []

--- a/packages/core/src/__tests__/bundle-budget-claim-alignment.test.ts
+++ b/packages/core/src/__tests__/bundle-budget-claim-alignment.test.ts
@@ -69,6 +69,9 @@ const CLAIMS: Record<string, { pattern: RegExp; mode: 'exact' | 'ceiling' }> = {
   'ai:client': { pattern: /-\s*ai\s*<\s*([\d.]+)\s*KB\s*\(client\)/, mode: 'exact' },
   'ai:server': { pattern: /<\s*([\d.]+)\s*KB\s*\(server\)/, mode: 'exact' },
   scheduling: { pattern: /^\s*-\s*scheduling\s*<\s*([\d.]+)\s*KB/m, mode: 'exact' },
+  // Anchored like `media` and `scheduling`: an unanchored /vue/ would match the
+  // word anywhere else in CLAUDE.md and read the wrong number.
+  vue: { pattern: /^\s*-\s*vue\s*<\s*([\d.]+)\s*KB/m, mode: 'exact' },
 }
 
 describe('v2 §1.2 — the bundle-size gate measures the engine entry too', () => {

--- a/packages/core/src/__tests__/vitest-config-alignment.test.ts
+++ b/packages/core/src/__tests__/vitest-config-alignment.test.ts
@@ -18,6 +18,8 @@ const PACKAGES = [
   'scheduling',
   'license',
   'ai',
+  // v2 §1.5 — the two bindings hold the canonical floor, ENFORCED not stated.
+  'vue',
 ] as const
 
 const REPO_ROOT = join(__dirname, '..', '..', '..', '..')

--- a/packages/vue/CLAUDE.md
+++ b/packages/vue/CLAUDE.md
@@ -28,6 +28,12 @@ no `@floating-ui/*`. The consumer renders their own card — see
 6. **`shallowRef`, never `ref`, for the snapshot and for any `DOMRect`.** A deep
    `ref` proxies the `stepVisitCount` Map and the `tour` object, and every
    downstream `Object.is` breaks against the proxy.
+7. **State machines live in core; this package holds bridges.** `useSpotlight`
+   is a `shallowRef` over `createSpotlight()`, and `useTour` a `shallowRef` over
+   the engine handle — the same bridge twice. If a composable here grows fields
+   and transitions of its own, that logic belongs in `@tour-kit/core/engine`
+   where the Svelte binding and the React hook can share it. §1.5 shipped the
+   spotlight machine three times before §1.5f pushed it down.
 
 ## Gotchas
 
@@ -43,6 +49,10 @@ no `@floating-ui/*`. The consumer renders their own card — see
 - **The card owns `deactivate()`, not the binding.** `useFocusTrap`'s `enabled`
   gate only decides whether `activate()` does anything — same as the React hook.
   Restoring focus when the tour ends is the card's effect cleanup.
+- **`it.skipIf(!distExists())` gates on the `dist/` DIRECTORY, not the files.**
+  Gating on the files turns a wrong path into a silent skip — the suite reports
+  green with the guards disarmed. `no-react-in-dist.test.ts` asserts the three
+  entry files exist as its first case for exactly that reason.
 - **Tests read core from `dist`.** That is the claim under test: the *published*
   `/engine` subpath is sufficient. Run through turbo (`turbo run test
   --filter=@tour-kit/vue`) so core builds first; do not add a source alias, which

--- a/packages/vue/CLAUDE.md
+++ b/packages/vue/CLAUDE.md
@@ -1,0 +1,58 @@
+# @tour-kit/vue
+
+The Vue 3 binding over `@tour-kit/core/engine`. Headless: no card, no overlay,
+no `@floating-ui/*`. The consumer renders their own card — see
+`examples/vue-app`.
+
+## The rules the shape depends on
+
+1. **Nothing constructs an engine in `setup()`.** `createEngineHandle` builds on
+   the first *verb*, and every kit member except `state` is `ensure()` in
+   disguise — `setOptions` and `setTours` included. Only `getState()` and
+   `subscribe()` are safe during setup.
+2. **Therefore `watch`, never `watchEffect`.** `watchEffect` (and
+   `watch(..., { immediate: true })`) runs its callback synchronously inside
+   `setup()`, which under Nuxt means registry writes, four storage adapters and
+   a `BroadcastChannel` **on the server**. The two watchers in
+   `provide-tour-kit.ts` are non-immediate on purpose; the mount hook does the
+   first push. `use-focus-trap.ts` is the one legitimate `immediate: true` —
+   `capture()` reads `document.activeElement` and constructs nothing.
+3. **`release()`, never `destroy()`.** `onScopeDispose` calls `release()`, which
+   flushes synchronously and defers the destroy by a microtask, so a teardown
+   immediately followed by a re-`ensure()` takes the same engine back.
+4. **Every attach returns a detach, and every detach runs on unmount.** They are
+   collected in one array in `provideTourKit`.
+5. **Never import `@tour-kit/core` bare.** The bare specifier pulls React into
+   the `.d.ts` chain. `src/__tests__/no-react-in-dist.test.ts` enforces it on
+   both the built files and the source.
+6. **`shallowRef`, never `ref`, for the snapshot and for any `DOMRect`.** A deep
+   `ref` proxies the `stepVisitCount` Map and the `tour` object, and every
+   downstream `Object.is` breaks against the proxy.
+
+## Gotchas
+
+- **A child's `onMounted` fires BEFORE the provider's.** `onMounted(() => tour.start())`
+  in a page component therefore lands before the provider's own boot. The
+  handle's lazy `ensure()` is what makes that work — do not "fix" it by
+  constructing earlier.
+- **The barrel does `export * from '@tour-kit/core/engine'`, deliberately.**
+  `/engine` is already the curated React-free surface; a hand-picked subset
+  would need its own alignment test and would still be wrong the day `/engine`
+  grows.
+- **`Escape` maps to `skip()`, not `stop()`**, and a skip persists.
+- **The card owns `deactivate()`, not the binding.** `useFocusTrap`'s `enabled`
+  gate only decides whether `activate()` does anything — same as the React hook.
+  Restoring focus when the tour ends is the card's effect cleanup.
+- **Tests read core from `dist`.** That is the claim under test: the *published*
+  `/engine` subpath is sufficient. Run through turbo (`turbo run test
+  --filter=@tour-kit/vue`) so core builds first; do not add a source alias, which
+  would also drag core's `src/**` into this package's coverage denominator.
+- **`private: true` until the v2 licence lands (§3.2).**
+
+## Commands
+
+```bash
+turbo run test --filter=@tour-kit/vue
+pnpm --filter @tour-kit/vue build
+pnpm --filter @tour-kit/vue typecheck
+```

--- a/packages/vue/LICENSE.md
+++ b/packages/vue/LICENSE.md
@@ -1,0 +1,9 @@
+# License
+
+`@tour-kit/vue` ships under the Tour Kit v2 licence terms, which are not yet
+published. Until they are, this package is `"private": true` and is **not**
+published to npm — a binding released under a placeholder licence is worse than
+one released four weeks later under the right one.
+
+See the root `LICENSE` and https://usertourkit.com/ for the licence covering the
+packages that are published today.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,35 @@
+# @tour-kit/vue
+
+Headless product tours for Vue 3, over the framework-agnostic Tour Kit engine.
+No React installed, anywhere.
+
+```ts
+// App.vue
+import { createVueRouterAdapter, provideTourKit } from '@tour-kit/vue'
+import { useRouter } from 'vue-router'
+
+const kit = provideTourKit({
+  tours,
+  router: createVueRouterAdapter(useRouter()),
+  routePersistence: { enabled: true, flowSession: { storage: 'sessionStorage' } },
+})
+
+kit.start('onboarding')
+```
+
+Anywhere below it:
+
+```ts
+import { useTour } from '@tour-kit/vue'
+
+const tour = useTour()
+tour.state.value.currentStep   // reactive; new identity per transition
+tour.next()                    // the thirteen verbs, stable identity
+```
+
+You render the card. `useSpotlight()` and `useFocusTrap()` are here for the
+behaviours; positioning is yours (`@floating-ui/dom` is a good choice — see
+`examples/vue-app`).
+
+Not published yet: this package ships under the Tour Kit v2 licence terms,
+which are not final. See `LICENSE.md`.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@tour-kit/vue",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Headless Vue 3 binding for the Tour Kit engine — product tours with no React installed.",
+  "author": "Tour Kit Team",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "homepage": "https://usertourkit.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/domidex01/tour-kit.git",
+    "directory": "packages/vue"
+  },
+  "bugs": {
+    "url": "https://github.com/domidex01/tour-kit/issues"
+  },
+  "keywords": [
+    "vue",
+    "vue3",
+    "onboarding",
+    "product-tour",
+    "guided-tour",
+    "walkthrough",
+    "headless",
+    "composable",
+    "tour-kit"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": ["dist", "README.md", "CHANGELOG.md"],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@tour-kit/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "vue": "^3.3.0",
+    "vue-router": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vue-router": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "catalog:",
+    "@vue/test-utils": "^2.4.6",
+    "jsdom": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "vitest-axe": "catalog:",
+    "vue": "^3.5.13"
+  }
+}

--- a/packages/vue/src/__tests__/_helpers/counting-factory.ts
+++ b/packages/vue/src/__tests__/_helpers/counting-factory.ts
@@ -1,0 +1,30 @@
+/**
+ * The options factory `createTourKit` takes, wrapped so it records how many
+ * engines were built.
+ *
+ * Construction COUNT and construction MOMENT are the only observable that
+ * separates "correct" from "works but boots during setup" — both produce a
+ * working tour. Every lifecycle case here reads `factory.mock.calls.length`.
+ *
+ * Copied from core's `lib/tour-engine/__tests__/_helpers/`, not imported: core
+ * does not export its test helpers. The copy is also a small proof of §1.5's
+ * thesis — every symbol it needs is on `/engine`.
+ *
+ * One deliberate difference from core's copy: this returns the OPTIONS, not the
+ * engine, because `createTourKit` takes `() => CreateTourEngineOptions` and does
+ * the `createTourEngine` call itself. The observable is identical — the handle
+ * invokes this exactly once per engine, at `ensure()` time — and keeping the
+ * `createTourEngine` call inside the binding is what lets the binding own the
+ * lazy construction the whole slice is about.
+ *
+ * Storage is a fresh `createMemoryStorage()` per engine: persistence defaults
+ * ON since §1.4a and jsdom's `localStorage` is shared across a file.
+ */
+import { type CreateTourEngineOptions, createMemoryStorage } from '@tour-kit/core/engine'
+import { vi } from 'vitest'
+
+export function countingFactory(overrides: Partial<CreateTourEngineOptions> = {}) {
+  return vi.fn(
+    (): CreateTourEngineOptions => ({ tours: [], storage: createMemoryStorage(), ...overrides })
+  )
+}

--- a/packages/vue/src/__tests__/_helpers/fake-router.ts
+++ b/packages/vue/src/__tests__/_helpers/fake-router.ts
@@ -1,0 +1,30 @@
+/**
+ * Structural stand-in for a Vue Router 4 instance — exactly what
+ * `createVueRouterAdapter` types, nothing more.
+ *
+ * `push` resolves to a `NavigationFailure`-shaped object when `failNext` is
+ * set: vue-router RESOLVES on a blocked navigation, it does not reject, and the
+ * engine reads a resolved `false` as `NAVIGATION_REJECTED`.
+ */
+import { vi } from 'vitest'
+
+export function fakeVueRouter(path = '/') {
+  const listeners = new Set<(to: { path: string }) => void>()
+  const router = {
+    currentRoute: { value: { path } },
+    failNext: false,
+    push: vi.fn(async (to: string): Promise<unknown> => {
+      if (router.failNext) return { type: 8, from: {}, to: {} }
+      router.currentRoute.value = { path: to }
+      for (const cb of [...listeners]) cb({ path: to })
+      return undefined
+    }),
+    afterEach: vi.fn((cb: (to: { path: string }) => void) => {
+      listeners.add(cb)
+      return () => {
+        listeners.delete(cb)
+      }
+    }),
+  }
+  return router
+}

--- a/packages/vue/src/__tests__/adapters/vue-router.test.ts
+++ b/packages/vue/src/__tests__/adapters/vue-router.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The adapter is a factory over a structural `Router`, which is what makes
+ * `vue-router` a type-only optional peer: this file never installs one.
+ */
+import { describe, expect, it } from 'vitest'
+import { createVueRouterAdapter } from '../../adapters/vue-router'
+import { fakeVueRouter } from '../_helpers/fake-router'
+
+describe('createVueRouterAdapter', () => {
+  it('reads the current path off currentRoute.value', () => {
+    const adapter = createVueRouterAdapter(fakeVueRouter('/settings'))
+    expect(adapter.getCurrentRoute()).toBe('/settings')
+  })
+
+  it('onRouteChange fires immediately with the current route', () => {
+    const router = fakeVueRouter('/')
+    const adapter = createVueRouterAdapter(router)
+    const seen: string[] = []
+
+    adapter.onRouteChange((r) => seen.push(r))
+
+    // Every existing adapter does this and the engine's route-restore path
+    // depends on it.
+    expect(seen).toEqual(['/'])
+  })
+
+  it('onRouteChange forwards later navigations and its teardown unsubscribes', async () => {
+    const router = fakeVueRouter('/')
+    const adapter = createVueRouterAdapter(router)
+    const seen: string[] = []
+
+    const off = adapter.onRouteChange((r) => seen.push(r))
+    await router.push('/settings')
+    expect(seen).toEqual(['/', '/settings'])
+
+    off()
+    await router.push('/profile')
+    expect(seen).toEqual(['/', '/settings'])
+  })
+
+  it('a resolved NavigationFailure maps to false, not a rejection', async () => {
+    const router = fakeVueRouter('/')
+    const adapter = createVueRouterAdapter(router)
+
+    await expect(adapter.navigate('/settings')).resolves.toBe(true)
+
+    router.failNext = true
+    // vue-router RESOLVES with a NavigationFailure on a blocked navigation.
+    // The engine reads a resolved `false` as NAVIGATION_REJECTED.
+    await expect(adapter.navigate('/blocked')).resolves.toBe(false)
+  })
+
+  it('matchRoute covers all three modes', () => {
+    const adapter = createVueRouterAdapter(fakeVueRouter('/settings/theme'))
+
+    expect(adapter.matchRoute('/settings/theme')).toBe(true)
+    expect(adapter.matchRoute('/settings')).toBe(false)
+    expect(adapter.matchRoute('/settings', 'startsWith')).toBe(true)
+    expect(adapter.matchRoute('theme', 'contains')).toBe(true)
+    expect(adapter.matchRoute('nope', 'contains')).toBe(false)
+  })
+})

--- a/packages/vue/src/__tests__/create-tour-kit.test.ts
+++ b/packages/vue/src/__tests__/create-tour-kit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The reactivity bridge: one `state.value` write per real transition, none for
+ * the reducer's identity fast paths, and zero engines built before a verb.
+ */
+import type { Tour } from '@tour-kit/core/engine'
+import { describe, expect, it, vi } from 'vitest'
+import { effectScope, watch } from 'vue'
+import { createTourKit } from '../create-tour-kit'
+import { countingFactory } from './_helpers/counting-factory'
+
+const tour = (id: string): Tour => ({
+  id,
+  steps: [
+    { id: 's1', target: '#a', content: 'one' },
+    { id: 's2', target: '#b', content: 'two' },
+  ],
+})
+
+describe('createTourKit', () => {
+  it('constructs no engine until the first verb', () => {
+    const factory = countingFactory({ tours: [tour('kit-inert')] })
+    const kit = createTourKit(factory)
+
+    // The two members a render may touch.
+    expect(kit.state.value.isActive).toBe(false)
+    kit.state.value.currentStep
+    expect(factory).toHaveBeenCalledTimes(0)
+  })
+
+  it('a verb constructs exactly one engine, and later verbs reuse it', async () => {
+    const factory = countingFactory({ tours: [tour('kit-one')] })
+    const kit = createTourKit(factory)
+
+    await kit.start('kit-one')
+    await kit.next()
+
+    expect(factory).toHaveBeenCalledTimes(1)
+    kit.handle.release()
+  })
+
+  it('writes state.value on a real transition and NOT on an identity fast path', async () => {
+    const factory = countingFactory({ tours: [tour('kit-identity')] })
+    const kit = createTourKit(factory)
+    const scope = effectScope()
+    const seen: Array<string | undefined> = []
+
+    scope.run(() => {
+      watch(kit.state, (s) => seen.push(s.currentStep?.id), { flush: 'sync' })
+    })
+
+    await kit.start('kit-identity')
+    const afterStart = seen.length
+    expect(seen[seen.length - 1]).toBe('s1')
+
+    // THE discriminating half. `prev()` on step 0 is the reducer's identity
+    // fast path: it hands the same snapshot reference back, so a `shallowRef`
+    // must not fire and a `ref` (deep, proxied) would.
+    await kit.prev()
+    expect(seen.length).toBe(afterStart)
+
+    // A real transition does fire. Not asserted as exactly one write: the
+    // engine notifies on `isTransitioning` too, so a step change is several
+    // notifies with the last one carrying the new step. The bridge's job is to
+    // mirror each notify, which is what this checks.
+    await kit.next()
+    expect(seen[seen.length - 1]).toBe('s2')
+    expect(seen.length).toBeGreaterThan(afterStart)
+
+    scope.stop()
+    kit.handle.release()
+  })
+
+  it('spreads the thirteen actions with stable identity', () => {
+    const factory = countingFactory({ tours: [tour('kit-stable')] })
+    const kit = createTourKit(factory)
+
+    const before = kit.next
+    expect(typeof kit.goToStep).toBe('function')
+    expect(typeof kit.triggerBranchAction).toBe('function')
+    expect(typeof kit.setDontShowAgain).toBe('function')
+    expect(kit.next).toBe(before)
+    expect(factory).toHaveBeenCalledTimes(0)
+  })
+
+  it('setOptions and setTours are verbs — they construct', () => {
+    const factory = countingFactory({ tours: [] })
+    const kit = createTourKit(factory)
+
+    kit.setTours([tour('kit-set')])
+
+    expect(factory).toHaveBeenCalledTimes(1)
+    kit.handle.release()
+  })
+
+  it('release() then a verb takes the same engine back', async () => {
+    const factory = countingFactory({ tours: [tour('kit-release')] })
+    const kit = createTourKit(factory)
+
+    await kit.start('kit-release')
+    kit.handle.release()
+    // Same tick: the handle's destroy is deferred by one microtask.
+    await kit.next()
+
+    expect(factory).toHaveBeenCalledTimes(1)
+    kit.handle.release()
+    await Promise.resolve()
+  })
+
+  it('a released handle reports the initial snapshot again after its destroy lands', async () => {
+    const factory = countingFactory({ tours: [tour('kit-destroyed')] })
+    const kit = createTourKit(factory)
+
+    await kit.start('kit-destroyed')
+    expect(kit.state.value.isActive).toBe(true)
+
+    kit.handle.release()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(kit.handle.getState().isActive).toBe(false)
+    expect(vi.isMockFunction(factory)).toBe(true)
+  })
+})

--- a/packages/vue/src/__tests__/manifest.test.ts
+++ b/packages/vue/src/__tests__/manifest.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+/**
+ * The manifest half of "no React installed". Modelled on
+ * `packages/analytics/src/__tests__/package-contract.test.ts`.
+ */
+import { describe, expect, it } from 'vitest'
+
+const pkg = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../../package.json'), 'utf8')
+) as {
+  private?: boolean
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>
+}
+
+describe('@tour-kit/vue package.json', () => {
+  it('names react in no dependency field at all', () => {
+    for (const field of ['dependencies', 'devDependencies', 'peerDependencies'] as const) {
+      const names = Object.keys(pkg[field] ?? {})
+      expect(names, field).not.toContain('react')
+      expect(names, field).not.toContain('react-dom')
+      expect(names, field).not.toContain('@types/react')
+    }
+  })
+
+  it('depends on core and peers on vue', () => {
+    expect(pkg.dependencies?.['@tour-kit/core']).toBe('workspace:*')
+    expect(pkg.peerDependencies?.vue).toBeDefined()
+  })
+
+  it('vue-router is an OPTIONAL peer — the adapter is a factory over primitives', () => {
+    // Without this a consumer with no router still has to install one.
+    expect(pkg.peerDependencies?.['vue-router']).toBeDefined()
+    expect(pkg.peerDependenciesMeta?.['vue-router']?.optional).toBe(true)
+  })
+
+  it('is private until the v2 licence lands (§3.2)', () => {
+    expect(pkg.private).toBe(true)
+  })
+})

--- a/packages/vue/src/__tests__/no-react-in-dist.test.ts
+++ b/packages/vue/src/__tests__/no-react-in-dist.test.ts
@@ -22,12 +22,28 @@ const DTS = join(PKG_ROOT, 'dist', 'index.d.ts')
  * `splitting: false` and one entry, so `dist/index.js` IS the whole closure —
  * no `closureOf` walk needed. Core's `_dist.ts` `distExists()` checks core's
  * schemas entry and is useless here.
+ *
+ * This gates on the DIRECTORY, not on the three files, and that distinction is
+ * the whole point. `it.skipIf(!distExists())` turns a wrong path into a SILENT
+ * SKIP — measured: pointing `ESM` at a nonexistent filename left the suite
+ * reporting "3 skipped" and green, which is exactly the vacuity the positive
+ * control below exists to prevent. Gating on `dist/` means a genuine no-build
+ * run still skips, while a wrong filename reaches the assertion in
+ * `names the three built entry files` and fails loudly.
  */
-const distExists = () => existsSync(ESM) && existsSync(CJS) && existsSync(DTS)
+const DIST = join(PKG_ROOT, 'dist')
+const distExists = () => existsSync(DIST)
 
 const FORBIDDEN = ['react', 'react-dom', 'clsx', 'tailwind-merge', 'zod']
 
 describe('@tour-kit/vue ships no React', () => {
+  it.skipIf(!distExists())('names the three built entry files', () => {
+    // The guard against `distExists()` silently disarming everything below.
+    for (const file of [ESM, CJS, DTS]) {
+      expect(existsSync(file), `${file} missing — the scan below would skip`).toBe(true)
+    }
+  })
+
   it.skipIf(!distExists())('CONTROL — the built files name `vue`, so the scan works', () => {
     for (const file of [ESM, CJS, DTS]) {
       expect(specifierPattern('vue').test(readFileSync(file, 'utf8')), `${file} names vue`).toBe(

--- a/packages/vue/src/__tests__/no-react-in-dist.test.ts
+++ b/packages/vue/src/__tests__/no-react-in-dist.test.ts
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+/**
+ * US-1: a Vue developer gets the whole engine with no React installed.
+ *
+ * The POSITIVE CONTROL is not decoration. A bare
+ * `expect(dist).not.toContain('react')` passes when the path is wrong, when the
+ * build never ran, or when the matcher is broken — and it passes forever.
+ * `vue` is `external` in tsup, so the built file genuinely names it; if that
+ * assertion fails, every negative one above it was meaningless.
+ */
+import { describe, expect, it } from 'vitest'
+import { specifierPattern } from '../../../../tooling/bundle-check/closure.mjs'
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const ESM = join(PKG_ROOT, 'dist', 'index.js')
+const CJS = join(PKG_ROOT, 'dist', 'index.cjs')
+const DTS = join(PKG_ROOT, 'dist', 'index.d.ts')
+
+/**
+ * `splitting: false` and one entry, so `dist/index.js` IS the whole closure —
+ * no `closureOf` walk needed. Core's `_dist.ts` `distExists()` checks core's
+ * schemas entry and is useless here.
+ */
+const distExists = () => existsSync(ESM) && existsSync(CJS) && existsSync(DTS)
+
+const FORBIDDEN = ['react', 'react-dom', 'clsx', 'tailwind-merge', 'zod']
+
+describe('@tour-kit/vue ships no React', () => {
+  it.skipIf(!distExists())('CONTROL — the built files name `vue`, so the scan works', () => {
+    for (const file of [ESM, CJS, DTS]) {
+      expect(specifierPattern('vue').test(readFileSync(file, 'utf8')), `${file} names vue`).toBe(
+        true
+      )
+    }
+  })
+
+  it.skipIf(!distExists())('names none of the React-side specifiers', () => {
+    for (const file of [ESM, CJS, DTS]) {
+      const source = readFileSync(file, 'utf8')
+      for (const pkg of FORBIDDEN) {
+        expect(specifierPattern(pkg).test(source), `${file} must not import ${pkg}`).toBe(false)
+      }
+    }
+  })
+
+  it.skipIf(!distExists())('imports @tour-kit/core/engine, never the bare main entry', () => {
+    for (const file of [ESM, CJS, DTS]) {
+      const source = readFileSync(file, 'utf8')
+      // The bare specifier pulls React into the .d.ts chain. `specifierPattern`
+      // allows a `/subpath`, so match the exact bare form here.
+      expect(/from\s*["']@tour-kit\/core["']/.test(source), `${file} imports bare core`).toBe(false)
+      expect(specifierPattern('@tour-kit/core').test(source), `${file} imports core`).toBe(true)
+    }
+  })
+
+  it('the source never imports the bare main entry either', async () => {
+    const { globSync } = await import('node:fs')
+    const files = globSync('src/**/*.ts', { cwd: PKG_ROOT })
+    for (const rel of files) {
+      const source = readFileSync(join(PKG_ROOT, rel), 'utf8')
+      expect(/from\s*["']@tour-kit\/core["']/.test(source), `${rel} imports bare core`).toBe(false)
+      expect(/from\s*["']react["']/.test(source), `${rel} imports react`).toBe(false)
+    }
+  })
+})

--- a/packages/vue/src/__tests__/provide-tour-kit.test.ts
+++ b/packages/vue/src/__tests__/provide-tour-kit.test.ts
@@ -1,0 +1,261 @@
+import type { CreateTourEngineOptions, Tour, TourEngine } from '@tour-kit/core/engine'
+import { mount } from '@vue/test-utils'
+/**
+ * The lifecycle cases — construction MOMENT, not just count.
+ *
+ * `provideTourKit` in `setup()` must construct nothing. Every kit member except
+ * `state` is `ensure()` in disguise, so an immediate watcher (or the
+ * `watchEffect` an earlier draft of the plan had) would build an engine inside
+ * `setup()` — on Nuxt, that is registry writes, four storage adapters and a
+ * `BroadcastChannel` on the server.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { type PropType, defineComponent, h, nextTick, onMounted } from 'vue'
+import type { TourKit } from '../create-tour-kit'
+import { type TourKitOptions, provideTourKit, useTour } from '../provide-tour-kit'
+
+/**
+ * The oracle: how many engines were built, and when.
+ *
+ * NOT a counted options getter — `provideTourKit` takes a `MaybeRefOrGetter`
+ * and `toValue`s it on every watcher evaluation, every `validateTour` pass and
+ * every `ensure()`, so the getter is read many times per engine by design.
+ * Wrapping `createTourEngine` itself counts constructions exactly, with the
+ * real engine underneath.
+ */
+const engineBuilds = vi.fn()
+
+vi.mock('@tour-kit/core/engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tour-kit/core/engine')>()
+  return {
+    ...actual,
+    createTourEngine: (options: CreateTourEngineOptions): TourEngine => {
+      engineBuilds(options)
+      return actual.createTourEngine({ ...options, storage: actual.createMemoryStorage() })
+    },
+  }
+})
+
+const tour = (id: string): Tour => ({
+  id,
+  steps: [
+    { id: 's1', target: '#a', content: 'one' },
+    { id: 's2', target: '#b', content: 'two' },
+  ],
+})
+
+function harness(options: TourKitOptions, slot?: () => unknown) {
+  return defineComponent({
+    setup(_props, { slots }) {
+      provideTourKit(() => options)
+      return () => (slot ? slot() : slots.default?.())
+    },
+  })
+}
+
+beforeEach(() => {
+  engineBuilds.mockClear()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  // biome-ignore lint/performance/noDelete: the test bridge writes a real global
+  delete (window as unknown as Record<string, unknown>).__tourKit__
+})
+
+describe('provideTourKit — lifecycle', () => {
+  it('constructs nothing during setup()', async () => {
+    // The count is read INSIDE setup(), not after `mount()` returns: Vue runs
+    // `onMounted` synchronously at the end of the initial render, so by the
+    // time `mount()` hands back, the provider's own boot has legitimately
+    // built one. The regression this pins is one built EARLIER than that —
+    // which is what an immediate `watch`, or the `watchEffect` the first draft
+    // of the plan had, would do, because every verb is `ensure()` in disguise
+    // and `setOptions` is a verb. On Nuxt that is registry writes, four
+    // storage adapters and a `BroadcastChannel` on the server.
+    let duringSetup = -1
+    const Harness = defineComponent({
+      setup() {
+        provideTourKit(() => ({ tours: [tour('vue-setup-inert')] }))
+        duringSetup = engineBuilds.mock.calls.length
+        return () => h('div')
+      },
+    })
+
+    const wrapper = mount(Harness)
+
+    expect(duringSetup).toBe(0)
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+    await Promise.resolve()
+  })
+
+  it("a child's onMounted verb — which fires BEFORE the provider's — builds exactly one engine", async () => {
+    const Child = defineComponent({
+      setup() {
+        const t = useTour()
+        onMounted(() => {
+          void t.start('vue-child-start')
+        })
+        return () => h('div', { 'data-testid': 'child' }, String(t.state.value.isActive))
+      },
+    })
+    const wrapper = mount(harness({ tours: [tour('vue-child-start')] }, () => h(Child)))
+
+    await vi.waitFor(() => expect(wrapper.get('[data-testid="child"]').text()).toBe('true'))
+
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+    await Promise.resolve()
+  })
+
+  it('a live prop change re-pushes setOptions without a second construction', async () => {
+    const tours = [tour('vue-live-props')]
+    const Harness = defineComponent({
+      props: { autoNavigate: { type: Boolean, default: false } },
+      setup(props) {
+        const kit = provideTourKit(() => ({ tours, autoNavigate: props.autoNavigate }))
+        return () => h('div', {}, String(kit.state.value.isActive))
+      },
+    })
+    const wrapper = mount(Harness, { props: { autoNavigate: false } })
+    await nextTick()
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+    expect(engineBuilds.mock.calls[0]?.[0]).toMatchObject({ autoNavigate: false })
+
+    await wrapper.setProps({ autoNavigate: true })
+    await nextTick()
+
+    // The watcher pushed the change through `setOptions`, which is a verb —
+    // and a verb on a live handle must NOT build a second engine.
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+    await Promise.resolve()
+  })
+
+  it('setTours pushes a new tour list without rebuilding the engine', async () => {
+    const held: { kit?: TourKit } = {}
+    const Harness = defineComponent({
+      props: { tours: { type: Array as PropType<Tour[]>, required: true } },
+      setup(props) {
+        held.kit = provideTourKit(() => ({ tours: props.tours as Tour[] }))
+        return () => h('div', {}, String(held.kit?.state.value.isActive))
+      },
+    })
+    const wrapper = mount(Harness, { props: { tours: [tour('vue-set-tours-a')] } })
+    await nextTick()
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ tours: [tour('vue-set-tours-a'), tour('vue-set-tours-b')] })
+    await nextTick()
+
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+    // And the new tour is really reachable through the same engine.
+    await held.kit?.start('vue-set-tours-b')
+    expect(held.kit?.state.value.isActive).toBe(true)
+
+    wrapper.unmount()
+    await Promise.resolve()
+  })
+
+  it('keyboard is on by default: Escape ends the tour', async () => {
+    const held: { kit?: TourKit } = {}
+    const Harness = defineComponent({
+      setup() {
+        held.kit = provideTourKit(() => ({ tours: [tour('vue-keyboard-on')] }))
+        return () => h('div')
+      },
+    })
+    const wrapper = mount(Harness)
+    await nextTick()
+
+    await held.kit?.start('vue-keyboard-on')
+    expect(held.kit?.state.value.isActive).toBe(true)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+
+    // Escape maps to skip(), not stop() — which is why the e2e case that
+    // presses it needs its own browser context.
+    expect(held.kit?.state.value.isActive).toBe(false)
+
+    wrapper.unmount()
+    await Promise.resolve()
+  })
+
+  it('keyboard: false opts out', async () => {
+    const held: { kit?: TourKit } = {}
+    const Harness = defineComponent({
+      setup() {
+        held.kit = provideTourKit(() => ({ tours: [tour('vue-keyboard-off')], keyboard: false }))
+        return () => h('div')
+      },
+    })
+    const wrapper = mount(Harness)
+    await nextTick()
+
+    await held.kit?.start('vue-keyboard-off')
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+
+    expect(held.kit?.state.value.isActive).toBe(true)
+
+    wrapper.unmount()
+    await Promise.resolve()
+  })
+
+  it('enableTestBridge installs window.__tourKit__ and unmount removes it', async () => {
+    const wrapper = mount(harness({ tours: [tour('vue-bridge')], enableTestBridge: true }))
+    await nextTick()
+
+    expect((window as unknown as Record<string, unknown>).__tourKit__).toBeDefined()
+
+    wrapper.unmount()
+    await Promise.resolve()
+
+    expect((window as unknown as Record<string, unknown>).__tourKit__).toBeUndefined()
+  })
+
+  it('unmount releases the engine and detaches the keyboard listener', async () => {
+    const held: { kit?: TourKit } = {}
+    const Harness = defineComponent({
+      setup() {
+        held.kit = provideTourKit(() => ({ tours: [tour('vue-teardown')] }))
+        return () => h('div')
+      },
+    })
+    const wrapper = mount(Harness)
+    await nextTick()
+    await held.kit?.start('vue-teardown')
+    expect(held.kit?.state.value.isActive).toBe(true)
+
+    wrapper.unmount()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // The engine is destroyed: the handle reports the initial snapshot again.
+    expect(held.kit?.handle.getState().isActive).toBe(false)
+
+    // And the keyboard listener is gone. A live listener would call a verb,
+    // and a verb on a released handle builds engine #2 — which is what this
+    // count catches.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    await nextTick()
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useTour', () => {
+  it('throws outside a provider', () => {
+    const Orphan = defineComponent({
+      setup() {
+        useTour()
+        return () => h('div')
+      },
+    })
+    expect(() => mount(Orphan)).toThrow(/within provideTourKit/)
+  })
+})

--- a/packages/vue/src/__tests__/ssr.test.ts
+++ b/packages/vue/src/__tests__/ssr.test.ts
@@ -1,0 +1,65 @@
+import type { CreateTourEngineOptions, Tour, TourEngine } from '@tour-kit/core/engine'
+// @vitest-environment node
+/**
+ * The Nuxt story. `// @vitest-environment node` is FILE-SCOPED, which is why
+ * this is its own file: one node case inside a jsdom file silently runs under
+ * jsdom and proves nothing.
+ *
+ * `setup()` runs on the server. `createTourEngine` touches `tourRegistry`,
+ * builds four storage adapters and opens a `BroadcastChannel`; none of that may
+ * happen there. The handle is inert until the first verb, and `getState()`
+ * returns `INITIAL_SNAPSHOT` until then — so a server render must build zero
+ * engines and render the initial values.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSSRApp, defineComponent, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { provideTourKit, useTour } from '../provide-tour-kit'
+
+const engineBuilds = vi.fn()
+
+vi.mock('@tour-kit/core/engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tour-kit/core/engine')>()
+  return {
+    ...actual,
+    createTourEngine: (options: CreateTourEngineOptions): TourEngine => {
+      engineBuilds(options)
+      return actual.createTourEngine(options)
+    },
+  }
+})
+
+const tour: Tour = {
+  id: 'ssr-tour',
+  steps: [{ id: 's1', target: '#a', content: 'one' }],
+}
+
+describe('SSR', () => {
+  beforeEach(() => engineBuilds.mockClear())
+
+  it('renderToString builds no engine and renders INITIAL_SNAPSHOT', async () => {
+    const Child = defineComponent({
+      setup() {
+        const t = useTour()
+        return () =>
+          h('div', { id: 'out' }, `${t.state.value.isActive}|${t.state.value.currentStepIndex}`)
+      },
+    })
+    const App = defineComponent({
+      setup() {
+        provideTourKit(() => ({ tours: [tour] }))
+        return () => h(Child)
+      },
+    })
+
+    const html = await renderToString(createSSRApp(App))
+
+    expect(engineBuilds).toHaveBeenCalledTimes(0)
+    expect(html).toContain('false|0')
+  })
+
+  it('there is no window or document to have touched', () => {
+    expect(typeof window).toBe('undefined')
+    expect(typeof document).toBe('undefined')
+  })
+})

--- a/packages/vue/src/__tests__/tour-provider.test.ts
+++ b/packages/vue/src/__tests__/tour-provider.test.ts
@@ -1,0 +1,78 @@
+import type { CreateTourEngineOptions, Tour, TourEngine } from '@tour-kit/core/engine'
+import { mount } from '@vue/test-utils'
+/**
+ * `<TourProvider>` is two lines over `provideTourKit`, and the two lines that
+ * matter are: props are the option bag, and the getter keeps them reactive.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick, onMounted } from 'vue'
+import { useTour } from '../provide-tour-kit'
+import { TourProvider } from '../tour-provider'
+
+const engineBuilds = vi.fn()
+
+vi.mock('@tour-kit/core/engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tour-kit/core/engine')>()
+  return {
+    ...actual,
+    createTourEngine: (options: CreateTourEngineOptions): TourEngine => {
+      engineBuilds(options)
+      return actual.createTourEngine({ ...options, storage: actual.createMemoryStorage() })
+    },
+  }
+})
+
+const tours: Tour[] = [{ id: 'provider-tour', steps: [{ id: 's1', target: '#a', content: 'one' }] }]
+
+const Child = defineComponent({
+  setup() {
+    const t = useTour()
+    onMounted(() => {
+      void t.start('provider-tour')
+    })
+    return () => h('div', { 'data-testid': 'out' }, String(t.state.value.isActive))
+  },
+})
+
+beforeEach(() => engineBuilds.mockClear())
+
+describe('<TourProvider>', () => {
+  it('provides a kit to its slot and renders the slot content', async () => {
+    const wrapper = mount(TourProvider, {
+      props: { tours },
+      slots: { default: () => h(Child) },
+    })
+
+    await vi.waitFor(() => expect(wrapper.get('[data-testid="out"]').text()).toBe('true'))
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+    await Promise.resolve()
+  })
+
+  it('a prop change reaches the engine without a rebuild', async () => {
+    const wrapper = mount(TourProvider, {
+      props: { tours, autoNavigate: false },
+      slots: { default: () => h('span', 'x') },
+    })
+    await nextTick()
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+    expect(engineBuilds.mock.calls[0]?.[0]).toMatchObject({ autoNavigate: false })
+
+    await wrapper.setProps({ autoNavigate: true })
+    await nextTick()
+
+    expect(engineBuilds).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+    await Promise.resolve()
+  })
+
+  it('renders nothing when no slot is given', async () => {
+    const wrapper = mount(TourProvider, { props: { tours } })
+    await nextTick()
+    expect(wrapper.html()).toBe('')
+    wrapper.unmount()
+    await Promise.resolve()
+  })
+})

--- a/packages/vue/src/__tests__/use-focus-trap.test.ts
+++ b/packages/vue/src/__tests__/use-focus-trap.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The two-phase contract. `capture()` records `document.activeElement` as the
+ * return target BEFORE the card mounts; `activate()` moves focus once it
+ * exists. Capturing at activate time records the card itself, and `Escape`
+ * then returns focus to nothing.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { effectScope, nextTick, shallowRef } from 'vue'
+import { useFocusTrap } from '../use-focus-trap'
+
+function card() {
+  const container = document.createElement('div')
+  const inner = document.createElement('button')
+  inner.type = 'button'
+  inner.id = 'inside'
+  container.appendChild(inner)
+  document.body.appendChild(container)
+  return container
+}
+
+function opener() {
+  const btn = document.createElement('button')
+  btn.type = 'button'
+  btn.id = 'opener'
+  document.body.appendChild(btn)
+  btn.focus()
+  return btn
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('useFocusTrap', () => {
+  it('captures before activation and restores focus on deactivate', async () => {
+    const start = opener()
+    const enabled = shallowRef(false)
+    const scope = effectScope()
+    const trap = scope.run(() => useFocusTrap(enabled))
+    if (!trap) throw new Error('scope did not run')
+
+    // Enable BEFORE the container exists — the real order: the card mounts on
+    // the next tick.
+    enabled.value = true
+    await nextTick()
+
+    trap.containerRef.value = card()
+    trap.activate()
+    expect(document.activeElement?.id).toBe('inside')
+
+    trap.deactivate()
+    expect(document.activeElement).toBe(start)
+
+    scope.stop()
+  })
+
+  it('activate() is inert while disabled', async () => {
+    const start = opener()
+    const enabled = shallowRef(false)
+    const scope = effectScope()
+    const trap = scope.run(() => useFocusTrap(enabled))
+    if (!trap) throw new Error('scope did not run')
+
+    trap.containerRef.value = card()
+    trap.activate()
+    await nextTick()
+
+    expect(document.activeElement).toBe(start)
+    scope.stop()
+  })
+
+  it('stopping the scope releases the trap without restoring focus', async () => {
+    opener()
+    const enabled = shallowRef(true)
+    const scope = effectScope()
+    const trap = scope.run(() => useFocusTrap(enabled))
+    if (!trap) throw new Error('scope did not run')
+
+    trap.containerRef.value = card()
+    trap.activate()
+    expect(document.activeElement?.id).toBe('inside')
+
+    scope.stop()
+
+    // release() is the unmount path: no focus restore, and the Tab handler is
+    // gone. Re-activating after a release must still work (the §1.3b
+    // `isTrapping` bug was exactly this).
+    expect(document.activeElement?.id).toBe('inside')
+  })
+})

--- a/packages/vue/src/__tests__/use-spotlight.test.ts
+++ b/packages/vue/src/__tests__/use-spotlight.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The retarget regression FIRST. `show(a)` then `show(b)` with no `hide()` is a
+ * real flow — an overlay advances a step that way — and the §1.3b execution
+ * shipped a version that kept tracking the first node.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { effectScope, nextTick } from 'vue'
+import { useSpotlight } from '../use-spotlight'
+
+function el(id: string, top: number) {
+  const node = document.createElement('div')
+  node.id = id
+  node.getBoundingClientRect = () =>
+    ({
+      top,
+      left: 0,
+      width: 100,
+      height: 20,
+      right: 100,
+      bottom: top + 20,
+      x: 0,
+      y: top,
+    }) as DOMRect
+  document.body.appendChild(node)
+  return node
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('useSpotlight', () => {
+  it('show() seeds the rect synchronously and hide() clears it', () => {
+    const scope = effectScope()
+    const s = scope.run(() => useSpotlight())
+    if (!s) throw new Error('scope did not run')
+
+    expect(s.isVisible.value).toBe(false)
+    expect(s.targetRect.value).toBeNull()
+
+    s.show(el('a', 10))
+    expect(s.isVisible.value).toBe(true)
+    expect(s.targetRect.value?.top).toBe(10)
+
+    s.hide()
+    expect(s.isVisible.value).toBe(false)
+    expect(s.targetRect.value).toBeNull()
+
+    scope.stop()
+  })
+
+  it('show(a) then show(b) stops tracking a — the §1.3b retarget regression', async () => {
+    const scope = effectScope()
+    const s = scope.run(() => useSpotlight())
+    if (!s) throw new Error('scope did not run')
+
+    const a = el('a', 10)
+    const b = el('b', 80)
+    s.show(a)
+    s.show(b)
+    expect(s.targetRect.value?.top).toBe(80)
+
+    // `hide()` stops the tracker the kit is holding — ONE handle, so a leaked
+    // tracker for `a` survives it. Asserting on a scroll *before* hide proves
+    // nothing: both trackers would fire in registration order and b's write
+    // would land last either way. After hide, any write at all is the leak.
+    s.hide()
+    expect(s.targetRect.value).toBeNull()
+
+    a.getBoundingClientRect = () => ({ top: 999 }) as DOMRect
+    b.getBoundingClientRect = () => ({ top: 888 }) as DOMRect
+    window.dispatchEvent(new Event('scroll'))
+    await new Promise((r) => requestAnimationFrame(() => r(null)))
+    await nextTick()
+
+    expect(s.targetRect.value).toBeNull()
+    scope.stop()
+  })
+
+  it('update() works while hidden, and computeSpotlight drives the styles', () => {
+    const scope = effectScope()
+    const s = scope.run(() => useSpotlight())
+    if (!s) throw new Error('scope did not run')
+
+    const a = el('a', 10)
+    s.show(a)
+    expect(s.overlayStyle.value).toBeTruthy()
+    expect(s.cutoutStyle.value).toBeTruthy()
+
+    a.getBoundingClientRect = () => ({ top: 42, left: 0, width: 1, height: 1 }) as DOMRect
+    s.update()
+    expect(s.targetRect.value?.top).toBe(42)
+
+    scope.stop()
+  })
+
+  it('stopping the scope stops the tracker', async () => {
+    const scope = effectScope()
+    const s = scope.run(() => useSpotlight())
+    if (!s) throw new Error('scope did not run')
+
+    const a = el('a', 10)
+    s.show(a)
+    scope.stop()
+
+    a.getBoundingClientRect = () => ({ top: 777 }) as DOMRect
+    window.dispatchEvent(new Event('scroll'))
+    await new Promise((r) => requestAnimationFrame(() => r(null)))
+
+    expect(s.targetRect.value?.top).toBe(10)
+  })
+})

--- a/packages/vue/src/__tests__/use-spotlight.test.ts
+++ b/packages/vue/src/__tests__/use-spotlight.test.ts
@@ -1,9 +1,14 @@
-/**
- * The retarget regression FIRST. `show(a)` then `show(b)` with no `hide()` is a
- * real flow — an overlay advances a step that way — and the §1.3b execution
- * shipped a version that kept tracking the first node.
- */
 import { afterEach, describe, expect, it } from 'vitest'
+/**
+ * The BRIDGE, not the machine.
+ *
+ * Since v2 §1.5f the spotlight state machine lives in core's
+ * `createSpotlight()` and has its own direct suite there — including the §1.3b
+ * retarget regression. Re-asserting it here would be a slow duplicate of a test
+ * that already exists, and if the two ever disagreed core's would be right.
+ * What is this binding's to prove is the Vue half: a `shallowRef` write per
+ * controller notification, and a scope dispose that unsubscribes AND destroys.
+ */
 import { effectScope, nextTick } from 'vue'
 import { useSpotlight } from '../use-spotlight'
 
@@ -11,90 +16,55 @@ function el(id: string, top: number) {
   const node = document.createElement('div')
   node.id = id
   node.getBoundingClientRect = () =>
-    ({
-      top,
-      left: 0,
-      width: 100,
-      height: 20,
-      right: 100,
-      bottom: top + 20,
-      x: 0,
-      y: top,
-    }) as DOMRect
+    ({ top, left: 0, width: 100, height: 20, right: 100, bottom: top + 20 }) as DOMRect
   document.body.appendChild(node)
   return node
 }
+
+const raf = () => new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
 
 afterEach(() => {
   document.body.innerHTML = ''
 })
 
-describe('useSpotlight', () => {
-  it('show() seeds the rect synchronously and hide() clears it', () => {
+describe('useSpotlight — the Vue bridge', () => {
+  it('mirrors the controller snapshot into reactive refs', () => {
     const scope = effectScope()
     const s = scope.run(() => useSpotlight())
     if (!s) throw new Error('scope did not run')
 
     expect(s.isVisible.value).toBe(false)
     expect(s.targetRect.value).toBeNull()
+    expect(s.cutoutStyle.value).toEqual({})
 
     s.show(el('a', 10))
+
     expect(s.isVisible.value).toBe(true)
     expect(s.targetRect.value?.top).toBe(10)
-
-    s.hide()
-    expect(s.isVisible.value).toBe(false)
-    expect(s.targetRect.value).toBeNull()
+    expect(s.overlayStyle.value).toMatchObject({ position: 'fixed' })
+    expect(s.cutoutStyle.value).toMatchObject({ position: 'absolute' })
 
     scope.stop()
   })
 
-  it('show(a) then show(b) stops tracking a — the §1.3b retarget regression', async () => {
+  it('a tracked rect change reaches the refs', async () => {
     const scope = effectScope()
     const s = scope.run(() => useSpotlight())
     if (!s) throw new Error('scope did not run')
 
     const a = el('a', 10)
-    const b = el('b', 80)
     s.show(a)
-    s.show(b)
-    expect(s.targetRect.value?.top).toBe(80)
 
-    // `hide()` stops the tracker the kit is holding — ONE handle, so a leaked
-    // tracker for `a` survives it. Asserting on a scroll *before* hide proves
-    // nothing: both trackers would fire in registration order and b's write
-    // would land last either way. After hide, any write at all is the leak.
-    s.hide()
-    expect(s.targetRect.value).toBeNull()
-
-    a.getBoundingClientRect = () => ({ top: 999 }) as DOMRect
-    b.getBoundingClientRect = () => ({ top: 888 }) as DOMRect
+    a.getBoundingClientRect = () => ({ top: 55, left: 0, width: 1, height: 1 }) as DOMRect
     window.dispatchEvent(new Event('scroll'))
-    await new Promise((r) => requestAnimationFrame(() => r(null)))
+    await raf()
     await nextTick()
 
-    expect(s.targetRect.value).toBeNull()
+    expect(s.targetRect.value?.top).toBe(55)
     scope.stop()
   })
 
-  it('update() works while hidden, and computeSpotlight drives the styles', () => {
-    const scope = effectScope()
-    const s = scope.run(() => useSpotlight())
-    if (!s) throw new Error('scope did not run')
-
-    const a = el('a', 10)
-    s.show(a)
-    expect(s.overlayStyle.value).toBeTruthy()
-    expect(s.cutoutStyle.value).toBeTruthy()
-
-    a.getBoundingClientRect = () => ({ top: 42, left: 0, width: 1, height: 1 }) as DOMRect
-    s.update()
-    expect(s.targetRect.value?.top).toBe(42)
-
-    scope.stop()
-  })
-
-  it('stopping the scope stops the tracker', async () => {
+  it('stopping the scope unsubscribes AND destroys the controller', async () => {
     const scope = effectScope()
     const s = scope.run(() => useSpotlight())
     if (!s) throw new Error('scope did not run')
@@ -103,9 +73,13 @@ describe('useSpotlight', () => {
     s.show(a)
     scope.stop()
 
+    // Destroy stops the tracker, so a scroll cannot move the last snapshot the
+    // ref saw. A bridge that unsubscribed but leaked the controller would leave
+    // a live rAF-throttled listener behind for the life of the page.
     a.getBoundingClientRect = () => ({ top: 777 }) as DOMRect
     window.dispatchEvent(new Event('scroll'))
-    await new Promise((r) => requestAnimationFrame(() => r(null)))
+    await raf()
+    await nextTick()
 
     expect(s.targetRect.value?.top).toBe(10)
   })

--- a/packages/vue/src/adapters/vue-router.ts
+++ b/packages/vue/src/adapters/vue-router.ts
@@ -8,7 +8,7 @@
  *
  * @module adapters/vue-router
  */
-import type { RouterAdapter } from '@tour-kit/core/engine'
+import { type RouterAdapter, matchRoutePattern } from '@tour-kit/core/engine'
 
 /**
  * What this adapter needs from a `Router`, and nothing more.
@@ -29,17 +29,7 @@ export function createVueRouterAdapter(router: VueRouterLike): RouterAdapter {
 
     navigate: (route) => router.push(route).then((failure) => !failure),
 
-    matchRoute: (pattern, mode = 'exact') => {
-      const currentPath = router.currentRoute.value.path
-      switch (mode) {
-        case 'startsWith':
-          return currentPath.startsWith(pattern)
-        case 'contains':
-          return currentPath.includes(pattern)
-        default:
-          return currentPath === pattern
-      }
-    },
+    matchRoute: (pattern, mode) => matchRoutePattern(router.currentRoute.value.path, pattern, mode),
 
     onRouteChange: (cb) => {
       // Fires immediately with the current route, matching every existing

--- a/packages/vue/src/adapters/vue-router.ts
+++ b/packages/vue/src/adapters/vue-router.ts
@@ -1,0 +1,52 @@
+/**
+ * `RouterAdapter` over Vue Router 4.
+ *
+ * A factory taking the router, not an import of `vue-router` — same shape as
+ * the React adapters (`packages/react/src/adapters/react-router.ts`), and the
+ * reason `vue-router` is an OPTIONAL peer: the type below is structural, so a
+ * test passes a plain object and nobody has to install a router to run one.
+ *
+ * @module adapters/vue-router
+ */
+import type { RouterAdapter } from '@tour-kit/core/engine'
+
+/**
+ * What this adapter needs from a `Router`, and nothing more.
+ *
+ * `push` RESOLVES with a `NavigationFailure` on a blocked navigation — it does
+ * not reject — which is why `navigate` below maps a truthy resolution to
+ * `false` rather than catching.
+ */
+export interface VueRouterLike {
+  currentRoute: { value: { path: string } }
+  push(to: string): Promise<unknown>
+  afterEach(cb: (to: { path: string }) => void): () => void
+}
+
+export function createVueRouterAdapter(router: VueRouterLike): RouterAdapter {
+  return {
+    getCurrentRoute: () => router.currentRoute.value.path,
+
+    navigate: (route) => router.push(route).then((failure) => !failure),
+
+    matchRoute: (pattern, mode = 'exact') => {
+      const currentPath = router.currentRoute.value.path
+      switch (mode) {
+        case 'startsWith':
+          return currentPath.startsWith(pattern)
+        case 'contains':
+          return currentPath.includes(pattern)
+        default:
+          return currentPath === pattern
+      }
+    },
+
+    onRouteChange: (cb) => {
+      // Fires immediately with the current route, matching every existing
+      // adapter — the engine's route-restore path depends on it.
+      cb(router.currentRoute.value.path)
+      // `afterEach` returns its own unsubscribe.
+      return router.afterEach((to) => cb(to.path))
+    },
+  }
+}

--- a/packages/vue/src/create-tour-kit.ts
+++ b/packages/vue/src/create-tour-kit.ts
@@ -1,0 +1,64 @@
+/**
+ * The reactivity bridge — the only Vue this file names is `shallowRef`.
+ *
+ * Two facts from `@tour-kit/core/engine` shape it:
+ *
+ * - `createEngineHandle` constructs nothing until the first *verb*. `getState()`
+ *   and `subscribe()` never construct, which is what makes `setup()` and the
+ *   server safe, and what makes a child's `onMounted(() => tour.start())` — which
+ *   fires BEFORE the provider's own mount hook — work anyway.
+ * - `getState()` returns the same object reference until the next transition.
+ *   `shallowRef` triggers on identity change, so the reducer's identity fast
+ *   paths cost nothing here. A deep `ref` would proxy the `stepVisitCount` Map
+ *   and the `tour` object, and every downstream `Object.is` would break against
+ *   the proxy — that is why this is `shallowRef` and not `ref`.
+ *
+ * @module create-tour-kit
+ */
+import {
+  type CreateTourEngineOptions,
+  type EngineHandle,
+  type TourActions,
+  type TourCallbackContext,
+  type TourEngineLiveOptions,
+  createEngineHandle,
+  createTourEngine,
+  pickActions,
+} from '@tour-kit/core/engine'
+import { type ShallowRef, shallowRef } from 'vue'
+
+/** What `provideTourKit` provides and `useTour` returns. */
+export interface TourKit extends TourActions {
+  /** The engine snapshot. Read `state.value` — new identity per transition. */
+  state: Readonly<ShallowRef<TourCallbackContext>>
+  setOptions: (patch: Partial<TourEngineLiveOptions>) => void
+  setTours: EngineHandle['setTours']
+  /**
+   * @internal — the provider's mount/unmount hooks and the `attach*` calls
+   *   need the handle itself. Consumers use the verbs above.
+   */
+  handle: EngineHandle
+}
+
+/**
+ * Build a kit over a lazily-constructed engine.
+ *
+ * Safe to call in `setup()` and on the server: nothing here is a verb.
+ */
+export function createTourKit(factory: () => CreateTourEngineOptions): TourKit {
+  const handle = createEngineHandle(() => createTourEngine(factory()))
+  const state = shallowRef(handle.getState())
+  // Never unsubscribed on purpose: the handle's listener set outlives
+  // `release()` (that is how a released handle can be taken back by the next
+  // verb), and the kit dies with the provider scope that owns it.
+  handle.subscribe(() => {
+    state.value = handle.getState()
+  })
+  return {
+    state,
+    ...pickActions(handle),
+    setOptions: handle.setOptions,
+    setTours: handle.setTours,
+    handle,
+  }
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * `@tour-kit/vue` — the Vue 3 binding over `@tour-kit/core/engine`.
+ *
+ * The star re-export is deliberate (Decision 3). `/engine` is already the
+ * curated React-free public surface — every line of it is a decision — and a
+ * binding's job is "that surface plus framework glue". A hand-picked subset
+ * would need its own alignment test and would still be wrong the day `/engine`
+ * grows. Adding to `/engine` is never breaking; removing from it is already
+ * breaking for every consumer. A local named export shadows a star export
+ * without error, so nothing below can collide.
+ *
+ * @module @tour-kit/vue
+ */
+export * from '@tour-kit/core/engine'
+
+export { type TourKit, createTourKit } from './create-tour-kit'
+export {
+  TOUR_KIT_KEY,
+  type TourKitOptions,
+  provideTourKit,
+  useTour,
+} from './provide-tour-kit'
+export { TourProvider } from './tour-provider'
+export { type UseSpotlightReturn, useSpotlight } from './use-spotlight'
+export { type UseFocusTrapReturn, useFocusTrap } from './use-focus-trap'
+export { type VueRouterLike, createVueRouterAdapter } from './adapters/vue-router'

--- a/packages/vue/src/provide-tour-kit.ts
+++ b/packages/vue/src/provide-tour-kit.ts
@@ -19,16 +19,12 @@
  * @module provide-tour-kit
  */
 import {
-  type KeyboardConfig,
-  type MultiPagePersistenceConfig,
-  type PersistenceConfig,
-  type RouterAdapter,
-  type Tour,
-  type TourEngineAnalytics,
-  type TourRouteError,
+  type BindingOptions,
   attachAdvanceOn,
   attachKeyboard,
   attachTestBridge,
+  engineOptionsFrom,
+  liveOptionsFrom,
   validateTour,
 } from '@tour-kit/core/engine'
 import {
@@ -45,55 +41,15 @@ import { type TourKit, createTourKit } from './create-tour-kit'
 
 export const TOUR_KIT_KEY: InjectionKey<TourKit> = Symbol('tour-kit')
 
-/** Everything `provideTourKit` accepts. Mirrors `<TourProvider>`'s props. */
-export interface TourKitOptions {
-  tours: Tour[]
-  router?: RouterAdapter
-  routePersistence?: MultiPagePersistenceConfig
-  persistence?: PersistenceConfig
-  autoNavigate?: boolean
-  analytics?: TourEngineAnalytics
-  onNavigationRequired?: (route: string, stepId: string) => void
-  onStepError?: (err: TourRouteError) => void
-  onTourPaused?: (tourId: string, reason: 'cross-tab') => void
-  /**
-   * `false` disables keyboard navigation; an object customises it. Default: on.
-   *
-   * React consumers get `Escape` for free because `<TourCard>` calls
-   * `useKeyboardNavigation()` itself. A headless consumer renders their own
-   * card, so the binding wires it or nobody does.
-   */
-  keyboard?: boolean | KeyboardConfig
-  /** Dev-only `window.__tourKit__`. Default `false`. */
-  enableTestBridge?: boolean
-}
-
-/** Split for the engine factory — read once, at `ensure()` time. */
-function optionsFrom(src: TourKitOptions) {
-  return {
-    tours: src.tours,
-    router: src.router,
-    routePersistence: src.routePersistence,
-    persistence: src.persistence,
-    autoNavigate: src.autoNavigate,
-    analytics: src.analytics,
-    onNavigationRequired: src.onNavigationRequired,
-    onStepError: src.onStepError,
-    onTourPaused: src.onTourPaused,
-  }
-}
-
-/** The subset that may legitimately change identity after mount. */
-function liveFrom(src: TourKitOptions) {
-  return {
-    router: src.router,
-    autoNavigate: src.autoNavigate,
-    analytics: src.analytics,
-    onNavigationRequired: src.onNavigationRequired,
-    onStepError: src.onStepError,
-    onTourPaused: src.onTourPaused,
-  }
-}
+/**
+ * Everything `provideTourKit` accepts.
+ *
+ * `BindingOptions` is core's — derived from `CreateTourEngineOptions`, so a new
+ * engine option arrives here without an edit and a renamed one stops compiling.
+ * Re-exported under the binding's own name because that is what a Vue consumer
+ * will look for; it is an alias, not a second declaration.
+ */
+export type TourKitOptions = BindingOptions
 
 /**
  * Provide a tour kit to this component's subtree.
@@ -108,12 +64,12 @@ export function provideTourKit(options: MaybeRefOrGetter<TourKitOptions>): TourK
   // construction, which is the real trust boundary.
   for (const tour of toValue(options).tours) validateTour(tour)
 
-  const kit = createTourKit(() => optionsFrom(toValue(options)))
+  const kit = createTourKit(() => engineOptionsFrom(toValue(options)))
   provide(TOUR_KIT_KEY, kit)
 
   // NON-immediate, on purpose — see rule 1 in the module header.
   watch(
-    () => liveFrom(toValue(options)),
+    () => liveOptionsFrom(toValue(options)),
     (live) => kit.setOptions(live)
   )
   watch(
@@ -128,7 +84,7 @@ export function provideTourKit(options: MaybeRefOrGetter<TourKitOptions>): TourK
     // Parity with `tour-provider.tsx`'s post-commit push. Cheap, and not
     // strictly needed — the factory reads `toValue(options)` lazily at
     // `ensure()` time anyway — but it keeps the two bindings identical.
-    kit.setOptions(liveFrom(o))
+    kit.setOptions(liveOptionsFrom(o))
     void kit.handle.boot()
 
     if (o.keyboard !== false) {

--- a/packages/vue/src/provide-tour-kit.ts
+++ b/packages/vue/src/provide-tour-kit.ts
@@ -1,0 +1,159 @@
+/**
+ * The Vue provider. Mirrors `<TourProvider>` (core, React) verb for verb; what
+ * differs is only the lifecycle vocabulary.
+ *
+ * Two rules the shape depends on, both from `engine-handle.ts`:
+ *
+ * 1. **Nothing constructs an engine in `setup()`.** Every kit member except
+ *    `state` is `ensure()` in disguise — `setOptions` and `setTours` included.
+ *    That is why the two watchers below are non-immediate: a `watchEffect`, or
+ *    a `watch(..., { immediate: true })`, runs its callback synchronously
+ *    inside `setup()`, which on Nuxt means registry writes, four storage
+ *    adapters and a `BroadcastChannel` on the server. Watchers do not run
+ *    during SSR at all, so a non-immediate `watch` is inert there by
+ *    construction.
+ * 2. **`release()`, never `destroy()`.** The handle flushes synchronously and
+ *    defers its `destroy()` by a microtask, so a teardown immediately followed
+ *    by a re-`ensure()` takes the same engine back.
+ *
+ * @module provide-tour-kit
+ */
+import {
+  type KeyboardConfig,
+  type MultiPagePersistenceConfig,
+  type PersistenceConfig,
+  type RouterAdapter,
+  type Tour,
+  type TourEngineAnalytics,
+  type TourRouteError,
+  attachAdvanceOn,
+  attachKeyboard,
+  attachTestBridge,
+  validateTour,
+} from '@tour-kit/core/engine'
+import {
+  type InjectionKey,
+  type MaybeRefOrGetter,
+  inject,
+  onMounted,
+  onScopeDispose,
+  provide,
+  toValue,
+  watch,
+} from 'vue'
+import { type TourKit, createTourKit } from './create-tour-kit'
+
+export const TOUR_KIT_KEY: InjectionKey<TourKit> = Symbol('tour-kit')
+
+/** Everything `provideTourKit` accepts. Mirrors `<TourProvider>`'s props. */
+export interface TourKitOptions {
+  tours: Tour[]
+  router?: RouterAdapter
+  routePersistence?: MultiPagePersistenceConfig
+  persistence?: PersistenceConfig
+  autoNavigate?: boolean
+  analytics?: TourEngineAnalytics
+  onNavigationRequired?: (route: string, stepId: string) => void
+  onStepError?: (err: TourRouteError) => void
+  onTourPaused?: (tourId: string, reason: 'cross-tab') => void
+  /**
+   * `false` disables keyboard navigation; an object customises it. Default: on.
+   *
+   * React consumers get `Escape` for free because `<TourCard>` calls
+   * `useKeyboardNavigation()` itself. A headless consumer renders their own
+   * card, so the binding wires it or nobody does.
+   */
+  keyboard?: boolean | KeyboardConfig
+  /** Dev-only `window.__tourKit__`. Default `false`. */
+  enableTestBridge?: boolean
+}
+
+/** Split for the engine factory — read once, at `ensure()` time. */
+function optionsFrom(src: TourKitOptions) {
+  return {
+    tours: src.tours,
+    router: src.router,
+    routePersistence: src.routePersistence,
+    persistence: src.persistence,
+    autoNavigate: src.autoNavigate,
+    analytics: src.analytics,
+    onNavigationRequired: src.onNavigationRequired,
+    onStepError: src.onStepError,
+    onTourPaused: src.onTourPaused,
+  }
+}
+
+/** The subset that may legitimately change identity after mount. */
+function liveFrom(src: TourKitOptions) {
+  return {
+    router: src.router,
+    autoNavigate: src.autoNavigate,
+    analytics: src.analytics,
+    onNavigationRequired: src.onNavigationRequired,
+    onStepError: src.onStepError,
+    onTourPaused: src.onTourPaused,
+  }
+}
+
+/**
+ * Provide a tour kit to this component's subtree.
+ *
+ * Call from `setup()` — or from `<TourProvider>`, which is a two-line wrapper
+ * around this. Construction is deferred to the first verb, so `setup()` and the
+ * server are untouched.
+ */
+export function provideTourKit(options: MaybeRefOrGetter<TourKitOptions>): TourKit {
+  // Parity with the React provider's render-time check: a misconfigured hidden
+  // step should throw where the author is. The engine validates again at
+  // construction, which is the real trust boundary.
+  for (const tour of toValue(options).tours) validateTour(tour)
+
+  const kit = createTourKit(() => optionsFrom(toValue(options)))
+  provide(TOUR_KIT_KEY, kit)
+
+  // NON-immediate, on purpose — see rule 1 in the module header.
+  watch(
+    () => liveFrom(toValue(options)),
+    (live) => kit.setOptions(live)
+  )
+  watch(
+    () => toValue(options).tours,
+    (tours) => kit.setTours(tours)
+  )
+
+  const detach: Array<() => void> = []
+
+  onMounted(() => {
+    const o = toValue(options)
+    // Parity with `tour-provider.tsx`'s post-commit push. Cheap, and not
+    // strictly needed — the factory reads `toValue(options)` lazily at
+    // `ensure()` time anyway — but it keeps the two bindings identical.
+    kit.setOptions(liveFrom(o))
+    void kit.handle.boot()
+
+    if (o.keyboard !== false) {
+      detach.push(
+        attachKeyboard(kit, typeof o.keyboard === 'object' ? o.keyboard : undefined, {
+          isEnabled: () => kit.handle.getState().isActive,
+        })
+      )
+    }
+    detach.push(attachAdvanceOn(kit.handle))
+    if (o.enableTestBridge) detach.push(attachTestBridge(kit.handle))
+  })
+
+  onScopeDispose(() => {
+    for (const d of detach) d()
+    detach.length = 0
+    kit.handle.release()
+  })
+
+  return kit
+}
+
+/** Read the kit provided by an ancestor. Throws outside one. */
+export function useTour(): TourKit {
+  const kit = inject(TOUR_KIT_KEY)
+  if (!kit) throw new Error('useTour must be used within provideTourKit() or <TourProvider>')
+  return kit
+}

--- a/packages/vue/src/tour-provider.ts
+++ b/packages/vue/src/tour-provider.ts
@@ -1,0 +1,44 @@
+/**
+ * `<TourProvider>` for Vue — a two-line wrapper over `provideTourKit`.
+ *
+ * A render function, not an SFC: a package that ships `.vue` files has to be
+ * published as source for the consumer's compiler to process, and this package
+ * is built by tsup like every other one here (Decision 7).
+ *
+ * @module tour-provider
+ */
+import type { Tour } from '@tour-kit/core/engine'
+import { type PropType, defineComponent } from 'vue'
+import { type TourKitOptions, provideTourKit } from './provide-tour-kit'
+
+export const TourProvider = defineComponent({
+  name: 'TourProvider',
+  props: {
+    tours: { type: Array as PropType<TourKitOptions['tours']>, required: true },
+    router: { type: Object as PropType<TourKitOptions['router']>, default: undefined },
+    routePersistence: {
+      type: Object as PropType<TourKitOptions['routePersistence']>,
+      default: undefined,
+    },
+    persistence: { type: Object as PropType<TourKitOptions['persistence']>, default: undefined },
+    autoNavigate: { type: Boolean, default: undefined },
+    analytics: { type: Object as PropType<TourKitOptions['analytics']>, default: undefined },
+    onNavigationRequired: {
+      type: Function as PropType<TourKitOptions['onNavigationRequired']>,
+      default: undefined,
+    },
+    onStepError: { type: Function as PropType<TourKitOptions['onStepError']>, default: undefined },
+    onTourPaused: {
+      type: Function as PropType<TourKitOptions['onTourPaused']>,
+      default: undefined,
+    },
+    keyboard: { type: [Boolean, Object] as PropType<TourKitOptions['keyboard']>, default: true },
+    enableTestBridge: { type: Boolean, default: false },
+  },
+  setup(props, { slots }) {
+    // `props` is a reactive object, so the getter is all the reactivity the
+    // non-immediate watchers in `provideTourKit` need.
+    provideTourKit(() => props as TourKitOptions & { tours: Tour[] })
+    return () => slots.default?.()
+  },
+})

--- a/packages/vue/src/use-focus-trap.ts
+++ b/packages/vue/src/use-focus-trap.ts
@@ -1,0 +1,53 @@
+/**
+ * `createFocusTrap` (core) with a Vue `ref` for the container and the
+ * enabled-flag watch the React wrapper has.
+ *
+ * Two-phase, like the React one: `capture()` records `document.activeElement`
+ * as the return target BEFORE the card mounts, and `activate()` moves focus
+ * once it exists. Capturing at activate time records the card itself and
+ * `Escape` returns focus to nothing.
+ *
+ * @module use-focus-trap
+ */
+import { type FocusTrapOptions, createFocusTrap } from '@tour-kit/core/engine'
+import {
+  type MaybeRefOrGetter,
+  type ShallowRef,
+  onScopeDispose,
+  shallowRef,
+  toValue,
+  watch,
+} from 'vue'
+
+export interface UseFocusTrapReturn {
+  /** Bind with `ref="containerRef"` (or `:ref`) on the element to trap. */
+  containerRef: ShallowRef<HTMLElement | null>
+  activate: () => void
+  deactivate: () => void
+}
+
+export function useFocusTrap(
+  enabled: MaybeRefOrGetter<boolean> = true,
+  options: FocusTrapOptions = {}
+): UseFocusTrapReturn {
+  const containerRef = shallowRef<HTMLElement | null>(null)
+  const trap = createFocusTrap(() => containerRef.value, options)
+
+  // `immediate` is safe here and nowhere else in this package: `capture()`
+  // reads `document.activeElement` and constructs nothing. It is not a verb.
+  watch(
+    () => toValue(enabled),
+    (on) => (on ? trap.capture() : trap.forget()),
+    { immediate: true }
+  )
+
+  onScopeDispose(trap.release)
+
+  return {
+    containerRef,
+    activate: () => {
+      if (toValue(enabled)) trap.activate()
+    },
+    deactivate: trap.deactivate,
+  }
+}

--- a/packages/vue/src/use-spotlight.ts
+++ b/packages/vue/src/use-spotlight.ts
@@ -1,0 +1,85 @@
+/**
+ * `hooks/use-spotlight.ts`'s shape on `shallowRef`s.
+ *
+ * `shallowRef` for the rect, deliberately: a `DOMRect` behind a deep `ref` is a
+ * Proxy, and every `Object.is` comparison downstream breaks against it.
+ *
+ * One tracker at a time. `show(a)` then `show(b)` with no `hide()` between is a
+ * real flow — an overlay advances a step that way — and the §1.3b execution
+ * shipped a regression where the second `show()` kept tracking the first node.
+ *
+ * @module use-spotlight
+ */
+import {
+  type SpotlightConfig,
+  type SpotlightCutoutStyle,
+  type SpotlightOverlayStyle,
+  computeSpotlight,
+  defaultSpotlightConfig,
+  trackRect,
+} from '@tour-kit/core/engine'
+import { type ComputedRef, type ShallowRef, computed, onScopeDispose, shallowRef } from 'vue'
+
+export interface UseSpotlightReturn {
+  isVisible: Readonly<ShallowRef<boolean>>
+  targetRect: Readonly<ShallowRef<DOMRect | null>>
+  overlayStyle: ComputedRef<SpotlightOverlayStyle>
+  cutoutStyle: ComputedRef<SpotlightCutoutStyle | Record<string, never>>
+  show: (target: HTMLElement, config?: SpotlightConfig) => void
+  hide: () => void
+  update: () => void
+}
+
+export function useSpotlight(): UseSpotlightReturn {
+  const isVisible = shallowRef(false)
+  const targetRect = shallowRef<DOMRect | null>(null)
+  const config = shallowRef<SpotlightConfig>(defaultSpotlightConfig)
+
+  let target: HTMLElement | null = null
+  let stop: (() => void) | null = null
+
+  const stopTracking = () => {
+    stop?.()
+    stop = null
+  }
+
+  const show = (next: HTMLElement, spotlightConfig?: SpotlightConfig) => {
+    // Retarget: the previous tracker has to go before the new one starts, or
+    // the spotlight follows the step the tour has already left.
+    stopTracking()
+    target = next
+    config.value = { ...defaultSpotlightConfig, ...spotlightConfig }
+    // Seeded synchronously so the tracker never needs an attach-time read.
+    targetRect.value = next.getBoundingClientRect()
+    isVisible.value = true
+    stop = trackRect(next, (rect) => {
+      targetRect.value = rect
+    }).stop
+  }
+
+  const hide = () => {
+    stopTracking()
+    target = null
+    targetRect.value = null
+    isVisible.value = false
+  }
+
+  /** Works while hidden too — there is no tracker then, and there is a target. */
+  const update = () => {
+    if (target) targetRect.value = target.getBoundingClientRect()
+  }
+
+  const styles = computed(() => computeSpotlight(targetRect.value, config.value))
+
+  onScopeDispose(stopTracking)
+
+  return {
+    isVisible,
+    targetRect,
+    overlayStyle: computed(() => styles.value.overlayStyle),
+    cutoutStyle: computed(() => styles.value.cutoutStyle ?? {}),
+    show,
+    hide,
+    update,
+  }
+}

--- a/packages/vue/src/use-spotlight.ts
+++ b/packages/vue/src/use-spotlight.ts
@@ -1,85 +1,54 @@
 /**
- * `hooks/use-spotlight.ts`'s shape on `shallowRef`s.
+ * `createSpotlight()` (core) behind a Vue `shallowRef`.
  *
- * `shallowRef` for the rect, deliberately: a `DOMRect` behind a deep `ref` is a
- * Proxy, and every `Object.is` comparison downstream breaks against it.
+ * The state machine — the four fields, the one-tracker-at-a-time retarget rule,
+ * the `computeSpotlight` call — lives in core since v2 §1.5f, because this
+ * binding and the Svelte one proved it was framework-agnostic by implementing
+ * it identically. What is left here is the bridge, and it is the same bridge
+ * `create-tour-kit.ts` uses over the engine: one `shallowRef` mirroring a
+ * reference-stable `getState()`.
  *
- * One tracker at a time. `show(a)` then `show(b)` with no `hide()` between is a
- * real flow — an overlay advances a step that way — and the §1.3b execution
- * shipped a regression where the second `show()` kept tracking the first node.
+ * `shallowRef` and not `ref`: the snapshot holds a `DOMRect`, and a deep `ref`
+ * would proxy it so every downstream `Object.is` breaks against the proxy.
  *
  * @module use-spotlight
  */
 import {
   type SpotlightConfig,
-  type SpotlightCutoutStyle,
-  type SpotlightOverlayStyle,
-  computeSpotlight,
-  defaultSpotlightConfig,
-  trackRect,
+  type SpotlightSnapshot,
+  createSpotlight,
 } from '@tour-kit/core/engine'
 import { type ComputedRef, type ShallowRef, computed, onScopeDispose, shallowRef } from 'vue'
 
 export interface UseSpotlightReturn {
-  isVisible: Readonly<ShallowRef<boolean>>
-  targetRect: Readonly<ShallowRef<DOMRect | null>>
-  overlayStyle: ComputedRef<SpotlightOverlayStyle>
-  cutoutStyle: ComputedRef<SpotlightCutoutStyle | Record<string, never>>
+  isVisible: ComputedRef<boolean>
+  targetRect: ComputedRef<SpotlightSnapshot['targetRect']>
+  overlayStyle: ComputedRef<SpotlightSnapshot['overlayStyle']>
+  cutoutStyle: ComputedRef<SpotlightSnapshot['cutoutStyle']>
   show: (target: HTMLElement, config?: SpotlightConfig) => void
   hide: () => void
   update: () => void
 }
 
 export function useSpotlight(): UseSpotlightReturn {
-  const isVisible = shallowRef(false)
-  const targetRect = shallowRef<DOMRect | null>(null)
-  const config = shallowRef<SpotlightConfig>(defaultSpotlightConfig)
+  const controller = createSpotlight()
+  const state: ShallowRef<SpotlightSnapshot> = shallowRef(controller.getState())
+  const unsubscribe = controller.subscribe(() => {
+    state.value = controller.getState()
+  })
 
-  let target: HTMLElement | null = null
-  let stop: (() => void) | null = null
-
-  const stopTracking = () => {
-    stop?.()
-    stop = null
-  }
-
-  const show = (next: HTMLElement, spotlightConfig?: SpotlightConfig) => {
-    // Retarget: the previous tracker has to go before the new one starts, or
-    // the spotlight follows the step the tour has already left.
-    stopTracking()
-    target = next
-    config.value = { ...defaultSpotlightConfig, ...spotlightConfig }
-    // Seeded synchronously so the tracker never needs an attach-time read.
-    targetRect.value = next.getBoundingClientRect()
-    isVisible.value = true
-    stop = trackRect(next, (rect) => {
-      targetRect.value = rect
-    }).stop
-  }
-
-  const hide = () => {
-    stopTracking()
-    target = null
-    targetRect.value = null
-    isVisible.value = false
-  }
-
-  /** Works while hidden too — there is no tracker then, and there is a target. */
-  const update = () => {
-    if (target) targetRect.value = target.getBoundingClientRect()
-  }
-
-  const styles = computed(() => computeSpotlight(targetRect.value, config.value))
-
-  onScopeDispose(stopTracking)
+  onScopeDispose(() => {
+    unsubscribe()
+    controller.destroy()
+  })
 
   return {
-    isVisible,
-    targetRect,
-    overlayStyle: computed(() => styles.value.overlayStyle),
-    cutoutStyle: computed(() => styles.value.cutoutStyle ?? {}),
-    show,
-    hide,
-    update,
+    isVisible: computed(() => state.value.isVisible),
+    targetRect: computed(() => state.value.targetRect),
+    overlayStyle: computed(() => state.value.overlayStyle),
+    cutoutStyle: computed(() => state.value.cutoutStyle),
+    show: controller.show,
+    hide: controller.hide,
+    update: controller.update,
   }
 }

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tooling/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/vue/tsup.config.ts
+++ b/packages/vue/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  // No `injectUseClient`: there is no `'use client'` on a non-React package,
+  // and stamping a React directive onto the package whose whole point is not
+  // being React would be a lie a bundler acts on.
+  external: ['@tour-kit/core', 'vue'],
+  treeshake: true,
+  splitting: false,
+  minify: true,
+  sourcemap: true,
+  target: 'es2020',
+  outDir: 'dist',
+})

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  // No plugin: the package ships zero `.vue` files (Decision 7), and
+  // @vue/test-utils mounts `defineComponent` render functions without one.
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'src/__tests__/', 'dist/', '**/*.d.ts', '**/index.ts'],
+      thresholds: {
+        statements: 80,
+        branches: 75,
+        functions: 80,
+        lines: 80,
+      },
+    },
+  },
+})

--- a/packages/vue/vitest.setup.ts
+++ b/packages/vue/vitest.setup.ts
@@ -1,0 +1,1 @@
+import 'vitest-axe/extend-expect'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,6 +44,24 @@ export default defineConfig({
       },
       testMatch: /next\/.*production/,
     },
+    // v2 §1.5 — the two non-React bindings. Both examples run the same
+    // three-step tour, so both lanes run the same eight cases.
+    {
+      name: 'vue-localhost',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:5175',
+      },
+      testMatch: /vue\/.*localhost/,
+    },
+    {
+      name: 'svelte-localhost',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:5176',
+      },
+      testMatch: /svelte\/.*localhost/,
+    },
   ],
 
   webServer: [
@@ -56,6 +74,12 @@ export default defineConfig({
     {
       command: 'pnpm --filter next-tour-kit-demo dev',
       port: 3000,
+      reuseExistingServer: true,
+      timeout: 60_000,
+    },
+    {
+      command: 'pnpm --filter vue-tour-kit-demo dev',
+      port: 5175,
       reuseExistingServer: true,
       timeout: 60_000,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
         version: 25.5.0
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -609,6 +609,34 @@ importers:
         specifier: ^6.0.5
         version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
+  examples/vue-app:
+    dependencies:
+      '@floating-ui/dom':
+        specifier: ^1.7.6
+        version: 1.7.6
+      '@tour-kit/vue':
+        specifier: workspace:*
+        version: link:../../packages/vue
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.42(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.5.0
+        version: 4.6.4(vue@3.5.42(typescript@5.9.3))
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^5.2.1
+        version: 5.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(vue@3.5.42(typescript@5.9.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vue-tsc:
+        specifier: ^2.2.10
+        version: 2.2.12(typescript@5.9.3)
+
   packages/adoption:
     dependencies:
       '@mui/base':
@@ -662,7 +690,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -717,7 +745,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -772,7 +800,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -860,7 +888,7 @@ importers:
         version: 4.2.2
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -930,7 +958,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -955,7 +983,7 @@ importers:
         version: 22.19.15
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1007,7 +1035,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1080,7 +1108,7 @@ importers:
         version: 4.2.2
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1129,7 +1157,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1193,7 +1221,7 @@ importers:
         version: 4.2.2
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1233,7 +1261,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1312,7 +1340,7 @@ importers:
         version: 4.2.2
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1355,7 +1383,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1428,7 +1456,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1480,7 +1508,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1490,6 +1518,40 @@ importers:
       vitest-axe:
         specifier: 'catalog:'
         version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
+
+  packages/vue:
+    dependencies:
+      '@tour-kit/core':
+        specifier: workspace:*
+        version: link:../core
+      vue-router:
+        specifier: ^4.0.0
+        version: 4.6.4(vue@3.5.42(typescript@5.9.3))
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
+      '@vue/test-utils':
+        specifier: ^2.4.6
+        version: 2.5.0(@vue/compiler-dom@3.5.42)(@vue/server-renderer@3.5.42)(vue@3.5.42(typescript@5.9.3))
+      jsdom:
+        specifier: 'catalog:'
+        version: 27.4.0
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest-axe:
+        specifier: 'catalog:'
+        version: 1.0.0-pre.5(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.42(typescript@5.9.3)
 
   tooling/biome: {}
 
@@ -1676,12 +1738,12 @@ packages:
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -1694,6 +1756,11 @@ packages:
 
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1799,8 +1866,8 @@ packages:
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@base-ui/react@1.4.1':
@@ -2842,6 +2909,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@one-ini/wasm@0.2.1':
+    resolution: {integrity: sha512-TUqERXGNTifZ9y2g3wPxQrw3HpHv/02DsW3D90T9x0hhonrL1ZqpSmNrU2XkoIq0fP1N6gZfVQzy2Fw1ZvGBNg==}
 
   '@opentelemetry/api-logs@0.208.0':
     resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
@@ -3973,6 +4043,13 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
   '@vitest/coverage-v8@4.1.2':
     resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
     peerDependencies:
@@ -4014,8 +4091,72 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
+  '@volar/language-core@2.4.15':
+    resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
+
+  '@volar/source-map@2.4.15':
+    resolution: {integrity: sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==}
+
+  '@volar/typescript@2.4.15':
+    resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
+
+  '@vue/compiler-core@3.5.42':
+    resolution: {integrity: sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==}
+
+  '@vue/compiler-dom@3.5.42':
+    resolution: {integrity: sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==}
+
+  '@vue/compiler-sfc@3.5.42':
+    resolution: {integrity: sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==}
+
+  '@vue/compiler-ssr@3.5.42':
+    resolution: {integrity: sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
+
+  '@vue/language-core@2.2.12':
+    resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/reactivity@3.5.42':
+    resolution: {integrity: sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==}
+
+  '@vue/runtime-core@3.5.42':
+    resolution: {integrity: sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==}
+
+  '@vue/runtime-dom@3.5.42':
+    resolution: {integrity: sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==}
+
+  '@vue/server-renderer@3.5.42':
+    resolution: {integrity: sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==}
+
+  '@vue/shared@3.5.42':
+    resolution: {integrity: sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==}
+
+  '@vue/test-utils@2.5.0':
+    resolution: {integrity: sha512-6Clu5EKR/r6cDPYrKsu+8wenciWJJ3rhS9OEGsfDlZeZIhlJeEPGIZQHxE4lHRJCzPSq3EWMsFxQUqCvrbHQuQ==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
+
   '@xstate/fsm@1.6.5':
     resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
+  abbrev@5.0.0:
+    resolution: {integrity: sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -4067,6 +4208,9 @@ packages:
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  alien-signals@1.0.13:
+    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -4289,6 +4433,9 @@ packages:
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -4427,6 +4574,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -4446,6 +4597,9 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -4543,6 +4697,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
+
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
@@ -4638,6 +4795,11 @@ packages:
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
+  editorconfig@3.0.2:
+    resolution: {integrity: sha512-T0ix8GhtxyKVfUFEcvdNDt3YGqlwkFHbD4/5bgFUDgFmxhI/cSRAeJ87/Sz//Cq8Eam6JX/e23RkoFO71P7aAA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -4893,6 +5055,9 @@ packages:
 
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -5277,6 +5442,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -5369,6 +5538,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -5436,6 +5609,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -5652,6 +5828,14 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-beautify@2.0.3:
+    resolution: {integrity: sha512-cyFbh3tkPhknnTD/0bLf0T0yy2ZIbqL05mttzbt4y1Zfr7NxqXQZ62dkBLKs3oHH/lpjmDRAnciJiSUyOy8XwQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -6123,6 +6307,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -6171,11 +6359,19 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6281,6 +6477,11 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  nopt@10.0.1:
+    resolution: {integrity: sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -6423,6 +6624,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -6576,6 +6780,10 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.28:
+    resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6608,6 +6816,9 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
@@ -7594,6 +7805,31 @@ packages:
       jsdom:
         optional: true
 
+  vscode-uri@3.2.0:
+    resolution: {integrity: sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==}
+
+  vue-component-type-helpers@3.3.11:
+    resolution: {integrity: sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==}
+
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  vue-tsc@2.2.12:
+    resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  vue@3.5.42:
+    resolution: {integrity: sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -7910,7 +8146,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -7923,10 +8159,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -7938,15 +8174,15 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -7974,14 +8210,14 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -7989,14 +8225,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -8012,24 +8248,28 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.29.2':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
 
   '@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -8142,25 +8382,25 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.29.0':
+  '@babel/types@7.29.8':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@base-ui/react@1.4.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -8864,7 +9104,7 @@ snapshots:
 
   '@mixpanel/rrweb-snapshot@2.0.0-alpha.18.4':
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.28
 
   '@mixpanel/rrweb-types@2.0.0-alpha.18.4': {}
 
@@ -9050,6 +9290,8 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@one-ini/wasm@0.2.1': {}
 
   '@opentelemetry/api-logs@0.208.0':
     dependencies:
@@ -10003,24 +10245,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@types/chai@5.2.3':
     dependencies:
@@ -10274,6 +10516,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(vue@3.5.42(typescript@5.9.3))':
+    dependencies:
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vue: 3.5.42(typescript@5.9.3)
+
   '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -10341,7 +10588,104 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@volar/language-core@2.4.15':
+    dependencies:
+      '@volar/source-map': 2.4.15
+
+  '@volar/source-map@2.4.15': {}
+
+  '@volar/typescript@2.4.15':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      path-browserify: 1.0.1
+      vscode-uri: 3.2.0
+
+  '@vue/compiler-core@3.5.42':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.42
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.42':
+    dependencies:
+      '@vue/compiler-core': 3.5.42
+      '@vue/shared': 3.5.42
+
+  '@vue/compiler-sfc@3.5.42':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.42
+      '@vue/compiler-dom': 3.5.42
+      '@vue/compiler-ssr': 3.5.42
+      '@vue/shared': 3.5.42
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.28
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.42':
+    dependencies:
+      '@vue/compiler-dom': 3.5.42
+      '@vue/shared': 3.5.42
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/devtools-api@6.6.4': {}
+
+  '@vue/language-core@2.2.12(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      '@vue/compiler-dom': 3.5.42
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.42
+      alien-signals: 1.0.13
+      minimatch: 9.0.9
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@vue/reactivity@3.5.42':
+    dependencies:
+      '@vue/shared': 3.5.42
+
+  '@vue/runtime-core@3.5.42':
+    dependencies:
+      '@vue/reactivity': 3.5.42
+      '@vue/shared': 3.5.42
+
+  '@vue/runtime-dom@3.5.42':
+    dependencies:
+      '@vue/reactivity': 3.5.42
+      '@vue/runtime-core': 3.5.42
+      '@vue/shared': 3.5.42
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.42':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.42
+      '@vue/runtime-dom': 3.5.42
+      '@vue/shared': 3.5.42
+
+  '@vue/shared@3.5.42': {}
+
+  '@vue/test-utils@2.5.0(@vue/compiler-dom@3.5.42)(@vue/server-renderer@3.5.42)(vue@3.5.42(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.42
+      js-beautify: 2.0.3
+      vue: 3.5.42(typescript@5.9.3)
+      vue-component-type-helpers: 3.3.11
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.42
+
   '@xstate/fsm@1.6.5': {}
+
+  abbrev@5.0.0: {}
 
   accepts@2.0.0:
     dependencies:
@@ -10400,6 +10744,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  alien-signals@1.0.13: {}
 
   ansi-colors@4.1.3: {}
 
@@ -10625,6 +10971,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -10756,6 +11106,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@14.0.3: {}
+
   commander@4.1.1: {}
 
   commander@7.2.0: {}
@@ -10767,6 +11119,11 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   consola@3.4.2: {}
 
@@ -10858,6 +11215,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  de-indent@1.0.2: {}
+
   debounce@1.2.1: {}
 
   debug@3.2.7:
@@ -10937,6 +11296,13 @@ snapshots:
       gopd: 1.2.0
 
   duplexer@0.1.2: {}
+
+  editorconfig@3.0.2:
+    dependencies:
+      '@one-ini/wasm': 0.2.1
+      commander: 14.0.3
+      minimatch: 10.2.4
+      semver: 7.7.4
 
   ee-first@1.1.1: {}
 
@@ -11268,7 +11634,7 @@ snapshots:
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       eslint: 9.39.4(jiti@2.6.1)
       hermes-parser: 0.25.1
       zod: 4.3.6
@@ -11400,6 +11766,8 @@ snapshots:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -11822,6 +12190,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globals@14.0.0: {}
 
   globals@16.4.0: {}
@@ -12001,6 +12375,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  he@1.2.0: {}
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -12063,6 +12439,8 @@ snapshots:
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -12266,6 +12644,16 @@ snapshots:
   jose@6.2.2: {}
 
   joycon@3.1.1: {}
+
+  js-beautify@2.0.3:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 3.0.2
+      glob: 13.0.6
+      js-cookie: 3.0.8
+      nopt: 10.0.1
+
+  js-cookie@3.0.8: {}
 
   js-tokens@10.0.0: {}
 
@@ -12526,8 +12914,8 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       source-map-js: 1.2.1
 
   make-dir@2.1.0:
@@ -13001,6 +13389,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.14
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -13042,6 +13434,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -13049,6 +13443,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.18: {}
 
   nanoid@5.1.7: {}
 
@@ -13161,6 +13557,10 @@ snapshots:
       semver: 6.3.1
 
   node-releases@2.0.36: {}
+
+  nopt@10.0.1:
+    dependencies:
+      abbrev: 5.0.0
 
   normalize-path@3.0.0: {}
 
@@ -13330,6 +13730,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -13417,12 +13819,12 @@ snapshots:
       postcss: 8.5.8
       tsx: 4.21.0
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.10
+      postcss: 8.5.28
       tsx: 4.21.0
 
   postcss-nested@6.2.0(postcss@8.5.8):
@@ -13444,13 +13846,19 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.10:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.28:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -13497,6 +13905,8 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.1.0: {}
+
+  proto-list@1.2.4: {}
 
   protobufjs@7.5.4:
     dependencies:
@@ -14499,7 +14909,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -14510,7 +14920,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.28)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -14519,7 +14929,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.10
+      postcss: 8.5.28
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -14758,7 +15168,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.28
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -14773,7 +15183,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.28
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -14880,6 +15290,31 @@ snapshots:
       jsdom: 29.0.1
     transitivePeerDependencies:
       - msw
+
+  vscode-uri@3.2.0: {}
+
+  vue-component-type-helpers@3.3.11: {}
+
+  vue-router@4.6.4(vue@3.5.42(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.42(typescript@5.9.3)
+
+  vue-tsc@2.2.12(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.15
+      '@vue/language-core': 2.2.12(typescript@5.9.3)
+      typescript: 5.9.3
+
+  vue@3.5.42(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.42
+      '@vue/compiler-sfc': 3.5.42
+      '@vue/runtime-dom': 3.5.42
+      '@vue/server-renderer': 3.5.42
+      '@vue/shared': 3.5.42
+    optionalDependencies:
+      typescript: 5.9.3
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -116,4 +116,9 @@ export const budgets = [
   ['ai:server', 'packages/ai/dist/server/index.js', 8000],
   ['scheduling', 'packages/scheduling/dist/index.js', 4000],
   ['license', 'packages/license/dist/index.js', 8000],
+  // v2 §1.5 — the two non-React bindings. Both are `external: ['@tour-kit/core',
+  // <framework>]`, so these rows measure the binding's own bytes: state bridge,
+  // provider lifecycle, two view helpers and a router adapter. Measured then
+  // gated at ~x1.2, the repo convention.
+  ['vue', 'packages/vue/dist/index.js', 1800],
 ]

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -77,11 +77,14 @@
  *     spotlight state machine down here after §1.5 shipped three copies of it
  *     — the React hook, `@tour-kit/vue` and `@tour-kit/svelte` — that differed
  *     only in reactivity primitive. Read the row together with the binding
- *     rows before calling it a regression: the bytes did not appear, they
- *     MOVED. A Vue consumer shipped engine 17 732 + vue 1 455 = 19 187 before
- *     and engine 18 098 + vue 1 093 = 19 191 after. The engine row alone looks
- *     worse; the thing a consumer downloads did not change, and there is now
- *     one implementation instead of three.
+ *     rows before calling it a regression: most of the bytes did not appear,
+ *     they MOVED. A Vue consumer ships engine + binding: 17 732 + 1 455 =
+ *     19 187 before, 18 098 + 1 243 = 19 341 after. So +154 B for that
+ *     consumer, not the zero an earlier estimate in the §1.5f commit message
+ *     guessed — the controller carries a listener set and an explicit snapshot
+ *     the three inlined copies did not. 154 B to delete two of three
+ *     implementations is the trade, and it is worth stating plainly rather
+ *     than rounding to "free".
  *
  *     Do NOT split a `/engine/dom` entry to keep this number flat: the row
  *     measures the import-everything worst case, a bundler tree-shakes the
@@ -131,5 +134,5 @@ export const budgets = [
   // <framework>]`, so these rows measure the binding's own bytes: state bridge,
   // provider lifecycle, two view helpers and a router adapter. Measured then
   // gated at ~x1.2, the repo convention.
-  ['vue', 'packages/vue/dist/index.js', 1800],
+  ['vue', 'packages/vue/dist/index.js', 1500],
 ]

--- a/tooling/tsconfig/library.json
+++ b/tooling/tsconfig/library.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "ES2021.WeakRef", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false
+  }
+}


### PR DESCRIPTION
Stacked on #126. A Vue 3 app gets the whole engine — state, navigation, branching, persistence, routing, audience/frequency, cross-tab sync, focus, keyboard, advance-on — with **no React installed**. The package imports only `@tour-kit/core/engine` and ships no card; the consumer renders their own.

> Stacked PRs show no CI until their base merges; this picks up CI when #126 lands and GitHub retargets it to `main`.

## Shape

Copied from §1.4's provider rather than redesigned.

- **`createTourKit`** — `createEngineHandle` + one `shallowRef` over `getState()`. `shallowRef` and not `ref`: a deep ref proxies the `stepVisitCount` Map and the `tour` object, and every downstream `Object.is` breaks against the proxy.
- **`provideTourKit`** — non-immediate `watch`, **never** `watchEffect`. Every kit member except `state` is `ensure()` in disguise, so an immediate watcher constructs the engine inside `setup()`; under Nuxt that is registry writes, four storage adapters and a `BroadcastChannel` on the server. Verified discriminating — adding `{ immediate: true }` reddens the setup-inert case.
- **`release()` on `onScopeDispose`**, never `destroy()`. Every `attach*` detach is collected and run on unmount.
- **`export * from '@tour-kit/core/engine'`**, deliberately. `/engine` is already the curated React-free surface; a hand-picked subset would need its own alignment test and would still be wrong the day `/engine` grows.

## The proof

`examples/vue-app` (port 5175): two routes, a three-step tour, its own card with the React card's exact floating-ui middleware stack. Eight Playwright cases in `e2e/_shared/binding-tour-flow.ts` — shared with the Svelte lane, because the point of §1.5 is that the two behave identically over one engine.

**Verified against the unfixed `attachAdvanceOn`**: all three advance-on cases go red in a real browser and green after. That is the hazard jsdom cannot observe.

## Three findings, all fixed here

1. **`flowSession` takes a `storage`, not an `enabled`** (the plan said `enabled`) — the example would have persisted nothing and the reload-resume case would have been silently vacuous.
2. **Core's `Placement` has a `-center` alignment floating-ui's does not.** The card strips it.
3. **The flow-session write is trailing-edge throttled at 200 ms, and a hard reload runs no teardown**, so a reload inside that window resumes on the *previous* step. True of the React provider too — its resume spec only passes because its assertions happen to outlast the window (it shows as flaky in a full run). The shared spec waits explicitly and says why. A `pagehide` flush would close it for all three bindings; out of §1.5's scope, flagged rather than silently widened.

## Gates

- Coverage **98.97 / 86.36 / 97.43 / 98.8** against an **enforced** 80/75/80/80 (`vitest-config-alignment` PACKAGES +1, which also required a `vitest.setup.ts` and the `vitest-axe` catalog dep the plan did not list)
- `vue` budget row at 1 800 B against a measured **1 455**
- `FREE_PACKAGES` +1; `biome.json` ignores SFCs, which `vue-tsc` typechecks instead
- `private: true` until the v2 licence lands (§3.2)

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt