### PR TITLE
v3 Phase 0.1 — @tour-kit/analytics/engine, the React-free subpath

### DIFF
--- a/.changeset/analytics-engine-subpath.md
+++ b/.changeset/analytics-engine-subpath.md
@@ -1,0 +1,20 @@
+---
+'@tour-kit/analytics': minor
+---
+
+Add `@tour-kit/analytics/engine`, a React-free subpath exposing the tracker and
+the five plugins for non-React consumers.
+
+```ts
+import { createAnalytics, consolePlugin } from '@tour-kit/analytics/engine'
+```
+
+Its runtime and its `.d.ts` chain name no `react`, no `react/jsx-runtime` and
+no `@tour-kit/license`, so a Vue, Svelte or Node project can build and
+typecheck against it with none of them installed. `AnalyticsProvider` and the
+two hooks stay on the main entry.
+
+The main entry and the four plugin entries now import `logger` from
+`@tour-kit/core/engine` rather than the bare `@tour-kit/core`. No runtime
+change — both core entries read the same chunk — but a bundler no longer has to
+resolve core's React barrel to tree-shake it.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -71,6 +71,11 @@
     "limit": "260 KB"
   },
   {
+    "name": "@tour-kit/analytics/engine",
+    "path": "packages/analytics/dist/engine/index.js",
+    "limit": "225 KB"
+  },
+  {
     "name": "@tour-kit/analytics/posthog",
     "path": "packages/analytics/dist/plugins/posthog.js",
     "limit": "1500 B",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,9 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
   - react <12 KB
   - hints <6 KB
   - analytics <4 KB (root; per-plugin <1.5 KB each)
+  - analytics/engine subpath <4 KB, measured 3 312 — the tracker and the five
+    plugins with no React, no jsx-runtime and no licence gate; it shares the
+    root row's ceiling because it is a strict subset of the root entry.
   - adoption, checklists <10 KB
   - announcements <14 KB, surveys <12.5 KB, license <8 KB
   - media <9 KB

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -112,6 +112,20 @@ Every event payload includes `timestamp` and `sessionId`; tour events also inclu
 
 ## API Reference
 
+### The React-free subpath
+
+`@tour-kit/analytics/engine` gives a Vue, Svelte or Node consumer the tracker
+and the five plugins with no `react`, no `react/jsx-runtime` and no
+`@tour-kit/license` in its runtime or its type declarations:
+
+```ts
+import { createAnalytics, consolePlugin } from '@tour-kit/analytics/engine'
+```
+
+It is a strict subset of the main entry — nothing moved, every name is at the
+same path with the same signature. `AnalyticsProvider`, `useAnalytics` and
+`useAnalyticsOptional` stay on the main entry, because they are React.
+
 ### Provider & hooks
 
 | Export | Description |

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -44,6 +44,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./engine": {
+      "import": {
+        "types": "./dist/engine/index.d.ts",
+        "default": "./dist/engine/index.js"
+      },
+      "require": {
+        "types": "./dist/engine/index.d.cts",
+        "default": "./dist/engine/index.cjs"
+      }
+    },
     "./posthog": {
       "import": {
         "types": "./dist/plugins/posthog.d.ts",

--- a/packages/analytics/src/__tests__/build/optional-imports.webpack-smoke.test.ts
+++ b/packages/analytics/src/__tests__/build/optional-imports.webpack-smoke.test.ts
@@ -70,6 +70,14 @@ const EXTERNALS = {
   'react-dom': 'module react-dom',
   'react/jsx-runtime': 'module react/jsx-runtime',
   '@tour-kit/core': 'module @tour-kit/core',
+  // v3 Phase 0 — tracker.ts and the four vendor plugins import `logger` from the
+  // engine subpath now. webpack object-externals match EXACTLY (which is why the
+  // three `react*` keys above are listed separately), so the subpath needs its
+  // own entry or the compile reports `Module not found` for a specifier a real
+  // consumer resolves fine — `@tour-kit/core` is a hard dependency and its
+  // `exports` map has `./engine`. This mirrors the built file's import list; it
+  // weakens no assertion.
+  '@tour-kit/core/engine': 'module @tour-kit/core/engine',
   '@tour-kit/license': 'module @tour-kit/license',
 }
 

--- a/packages/analytics/src/__tests__/no-react-in-engine-dist.test.ts
+++ b/packages/analytics/src/__tests__/no-react-in-engine-dist.test.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
   RELATIVE_SPECIFIER,
+  SPECIFIER_PREFIX,
   closureOf,
   specifierPattern,
 } from '../../../../tooling/bundle-check/closure.mjs'
@@ -43,6 +44,24 @@ const MAIN_JS = join(DIST, 'index.js')
 const MAIN_DTS = join(DIST, 'index.d.ts')
 
 const FORBIDDEN = ['react', 'react-dom', '@tour-kit/license'] as const
+
+/**
+ * The BARE `@tour-kit/core`, in every call shape a bundler emits.
+ *
+ * Built from `SPECIFIER_PREFIX` rather than hand-rolled, because the hand-rolled
+ * version covered `from` and `require(` and silently missed `import(` — and this
+ * repo reaches bare specifiers that way on purpose: the four vendor plugins load
+ * `posthog-js`, `mixpanel-browser` and `@amplitude/analytics-browser` through
+ * lazy `import()` behind magic comments, and all three appear in this package's
+ * engine dist. A guard that cannot see the shape its own package uses most is
+ * not a guard.
+ *
+ * The closing quote sits immediately after `core`, so `@tour-kit/core/engine`
+ * does NOT match — which is the whole point of this check, and why
+ * `specifierPattern('@tour-kit/core')` cannot serve here: it allows a
+ * `/subpath` and so can only ever prove presence.
+ */
+const BARE_CORE = new RegExp(`${SPECIFIER_PREFIX}["']@tour-kit/core["']`)
 
 const read = (p: string) => readFileSync(p, 'utf8')
 // rollup-plugin-dts chunks shared declarations even with `splitting: false`
@@ -85,25 +104,17 @@ describe('@tour-kit/analytics/engine ships no React', () => {
 
   it.skipIf(!distExists())('imports @tour-kit/core/engine, never the bare main entry', () => {
     // `specifierPattern('@tour-kit/core')` matches the `/engine` form too, so it
-    // can only prove PRESENCE. Absence of the bare form needs its own literal
-    // regex, in both the `from` and `require(` spellings.
+    // can only prove PRESENCE. Absence of the bare form needs `BARE_CORE`.
     for (const f of [ENGINE_JS, ENGINE_CJS]) {
       const source = read(f)
-      expect(/from\s*["']@tour-kit\/core["']/.test(source), `${f} imports bare core`).toBe(false)
-      expect(
-        /require\(\s*["']@tour-kit\/core["']\s*\)/.test(source),
-        `${f} requires bare core`
-      ).toBe(false)
+      expect(BARE_CORE.test(source), `${f} imports bare core`).toBe(false)
       expect(
         specifierPattern('@tour-kit/core').test(source),
         `${f} should import core/engine`
       ).toBe(true)
     }
     for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
-      expect(
-        /from\s*["']@tour-kit\/core["']/.test(readDts(entry)),
-        `${entry} names bare core`
-      ).toBe(false)
+      expect(BARE_CORE.test(readDts(entry)), `${entry} names bare core`).toBe(false)
     }
   })
 

--- a/packages/analytics/src/__tests__/no-react-in-engine-dist.test.ts
+++ b/packages/analytics/src/__tests__/no-react-in-engine-dist.test.ts
@@ -1,0 +1,190 @@
+/**
+ * v3 Phase 0 — `@tour-kit/analytics/engine` ships no React.
+ *
+ * US-1: a Vue/Svelte/Node developer tracks tour events with React not
+ * installed. That is a property of the BYTES tsup emitted, so every case here
+ * reads a real built file — nothing is faked, stubbed or mocked.
+ *
+ * The two anti-vacuity devices are not decoration:
+ *   - Case 1 asserts the four engine files exist. A wrong path makes every
+ *     negative assertion below pass forever.
+ *   - Case 2 is a POSITIVE CONTROL over the sibling main entry, which
+ *     legitimately names React and the licence gate. If it stops tripping,
+ *     either the matcher broke or the package changed shape — both deserve a
+ *     red, and without it a broken regex is green forever.
+ *
+ * `splitting: false` in this package, so the built entry IS its own closure —
+ * no walk needed for the JS. The declarations are different: rollup-plugin-dts
+ * chunks shared types regardless, under a content-hashed name that changes on
+ * every rebuild, so the d.ts scan walks with `closureOf` and never spells the
+ * hash.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  RELATIVE_SPECIFIER,
+  closureOf,
+  specifierPattern,
+} from '../../../../tooling/bundle-check/closure.mjs'
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const DIST = join(PKG_ROOT, 'dist')
+// The DIRECTORY, not the files: gating on a filename turns a typo into a
+// silent skip (measured in v2 §1.5 — "3 skipped", green, proving nothing).
+const distExists = () => existsSync(DIST)
+
+const ENGINE_JS = join(DIST, 'engine', 'index.js')
+const ENGINE_CJS = join(DIST, 'engine', 'index.cjs')
+const ENGINE_DTS = join(DIST, 'engine', 'index.d.ts')
+const ENGINE_DCTS = join(DIST, 'engine', 'index.d.cts')
+const MAIN_JS = join(DIST, 'index.js')
+const MAIN_DTS = join(DIST, 'index.d.ts')
+
+const FORBIDDEN = ['react', 'react-dom', '@tour-kit/license'] as const
+
+const read = (p: string) => readFileSync(p, 'utf8')
+// rollup-plugin-dts chunks shared declarations even with `splitting: false`
+// (a content-hashed `dist/plugin-*.d.ts` exists today); `closureOf` follows
+// them because `resolveEmitted` maps `.js → .d.ts` and `.cjs → .d.cts`. It
+// tries the literal path first, so a `'../plugins/posthog.js'` re-export also
+// pulls the real plugin JS in — a superset scan, deliberately kept.
+const readDts = (entry: string) => closureOf(entry).map(read).join('\n')
+
+describe('@tour-kit/analytics/engine ships no React', () => {
+  it.skipIf(!distExists())('names the four built engine files', () => {
+    for (const f of [ENGINE_JS, ENGINE_CJS, ENGINE_DTS, ENGINE_DCTS]) {
+      expect(existsSync(f), `${f} missing — every scan below would be vacuous`).toBe(true)
+    }
+  })
+
+  it.skipIf(!distExists())('CONTROL — the main entry trips the same matcher', () => {
+    // If this stops tripping, the matcher broke or the package changed shape.
+    expect(specifierPattern('react').test(read(MAIN_JS))).toBe(true)
+    expect(specifierPattern('@tour-kit/license').test(read(MAIN_JS))).toBe(true)
+    expect(specifierPattern('react').test(read(MAIN_DTS))).toBe(true)
+  })
+
+  it.skipIf(!distExists())('the engine JS names none of the React-side specifiers', () => {
+    for (const f of [ENGINE_JS, ENGINE_CJS]) {
+      for (const pkg of FORBIDDEN) {
+        expect(specifierPattern(pkg).test(read(f)), `${f} must not import ${pkg}`).toBe(false)
+      }
+    }
+  })
+
+  it.skipIf(!distExists())('the engine .d.ts closure names none of them either', () => {
+    for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
+      const source = readDts(entry)
+      for (const pkg of FORBIDDEN) {
+        expect(specifierPattern(pkg).test(source), `${entry} closure names ${pkg}`).toBe(false)
+      }
+    }
+  })
+
+  it.skipIf(!distExists())('imports @tour-kit/core/engine, never the bare main entry', () => {
+    // `specifierPattern('@tour-kit/core')` matches the `/engine` form too, so it
+    // can only prove PRESENCE. Absence of the bare form needs its own literal
+    // regex, in both the `from` and `require(` spellings.
+    for (const f of [ENGINE_JS, ENGINE_CJS]) {
+      const source = read(f)
+      expect(/from\s*["']@tour-kit\/core["']/.test(source), `${f} imports bare core`).toBe(false)
+      expect(
+        /require\(\s*["']@tour-kit\/core["']\s*\)/.test(source),
+        `${f} requires bare core`
+      ).toBe(false)
+      expect(
+        specifierPattern('@tour-kit/core').test(source),
+        `${f} should import core/engine`
+      ).toBe(true)
+    }
+    for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
+      expect(
+        /from\s*["']@tour-kit\/core["']/.test(readDts(entry)),
+        `${entry} names bare core`
+      ).toBe(false)
+    }
+  })
+
+  it.skipIf(!distExists())('core is externalised, not bundled in', () => {
+    // The failure this guards: tsup stops treating `@tour-kit/core/engine` as
+    // external and inlines core. The budget row would only catch it after the
+    // ~50 B threshold, and `analytics:main` would jump by kilobytes. Naming a
+    // symbol that exists ONLY inside core is the cheap direct test.
+    expect(read(MAIN_JS)).not.toMatch(/createTourEngine/)
+    expect(read(ENGINE_JS)).not.toMatch(/createTourEngine/)
+  })
+
+  it.skipIf(!distExists())("'use client' lands on the React entry only", () => {
+    const startsWithDirective = (p: string) => /^['"]use client['"];?/.test(read(p))
+    expect(startsWithDirective(ENGINE_JS)).toBe(false)
+    expect(startsWithDirective(ENGINE_CJS)).toBe(false)
+    // Both halves: losing the directive on the main entry is equally a break —
+    // it is what lets <AnalyticsProvider> work inside an RSC tree.
+    expect(startsWithDirective(MAIN_JS)).toBe(true)
+    expect(startsWithDirective(join(DIST, 'index.cjs'))).toBe(true)
+  })
+
+  it.skipIf(!distExists())('every path the ./engine exports block names resolves', () => {
+    // The `types` condition of an `exports` block is never exercised by an
+    // `import()` — core solves this with a separate portability test, which
+    // neither new package gets. This is the cheap closure: a `.d.mts` typo, a
+    // dropped `./`, or a `.d.ts`/`.d.cts` swap is invisible to every other case
+    // here and breaks a consumer's typecheck rather than their build.
+    const pkg = JSON.parse(read(join(PKG_ROOT, 'package.json'))) as {
+      exports: Record<string, { import: Record<string, string>; require: Record<string, string> }>
+    }
+    const block = pkg.exports['./engine']
+    expect(block, 'package.json has no "./engine" exports key').toBeDefined()
+
+    const paths = [
+      block.import.types,
+      block.import.default,
+      block.require.types,
+      block.require.default,
+    ]
+    expect(paths.filter(Boolean)).toHaveLength(4)
+    for (const rel of paths) {
+      expect(rel.startsWith('./'), `${rel} is not a relative exports target`).toBe(true)
+      expect(existsSync(join(PKG_ROOT, rel)), `${rel} does not exist on disk`).toBe(true)
+    }
+  })
+
+  it('no source file the engine barrel reaches imports react, license or bare core', () => {
+    // Walk the barrel's relative imports to fixpoint. `.ts` first, then
+    // `/index.ts`, so `../utils`-style directory imports resolve too.
+    // RELATIVE_SPECIFIER is a module-level /g regex: matchAll only, never .test.
+    const seen = new Set<string>()
+    const queue = [join(PKG_ROOT, 'src', 'engine', 'index.ts')]
+    while (queue.length > 0) {
+      const file = queue.shift() as string
+      if (seen.has(file)) continue
+      seen.add(file)
+      const source = read(file)
+      for (const [, spec] of source.matchAll(RELATIVE_SPECIFIER)) {
+        const base = resolve(dirname(file), spec)
+        const next = [`${base}.ts`, join(base, 'index.ts'), `${base}.tsx`].find(existsSync)
+        if (!next) throw new Error(`${file}: cannot resolve ${spec}`)
+        queue.push(next)
+      }
+    }
+    const files = [...seen]
+    // The walker can fail silently; say out loud what it must have found.
+    // The floor is pinned at today's exact count (barrel + tracker + queue +
+    // 5 plugins + 2 type files = 10) — an anti-vacuity floor, not a target.
+    expect(files.some((f) => f.endsWith('core/tracker.ts'))).toBe(true)
+    expect(files.some((f) => f.endsWith('plugins/posthog.ts'))).toBe(true)
+    expect(files.length).toBeGreaterThanOrEqual(10)
+
+    for (const file of files) {
+      const source = read(file)
+      expect(file.endsWith('.tsx'), `${file} is a React file`).toBe(false)
+      expect(/from\s*["']react(\/[^"']*)?["']/.test(source), `${file} imports react`).toBe(false)
+      expect(/from\s*["']@tour-kit\/license["']/.test(source), `${file} imports license`).toBe(
+        false
+      )
+      expect(/from\s*["']@tour-kit\/core["']/.test(source), `${file} imports bare core`).toBe(false)
+    }
+  })
+})

--- a/packages/analytics/src/__tests__/subpath-resolution.test.ts
+++ b/packages/analytics/src/__tests__/subpath-resolution.test.ts
@@ -1,0 +1,64 @@
+/**
+ * v3 Phase 0 — `@tour-kit/analytics/engine` actually resolves.
+ *
+ * US-2: the `exports` map is proven, not just written. The guard file next door
+ * reads bytes; this one asks Node to resolve the subpath for real, in both
+ * module systems — ESM through a dynamic `import()` (a self-reference through
+ * `exports`, which needs no self-link in `node_modules`) and CJS through a
+ * child process, because this worker is ESM.
+ *
+ * The refusal list is a first-class assertion, not a footnote: the barrel is
+ * defined as much by what it withholds as by what it exports. Without it,
+ * `export *` from the main entry would satisfy every other case in this file.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const distExists = () => existsSync(join(PKG_ROOT, 'dist'))
+
+describe('@tour-kit/analytics/engine subpath resolution', () => {
+  it.skipIf(!distExists())('resolves via dynamic `import()` (ESM)', async () => {
+    const mod = await import('@tour-kit/analytics/engine')
+    expect(typeof mod.createAnalytics).toBe('function')
+    expect(typeof mod.TourAnalytics).toBe('function')
+    // All five plugins are factories, so `function` is the right typeof.
+    for (const name of [
+      'consolePlugin',
+      'posthogPlugin',
+      'mixpanelPlugin',
+      'amplitudePlugin',
+      'googleAnalyticsPlugin',
+    ] as const) {
+      expect(typeof mod[name], name).toBe('function')
+    }
+  })
+
+  it.skipIf(!distExists())('resolves via `require()` in a child Node process (CJS)', () => {
+    const stdout = execFileSync(
+      process.execPath,
+      [
+        '-e',
+        "const m = require('@tour-kit/analytics/engine'); console.log(typeof m.createAnalytics, typeof m.consolePlugin, 'AnalyticsProvider' in m);",
+      ],
+      { encoding: 'utf8', cwd: PKG_ROOT }
+    )
+    expect(stdout.trim()).toBe('function function false')
+  })
+
+  it.skipIf(!distExists())('does NOT re-export the React surface', async () => {
+    const mod = (await import('@tour-kit/analytics/engine')) as Record<string, unknown>
+    for (const name of [
+      'AnalyticsProvider',
+      'useAnalytics',
+      'useAnalyticsOptional',
+      // Not React, but equally not public: the tracker's internal queue seam.
+      'createEventQueue',
+    ]) {
+      expect(mod, `@tour-kit/analytics/engine must not export ${name}`).not.toHaveProperty(name)
+    }
+  })
+})

--- a/packages/analytics/src/core/tracker.ts
+++ b/packages/analytics/src/core/tracker.ts
@@ -1,4 +1,4 @@
-import { logger } from '@tour-kit/core'
+import { logger } from '@tour-kit/core/engine'
 import type { TourEvent, TourEventData, TourEventName } from '../types/events'
 import type { AnalyticsConfig, AnalyticsPlugin } from '../types/plugin'
 import { type EventQueue, createEventQueue } from './event-queue'

--- a/packages/analytics/src/engine/index.ts
+++ b/packages/analytics/src/engine/index.ts
@@ -1,0 +1,31 @@
+/**
+ * `@tour-kit/analytics/engine` — the React-free door (v3 Phase 0).
+ *
+ * Everything here is reachable from the main entry at the same path with the
+ * same signature; nothing moved. What this entry adds is a runtime and a
+ * `.d.ts` chain that never name `react`, `react-dom` or `@tour-kit/license`,
+ * so a Vue, Svelte or Node consumer can build and typecheck against the
+ * tracker and the plugins with none of them installed.
+ *
+ * Rules, each with a test behind it (`no-react-in-engine-dist.test.ts`,
+ * `subpath-resolution.test.ts`):
+ * - Re-exports and comments only. No declaration, no side-effect import —
+ *   `sideEffects: false` in the manifest is only true while nothing runs here.
+ * - Never `./core/context` (React + LicenseGate) and never `./index`.
+ * - `logger` reaches this closure through `@tour-kit/core/engine`, never the
+ *   bare main entry (0.1a); a bare import puts core's React barrel in a
+ *   Vue consumer's resolution graph.
+ * - `createEventQueue` stays internal; it is the tracker's seam, not an API.
+ *
+ * The licence gate lives in the React provider and stays there. Whether a
+ * non-React consumer should be gated is a commercial question
+ * (handoff §Open questions 1), not a property of this file.
+ */
+export { TourAnalytics, createAnalytics } from '../core/tracker'
+export { consolePlugin } from '../plugins/console'
+export { posthogPlugin } from '../plugins/posthog'
+export { mixpanelPlugin } from '../plugins/mixpanel'
+export { amplitudePlugin } from '../plugins/amplitude'
+export { googleAnalyticsPlugin } from '../plugins/google-analytics'
+export type { TourEvent, TourEventName, TourEventData } from '../types/events'
+export type { AnalyticsPlugin, AnalyticsConfig } from '../types/plugin'

--- a/packages/analytics/src/plugins/amplitude.ts
+++ b/packages/analytics/src/plugins/amplitude.ts
@@ -1,4 +1,4 @@
-import { logger } from '@tour-kit/core'
+import { logger } from '@tour-kit/core/engine'
 import type { TourEvent } from '../types/events'
 import type { AnalyticsPlugin } from '../types/plugin'
 

--- a/packages/analytics/src/plugins/google-analytics.ts
+++ b/packages/analytics/src/plugins/google-analytics.ts
@@ -1,4 +1,4 @@
-import { logger } from '@tour-kit/core'
+import { logger } from '@tour-kit/core/engine'
 import type { TourEvent } from '../types/events'
 import type { AnalyticsPlugin } from '../types/plugin'
 

--- a/packages/analytics/src/plugins/mixpanel.ts
+++ b/packages/analytics/src/plugins/mixpanel.ts
@@ -1,4 +1,4 @@
-import { logger } from '@tour-kit/core'
+import { logger } from '@tour-kit/core/engine'
 import type { TourEvent } from '../types/events'
 import type { AnalyticsPlugin } from '../types/plugin'
 

--- a/packages/analytics/src/plugins/posthog.ts
+++ b/packages/analytics/src/plugins/posthog.ts
@@ -1,4 +1,4 @@
-import { logger } from '@tour-kit/core'
+import { logger } from '@tour-kit/core/engine'
 import type { TourEvent } from '../types/events'
 import type { AnalyticsPlugin } from '../types/plugin'
 

--- a/packages/analytics/tsup.config.ts
+++ b/packages/analytics/tsup.config.ts
@@ -4,6 +4,11 @@ import { injectUseClient } from '../../tooling/build/use-client'
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    // v3 Phase 0 — the React-free door. Deliberately absent from the
+    // `injectUseClient` list below: stamping 'use client' here would mark a
+    // framework-agnostic entry client-only. Both halves are asserted in
+    // `src/__tests__/no-react-in-engine-dist.test.ts`.
+    'engine/index': 'src/engine/index.ts',
     'plugins/posthog': 'src/plugins/posthog.ts',
     'plugins/mixpanel': 'src/plugins/mixpanel.ts',
     'plugins/amplitude': 'src/plugins/amplitude.ts',

--- a/packages/analytics/vitest.config.ts
+++ b/packages/analytics/vitest.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
         '**/*.config.ts',
         'src/types/',
         'src/index.ts',
+        // re-export barrel: no statements to cover (v3 Phase 0)
+        'src/engine/index.ts',
         'src/hooks/',
         'src/plugins/index.ts',
       ],

--- a/packages/core/src/__tests__/bundle-budget-claim-alignment.test.ts
+++ b/packages/core/src/__tests__/bundle-budget-claim-alignment.test.ts
@@ -67,6 +67,14 @@ const CLAIMS: Record<string, { pattern: RegExp; mode: 'exact' | 'ceiling' }> = {
   'analytics:mixpanel': { pattern: /per-plugin\s*<\s*([\d.]+)\s*KB/, mode: 'ceiling' },
   'analytics:amplitude': { pattern: /per-plugin\s*<\s*([\d.]+)\s*KB/, mode: 'ceiling' },
   'analytics:ga': { pattern: /per-plugin\s*<\s*([\d.]+)\s*KB/, mode: 'ceiling' },
+  // v3 Phase 0 — anchored on `analytics/engine subpath` exactly as `core:engine`
+  // is on `core/engine subpath`. The sibling `analytics:main` pattern is
+  // `/^\s*-\s*analytics\s*<…/m`, so a bullet beginning `- analytics/engine`
+  // cannot satisfy it (the character after the name is `/`, not whitespace).
+  'analytics:engine': {
+    pattern: /analytics\/engine subpath[^\n]*?<\s*([\d.]+)\s*KB/,
+    mode: 'exact',
+  },
   adoption: { pattern: /adoption,\s*checklists\s*<\s*([\d.]+)\s*KB/, mode: 'exact' },
   checklists: { pattern: /adoption,\s*checklists\s*<\s*([\d.]+)\s*KB/, mode: 'exact' },
   announcements: { pattern: /announcements\s*<\s*([\d.]+)\s*KB/, mode: 'exact' },

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -136,6 +136,14 @@ export const budgets = [
   ['analytics:mixpanel', 'packages/analytics/dist/plugins/mixpanel.js', 1500],
   ['analytics:amplitude', 'packages/analytics/dist/plugins/amplitude.js', 1000],
   ['analytics:ga', 'packages/analytics/dist/plugins/google-analytics.js', 1000],
+  // v3 Phase 0 — the React-free door. Measured 3 312 by this gate (main is
+  // 3 659; the difference is `core/context.tsx`, the LicenseGate wrapper and
+  // React's jsx-runtime import). It shares `analytics:main`'s 4 000 ceiling
+  // DELIBERATELY: the engine is a strict SUBSET of main, so a subset that
+  // outgrows its superset's budget is a build-shape bug (core bundled in, an
+  // external lost), not a size regression to re-baseline. 3 312 x 1.2 = 3 974
+  // rounds to the same place anyway.
+  ['analytics:engine', 'packages/analytics/dist/engine/index.js', 4000],
   ['adoption', 'packages/adoption/dist/index.js', 10000],
   ['checklists', 'packages/checklists/dist/index.js', 10000],
   ['announcements', 'packages/announcements/dist/index.js', 14000],


### PR DESCRIPTION
PR A of two. v3 Phase 0 applies the v2 engine recipe to the two easiest packages — not to extract anything, but to **time the packaging half** and record where the recipe does not fit. The output that matters is the hours and the gap list, not the subpath.

```ts
import { createAnalytics, consolePlugin } from '@tour-kit/analytics/engine'
```

A re-export barrel, one tsup entry, one `exports` key. Nothing moved: every name is reachable from the main entry at the same path with the same signature. What the entry adds is a runtime and a `.d.ts` chain that never name `react`, `react-dom` or `@tour-kit/license`.

| | |
|---|---|
| `dist/engine/index.js` specifiers | exactly one — `@tour-kit/core/engine` |
| `head -c 12` | `import { log` (main still `'use client'`) |
| `require('@tour-kit/analytics/engine')` | `function function false` |
| `analytics:engine` | **3 312** gz / 4 000 budget |
| `analytics:main` | 3 655 → **3 659** (+4 B: the specifier got seven characters longer) |

## The one non-mechanical finding

Analytics' pure leaves — `core/tracker.ts` and the four vendor plugins — imported `logger` from the **bare** `@tour-kit/core`. That points a non-React consumer's bundler at core's React barrel, which it must *resolve* before it can tree-shake it. `logger` is already on `@tour-kit/core/engine`, so the fix is five one-line changes, and the rule it produces is the first entry in the Phase 0 gap list:

> Every bare `@tour-kit/core` import in a file the engine barrel reaches becomes `@tour-kit/core/engine`, and the symbol must already be on that barrel. If it is not, add it to core's barrel in the same PR. Before committing, grep the package's `__tests__` for the old specifier.

That last sentence is there because of what happened next.

## What the recipe did not cover: fixtures that mirror the build (D1)

`build/optional-imports.webpack-smoke.test.ts` compiles the built `dist/index.js` with Next's compiled webpack and stubs its imports through an `EXTERNALS` object keyed by **exact** specifier — webpack object-externals do not prefix-match, which is why the three `react*` keys are already listed separately. So the re-point turned it red, seen before fixing:

```
× built dist/index.js produces NO "Module not found" (optional peers ignored)
  AssertionError: expected 1 to be +0
```

This is the phase's "existing suites untouched" rule meeting a case it cannot satisfy. The fixture *mirrors the built file's import list*; adding a key weakens no assertion, and the control case (strip the magic comment, expect the failure) is untouched. It is not a consumer regression either — `@tour-kit/core` is a hard dependency whose `exports` map has `./engine`, so a real `next build` resolves it.

So the rule gains a named exception, and **both** gate sentences in `plan/v3/handoff.md` now carry it in words. `src/__tests__/core/tracker.test.ts:1` also imports `logger` from bare core for a spy and is deliberately left alone — core's two entries read the same chunk, so it is the same object.

## The guards, and proof they can fail

12 cases across two new files. No fakes, no mocks: every case reads a real built artifact or spawns a real `node`. Two anti-vacuity devices carry the file — case 1 asserts the four engine files exist, and a **positive control** asserts the same matcher still trips on the sibling main entry. Without the control, a broken regex or a wrong path is green forever; vue's "the file names `vue`" has no analogue when the engine names almost nothing.

Each of the three deliberate breaks was seen red before this PR:

| Break | Cases that went red |
|---|---|
| `export { AnalyticsProvider } from '../core/context'` on the barrel | **5** — engine JS forbidden, d.ts closure, source walk, CJS resolution, refusal list |
| revert the `tracker.ts` re-point | **2** — "imports core/engine never the bare form", source walk |
| add `engine/index` to `injectUseClient` | **1** — the directive case |

## Two cases beyond the plan's ten

Both close gaps the plan names but does not test, so the count is 12 rather than 10:

- **core is externalised, not bundled in.** The plan lists this as a manual `grep -c createTourEngine`; the budget row alone would only catch it after the ~50 B threshold it names.
- **every path the `./engine` exports block names resolves.** The `types` condition is exercised by no `import()` — core solves this with a separate portability test that neither new package gets. A `.d.mts` typo or a `.d.ts`/`.d.cts` swap breaks a consumer's typecheck and is invisible to every other case.

## Ordering constraint worth knowing for PR B

`analytics` and `scheduling` typecheck their own test files; `core` does not. So a `subpath-resolution.test.ts` written before the `exports` key exists is a hard TS error that blocks the safe-ship-gate hook on every later edit. Barrel → tsup entry → `exports` key → build → *then* the tests. You cannot stage a type-level red here.

## Wiki drift fixed while there

The page claimed `useAnalytics`, `useAnalyticsOptional` and four types were "re-exported from `@tour-kit/core`". None are — nothing under `src/types/` or `src/core/context.tsx` imports core at all. The cause is worth remembering: the package has its own `src/core/` directory, and "defined in core" reads as the *package* to anyone who has not opened the tree. Version was also stale in two places and disagreed with itself (frontmatter 0.11.6, Identity 0.11.5, actual 0.12.1).

## Verification

- `pnpm --filter @tour-kit/analytics exec vitest run <the two new files>` → **12 passed, 0 skipped**
- full analytics suite **250 passed, 11 skipped** — one pre-existing file changed, the D1 fixture
- `pnpm dist:size` green, `analytics:engine` 3 312 / 4 000
- `bundle-budget-claim-alignment` **25 passed** with the new `CLAIMS` entry
- `pnpm typecheck` 35/35, `git ls-files | xargs biome check` clean, `pnpm install --frozen-lockfile` unchanged
- the source walk finds **exactly 10** files, matching the test plan's enumeration file for file

`plan/` and `wiki-tech/` are gitignored, so the handoff edit, the wiki page and the log entry land on disk but not in this diff.

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt