### PR TITLE
v2 §1.6 — the engine barrel ships as a CDN build

### DIFF
--- a/.changeset/engine-cdn-build.md
+++ b/.changeset/engine-cdn-build.md
@@ -1,0 +1,21 @@
+---
+'@tour-kit/core': minor
+---
+
+`@tour-kit/core/engine` ships as a CDN build.
+
+`dist/engine/index.global.js` is the engine subpath as one self-contained
+script that defines `window.TourKit` with everything that subpath exports —
+`createTourEngine`, the DOM behaviours, the storage adapters, the predicates.
+The new `unpkg` and `jsdelivr` fields point at it, so
+`https://unpkg.com/@tour-kit/core` serves it with no path:
+
+```html
+<script src="https://unpkg.com/@tour-kit/core@2/dist/engine/index.global.js"></script>
+<script>
+  TourKit.createTourEngine({ tours: [/* … */] }).start('welcome')
+</script>
+```
+
+It is the engine only and renders nothing; the card is yours. `@tour-kit/react`
+has no CDN build. No API change, and `exports` is untouched.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -22,6 +22,11 @@
     "limit": "15 KB"
   },
   {
+    "name": "@tour-kit/core/engine (IIFE)",
+    "path": "packages/core/dist/engine/index.global.js",
+    "limit": "16 KB"
+  },
+  {
     "name": "@tour-kit/react",
     "path": "packages/react/dist/index.js",
     "limit": "185 KB",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,15 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     those bytes MOVED rather than appeared — a Vue consumer ships engine +
     binding, and that total went 19 187 → 19 341, so +154 B net for deleting
     two of the three implementations)
+  - core/engine IIFE (`dist/engine/index.global.js`, the CDN door) <18.5 KB,
+    measured 17 492. It is the engine closure in one file — same source, one
+    format — so it shares `core/engine`'s ceiling instead of the measured-×1.2
+    convention, and trips at the same time; rollup drops the chunk boundary,
+    which is why it is 606 B *smaller* than the two-file ESM closure it
+    mirrors. `platform: 'browser'` on its own tsup item is why it contains no
+    `process.env`: without it esbuild leaves four reads, two unguarded, and a
+    browser throws `ReferenceError: process is not defined` on the first
+    `interpolate()` or segment audience.
   - react <12 KB
   - hints <6 KB
   - analytics <4 KB (root; per-plugin <1.5 KB each)

--- a/apps/smoke/README.md
+++ b/apps/smoke/README.md
@@ -11,6 +11,10 @@ Its job: catch "broken tarball" bugs that `examples/dashboard-next` can't see be
 - Undeclared or mis-declared peer dependencies
 - Named-export drift between TypeScript types and the shipped JS
 - Runtime errors on module load (SSR dispatcher misuse, hooks at top level, etc.)
+- CDN build breakage — `dist/engine/index.global.js` missing from the tarball,
+  the `unpkg`/`jsdelivr` fields drifting off it, or the file failing to define
+  `TourKit` and run a tour (`pnpm probe:cdn`, the only step here that executes
+  the published JavaScript — the page probe is `curl`)
 
 ## What it doesn't catch
 

--- a/apps/smoke/package.json
+++ b/apps/smoke/package.json
@@ -10,6 +10,7 @@
     "start": "next start -p 3100",
     "typecheck": "tsc --noEmit",
     "probe": "curl -sf --max-time 60 --retry 20 --retry-delay 2 --retry-all-errors --retry-connrefused http://localhost:3100/ | grep -q 'data-smoke-ok'",
+    "probe:cdn": "node ./scripts/probe-cdn.mjs",
     "smoke": "pnpm install:npm && pnpm typecheck && bash ./scripts/run-smoke.sh"
   },
   "dependencies": {

--- a/apps/smoke/scripts/probe-cdn.mjs
+++ b/apps/smoke/scripts/probe-cdn.mjs
@@ -1,0 +1,87 @@
+/**
+ * v2 §1.6 — does the PUBLISHED tarball carry a working CDN build?
+ *
+ * `run-smoke.sh` probes the smoke page with `curl`, which executes no
+ * JavaScript, so a `<script>` tag on that page would prove nothing. This script
+ * is the JavaScript half: it reads the file at the exact path unpkg serves
+ * (`node_modules/@tour-kit/core/dist/engine/index.global.js` IS the unpkg URL
+ * minus the host), checks the two manifest fields that point a CDN at it, and
+ * runs a tour out of it.
+ *
+ * Zero dependencies on purpose — `apps/smoke` installs with
+ * `--ignore-workspace`, so anything imported here has to already be in the
+ * published dependency tree.
+ *
+ * `vm.runInThisContext` rather than the `new Function` trick the vitest suite
+ * uses: this is a one-shot process, so leaking `globalThis.TourKit` costs
+ * nothing and reads more like what a browser does. There is no DOM here (Node
+ * 20 in the workflow, no jsdom), so the tour below has no targets — which is
+ * the headless proof, in the realm a CDN user's page is furthest from.
+ *
+ * KNOWN WINDOW: the smoke app installs `latest`. Between merging §1.6 and the
+ * release that publishes the file, this script is RED, and deliberately has no
+ * skip — one keyed on the `unpkg` field would also skip the day someone deletes
+ * that field.
+ */
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import vm from 'node:vm'
+
+const require = createRequire(import.meta.url)
+
+function fail(msg) {
+  console.error(`[smoke] FAIL — ${msg}`)
+  process.exit(1)
+}
+
+// `./package.json` is an explicit entry in core's `exports` map, so this
+// resolves without reaching into node_modules by hand.
+const pkgPath = require.resolve('@tour-kit/core/package.json')
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+
+const rel = 'dist/engine/index.global.js'
+for (const field of ['unpkg', 'jsdelivr']) {
+  if (pkg[field] !== `./${rel}`) {
+    fail(`${field} field is ${pkg[field]}, expected ./${rel}`)
+  }
+}
+
+let source
+try {
+  source = readFileSync(join(dirname(pkgPath), rel), 'utf8')
+} catch (error) {
+  fail(`cannot read ${rel} from the installed tarball: ${error.message}`)
+}
+
+if (!source.startsWith('var TourKit=')) fail('IIFE does not open with the global assignment')
+// `require(` would be an external that leaked in as a throwing `__require` shim;
+// `process.env` would be the `platform: 'browser'` flag having been dropped.
+if (/\brequire\s*\(|process\.env/.test(source)) fail('IIFE leaks require( or process.env')
+
+vm.runInThisContext(source)
+
+const { createTourEngine, createMemoryStorage } = globalThis.TourKit
+const engine = createTourEngine({
+  tours: [
+    {
+      id: 't',
+      steps: [
+        { id: 's1', content: 'a' },
+        { id: 's2', content: 'b' },
+      ],
+    },
+  ],
+  storage: createMemoryStorage(),
+})
+
+await engine.start('t')
+await engine.next()
+
+const landed = engine.getState().currentStep?.id
+if (landed !== 's2') fail(`expected to advance to s2, got ${landed}`)
+engine.destroy()
+
+console.log(
+  `[smoke] OK — ${rel} from @tour-kit/core@${pkg.version} defines TourKit and runs a tour`
+)

--- a/apps/smoke/scripts/run-smoke.sh
+++ b/apps/smoke/scripts/run-smoke.sh
@@ -17,6 +17,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# v2 §1.6 — the CDN build, checked FIRST. It reads a file out of the installed
+# tarball and runs it in a `vm`: no port, no page, no dev server. Gating it
+# behind `next dev` would invert the failure mode — a release that breaks the
+# app's boot is exactly when you want to know whether the tarball is intact, and
+# behind the boot you would learn nothing. It is also the only step in this
+# script that executes the published JavaScript; `probe` below is curl.
+log "probing the CDN build"
+pnpm probe:cdn
+
 log "booting next dev on :3100"
 pnpm dev > /tmp/tour-kit-smoke-dev.log 2>&1 &
 DEV_PID=$!
@@ -38,12 +47,6 @@ done
 log "probing http://localhost:3100/"
 if pnpm probe; then
   log "OK — smoke page rendered with data-smoke-ok marker"
-  # v2 §1.6 — the CDN build. `probe` above is curl, which executes no
-  # JavaScript, so this is the only thing here that actually RUNS the tarball.
-  # `set -e` is in force inside this branch (it is suspended only for the
-  # command in the `if` condition), so a non-zero exit aborts the script.
-  log "probing the CDN build"
-  pnpm probe:cdn
   exit 0
 else
   log "FAIL — smoke probe could not find data-smoke-ok marker"

--- a/apps/smoke/scripts/run-smoke.sh
+++ b/apps/smoke/scripts/run-smoke.sh
@@ -38,6 +38,12 @@ done
 log "probing http://localhost:3100/"
 if pnpm probe; then
   log "OK — smoke page rendered with data-smoke-ok marker"
+  # v2 §1.6 — the CDN build. `probe` above is curl, which executes no
+  # JavaScript, so this is the only thing here that actually RUNS the tarball.
+  # `set -e` is in force inside this branch (it is suspended only for the
+  # command in the `if` condition), so a non-zero exit aborts the script.
+  log "probing the CDN build"
+  pnpm probe:cdn
   exit 0
 else
   log "FAIL — smoke probe could not find data-smoke-ok marker"

--- a/e2e/scripts/verify-npm-install.sh
+++ b/e2e/scripts/verify-npm-install.sh
@@ -32,6 +32,12 @@ node -e "const l = require('@tour-kit/license'); console.log('ProGate:', typeof 
 node -e "const l = require('@tour-kit/license'); console.log('useLicenseGate:', typeof l.useLicenseGate === 'function' ? 'OK' : 'MISSING')"
 node -e "const l = require('@tour-kit/license'); console.log('LicenseProvider:', typeof l.LicenseProvider === 'function' ? 'OK' : 'MISSING')"
 
+# v2 §1.6 — the CDN door, asked of the REAL cdn. The only place in the repo that
+# does: this script is manual and post-publish, so propagation lag or an unpkg
+# outage costs nothing. CI never asks.
+echo "unpkg serves the engine IIFE:"
+curl -sfI "https://unpkg.com/@tour-kit/core/dist/engine/index.global.js" | head -1
+
 echo ""
 echo "=== Dependency Verification ==="
 for pkg in adoption ai analytics announcements checklists media scheduling; do

--- a/e2e/vue/engine-iife.localhost.spec.ts
+++ b/e2e/vue/engine-iife.localhost.spec.ts
@@ -1,0 +1,84 @@
+import { join } from 'node:path'
+import { expect, test } from '@playwright/test'
+
+/**
+ * v2 §1.6 — the CDN door through a real classic `<script src>`.
+ *
+ * The vitest suite (`packages/core/src/__tests__/engine-iife-dist.test.ts`)
+ * covers the bytes and two evaluation realms; jsdom only *approximates*
+ * script-tag semantics, and Chromium is them. What this case adds: the global
+ * actually landing on `window` from a network-delivered classic script, the
+ * IIFE wrapper's `'use strict'` staying inside itself, and the file loading
+ * with no CSP or MIME complaint.
+ *
+ * It lives in the vue lane because Playwright matches projects by directory
+ * (`testMatch: /vue\/.*localhost/`) and `webServer` is global — a dedicated
+ * project would boot the same four dev servers for no benefit.
+ *
+ * SETUP: this reads `packages/core/dist/` directly, so run
+ * `pnpm build --filter=@tour-kit/core` before `pnpm e2e:vue`.
+ *
+ * No server of its own: `page.route` fulfils the script from disk. `cdn.invalid`
+ * is a reserved TLD, so a routing mistake fails loudly instead of quietly
+ * reaching the network.
+ */
+// `__dirname`, not `import.meta.url`: the repo root has no `"type": "module"`,
+// so Playwright transpiles specs to CJS and an `import.meta` reference makes
+// the loader treat the file as ESM while the emitted body still uses `require`
+// — "ReferenceError: require is not defined in ES module scope", at line 1.
+const IIFE_PATH = join(__dirname, '../../packages/core/dist/engine/index.global.js')
+
+declare global {
+  interface Window {
+    TourKit: {
+      createTourEngine(options: unknown): {
+        start(id: string): Promise<void>
+        next(): Promise<void>
+        getState(): { currentStep?: { id: string } | null }
+      }
+      createMemoryStorage(): unknown
+    }
+  }
+}
+
+test('the IIFE loads from a <script src> and runs a tour', async ({ page }) => {
+  const problems: string[] = []
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') problems.push(msg.text())
+  })
+  page.on('pageerror', (error) => problems.push(`pageerror: ${error.message}`))
+
+  await page.route('https://cdn.invalid/**', (route) =>
+    route.fulfill({ path: IIFE_PATH, contentType: 'text/javascript' })
+  )
+  await page.setContent(
+    '<button id="a">A</button><button id="b">B</button>' +
+      '<script src="https://cdn.invalid/engine.global.js"></script>'
+  )
+
+  await page.waitForFunction(() => typeof window.TourKit?.createTourEngine === 'function')
+
+  const landed = await page.evaluate(async () => {
+    const TourKit = window.TourKit
+    const engine = TourKit.createTourEngine({
+      tours: [
+        {
+          id: 't',
+          steps: [
+            { id: 's1', target: '#a', content: 'first' },
+            { id: 's2', target: '#b', content: 'second' },
+          ],
+        },
+      ],
+      storage: TourKit.createMemoryStorage(),
+    })
+    await engine.start('t')
+    await engine.next()
+    return engine.getState().currentStep?.id
+  })
+
+  expect(landed).toBe('s2')
+  // A `ReferenceError: process is not defined` from a `platform`-less build
+  // would land here, not in the assertion above.
+  expect(problems).toEqual([])
+})

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -17,6 +17,24 @@ Framework-agnostic foundation layer. Contains all business logic - UI packages a
 - The old hand-rolled `calculatePosition()`/collision engine was removed in Slice 0 (dead,
   barrel-private).
 
+### The CDN build (v2 §1.6)
+- `tsup.config.ts` is `defineConfig([main, iife])`. The IIFE
+  (`dist/engine/index.global.js`, `window.TourKit`, what `unpkg`/`jsdelivr`
+  serve) is its OWN item and must stay that way: adding `'iife'` to the main
+  item's `format` would also emit IIFEs of `index` and `schemas`, whose
+  externals become a `__require("react")` shim that throws on load.
+- `platform: 'browser'` on that item is load-bearing, not cosmetic. esbuild
+  defines `process.env.NODE_ENV` itself only under that platform; without it the
+  file keeps four `process.env` reads — two guarded, two not (`interpolate`'s
+  `warnOnMissing` default parameter, `audience`'s segment warning) — and a
+  browser throws `ReferenceError: process is not defined` on the first call.
+  The file LOADS either way, so the guard is two cases in
+  `engine-iife-dist.test.ts`: a `process.env` grep, and a run inside a `vm`
+  realm with no `process`. vitest's jsdom HAS `process`, so a jsdom run is blind
+  to this.
+- The main item's `clean` is therefore `['!**/*.global.js*']`, not `true` —
+  tsup builds array items in parallel and each cleans on its own.
+
 ### Storage Adapters
 - `createStorageAdapter()` - Factory for custom storage backends
 - `createPrefixedStorage()` - Namespaces keys to avoid collisions

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -53,8 +53,28 @@ import { type TourStep, matchesAudience, validateTour } from '@tour-kit/core/eng
 ```
 
 It is a subset of what `@tour-kit/core` already exports at the same paths —
-nothing moved. Note that it currently has no way to *run* a tour; that arrives
-with `createTourEngine()`.
+nothing moved. It runs tours too: `createTourEngine()` plus the DOM behaviours
+(`createFocusTrap`, `attachKeyboard`, `trackRect`, `createSpotlight`,
+`attachAdvanceOn`) need no React at all.
+
+#### From a CDN, no bundler
+
+The same subpath ships as a self-contained script that defines `window.TourKit`:
+
+```html
+<script src="https://unpkg.com/@tour-kit/core@2/dist/engine/index.global.js"></script>
+<script>
+  const { createTourEngine } = TourKit
+  const engine = createTourEngine({
+    tours: [{ id: 'welcome', steps: [{ id: 'a', target: '#a', content: 'Hi' }] }],
+  })
+  engine.start('welcome')
+</script>
+```
+
+It is the engine only — state, navigation, persistence, focus/keyboard/spotlight
+helpers — and renders nothing; the card is yours. `@tour-kit/react` has no CDN
+build.
 
 ## Quick Start
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,8 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "unpkg": "./dist/engine/index.global.js",
+  "jsdelivr": "./dist/engine/index.global.js",
   "exports": {
     ".": {
       "import": {

--- a/packages/core/src/__tests__/_dist.ts
+++ b/packages/core/src/__tests__/_dist.ts
@@ -29,6 +29,12 @@ export const ENGINE_CJS = join(PKG_ROOT, 'dist', 'engine', 'index.cjs')
 export const ENGINE_DTS = join(PKG_ROOT, 'dist', 'engine', 'index.d.ts')
 export const ENGINE_DCTS = join(PKG_ROOT, 'dist', 'engine', 'index.d.cts')
 
+// v2 §1.6 — the CDN door. Same subpath, one self-contained IIFE: this is the
+// exact path `unpkg`/`jsdelivr` serve out of the tarball, so the constant and
+// those two package.json fields have to agree (asserted in
+// `engine-iife-dist.test.ts`'s manifest describe).
+export const ENGINE_IIFE = join(PKG_ROOT, 'dist', 'engine', 'index.global.js')
+
 /**
  * Is the package built at all? Guards `it.skipIf` on a fresh clone.
  *

--- a/packages/core/src/__tests__/bundle-budget-claim-alignment.test.ts
+++ b/packages/core/src/__tests__/bundle-budget-claim-alignment.test.ts
@@ -52,7 +52,14 @@ const SIZE_LIMIT = '.size-limit.json'
  */
 const CLAIMS: Record<string, { pattern: RegExp; mode: 'exact' | 'ceiling' }> = {
   core: { pattern: /^\s*-\s*core\s*<\s*([\d.]+)\s*KB/m, mode: 'exact' },
-  'core:engine': { pattern: /core\/engine[^\n]*?<\s*([\d.]+)\s*KB/, mode: 'exact' },
+  // Both anchored on the word that distinguishes them. The `core:engine`
+  // pattern used to be a bare /core\/engine[^\n]*?<…/ — unanchored and
+  // first-match, which was fine while it was the only `core/engine … <N KB`
+  // bullet in the file. v2 §1.6 adds the second one, so an unanchored pattern
+  // would read whichever bullet comes first; both claim 18.5 today, so the two
+  // rows could silently swap and nothing would notice until they diverged.
+  'core:engine': { pattern: /core\/engine subpath[^\n]*?<\s*([\d.]+)\s*KB/, mode: 'exact' },
+  'core:engine:iife': { pattern: /core\/engine IIFE[^\n]*?<\s*([\d.]+)\s*KB/, mode: 'exact' },
   react: { pattern: /^\s*-\s*react\s*<\s*([\d.]+)\s*KB/m, mode: 'exact' },
   hints: { pattern: /^\s*-\s*hints\s*<\s*([\d.]+)\s*KB/m, mode: 'exact' },
   'analytics:main': { pattern: /^\s*-\s*analytics\s*<\s*([\d.]+)\s*KB/m, mode: 'exact' },

--- a/packages/core/src/__tests__/engine-iife-dist.test.ts
+++ b/packages/core/src/__tests__/engine-iife-dist.test.ts
@@ -16,13 +16,9 @@
  * deleting the realm case leaves a proxy nobody can justify.
  */
 import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import vm from 'node:vm'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ENGINE_IIFE, distExists } from './_dist'
-
-const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
 interface TourKitEngine {
   start(id: string): Promise<void>
@@ -68,11 +64,25 @@ const source = (): string => {
  */
 const loadIIFE = (): TourKitGlobal => new Function(`${source()}\nreturn TourKit`)() as TourKitGlobal
 
-const TWO_STEP_TOUR = {
+/** Two steps against real DOM targets — for the jsdom describe. */
+const TARGETED_TOUR = {
   id: 't',
   steps: [
     { id: 's1', target: '#a', content: 'first' },
     { id: 's2', target: '#b', content: 'second' },
+  ],
+}
+
+/**
+ * The same two steps with no `target` — for the `vm` realm, which has no
+ * `document` at all. The missing targets are the point, not an oversight: this
+ * is the headless path, and a step with a target would look for one.
+ */
+const TARGETLESS_TOUR = {
+  id: 't',
+  steps: [
+    { id: 's1', content: 'first' },
+    { id: 's2', content: 'second' },
   ],
 }
 
@@ -135,7 +145,7 @@ describe.skipIf(!distExists())('v2 §1.6 — it runs a tour under jsdom', () => 
     expect(typeof TourKit.createTourEngine).toBe('function')
 
     const engine = TourKit.createTourEngine({
-      tours: [TWO_STEP_TOUR],
+      tours: [TARGETED_TOUR],
       storage: TourKit.createMemoryStorage(),
     })
 
@@ -189,14 +199,16 @@ describe.skipIf(!distExists())('v2 §1.6 — it runs in a realm with no `process
    * nothing to do with the flag under test. `process` is deliberately NOT
    * passed: it is the whole discriminator.
    */
-  const realm = () => {
+  const realm = (): { ctx: vm.Context; TourKit: TourKitGlobal } => {
     const ctx = vm.createContext({ console, setTimeout, clearTimeout, AbortController })
     vm.runInContext(source(), ctx)
-    return ctx
+    // The one cast, here rather than at three call sites: `vm.Context` is
+    // `object`, so every consumer would otherwise re-assert the same shape.
+    return { ctx, TourKit: (ctx as { TourKit: TourKitGlobal }).TourKit }
   }
 
   it('the realm really has no `process` (control — otherwise this proves nothing)', () => {
-    expect(vm.runInContext('typeof process', realm())).toBe('undefined')
+    expect(vm.runInContext('typeof process', realm().ctx)).toBe('undefined')
   })
 
   it('loads, and `interpolate()` returns instead of throwing', () => {
@@ -205,55 +217,18 @@ describe.skipIf(!distExists())('v2 §1.6 — it runs in a realm with no `process
     // `warnOnMissing = process.env.NODE_ENV !== 'production'` default parameter.
     // Note the file LOADS either way — the throw is deferred to the first call,
     // so a test that only evaluates the source proves nothing.
-    expect(vm.runInContext('TourKit.interpolate("hi {{name}}", {})', realm())).toBe('hi ')
+    expect(vm.runInContext('TourKit.interpolate("hi {{name}}", {})', realm().ctx)).toBe('hi ')
   })
 
   it('runs a target-less tour with no DOM at all', async () => {
-    const ctx = realm() as unknown as { TourKit: TourKitGlobal }
-    const { createTourEngine, createMemoryStorage } = ctx.TourKit
+    const { createTourEngine, createMemoryStorage } = realm().TourKit
     const engine = createTourEngine({
-      tours: [
-        {
-          id: 't',
-          steps: [
-            { id: 's1', content: 'a' },
-            { id: 's2', content: 'b' },
-          ],
-        },
-      ],
+      tours: [TARGETLESS_TOUR],
       storage: createMemoryStorage(),
     })
     await engine.start('t')
     await engine.next()
     expect(engine.getState().currentStep?.id).toBe('s2')
     engine.destroy()
-  })
-})
-
-describe('v2 §1.6 — the manifest points a CDN at the file', () => {
-  // NOT skipIf: these are package.json facts and hold on an unbuilt clone. Only
-  // the "resolves to a real file" case needs dist, and it is guarded on its own.
-  //
-  // Why this describe exists at all: `apps/smoke`'s probe is the only other
-  // thing that reads these two fields, and it runs POST-PUBLISH. Without this,
-  // a typo (`.global.mjs`, a dropped `./`, a rename) ships.
-  const pkg = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf8')) as {
-    unpkg?: string
-    jsdelivr?: string
-    files?: string[]
-  }
-  const EXPECTED = './dist/engine/index.global.js'
-
-  it.each(['unpkg', 'jsdelivr'] as const)('%s points at the IIFE', (field) => {
-    // `https://unpkg.com/@tour-kit/core` with no path serves this file.
-    expect(pkg[field]).toBe(EXPECTED)
-  })
-
-  it('the published `files` list still ships dist', () => {
-    expect(pkg.files).toContain('dist')
-  })
-
-  it.skipIf(!distExists())('the path those fields name actually resolves', () => {
-    expect(existsSync(join(PKG_ROOT, EXPECTED))).toBe(true)
   })
 })

--- a/packages/core/src/__tests__/engine-iife-dist.test.ts
+++ b/packages/core/src/__tests__/engine-iife-dist.test.ts
@@ -1,0 +1,259 @@
+/**
+ * v2 §1.6 — the CDN door: `dist/engine/index.global.js`.
+ *
+ * This is the first consumer that evaluates the engine with NO bundler define
+ * and NO Node globals, so the file is guarded on two axes:
+ *
+ *   TEXT   — what the bytes may not contain (`require(`, `import.meta`,
+ *            `process.env`). Fast, unambiguous, and the `process.env` case is
+ *            the one that goes red if `platform: 'browser'` is ever tidied out
+ *            of `tsup.config.ts`. Nothing else here does.
+ *   REALM  — what the file DOES, in the realm that matters. vitest's jsdom has
+ *            `process`, so a jsdom run passes identically on a build that would
+ *            throw for every CDN user. The `vm` realm below does not.
+ *
+ * Neither axis is sufficient. Deleting the grep leaves the cause undocumented;
+ * deleting the realm case leaves a proxy nobody can justify.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import vm from 'node:vm'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ENGINE_IIFE, distExists } from './_dist'
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+interface TourKitEngine {
+  start(id: string): Promise<void>
+  next(): Promise<void>
+  destroy(): void
+  subscribe(listener: () => void): () => void
+  getState(): { isActive: boolean; currentStep?: { id: string } | null }
+}
+
+/**
+ * A local shape, not a contract. `packages/core/tsconfig.json` excludes
+ * `**\/*.test.ts`, so `tsc` (and the safe-ship-gate hook) never sees this file —
+ * this interface exists to keep the calls readable and biome off `any`, and it
+ * will NOT catch a barrel change. The `>= 80` key count below is what does.
+ */
+interface TourKitGlobal {
+  createTourEngine(options: unknown): TourKitEngine
+  createMemoryStorage(): unknown
+  createFocusTrap: unknown
+  interpolate(template: string, values: Record<string, unknown>): string
+  [key: string]: unknown
+}
+
+/** Read once, lazily — 54 KB, a dozen cases, and an unbuilt package must skip rather than throw. */
+let cached: string | null = null
+const source = (): string => {
+  cached ??= readFileSync(ENGINE_IIFE, 'utf8')
+  return cached
+}
+
+/**
+ * Evaluate the IIFE into a local binding.
+ *
+ * The `\n` is LOAD-BEARING: the file's last line is a `//# sourceMappingURL=`
+ * comment with no trailing newline (there are two of them — tsup appends one,
+ * rollup's IIFE wrapper the other), so `` `${src}; return TourKit` `` puts the
+ * `return` inside that comment and this yields `undefined` — a permanent false
+ * red against a perfectly good build.
+ *
+ * `new Function` keeps `var TourKit` function-scoped, so nothing leaks into the
+ * next test file in this worker. `vm.runInThisContext` would leak; do not swap
+ * it in. (`apps/smoke`'s probe uses it freely — it is a one-shot script.)
+ */
+const loadIIFE = (): TourKitGlobal => new Function(`${source()}\nreturn TourKit`)() as TourKitGlobal
+
+const TWO_STEP_TOUR = {
+  id: 't',
+  steps: [
+    { id: 's1', target: '#a', content: 'first' },
+    { id: 's2', target: '#b', content: 'second' },
+  ],
+}
+
+describe.skipIf(!distExists())('v2 §1.6 — the IIFE is emitted and shaped like a CDN script', () => {
+  it('exists', () => {
+    // The FILE, never the directory: `clean` leaves an empty `dist/engine/`
+    // behind, so a directory check passes on a build that emits nothing.
+    expect(existsSync(ENGINE_IIFE)).toBe(true)
+  })
+
+  it('starts with the global assignment', () => {
+    expect(source().slice(0, 12)).toBe('var TourKit=')
+  })
+
+  it('has no `require(` — an external that leaked would appear as one', () => {
+    // esbuild turns an external import into a `__require("clsx")` shim that
+    // throws `Dynamic require of "clsx" is not supported` on load. This is the
+    // guard behind "never add 'iife' to the main item's format" — an IIFE of
+    // `index` or `schemas` ships exactly that shim for react/zod.
+    expect(source().match(/\brequire\s*\(/g) ?? []).toEqual([])
+  })
+
+  it('has no `import.meta` — a classic script has no module scope', () => {
+    expect(source().match(/import\.meta/g) ?? []).toEqual([])
+  })
+
+  it("has no `process.env` — platform:'browser' is what keeps a browser from throwing", () => {
+    // THE red-first case. Build once WITHOUT `platform: 'browser'` on the IIFE
+    // item and this reports 4 matches: two guarded (`typeof process` in
+    // logger/test-bridge) and two NOT — `interpolate`'s `warnOnMissing` default
+    // parameter and `audience`'s segment warning. Those two are why a CDN user
+    // gets `ReferenceError: process is not defined` on their first tour.
+    //
+    // It is also the ONLY case in this file that goes red on that build: the
+    // `require(` count is 0 either way, and the jsdom run passes either way
+    // (vitest's jsdom has `process`). See the realm describe below.
+    expect(source().match(/process\.env/g) ?? []).toEqual([])
+  })
+
+  it('does NOT start with the `use client` directive', () => {
+    // The React entry gets it via tsup's inline onSuccess; the engine door must
+    // not, or a framework-agnostic file is marked client-only.
+    expect(/^['"]use client['"];?/.test(source())).toBe(false)
+  })
+})
+
+describe.skipIf(!distExists())('v2 §1.6 — it runs a tour under jsdom', () => {
+  beforeEach(() => {
+    // Hand-appended nodes are ours to clean: the shared afterEach `cleanup()`
+    // only removes what @testing-library rendered, and a stale `#a` from a
+    // previous case wins the selector.
+    document.body.innerHTML = '<button id="a">A</button><button id="b">B</button>'
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('creates an engine, starts, advances, destroys', async () => {
+    const TourKit = loadIIFE()
+    expect(typeof TourKit.createTourEngine).toBe('function')
+
+    const engine = TourKit.createTourEngine({
+      tours: [TWO_STEP_TOUR],
+      storage: TourKit.createMemoryStorage(),
+    })
+
+    let notifications = 0
+    const unsubscribe = engine.subscribe(() => {
+      notifications++
+    })
+
+    await engine.start('t')
+    expect(engine.getState().isActive).toBe(true)
+    expect(engine.getState().currentStep?.id).toBe('s1')
+    // `>= 1`, never a total: the running count after `next()` is 4 today, which
+    // is a dispatch-chain detail and will drift.
+    expect(notifications).toBeGreaterThanOrEqual(1)
+
+    await engine.next()
+    expect(engine.getState().currentStep?.id).toBe('s2')
+
+    unsubscribe()
+    expect(() => engine.destroy()).not.toThrow()
+  })
+
+  it('carries the DOM behaviours, not just the state machine', () => {
+    expect(typeof loadIIFE().createFocusTrap).toBe('function')
+  })
+
+  it('exports the whole barrel — a collapsed bundle would not', () => {
+    // 88 keys today. `>=` on purpose: the barrel grows every slice, and a `toBe`
+    // would fail the build for adding an export. This tripwire is for the
+    // barrel COLLAPSING (a bad treeshake, a wrong entry), which 80 catches.
+    expect(Object.keys(loadIIFE()).length).toBeGreaterThanOrEqual(80)
+  })
+
+  it('does not pollute globalThis', () => {
+    loadIIFE()
+    expect((globalThis as Record<string, unknown>).TourKit).toBeUndefined()
+  })
+})
+
+describe.skipIf(!distExists())('v2 §1.6 — it runs in a realm with no `process`', () => {
+  /**
+   * The browser case, as close as vitest can get to it. jsdom gives us
+   * `document` but keeps Node's `process`, so every case above passes on a
+   * `platform: 'node'` build too. This realm has neither, which is what makes it
+   * the only in-vitest witness for the platform flag.
+   *
+   * The realm supplies its own `Object`/`Array`/`Promise` intrinsics; the four
+   * globals passed in are the ones a browser has and a bare `vm` context does
+   * not. `AbortController` is one of them — `createTourEngine`'s boot dispatch
+   * constructs one, so leaving it out fails this case for a reason that has
+   * nothing to do with the flag under test. `process` is deliberately NOT
+   * passed: it is the whole discriminator.
+   */
+  const realm = () => {
+    const ctx = vm.createContext({ console, setTimeout, clearTimeout, AbortController })
+    vm.runInContext(source(), ctx)
+    return ctx
+  }
+
+  it('the realm really has no `process` (control — otherwise this proves nothing)', () => {
+    expect(vm.runInContext('typeof process', realm())).toBe('undefined')
+  })
+
+  it('loads, and `interpolate()` returns instead of throwing', () => {
+    // Against a `platform`-less build this is
+    // `ReferenceError: process is not defined`, thrown from `interpolate`'s
+    // `warnOnMissing = process.env.NODE_ENV !== 'production'` default parameter.
+    // Note the file LOADS either way — the throw is deferred to the first call,
+    // so a test that only evaluates the source proves nothing.
+    expect(vm.runInContext('TourKit.interpolate("hi {{name}}", {})', realm())).toBe('hi ')
+  })
+
+  it('runs a target-less tour with no DOM at all', async () => {
+    const ctx = realm() as unknown as { TourKit: TourKitGlobal }
+    const { createTourEngine, createMemoryStorage } = ctx.TourKit
+    const engine = createTourEngine({
+      tours: [
+        {
+          id: 't',
+          steps: [
+            { id: 's1', content: 'a' },
+            { id: 's2', content: 'b' },
+          ],
+        },
+      ],
+      storage: createMemoryStorage(),
+    })
+    await engine.start('t')
+    await engine.next()
+    expect(engine.getState().currentStep?.id).toBe('s2')
+    engine.destroy()
+  })
+})
+
+describe('v2 §1.6 — the manifest points a CDN at the file', () => {
+  // NOT skipIf: these are package.json facts and hold on an unbuilt clone. Only
+  // the "resolves to a real file" case needs dist, and it is guarded on its own.
+  //
+  // Why this describe exists at all: `apps/smoke`'s probe is the only other
+  // thing that reads these two fields, and it runs POST-PUBLISH. Without this,
+  // a typo (`.global.mjs`, a dropped `./`, a rename) ships.
+  const pkg = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf8')) as {
+    unpkg?: string
+    jsdelivr?: string
+    files?: string[]
+  }
+  const EXPECTED = './dist/engine/index.global.js'
+
+  it.each(['unpkg', 'jsdelivr'] as const)('%s points at the IIFE', (field) => {
+    // `https://unpkg.com/@tour-kit/core` with no path serves this file.
+    expect(pkg[field]).toBe(EXPECTED)
+  })
+
+  it('the published `files` list still ships dist', () => {
+    expect(pkg.files).toContain('dist')
+  })
+
+  it.skipIf(!distExists())('the path those fields name actually resolves', () => {
+    expect(existsSync(join(PKG_ROOT, EXPECTED))).toBe(true)
+  })
+})

--- a/packages/core/src/__tests__/manifest.test.ts
+++ b/packages/core/src/__tests__/manifest.test.ts
@@ -1,0 +1,49 @@
+/**
+ * `packages/core/package.json` facts that nothing else pins.
+ *
+ * Core's manifest assertions were scattered — `peer-dep-optional.test.ts` owns
+ * the optional-peer contract, `credibility-surface.guard.test.ts` owns the
+ * keywords — and v2 §1.6 added two CDN fields with no home at all. This is that
+ * home, modelled on `packages/vue/src/__tests__/manifest.test.ts` and
+ * `packages/analytics/src/__tests__/package-contract.test.ts`. New manifest
+ * facts belong here rather than wherever the feature that added them lives.
+ *
+ * Deliberately NOT a dist-tier file: these hold on an unbuilt clone, so only
+ * the one case that resolves a path guards on `distExists()`.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { distExists } from './_dist'
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+const pkg = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf8')) as {
+  unpkg?: string
+  jsdelivr?: string
+  files?: string[]
+}
+
+/** v2 §1.6 — what `unpkg` and `jsdelivr` must both name. */
+const IIFE = './dist/engine/index.global.js'
+
+describe('v2 §1.6 — the manifest points a CDN at the IIFE', () => {
+  // The only other thing that reads these two fields is
+  // `apps/smoke/scripts/probe-cdn.mjs`, and that runs POST-PUBLISH. Without
+  // these cases a typo (`.global.mjs`, a dropped `./`, a rename) ships and is
+  // found by a user.
+  it.each(['unpkg', 'jsdelivr'] as const)('%s points at the IIFE', (field) => {
+    // `https://unpkg.com/@tour-kit/core` with no path serves whatever this
+    // names; without the field it would serve `main`, the React CJS build.
+    expect(pkg[field]).toBe(IIFE)
+  })
+
+  it('the published `files` list still ships dist', () => {
+    expect(pkg.files).toContain('dist')
+  })
+
+  it.skipIf(!distExists())('the path those fields name actually resolves', () => {
+    expect(existsSync(join(PKG_ROOT, IIFE))).toBe(true)
+  })
+})

--- a/packages/core/src/__tests__/no-react-in-engine-dist.test.ts
+++ b/packages/core/src/__tests__/no-react-in-engine-dist.test.ts
@@ -26,6 +26,7 @@ import {
   ENGINE_CJS,
   ENGINE_DCTS,
   ENGINE_DTS,
+  ENGINE_IIFE,
   ENGINE_MJS,
   MAIN_CJS,
   MAIN_DTS,
@@ -51,6 +52,13 @@ const ENGINE_ENTRIES: Array<[label: string, path: string]> = [
   ['dist/engine/index.cjs (CJS runtime)', ENGINE_CJS],
   ['dist/engine/index.d.ts (ESM types)', ENGINE_DTS],
   ['dist/engine/index.d.cts (CJS types)', ENGINE_DCTS],
+  // v2 §1.6 — the CDN build. Its closure is one file (it has no relative
+  // imports to follow), so the five scans below read a haystack that is empty
+  // of all five today. Not theatre: the failure mode here is not a relative
+  // import, it is an EXTERNAL — the day `clsx` enters the engine barrel,
+  // esbuild emits `__require("clsx")` into this file and both this scan and
+  // `engine-iife-dist.test.ts`'s `require(` guard catch it independently.
+  ['dist/engine/index.global.js (IIFE)', ENGINE_IIFE],
 ]
 
 describe.skipIf(!distExists())('v2 §1.2 — the engine entry is emitted at all', () => {
@@ -97,6 +105,10 @@ describe.skipIf(!distExists())(
 
     it('dist/engine/index.cjs does NOT start with it', () => {
       expect(startsWithDirective(ENGINE_CJS)).toBe(false)
+    })
+
+    it('dist/engine/index.global.js does NOT start with it', () => {
+      expect(startsWithDirective(ENGINE_IIFE)).toBe(false)
     })
 
     it('dist/index.js STILL starts with it', () => {

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,8 +1,34 @@
 import * as fs from 'node:fs'
 import { defineConfig } from 'tsup'
 
+/**
+ * The specifiers core never bundles. ONE list, spread into both items below.
+ *
+ * Stating it twice is the drift this file exists to prevent: a sixth external
+ * added to the main item alone would be BUNDLED into the IIFE — not emitted as
+ * the throwing `__require()` shim the item comment warns about, just silently
+ * inlined, where the `require(` guard cannot see it and the `core:engine:iife`
+ * size row absorbs the bytes without a word.
+ */
+const EXTERNAL = ['react', 'react-dom', 'clsx', 'tailwind-merge', 'zod']
+
+/**
+ * Output policy both items share. They differ in entry, format, platform and
+ * clean — everything a reader needs to compare is therefore in the two items,
+ * and everything that must not diverge is here.
+ */
+const SHARED = {
+  external: EXTERNAL,
+  outDir: 'dist',
+  treeshake: true,
+  minify: true,
+  sourcemap: true,
+  target: 'es2020',
+} as const
+
 export default defineConfig([
   {
+    ...SHARED,
     entry: {
       index: 'src/index.ts',
       'schemas/index': 'src/lib/schemas/index.ts',
@@ -25,13 +51,7 @@ export default defineConfig([
     // Consequence to know: this also protects a STALE `.global.js` forever. If
     // the IIFE entry is ever renamed, check `ls dist/engine/` shows exactly one.
     clean: ['!**/*.global.js*'],
-    external: ['react', 'react-dom', 'clsx', 'tailwind-merge', 'zod'],
-    treeshake: true,
     splitting: true,
-    minify: true,
-    sourcemap: true,
-    target: 'es2020',
-    outDir: 'dist',
     // esbuild's banner option is stripped by minify (the directive is treated
     // as a dead expression once it follows other code). Prepend in onSuccess
     // so the 'use client' directive survives — required for the React-stateful
@@ -61,6 +81,7 @@ export default defineConfig([
     // esbuild turns their externals into a `__require("react")` shim that
     // throws `Dynamic require of "react" is not supported` on load. Two
     // landmines in the tarball for a file nobody asked for.
+    ...SHARED,
     entry: { 'engine/index': 'src/engine/index.ts' },
     format: ['iife'],
     globalName: 'TourKit',
@@ -74,17 +95,11 @@ export default defineConfig([
     // `engine-iife-dist.test.ts` both greps for `process.env` and runs the file
     // in a `vm` realm that has no `process`.
     platform: 'browser',
-    outDir: 'dist',
     // The main item cleans (with the negative glob above); both build in
     // parallel, so a second clean here would be the race that guards nothing.
     clean: false,
     // A classic script has no types to resolve; `dist/engine/index.d.ts`
     // already serves every consumer who typechecks.
     dts: false,
-    external: ['react', 'react-dom', 'clsx', 'tailwind-merge', 'zod'],
-    treeshake: true,
-    minify: true,
-    sourcemap: true,
-    target: 'es2020',
   },
 ])

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,45 +1,90 @@
 import * as fs from 'node:fs'
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-  entry: {
-    index: 'src/index.ts',
-    'schemas/index': 'src/lib/schemas/index.ts',
-    // v2 §1.2 — the React-free door. `splitting: true` puts the 35 shared
-    // modules in a `chunk-*.js` beside it, so `dist/engine/index.js` is a
-    // re-export shell: anything measuring or scanning it must follow the
-    // import closure, never stat the entry file (see
-    // `tooling/bundle-check/check-dist-gzip.mjs` and `_dist.ts`'s
-    // `readClosure`).
-    'engine/index': 'src/engine/index.ts',
-  },
-  format: ['cjs', 'esm'],
-  dts: true,
-  clean: true,
-  external: ['react', 'react-dom', 'clsx', 'tailwind-merge', 'zod'],
-  treeshake: true,
-  splitting: true,
-  minify: true,
-  sourcemap: true,
-  target: 'es2020',
-  outDir: 'dist',
-  // esbuild's banner option is stripped by minify (the directive is treated
-  // as a dead expression once it follows other code). Prepend in onSuccess
-  // so the 'use client' directive survives — required for the React-stateful
-  // exports (TourProvider, useTour, etc.) to work in Next.js Server Components.
-  // The entry list here is deliberately NOT the entry list above: only the
-  // React entry gets the directive. Stamping it onto `dist/engine/*` would
-  // mark the framework-agnostic door as client-only. If this is ever migrated
-  // to the shared `tooling/build/use-client.ts` injector, keep passing these
-  // two files and nothing more — `no-react-in-engine-dist.test.ts` asserts
-  // both halves.
-  async onSuccess() {
-    for (const file of ['dist/index.js', 'dist/index.cjs']) {
-      if (!fs.existsSync(file)) continue
-      const content = fs.readFileSync(file, 'utf8')
-      if (!/^['"]use client['"];?/.test(content)) {
-        fs.writeFileSync(file, `'use client';\n${content}`)
+export default defineConfig([
+  {
+    entry: {
+      index: 'src/index.ts',
+      'schemas/index': 'src/lib/schemas/index.ts',
+      // v2 §1.2 — the React-free door. `splitting: true` puts the 35 shared
+      // modules in a `chunk-*.js` beside it, so `dist/engine/index.js` is a
+      // re-export shell: anything measuring or scanning it must follow the
+      // import closure, never stat the entry file (see
+      // `tooling/bundle-check/check-dist-gzip.mjs` and `_dist.ts`'s
+      // `readClosure`).
+      'engine/index': 'src/engine/index.ts',
+    },
+    format: ['cjs', 'esm'],
+    dts: true,
+    // v2 §1.6 — NOT `true`. tsup builds array items in parallel and each runs its
+    // own clean (`tsup/dist/index.js:1589-1594`), so a plain `clean: true` here
+    // races the IIFE item's output and can delete it. The array is passed through
+    // as extra globs to `removeFiles(['**/*', ...extra])`, and tsup itself
+    // `unshift`s a negative `'!**/*.d.{ts,cts,mts}'` onto it when `dts` is on —
+    // so negation through this path is tsup's own mechanism, not a trick.
+    // Consequence to know: this also protects a STALE `.global.js` forever. If
+    // the IIFE entry is ever renamed, check `ls dist/engine/` shows exactly one.
+    clean: ['!**/*.global.js*'],
+    external: ['react', 'react-dom', 'clsx', 'tailwind-merge', 'zod'],
+    treeshake: true,
+    splitting: true,
+    minify: true,
+    sourcemap: true,
+    target: 'es2020',
+    outDir: 'dist',
+    // esbuild's banner option is stripped by minify (the directive is treated
+    // as a dead expression once it follows other code). Prepend in onSuccess
+    // so the 'use client' directive survives — required for the React-stateful
+    // exports (TourProvider, useTour, etc.) to work in Next.js Server Components.
+    // The entry list here is deliberately NOT the entry list above: only the
+    // React entry gets the directive. Stamping it onto `dist/engine/*` would
+    // mark the framework-agnostic door as client-only. If this is ever migrated
+    // to the shared `tooling/build/use-client.ts` injector, keep passing these
+    // two files and nothing more — `no-react-in-engine-dist.test.ts` asserts
+    // both halves.
+    async onSuccess() {
+      for (const file of ['dist/index.js', 'dist/index.cjs']) {
+        if (!fs.existsSync(file)) continue
+        const content = fs.readFileSync(file, 'utf8')
+        if (!/^['"]use client['"];?/.test(content)) {
+          fs.writeFileSync(file, `'use client';\n${content}`)
+        }
       }
-    }
+    },
   },
-})
+  {
+    // v2 §1.6 — the CDN door: the `/engine` barrel as one self-contained IIFE
+    // at `dist/engine/index.global.js`, which `unpkg` and `jsdelivr` point at.
+    //
+    // Its OWN item, never a third format on the item above: `format: [...,
+    // 'iife']` there would also emit IIFEs of `index` and `schemas`, and
+    // esbuild turns their externals into a `__require("react")` shim that
+    // throws `Dynamic require of "react" is not supported` on load. Two
+    // landmines in the tarball for a file nobody asked for.
+    entry: { 'engine/index': 'src/engine/index.ts' },
+    format: ['iife'],
+    globalName: 'TourKit',
+    // LOAD-BEARING. esbuild defines `process.env.NODE_ENV` itself only under
+    // `platform: 'browser'`; with tsup's default (`node`) the output keeps four
+    // `process.env` reads, two of them unguarded (`lib/interpolate.ts`'s
+    // `warnOnMissing` default parameter and `lib/audience.ts`'s segment
+    // warning), and a browser throws `ReferenceError: process is not defined`
+    // on the first `interpolate()` or segment audience. The file LOADS either
+    // way — the throw is deferred to the first call, which is why
+    // `engine-iife-dist.test.ts` both greps for `process.env` and runs the file
+    // in a `vm` realm that has no `process`.
+    platform: 'browser',
+    outDir: 'dist',
+    // The main item cleans (with the negative glob above); both build in
+    // parallel, so a second clean here would be the race that guards nothing.
+    clean: false,
+    // A classic script has no types to resolve; `dist/engine/index.d.ts`
+    // already serves every consumer who typechecks.
+    dts: false,
+    external: ['react', 'react-dom', 'clsx', 'tailwind-merge', 'zod'],
+    treeshake: true,
+    minify: true,
+    sourcemap: true,
+    target: 'es2020',
+  },
+])

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -91,6 +91,20 @@
  *     rest (`sideEffects: false`), and the only consumer who pays all of it is
  *     the §1.6 IIFE — where shipping focus/keyboard/spotlight is the point. A
  *     type-only consumer still ships zero.
+ *   - core:engine:iife: 18.5 KB against a measured 17 492 — the SAME ceiling as
+ *     `core:engine`, deliberately, not the repo's measured-x1.2 convention.
+ *     This row is the same source in one format: rollup drops the chunk
+ *     boundary, so the IIFE is 606 B SMALLER than the two-file ESM closure it
+ *     mirrors (17 492 vs 18 098). It moves in lockstep with the row above, so
+ *     it should trip at the same time; x1.2 would put it near 21 000 and leave
+ *     3.5 KB nobody would notice drift into. The vue/svelte rows got x1.2
+ *     because they have no sibling row to track.
+ *
+ *     This is also the answer to the prediction in the row above — "the §1.6
+ *     IIFE is the consumer who pays all of it". It did, and it fit: no
+ *     re-baseline, ~1 KB of headroom. If this row and `core:engine` ever
+ *     diverge by more than ~600 B, one of the two builds changed shape
+ *     (a lost treeshake, a new format flag), not the source.
  *   - hints, announcements, surveys, media, ai:client: re-baselined in v2 §1.2
  *     WITHOUT a byte being added. All five ship a `headless` entry alongside
  *     `index`, so they have been split since long before core was, and the
@@ -114,6 +128,7 @@
 export const budgets = [
   ['core', 'packages/core/dist/index.js', 23000],
   ['core:engine', 'packages/core/dist/engine/index.js', 18500],
+  ['core:engine:iife', 'packages/core/dist/engine/index.global.js', 18500],
   ['react', 'packages/react/dist/index.js', 12000],
   ['hints', 'packages/hints/dist/index.js', 6000],
   ['analytics:main', 'packages/analytics/dist/index.js', 4000],


### PR DESCRIPTION
Stacked on #128. `dist/engine/index.global.js` — the `@tour-kit/core/engine` barrel as one self-contained IIFE defining `window.TourKit`, served straight out of the tarball by new `unpkg`/`jsdelivr` fields. No new package, no new export path, no API change: the global *is* the barrel (88 keys).

```html
<script src="https://unpkg.com/@tour-kit/core@2/dist/engine/index.global.js"></script>
<script>
  TourKit.createTourEngine({ tours: [/* … */] }).start('welcome')
</script>
```

## The part that is not trivial

The build step is one tsup item. What is not trivial is that a browser IIFE is the first consumer that evaluates the engine with **no bundler define and no Node globals**, and the engine chunk reads `process.env.NODE_ENV` four times — two of them unguarded (`lib/interpolate.ts`'s `warnOnMissing` default parameter, `lib/audience.ts`'s segment warning). Without `platform: 'browser'` on that item, esbuild does not define it away and the file throws `ReferenceError: process is not defined` the first time a CDN user calls `interpolate()` or hits a segment audience.

The file **loads either way** — the throw is deferred to the first call. So the guard is two cases, not one, and the second one matters more than it looks: **vitest's jsdom has `process`**, so a "does it run a tour" case passes identically on a build with the flag and one without. The realm has to be honest. Red-first, against a build with the flag removed:

```
× has no `process.env` — platform:'browser' is what keeps a browser from throwing
  AssertionError: expected [ 'process.env', 'process.env', …(2) ] to deeply equal []
× loads, and `interpolate()` returns instead of throwing
  ReferenceError: process is not defined
```

`require(` is 0 on that build and the jsdom run passes on it — those cases guard something else (an external leaking in as a throwing `__require` shim).

## Three smokes, three different failures

| Check | Runs | Catches |
|---|---|---|
| `engine-iife-dist.test.ts` — text guards, jsdom run, process-free `vm` realm, manifest | every PR (turbo `test` → `build`) | the flag dropped, an external leaking, the entry renamed, the file not emitted, the `unpkg`/`jsdelivr` fields drifting |
| `e2e/vue/engine-iife.localhost.spec.ts` — real `<script src>` in Chromium via `page.route` | local `pnpm e2e:vue` | classic-script semantics jsdom approximates: the global landing on `window`, a clean console |
| `apps/smoke/scripts/probe-cdn.mjs` | post-publish (`smoke-npm.yml`) | the file missing from the published tarball |

Both halves of the smoke, as evidence it discriminates:

```
[smoke] FAIL — unpkg field is undefined, expected ./dist/engine/index.global.js    ← npm latest (1.0.7)
[smoke] OK — dist/engine/index.global.js from @tour-kit/core@1.0.7 defines TourKit and runs a tour    ← local pack
```

**Known window:** `apps/smoke` installs `latest`, so between merging this and the release that publishes the file, `probe:cdn` is red. Deliberately, with no skip — one keyed on the `unpkg` field would also skip the day someone deletes that field. Merge close to a release or accept one red canary.

## Two decisions worth disagreeing with here rather than later

**The IIFE is its own tsup config item**, never a third format on the existing one: `format: [..., 'iife']` there would also emit IIFEs of `index` and `schemas`, whose externals become a `__require("react")` shim that throws on load — two landmines in the tarball for files nobody asked for. Consequence: tsup builds array items in parallel and each runs its own clean, so the main item's `clean: true` becomes `clean: ['!**/*.global.js*']` or it races the IIFE's output away. That negation is tsup's own mechanism (it `unshift`s `'!**/*.d.{ts,cts,mts}'` onto the same array when `dts` is on), so the race is closed by construction rather than by a flaky timing test. It does mean the negation protects a *stale* `.global.js` forever — after any rename of that entry, check `ls dist/engine/` shows exactly one.

**The size row shares `core:engine`'s 18 500 ceiling** rather than the repo's measured-×1.2 convention. This is the same source in one format, so it moves in lockstep with that row and should trip with it; ×1.2 would put it near 21 000 and leave 3.5 KB nobody would notice drift into. Measured **17 492** — 606 B *smaller* than the two-file ESM closure it mirrors, because rollup drops the chunk boundary. That also settles the prediction in the `core:engine` note ("the §1.6 IIFE is the consumer who pays all of it"): it did, and it fit with ~1 KB spare, no re-baseline.

## One thing this PR fixes that it did not create

`CLAIMS['core:engine']` in `bundle-budget-claim-alignment.test.ts` was `/core\/engine[^\n]*?<\s*([\d.]+)\s*KB/` — unanchored and first-match. Harmless while it was the only `core/engine … <N KB` bullet in `CLAUDE.md`; this PR writes the second one. Both are anchored now (`subpath` / `IIFE`), because both claim 18.5 today, so the two rows could silently swap bullets and nothing would notice until the numbers diverged.

## One finding NOT fixed here, on purpose

`core` measures **22 857**, while `CLAUDE.md` and `budgets.mjs` both say "measured 22 621" from §1.5f. Verified this is not §1.6's: reverting `tsup.config.ts` and `package.json` to the pre-§1.6 state and rebuilding gives 22 857 too. It is pre-existing drift on the §1.5 stack, still inside the 23 000 budget and passing the gate (the claim test checks the budget, not the measurement). Left alone so §1.6's numbers stay attributable — the fix belongs on #128, which is still open.

## Verification

- `pnpm --filter @tour-kit/core test` — **1640 passed**, 3 skipped, including 17 new cases and the widened `ENGINE_ENTRIES`
- `pnpm dist:size` — all within budget, `core:engine:iife` 17 492 / 18 500
- `pnpm exec size-limit` — `@tour-kit/core/engine (IIFE)` 15.27 kB / 16 KB (size-limit re-bundles through esbuild, so this is not the file's own brotli of 15 493)
- `pnpm e2e:vue` — **9 passed** including `engine-iife`
- `pnpm --filter @tour-kit/core typecheck`, root `tsc --noEmit` (Playwright specs), `git ls-files | xargs biome check` (CI's file set), `pnpm install --frozen-lockfile` — all clean, no new dependency anywhere
- double build and `rm` + rebuild both leave exactly one `.global.js`; `dist/index.global.js` and `dist/schemas/index.global.js` do not exist

`wiki-tech/packages/core.md` (fourth entry-points row + the platform-flag paragraph) and `wiki-tech/concepts/tour-engine.md` ("The CDN proof") are updated on disk but `wiki-tech/` is gitignored, so they are not in this diff.

Plan: `plan/v2/1-6-engine-cdn-build.md` + `plan/v2/1-6-engine-cdn-build-tests.md`.

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt

---

## Review pass (f9d9d13a)

A quality audit of this PR found four things, all fixed in one follow-up commit with **no behavior change** — `dist/engine/index.global.js`, `dist/index.js` and `dist/index.cjs` are md5-identical before and after, and the size rows are unmoved.

The one that mattered: **`tsup.config.ts` stated the five externals twice**, once per config item. That is the precise drift the file exists to prevent — a sixth external added to the main item alone would be *bundled* into the IIFE rather than emitted as the throwing `__require()` shim Decision 1 warns about, where the `require(` guard cannot see it and the `core:engine:iife` row just absorbs the bytes. One `EXTERNAL` list and one `SHARED` output policy now; the two items differ only in entry, format, platform and clean.

Also: `probe:cdn` no longer runs behind `next dev` (it reads a file and runs a `vm` — a release that breaks the app's boot is exactly when you want the tarball checked, and behind the boot you learned nothing); the manifest describe moved into a new `packages/core/src/__tests__/manifest.test.ts`, the home `vue`/`svelte`/`analytics` have and core lacked, since it was the only non-`skipIf(!distExists())` block in a dist-tier file; and the double cast in the realm helper collapsed to one.

Both red-first guards re-verified against the `platform`-less build afterwards.

## Tarball cost, stated

The IIFE (53 982 B) plus its sourcemap (348 563 B) add **402 KB to a 516 KB tarball**, paid by every npm consumer for a file only CDN users load. This is consistent with existing policy — two 349 KB chunk maps already ship — and `sourcemap: true` matches the ESM/CJS items, but nothing in the repo gates tarball size, so the number belongs here rather than nowhere. If tarball size ever becomes a row, revisit all the maps together rather than this one.