### PR TITLE
v3 Phase 0.2 — @tour-kit/scheduling/engine, the React-free subpath

### DIFF
--- a/.changeset/scheduling-engine-subpath.md
+++ b/.changeset/scheduling-engine-subpath.md
@@ -1,0 +1,19 @@
+---
+'@tour-kit/scheduling': minor
+---
+
+Add `@tour-kit/scheduling/engine`, a React-free subpath exposing every schedule
+evaluation function and constant for non-React consumers.
+
+```ts
+import { checkSchedule, isWithinBusinessHours } from '@tour-kit/scheduling/engine'
+```
+
+The built entry names no bare specifier at all — this package depends on
+nothing at runtime — so a Vue, Svelte or Node project can evaluate a schedule
+with neither React, `@tour-kit/license` nor `@tour-kit/analytics` installed.
+`<ScheduleGate>`, `useSchedule`, `useScheduleStatus` and `useUserTimezone` stay
+on the main entry.
+
+No source moved and no behaviour changed; the main entry is byte-for-byte the
+same size as before.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -107,6 +107,12 @@
     "ignore": ["@tour-kit/analytics"]
   },
   {
+    "name": "@tour-kit/scheduling/engine",
+    "path": "packages/scheduling/dist/engine/index.js",
+    "limit": "3 KB",
+    "ignore": ["@tour-kit/analytics"]
+  },
+  {
     "name": "@tour-kit/license",
     "path": "packages/license/dist/index.js",
     "limit": "70 KB"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,9 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
   - media <9 KB
   - ai <7 KB (client), <8 KB (server)
   - scheduling <4 KB
+  - scheduling/engine subpath <3.6 KB, measured 3 039 — twenty-four evaluation
+    functions and three constants; the hooks, the gate and the analytics peer
+    stay on the main entry.
   - vue <1.5 KB
   - svelte <1.3 KB
 

--- a/packages/core/src/__tests__/bundle-budget-claim-alignment.test.ts
+++ b/packages/core/src/__tests__/bundle-budget-claim-alignment.test.ts
@@ -76,6 +76,13 @@ const CLAIMS: Record<string, { pattern: RegExp; mode: 'exact' | 'ceiling' }> = {
   'ai:client': { pattern: /-\s*ai\s*<\s*([\d.]+)\s*KB\s*\(client\)/, mode: 'exact' },
   'ai:server': { pattern: /<\s*([\d.]+)\s*KB\s*\(server\)/, mode: 'exact' },
   scheduling: { pattern: /^\s*-\s*scheduling\s*<\s*([\d.]+)\s*KB/m, mode: 'exact' },
+  // v3 Phase 0 — anchored on `scheduling/engine subpath`. The sibling
+  // `scheduling` pattern is `/^\s*-\s*scheduling\s*<…/m`, so a bullet
+  // beginning `- scheduling/engine` cannot satisfy it.
+  'scheduling:engine': {
+    pattern: /scheduling\/engine subpath[^\n]*?<\s*([\d.]+)\s*KB/,
+    mode: 'exact',
+  },
   // Anchored like `media` and `scheduling`: an unanchored /vue/ would match the
   // word anywhere else in CLAUDE.md and read the wrong number.
   vue: { pattern: /^\s*-\s*vue\s*<\s*([\d.]+)\s*KB/m, mode: 'exact' },

--- a/packages/scheduling/README.md
+++ b/packages/scheduling/README.md
@@ -144,6 +144,20 @@ If all checks pass → schedule is **active**.
 
 ## API Reference
 
+### The React-free subpath
+
+`@tour-kit/scheduling/engine` gives a Vue, Svelte or Node consumer every
+evaluation function and constant with no `react`, no `@tour-kit/license` and no
+`@tour-kit/analytics` in its runtime or its type declarations:
+
+```ts
+import { checkSchedule, isWithinBusinessHours } from '@tour-kit/scheduling/engine'
+```
+
+It is a strict subset of the main entry — nothing moved. `<ScheduleGate>` and
+the three hooks stay on the main entry, because they are React.
+
+
 ### Component
 
 ```ts

--- a/packages/scheduling/package.json
+++ b/packages/scheduling/package.json
@@ -43,6 +43,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./engine": {
+      "import": {
+        "types": "./dist/engine/index.d.ts",
+        "default": "./dist/engine/index.js"
+      },
+      "require": {
+        "types": "./dist/engine/index.d.cts",
+        "default": "./dist/engine/index.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": ["dist", "README.md", "CHANGELOG.md"],

--- a/packages/scheduling/src/__tests__/no-react-in-engine-dist.test.ts
+++ b/packages/scheduling/src/__tests__/no-react-in-engine-dist.test.ts
@@ -23,6 +23,7 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
   RELATIVE_SPECIFIER,
+  SPECIFIER_PREFIX,
   closureOf,
   specifierPattern,
 } from '../../../../tooling/bundle-check/closure.mjs'
@@ -57,6 +58,13 @@ const FORBIDDEN = ['react', 'react-dom', '@tour-kit/license', '@tour-kit/analyti
  * demonstrably contains.
  */
 const CONTROL_SPECIFIERS = ['react', '@tour-kit/license', '@tour-kit/analytics'] as const
+
+/**
+ * Any BARE specifier, in every call shape a bundler emits — `from`, `import(`
+ * and `require(`. The leading `[^"'.]` excludes relative paths, which all start
+ * with `.`; everything else is a package.
+ */
+const BARE_SPECIFIER = new RegExp(`${SPECIFIER_PREFIX}["'][^"'.]`)
 
 const read = (p: string) => readFileSync(p, 'utf8')
 // rollup-plugin-dts chunks shared declarations even with `splitting: false`,
@@ -105,15 +113,20 @@ describe('@tour-kit/scheduling/engine ships no React', () => {
     // must not import, pin the stronger property: every specifier it emits is
     // relative. A new dependency of any kind — not just a React-side one —
     // fails here, which is the case analytics spends on `@tour-kit/core/engine`.
-    const bareFrom = /from\s*["'][^"'.]/
-    const bareRequire = /require\(\s*["'][^"'.]/
+    //
+    // Built from `SPECIFIER_PREFIX`, not hand-rolled. The hand-rolled version
+    // was two regexes covering `from` and `require(`, which left `import(`
+    // unguarded — and a lazy `import('some-package')` is precisely how a bare
+    // specifier enters a bundle in this repo (analytics' four vendor plugins
+    // load their SDKs that way). A case that claims NO bare specifier AT ALL
+    // has to mean all three call shapes, or the title is a lie.
     for (const f of [ENGINE_JS, ENGINE_CJS]) {
-      expect(bareFrom.test(read(f)), `${f} imports a bare specifier`).toBe(false)
-      expect(bareRequire.test(read(f)), `${f} requires a bare specifier`).toBe(false)
+      expect(BARE_SPECIFIER.test(read(f)), `${f} names a bare specifier`).toBe(false)
     }
     for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
-      const source = readDts(entry)
-      expect(bareFrom.test(source), `${entry} closure names a bare specifier`).toBe(false)
+      expect(BARE_SPECIFIER.test(readDts(entry)), `${entry} closure names a bare specifier`).toBe(
+        false
+      )
     }
   })
 

--- a/packages/scheduling/src/__tests__/no-react-in-engine-dist.test.ts
+++ b/packages/scheduling/src/__tests__/no-react-in-engine-dist.test.ts
@@ -1,0 +1,192 @@
+/**
+ * v3 Phase 0 — `@tour-kit/scheduling/engine` ships no React.
+ *
+ * US-1: a Vue/Svelte/Node developer evaluates a schedule with React not
+ * installed. That is a property of the BYTES tsup emitted, so every case here
+ * reads a real built file — nothing is faked, stubbed or mocked.
+ *
+ * This package is the harder of the two to guard, because its engine names
+ * *nothing* — so "does the file mention X" cannot be its own control. The
+ * sibling main entry is the control instead: it legitimately names three of the
+ * four forbidden specifiers (see CONTROL_SPECIFIERS for why not the fourth),
+ * and if it ever stops, either the matcher broke or the package changed shape.
+ * Both deserve a red.
+ *
+ * `splitting: false`, so the built entry IS its own closure for the JS. The
+ * declarations are not: rollup-plugin-dts chunks shared types regardless, under
+ * a content-hashed name that changes every rebuild, so the d.ts scan walks with
+ * `closureOf` and never spells the hash.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  RELATIVE_SPECIFIER,
+  closureOf,
+  specifierPattern,
+} from '../../../../tooling/bundle-check/closure.mjs'
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const DIST = join(PKG_ROOT, 'dist')
+// The DIRECTORY, not the files: gating on a filename turns a typo into a
+// silent skip (measured in v2 §1.5 — "3 skipped", green, proving nothing).
+const distExists = () => existsSync(DIST)
+
+const ENGINE_JS = join(DIST, 'engine', 'index.js')
+const ENGINE_CJS = join(DIST, 'engine', 'index.cjs')
+const ENGINE_DTS = join(DIST, 'engine', 'index.d.ts')
+const ENGINE_DCTS = join(DIST, 'engine', 'index.d.cts')
+const MAIN_JS = join(DIST, 'index.js')
+const MAIN_DTS = join(DIST, 'index.d.ts')
+
+// `@tour-kit/analytics` is the hooks' optional peer. It must not follow the
+// twenty-four pure functions through the engine door.
+const FORBIDDEN = ['react', 'react-dom', '@tour-kit/license', '@tour-kit/analytics'] as const
+
+/**
+ * What the CONTROL asserts the main entry still names — deliberately NOT the
+ * same list as FORBIDDEN, and the difference is measured rather than assumed.
+ *
+ * `react-dom` is in this package's tsup `external` list, but nothing in the
+ * package actually imports it, so it appears in neither built entry. A control
+ * that loops over FORBIDDEN therefore fails against a perfectly correct build
+ * ("main should name react-dom: expected false to be true"). Forbidding it on
+ * the engine side is still right — it is a React-side specifier that must never
+ * appear — but a guard may only use as its control what the sibling entry
+ * demonstrably contains.
+ */
+const CONTROL_SPECIFIERS = ['react', '@tour-kit/license', '@tour-kit/analytics'] as const
+
+const read = (p: string) => readFileSync(p, 'utf8')
+// rollup-plugin-dts chunks shared declarations even with `splitting: false`,
+// under a content-hashed name that changes on every rebuild — so never spell
+// it, walk it. `closureOf` maps `.js → .d.ts` / `.cjs → .d.cts` and tries the
+// literal path first, so this over-includes real JS. That is a superset scan,
+// and it is stronger than the declaration chain alone.
+const readDts = (entry: string) => closureOf(entry).map(read).join('\n')
+
+describe('@tour-kit/scheduling/engine ships no React', () => {
+  it.skipIf(!distExists())('names the four built engine files', () => {
+    for (const f of [ENGINE_JS, ENGINE_CJS, ENGINE_DTS, ENGINE_DCTS]) {
+      expect(existsSync(f), `${f} missing — every scan below would be vacuous`).toBe(true)
+    }
+  })
+
+  it.skipIf(!distExists())('CONTROL — the main entry trips the same matcher', () => {
+    // The engine names nothing external, so "the file mentions X" cannot be its
+    // own control. The sibling entry is. If any of these stops tripping, the
+    // matcher broke or the package changed shape.
+    for (const pkg of CONTROL_SPECIFIERS) {
+      expect(specifierPattern(pkg).test(read(MAIN_JS)), `main should name ${pkg}`).toBe(true)
+    }
+    expect(specifierPattern('react').test(read(MAIN_DTS))).toBe(true)
+  })
+
+  it.skipIf(!distExists())('the engine JS names none of the React-side specifiers', () => {
+    for (const f of [ENGINE_JS, ENGINE_CJS]) {
+      for (const pkg of FORBIDDEN) {
+        expect(specifierPattern(pkg).test(read(f)), `${f} must not import ${pkg}`).toBe(false)
+      }
+    }
+  })
+
+  it.skipIf(!distExists())('the engine .d.ts closure names none of them either', () => {
+    for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
+      const source = readDts(entry)
+      for (const pkg of FORBIDDEN) {
+        expect(specifierPattern(pkg).test(source), `${entry} closure names ${pkg}`).toBe(false)
+      }
+    }
+  })
+
+  it.skipIf(!distExists())('the engine names NO bare specifier at all', () => {
+    // Scheduling's engine depends on nothing. Rather than enumerate what it
+    // must not import, pin the stronger property: every specifier it emits is
+    // relative. A new dependency of any kind — not just a React-side one —
+    // fails here, which is the case analytics spends on `@tour-kit/core/engine`.
+    const bareFrom = /from\s*["'][^"'.]/
+    const bareRequire = /require\(\s*["'][^"'.]/
+    for (const f of [ENGINE_JS, ENGINE_CJS]) {
+      expect(bareFrom.test(read(f)), `${f} imports a bare specifier`).toBe(false)
+      expect(bareRequire.test(read(f)), `${f} requires a bare specifier`).toBe(false)
+    }
+    for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
+      const source = readDts(entry)
+      expect(bareFrom.test(source), `${entry} closure names a bare specifier`).toBe(false)
+    }
+  })
+
+  it.skipIf(!distExists())("'use client' lands on the React entry only", () => {
+    const startsWithDirective = (p: string) => /^['"]use client['"];?/.test(read(p))
+    expect(startsWithDirective(ENGINE_JS)).toBe(false)
+    expect(startsWithDirective(ENGINE_CJS)).toBe(false)
+    // Both halves: losing the directive on the main entry is equally a break —
+    // it is what lets <ScheduleGate> work inside an RSC tree.
+    expect(startsWithDirective(MAIN_JS)).toBe(true)
+    expect(startsWithDirective(join(DIST, 'index.cjs'))).toBe(true)
+  })
+
+  it.skipIf(!distExists())('every path the ./engine exports block names resolves', () => {
+    // The `types` condition of an `exports` block is never exercised by an
+    // `import()` — core solves this with a separate portability test, which
+    // neither new package gets. This is the cheap closure: a `.d.mts` typo, a
+    // dropped `./`, or a `.d.ts`/`.d.cts` swap is invisible to every other case
+    // here and breaks a consumer's typecheck rather than their build.
+    const pkg = JSON.parse(read(join(PKG_ROOT, 'package.json'))) as {
+      exports: Record<string, { import: Record<string, string>; require: Record<string, string> }>
+    }
+    const block = pkg.exports['./engine']
+    expect(block, 'package.json has no "./engine" exports key').toBeDefined()
+
+    const paths = [
+      block.import.types,
+      block.import.default,
+      block.require.types,
+      block.require.default,
+    ]
+    expect(paths.filter(Boolean)).toHaveLength(4)
+    for (const rel of paths) {
+      expect(rel.startsWith('./'), `${rel} is not a relative exports target`).toBe(true)
+      expect(existsSync(join(PKG_ROOT, rel)), `${rel} does not exist on disk`).toBe(true)
+    }
+  })
+
+  it('no source file the engine barrel reaches imports react, license or analytics', () => {
+    // Walk the barrel's relative imports to fixpoint. `.ts` first, then
+    // `/index.ts`, so `../utils`-style directory imports resolve.
+    // RELATIVE_SPECIFIER is a module-level /g regex: matchAll only, never .test.
+    const seen = new Set<string>()
+    const queue = [join(PKG_ROOT, 'src', 'engine', 'index.ts')]
+    while (queue.length > 0) {
+      const file = queue.shift() as string
+      if (seen.has(file)) continue
+      seen.add(file)
+      for (const [, spec] of read(file).matchAll(RELATIVE_SPECIFIER)) {
+        const base = resolve(dirname(file), spec)
+        const next = [`${base}.ts`, join(base, 'index.ts'), `${base}.tsx`].find(existsSync)
+        if (!next) throw new Error(`${file}: cannot resolve ${spec}`)
+        queue.push(next)
+      }
+    }
+    const files = [...seen]
+    // A silently-empty walk passes every assertion below it forever. Say out
+    // loud what it must have found. 15 = barrel + utils/index + 9 util leaves
+    // + types/index + 3 type files, today's exact count — a floor, not a target.
+    expect(files.some((f) => f.endsWith('utils/is-schedule-active.ts'))).toBe(true)
+    expect(files.some((f) => f.endsWith('types/schedule.ts'))).toBe(true)
+    expect(files.length).toBeGreaterThanOrEqual(15)
+
+    for (const file of files) {
+      const source = read(file)
+      expect(file.endsWith('.tsx'), `${file} is a React file`).toBe(false)
+      expect(/from\s*["']react(\/[^"']*)?["']/.test(source), `${file} imports react`).toBe(false)
+      expect(/from\s*["']@tour-kit\/license["']/.test(source), `${file} imports license`).toBe(
+        false
+      )
+      expect(/from\s*["']@tour-kit\/analytics["']/.test(source), `${file} imports analytics`).toBe(
+        false
+      )
+    }
+  })
+})

--- a/packages/scheduling/src/__tests__/subpath-resolution.test.ts
+++ b/packages/scheduling/src/__tests__/subpath-resolution.test.ts
@@ -1,0 +1,62 @@
+/**
+ * v3 Phase 0 — `@tour-kit/scheduling/engine` actually resolves.
+ *
+ * US-2: the `exports` map is proven, not just written. The guard file next door
+ * reads bytes; this one asks Node to resolve the subpath for real, in both
+ * module systems — ESM through a dynamic `import()` (a self-reference through
+ * `exports`, which needs no self-link in `node_modules`) and CJS through a
+ * child process, because this worker is ESM.
+ *
+ * The refusal list is a first-class assertion, not a footnote: the barrel is
+ * defined as much by what it withholds as by what it exports. Without it,
+ * `export *` from the main entry would satisfy every other case in this file —
+ * and this barrel really is two `export *` lines, so that is not hypothetical.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const distExists = () => existsSync(join(PKG_ROOT, 'dist'))
+
+describe('@tour-kit/scheduling/engine subpath resolution', () => {
+  it.skipIf(!distExists())('resolves via dynamic `import()` (ESM)', async () => {
+    const mod = await import('@tour-kit/scheduling/engine')
+    // One per evaluation family, not all twenty-four: the barrel is `export *`,
+    // so a representative from each leaf proves the re-export chain without
+    // duplicating `utils/index.ts` as a list that rots.
+    for (const name of [
+      'checkSchedule',
+      'isScheduleActive',
+      'getScheduleStatus',
+      'matchesRecurringPattern',
+      'isWithinBusinessHours',
+    ] as const) {
+      expect(typeof mod[name], name).toBe('function')
+    }
+    // The two constants come through `../types`, the other star-export.
+    expect(Array.isArray(mod.DAY_NAMES)).toBe(true)
+    expect(typeof mod.BUSINESS_HOURS_PRESETS).toBe('object')
+  })
+
+  it.skipIf(!distExists())('resolves via `require()` in a child Node process (CJS)', () => {
+    const stdout = execFileSync(
+      process.execPath,
+      [
+        '-e',
+        "const m = require('@tour-kit/scheduling/engine'); console.log(typeof m.checkSchedule, typeof m.getScheduleStatus, Array.isArray(m.DAY_NAMES), 'useSchedule' in m);",
+      ],
+      { encoding: 'utf8', cwd: PKG_ROOT }
+    )
+    expect(stdout.trim()).toBe('function function true false')
+  })
+
+  it.skipIf(!distExists())('does NOT re-export the React surface', async () => {
+    const mod = (await import('@tour-kit/scheduling/engine')) as Record<string, unknown>
+    for (const name of ['ScheduleGate', 'useSchedule', 'useScheduleStatus', 'useUserTimezone']) {
+      expect(mod, `@tour-kit/scheduling/engine must not export ${name}`).not.toHaveProperty(name)
+    }
+  })
+})

--- a/packages/scheduling/src/engine/index.ts
+++ b/packages/scheduling/src/engine/index.ts
@@ -1,0 +1,34 @@
+/**
+ * `@tour-kit/scheduling/engine` — the React-free door (v3 Phase 0).
+ *
+ * Everything here is reachable from the main entry at the same path with the
+ * same signature; nothing moved. What this entry adds is a runtime and a
+ * `.d.ts` chain that never name `react`, `react-dom`, `@tour-kit/license` or
+ * `@tour-kit/analytics`, so a Vue, Svelte or Node consumer can evaluate a
+ * schedule with none of them installed.
+ *
+ * Rules, each with a test behind it (`no-react-in-engine-dist.test.ts`,
+ * `subpath-resolution.test.ts`):
+ * - Re-exports and comments only. No declaration, no side-effect import —
+ *   `sideEffects: false` in the manifest is only true while nothing runs here.
+ * - Never `../components/schedule-gate` (React + LicenseGate), never
+ *   `../hooks/*` (React, and `@tour-kit/analytics` behind them), never
+ *   `../index`.
+ * - The built file names NO bare specifier at all. This package depends on
+ *   nothing at runtime, and the guard pins that stronger property rather than
+ *   enumerating what it must not import.
+ *
+ * `export *` is safe here, where the core rule is "import leaves, never the
+ * mixed barrels": that rule is about barrels that mix React in, and neither of
+ * these does. `../utils` is values-only (24 functions + `DAY_GROUPS`) and
+ * `../types` is types plus two constants (`DAY_NAMES`,
+ * `BUSINESS_HOURS_PRESETS`), with zero name overlap between them — so the two
+ * star-exports cannot collide.
+ *
+ * There is no `createSchedulingEngine` and there should not be: this package
+ * has no engine object, it is twenty-four pure functions and three constants.
+ * Naming things the recipe's way when they are not the recipe's shape is how
+ * v2 §1.5 shipped three copies of the spotlight machine.
+ */
+export * from '../utils'
+export * from '../types'

--- a/packages/scheduling/tsup.config.ts
+++ b/packages/scheduling/tsup.config.ts
@@ -2,7 +2,14 @@ import { defineConfig } from 'tsup'
 import { injectUseClient } from '../../tooling/build/use-client'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: {
+    index: 'src/index.ts',
+    // v3 Phase 0 — the React-free door. Deliberately absent from the
+    // `injectUseClient(['index'])` call below: stamping 'use client' here would
+    // mark a framework-agnostic entry client-only. Both halves are asserted in
+    // `src/__tests__/no-react-in-engine-dist.test.ts`.
+    'engine/index': 'src/engine/index.ts',
+  },
   format: ['cjs', 'esm'],
   dts: true,
   clean: true,

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -144,6 +144,14 @@ export const budgets = [
   ['ai:client', 'packages/ai/dist/index.js', 7000],
   ['ai:server', 'packages/ai/dist/server/index.js', 8000],
   ['scheduling', 'packages/scheduling/dist/index.js', 4000],
+  // v3 Phase 0 — the React-free door. Measured 3 039 by this gate; the three
+  // hooks, <ScheduleGate> and the `@tour-kit/analytics` peer behind them are
+  // the 670 B difference from the main row (3 709). Unlike `analytics:engine`,
+  // this does NOT share its sibling's ceiling: `scheduling` sits at 4 000 with
+  // only 291 B of headroom, so sharing would leave ~1 KB nobody would notice
+  // drift into. 3 039 x 1.2 = 3 647, and 3 600 is a hair under that (561 B,
+  // 18 % headroom) for a round 3.6 KB claim.
+  ['scheduling:engine', 'packages/scheduling/dist/engine/index.js', 3600],
   ['license', 'packages/license/dist/index.js', 8000],
   // v2 §1.5 — the two non-React bindings. Both are `external: ['@tour-kit/core',
   // <framework>]`, so these rows measure the binding's own bytes: state bridge,


### PR DESCRIPTION
PR B of two, and the timed one. This task exists to be *0.1 with the names changed*, so the measurement is the deliverable: **hours(0.2) / hours(0.1) = 0.89**. See #131 for PR A.

```ts
import { checkSchedule, isWithinBusinessHours } from '@tour-kit/scheduling/engine'
```

Two `export *` lines, one tsup entry, one `exports` key, and **no source change anywhere else in the package** — `git diff main -- src/utils src/types` is empty, as the plan requires.

| | |
|---|---|
| `dist/engine/index.js` specifiers | **none at all** |
| `head -c 12` | `function g()` (main still `'use client'`) |
| `require('@tour-kit/scheduling/engine')` | `function function true false` |
| `scheduling:engine` | **3 039** gz / 3 600 budget |
| `scheduling` | **3 709**, unchanged — no source moved |

`export *` is safe here even though core's rule is "import leaves, never the mixed barrels": that rule is about barrels that mix React in, and neither of these does. `../utils` is values-only, `../types` is types plus two constants, and they have zero name overlap.

There is deliberately **no `createSchedulingEngine`**. This package has no engine object — it is twenty-four pure functions and three constants. Naming things the recipe's way when they are not the recipe's shape is how v2 §1.5 shipped three copies of the spotlight machine.

## The finding PR A did not produce: the control list is not the forbidden list

The positive control went red against a correct build:

```
× CONTROL — the main entry trips the same matcher
  AssertionError: main should name react-dom: expected false to be true
```

`react-dom` sits in the tsup `external` list of **both** packages, but nothing in either imports it, so it appears in neither built entry. The test plan's §7 example loops the control over `FORBIDDEN`, which cannot pass. Forbidding `react-dom` on the engine side stays correct — it is a React-side specifier that must never appear — but a guard may only use as its *control* what the sibling entry demonstrably contains. The two lists are now separate with the reason in the file.

Worth noting what this was: the positive control catching a bug in itself, before the suite was ever green. That is exactly the failure mode it exists for, pointed inward.

## Budget rows are not decided by symmetry

`analytics:engine` shares its sibling's 4 000 ceiling — its engine is a strict subset of a row with real headroom. `scheduling:engine` does **not**: `scheduling` sits at 4 000 with only 291 B free, so sharing would leave ~1 KB nobody would notice drift into. 3 039 × 1.2 = 3 647, and 3 600 is a hair under that at 18 % headroom for a round claim. Same recipe, two different answers, decided by the numbers rather than by symmetry.

The same non-uniformity shows in `.size-limit.json`: this row reads **2.46 kB** brotli against analytics/engine's **184.65 kB**. Neither is wrong — analytics' root row carries no `ignore` list so its number bundles `@tour-kit/core/engine` in, while this engine genuinely depends on nothing. The limit has to come from measuring that row.

## Guards, and proof they can fail

11 cases across two new files (one fewer than analytics: the "core is externalised" case is analytics-specific). The case analytics spends on `@tour-kit/core/engine` becomes the stronger property here — **every specifier the built file emits is relative**, so a new dependency of any kind fails, not just a React-side one.

| Break | Cases that went red |
|---|---|
| `export { ScheduleGate }` on the barrel | **5** — engine JS, d.ts closure, no-bare-specifier, source walk, refusal list |
| `export { useSchedule }` on the barrel | **5** — same minus d.ts, plus CJS resolution |
| add `engine/index` to `injectUseClient` | **1** — the directive case |

## Coverage: measured, not assumed (test plan C2)

No exclude added. The plan predicted the barrel would report 100 %, the test plan corrected that to 0 %, and the measured answer is **neither** — `src/engine/index.ts` does not appear in the report at all, because no test imports the source barrel (they read the built dist through the subpath). The 0 % row that exists is the pre-existing `types/index.ts`. Aggregate unmoved at 95.91 / 87.86 / 100 / 96.42 against floors 75 / 65 / 80 / 75.

## Verification

- `pnpm --filter @tour-kit/scheduling exec vitest run <the two new files>` → **11 passed, 0 skipped**
- full scheduling suite **134 passed**, zero pre-existing files touched
- `pnpm dist:size` green — `scheduling:engine` 3 039 / 3 600, `scheduling` unchanged at 3 709
- `bundle-budget-claim-alignment` 25 passed with the new `CLAIMS` entry
- `pnpm typecheck` 35/35, `git ls-files | xargs biome check` clean
- the source walk finds **exactly 15** files, matching the test plan's enumeration
- `git diff main --stat -- src/utils src/types` — **empty**

`grep -c "engine subpath" CLAUDE.md` prints 2 on this branch and reaches the required 3 once #131 merges — this branch is off `main` and carries only its own bullet.

`plan/` and `wiki-tech/` are gitignored, so the wiki page and log entry land on disk but not in this diff.

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt