### PR TITLE
feat(core): createHandle, the engine-agnostic half of createEngineHandle (v3 Phase 1, PR A)

### DIFF
--- a/.changeset/core-create-handle.md
+++ b/.changeset/core-create-handle.md
@@ -1,0 +1,9 @@
+---
+"@tour-kit/core": minor
+---
+
+`createHandle`, the engine-agnostic lifecycle primitive behind `createEngineHandle`, exported from `@tour-kit/core/engine`.
+
+`createHandle<E, S>(factory, initial)` is the half of the handle that knows nothing about tours: lazy `ensure()`, a listener set that outlives any one engine, one fan-out on construction, and a `release()` whose `destroy()` is deferred by a microtask so a StrictMode teardown-and-rerun takes it back. `createEngineHandle` is now that composition plus the seventeen tour verbs — its signature and `EngineHandle`'s shape are unchanged, so the React, Vue and Svelte bindings are untouched.
+
+A package that grows its own engine composes `createHandle` instead of writing a second lifecycle. `EngineLike`'s `flush` is optional, so an engine whose writes are synchronous needs none.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,9 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     `engine-not-in-main-closure.test.ts` asserted the opposite and was deleted
     in §1.4e; the invariant that still holds is `no-react-in-engine-dist`.
     v2 §1.5 took it to 22 621 (+47 B) — the six binding-contract re-exports
-    on `/engine` plus `attachAdvanceOn`'s deferred bind)
+    on `/engine` plus `attachAdvanceOn`'s deferred bind. v3 Phase 1 took it to
+    22 879 (+20 B over the 22 857 the gate actually printed before it) for
+    `createHandle`, the engine-agnostic half of `createEngineHandle`)
   - core/engine subpath <18.5 KB (the non-React consumer's worst case: the
     engine — reducer, boot resolver, actions, transition effects, four
     storage adapters — plus the v2 §1.3b DOM behaviours (focus trap,
@@ -162,7 +164,10 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     spotlight state machine that §1.5 had shipped in three copies. Most of
     those bytes MOVED rather than appeared — a Vue consumer ships engine +
     binding, and that total went 19 187 → 19 341, so +154 B net for deleting
-    two of the three implementations)
+    two of the three implementations. v3 Phase 1 took it to 18 124 (+25 B):
+    `createHandle` plus its `EngineLike`/`Handle` types, which a package with
+    its own engine composes instead of writing a second lifecycle —
+    `@tour-kit/hints/engine` is the first)
   - core/engine IIFE (`dist/engine/index.global.js`, the CDN door) <18.5 KB,
     measured 17 492. It is the engine closure in one file — same source, one
     format — so it shares `core/engine`'s ceiling instead of the measured-×1.2

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -58,6 +58,16 @@ Framework-agnostic foundation layer. Contains all business logic - UI packages a
   one microtask, so React tearing an effect down and re-running it can take it
   back. Without that, the replacement engine re-boots and every restore side
   effect fires twice in dev.
+- **`createEngineHandle` is a facade, `createHandle` is the primitive** (v3
+  Phase 1): the lifecycle half — lazy `ensure()`, the listener set that
+  outlives any one engine, the construction fan-out, the deferred `release()` —
+  is `createHandle<E, S>(factory, initial)` and knows nothing about tours;
+  `createEngineHandle` is it plus the seventeen tour verbs. Both are on
+  `/engine`. A package with its own engine composes `createHandle` rather than
+  re-implementing the lifecycle. `EngineLike`'s `flush` is optional, so a
+  synchronous engine needs none. `createEngineHandle`'s signature must not
+  drift: `src/__tests__/types/engine-handle.test-d.ts` pins it and only
+  `pnpm typecheck:types` runs that file — no vitest run reports it.
 - **Context null checks**: All context hooks throw if used outside provider - this is intentional
 - **SSR**: Hooks handle SSR by checking `typeof window` before accessing DOM APIs
 - **Refs over state**: Position-related values use refs to avoid re-render cascades

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -261,6 +261,12 @@ export {
   pickActions,
 } from '../lib/tour-engine/engine-handle'
 export type { EngineHandle } from '../lib/tour-engine/engine-handle'
+// v3 Phase 1 — the engine-agnostic half of the handle. `createEngineHandle` is
+// this plus the seventeen tour verbs; a package with its own engine (hints,
+// checklists…) composes `createHandle` with its own instead of writing a
+// second lifecycle.
+export { createHandle } from '../lib/tour-engine/engine-handle'
+export type { EngineLike, Handle } from '../lib/tour-engine/engine-handle'
 export type { TourEngineLiveOptions } from '../lib/tour-engine/create-tour-engine'
 export type { TourEngineAnalytics } from '../lib/tour-engine/context'
 // The option bag all three bindings take, and the two splits it feeds the

--- a/packages/core/src/lib/tour-engine/__tests__/engine-handle.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/engine-handle.test.ts
@@ -12,7 +12,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { tourRegistry } from '../../../registry/tour-registry'
-import { INITIAL_SNAPSHOT, createEngineHandle } from '../engine-handle'
+import { INITIAL_SNAPSHOT, createEngineHandle, createHandle } from '../engine-handle'
 import type { EngineHandle } from '../engine-handle'
 import { countingFactory } from './_helpers/counting-factory'
 import { makeTour, visibleStep } from './_helpers/make-tour'
@@ -187,5 +187,117 @@ describe('verb identity is the handle lifetime', () => {
 
     expect(handle.start).toBe(before)
     expect(handle.next).toBe(handle.next)
+  })
+})
+
+/**
+ * v3 Phase 1 — `createHandle` is the engine-agnostic half.
+ *
+ * Everything above drives it through `createEngineHandle` and a real
+ * `TourEngine`, which cannot distinguish "the lifecycle is generic" from "the
+ * lifecycle happens to work for tours". So these six drive it over a fake
+ * `EngineLike` that is not a tour engine and deliberately has **no `flush`** —
+ * that optional member is what lets a package whose writes are synchronous
+ * (hints) compose the same handle.
+ */
+function fakeEngine() {
+  let constructed = 0
+  const listeners = new Set<() => void>()
+  const state = { n: 0 }
+  const factory = () => {
+    constructed++
+    return {
+      getState: () => state,
+      subscribe: (l: () => void) => {
+        listeners.add(l)
+        return () => {
+          listeners.delete(l)
+        }
+      },
+      destroy: () => {
+        listeners.clear()
+      },
+      // no `flush` — release() must not throw
+    }
+  }
+  return { factory, state, count: () => constructed }
+}
+
+describe('createHandle is engine-agnostic', () => {
+  // Annotated, not inferred: `Object.freeze({ n: -1 })` widens to `Readonly<{ n: -1 }>`
+  // and the fake's `{ n: number }` state is then not assignable to `EngineLike<S>`.
+  const INITIAL: { n: number } = Object.freeze({ n: -1 })
+
+  it('getState() before ensure() returns the `initial` argument by reference', () => {
+    const fake = fakeEngine()
+    const h = createHandle(fake.factory, INITIAL)
+
+    expect(h.getState()).toBe(INITIAL)
+    expect(fake.count(), 'getState() constructed the engine').toBe(0)
+  })
+
+  it('subscribe() alone constructs nothing', () => {
+    const fake = fakeEngine()
+    const h = createHandle(fake.factory, INITIAL)
+
+    const off = h.subscribe(() => {})
+    off()
+
+    expect(fake.count()).toBe(0)
+  })
+
+  it('ensure() constructs once and fans out once', () => {
+    const fake = fakeEngine()
+    const h = createHandle(fake.factory, INITIAL)
+    let notified = 0
+    h.subscribe(() => notified++)
+
+    const first = h.ensure()
+    const second = h.ensure()
+
+    expect(fake.count()).toBe(1)
+    expect(second).toBe(first)
+    expect(notified, 'the second ensure() fanned out again').toBe(1)
+    expect(h.getState()).toBe(fake.state)
+  })
+
+  it('release() is deferred one microtask, and ensure() in the same tick takes it back', async () => {
+    const fake = fakeEngine()
+    const h = createHandle(fake.factory, INITIAL)
+    const engine = h.ensure()
+
+    h.release()
+    expect(h.ensure(), 'the release was not taken back').toBe(engine)
+    await Promise.resolve()
+    expect(fake.count(), 'the deferred destroy fired anyway').toBe(1)
+    expect(h.getState()).toBe(fake.state)
+
+    // A release with nothing to take it back really does land.
+    h.release()
+    await Promise.resolve()
+    expect(h.getState()).toBe(INITIAL)
+    expect(h.ensure(), 'the replacement is a new engine').not.toBe(engine)
+    expect(fake.count()).toBe(2)
+  })
+
+  it('release() on an engine with no `flush` does not throw', async () => {
+    const fake = fakeEngine()
+    const h = createHandle(fake.factory, INITIAL)
+    h.ensure()
+
+    expect(() => h.release()).not.toThrow()
+    await Promise.resolve()
+    expect(h.getState()).toBe(INITIAL)
+  })
+
+  it('a listener subscribed before construction fires on the construction fan-out', () => {
+    const fake = fakeEngine()
+    const h = createHandle(fake.factory, INITIAL)
+    let notified = 0
+    h.subscribe(() => notified++)
+
+    expect(notified).toBe(0)
+    h.ensure()
+    expect(notified).toBe(1)
   })
 })

--- a/packages/core/src/lib/tour-engine/engine-handle.ts
+++ b/packages/core/src/lib/tour-engine/engine-handle.ts
@@ -50,31 +50,37 @@ export const INITIAL_SNAPSHOT: TourCallbackContext = Object.freeze({
   data: {},
 })
 
-export interface EngineHandle extends Omit<TourEngine, 'destroy'> {
-  /**
-   * Construct on the first call and return the live engine.
-   *
-   * Never call this from render — that is the `registered twice` hazard. The
-   * provider's own mount effect is the latest it can happen; a child's verb is
-   * the earliest.
-   */
-  ensure: () => TourEngine
-  /** `INITIAL_SNAPSHOT` until the first `ensure()`; then the engine's cached snapshot. */
-  getState: () => TourCallbackContext
-  /**
-   * Stop being the live engine.
-   *
-   * Pending writes are flushed synchronously; the `destroy()` itself lands one
-   * microtask later, so a verb or `ensure()` in the same tick — React tearing
-   * an effect down and re-running it — takes the release back and keeps the
-   * engine, its state and its completed boot. Subscribers survive either way,
-   * so a genuinely new engine re-attaches them. Idempotent.
-   */
+/**
+ * v3 Phase 1 — the engine-agnostic half of the handle.
+ *
+ * Lazy `ensure()`, a listener set that outlives any one engine, one fan-out on
+ * construction, and a microtask-deferred `release()`. Nothing here knows what a
+ * tour is; `createEngineHandle` below is this plus the seventeen tour verbs.
+ * `flush` is optional because an engine whose writes are synchronous has
+ * nothing to flush.
+ */
+export interface EngineLike<S> {
+  getState: () => S
+  subscribe: (listener: () => void) => () => void
+  destroy: () => void
+  flush?: () => void
+}
+
+export interface Handle<E extends EngineLike<S>, S> {
+  /** Construct on the first call and return the live engine. Never from render. */
+  ensure: () => E
+  /** `initial` until the first `ensure()`; then the engine's own snapshot. */
+  getState: () => S
+  subscribe: (listener: () => void) => () => void
+  /** Flush now; destroy one microtask later unless a verb takes it back. Idempotent. */
   release: () => void
 }
 
-export function createEngineHandle(factory: () => TourEngine): EngineHandle {
-  let engine: TourEngine | null = null
+export function createHandle<E extends EngineLike<S>, S>(
+  factory: () => E,
+  initial: S
+): Handle<E, S> {
+  let engine: E | null = null
   let off: (() => void) | null = null
   let pendingRelease = false
   const listeners = new Set<() => void>()
@@ -83,7 +89,7 @@ export function createEngineHandle(factory: () => TourEngine): EngineHandle {
     for (const listener of listeners) listener()
   }
 
-  const ensure = (): TourEngine => {
+  const ensure = (): E => {
     // A release scheduled earlier in this same tick was React tearing the
     // effect down before re-running it. Take it back.
     pendingRelease = false
@@ -91,9 +97,9 @@ export function createEngineHandle(factory: () => TourEngine): EngineHandle {
     engine = factory()
     off = engine.subscribe(fanOut)
     // One fan-out on construction: the snapshot identity just moved from the
-    // module constant to the engine's, so `useSyncExternalStore` has to
-    // re-read even though the values are equal. That extra render is the price
-    // of not constructing during render.
+    // constant to the engine's, so a store subscriber has to re-read even
+    // though the values are equal. That extra render is the price of not
+    // constructing during render.
     fanOut()
     return engine
   }
@@ -101,7 +107,7 @@ export function createEngineHandle(factory: () => TourEngine): EngineHandle {
   return {
     ensure,
 
-    getState: () => engine?.getState() ?? INITIAL_SNAPSHOT,
+    getState: () => (engine ? engine.getState() : initial),
 
     subscribe: (listener: () => void) => {
       listeners.add(listener)
@@ -127,17 +133,18 @@ export function createEngineHandle(factory: () => TourEngine): EngineHandle {
      * dropped. Anything asserting on that after an `unmount()` needs one
      * `await`.
      *
-     * The one thing that cannot wait is the pending throttled write, so
-     * `flush()` runs NOW. The flow-session save is trailing-edge throttled at
-     * 200 ms, and an unmount immediately followed by a remount — a fast
+     * The one thing that cannot wait is a pending throttled write, so
+     * `flush()` runs NOW. Core's flow-session save is trailing-edge throttled
+     * at 200 ms, and an unmount immediately followed by a remount — a fast
      * client-side route change — would otherwise let the new engine boot and
-     * read the step the old one had already left.
+     * read the step the old one had already left. `flush` is optional on
+     * `EngineLike`: an engine whose writes are synchronous has none pending.
      *
      * No fan-out either way: the binding is either leaving or about to re-read.
      */
     release: () => {
       if (!engine || pendingRelease) return
-      engine.flush()
+      engine.flush?.()
       pendingRelease = true
       queueMicrotask(() => {
         if (!pendingRelease) return
@@ -148,6 +155,37 @@ export function createEngineHandle(factory: () => TourEngine): EngineHandle {
         engine = null
       })
     },
+  }
+}
+
+export interface EngineHandle extends Omit<TourEngine, 'destroy'> {
+  /**
+   * Construct on the first call and return the live engine.
+   *
+   * Never call this from render — that is the `registered twice` hazard. The
+   * provider's own mount effect is the latest it can happen; a child's verb is
+   * the earliest.
+   */
+  ensure: () => TourEngine
+  /** `INITIAL_SNAPSHOT` until the first `ensure()`; then the engine's cached snapshot. */
+  getState: () => TourCallbackContext
+  /**
+   * Stop being the live engine.
+   *
+   * Pending writes are flushed synchronously; the `destroy()` itself lands one
+   * microtask later, so a verb or `ensure()` in the same tick — React tearing
+   * an effect down and re-running it — takes the release back and keeps the
+   * engine, its state and its completed boot. Subscribers survive either way,
+   * so a genuinely new engine re-attaches them. Idempotent.
+   */
+  release: () => void
+}
+
+export function createEngineHandle(factory: () => TourEngine): EngineHandle {
+  const h = createHandle<TourEngine, TourCallbackContext>(factory, INITIAL_SNAPSHOT)
+  const ensure = h.ensure
+  return {
+    ...h,
 
     boot: (...a) => ensure().boot(...a),
     start: (...a) => ensure().start(...a),

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -35,7 +35,9 @@
  *     `navigateToStepImpl`, `commitStart` in `actions.ts`, the Group B block
  *     in `transition-effects.ts`); 21 851 -> 22 574 in v2 §1.4; 22 574 ->
  *     22 621 in v2 §1.5 (the six binding-contract re-exports on `/engine`
- *     plus `attachAdvanceOn`'s deferred bind).
+ *     plus `attachAdvanceOn`'s deferred bind); 22 857 -> 22 879 in v3 Phase 1
+ *     (+20 B for `createHandle`, the engine-agnostic half of
+ *     `createEngineHandle`, and its two type exports on `/engine`).
  *
  *     §1.4's +725 B is the closure FLIPPING, by design. `<TourProvider>` is a
  *     binding over `createTourEngine()` now, so the factory and the engine
@@ -85,6 +87,13 @@
  *     the three inlined copies did not. 154 B to delete two of three
  *     implementations is the trade, and it is worth stating plainly rather
  *     than rounding to "free".
+ *
+ *     v3 Phase 1 added 25 B (18 098 -> 18 124): `createHandle`, the
+ *     engine-agnostic half of `createEngineHandle` (lazy `ensure()`, the
+ *     listener set, the microtask-deferred `release()`), plus its `EngineLike`
+ *     and `Handle` types. It is on `/engine` because a package with its own
+ *     engine composes it rather than writing a second lifecycle —
+ *     `@tour-kit/hints/engine` is the first.
  *
  *     Do NOT split a `/engine/dom` entry to keep this number flat: the row
  *     measures the import-everything worst case, a bundler tree-shakes the


### PR DESCRIPTION
**v3 Phase 1, PR A of three.** Plan: `plan/v3/1-hints-honest-pilot.md`, Task 1.0 / Decision 1.

## Why

The v3 handoff's step 6 says "rebuild the provider as a binding over `createEngineHandle` … do not write a second handle". That reads as a factory-agnostic primitive. It is not one — `createEngineHandle` is a `TourEngine` facade: `(factory: () => TourEngine) => EngineHandle`, with `EngineHandle extends Omit<TourEngine, 'destroy'>` and seventeen tour verbs forwarded by hand. A hints engine cannot satisfy it and the verbs mean nothing to it.

The reusable part was never TourEngine-specific: lazy `ensure()`, a listener set that outlives any one engine, one fan-out on construction, and the microtask-deferred `release()` that makes a StrictMode effect double-invoke a remount rather than a re-boot.

## What

- `createHandle<E extends EngineLike<S>, S>(factory, initial): Handle<E, S>` in `lib/tour-engine/engine-handle.ts`, exported from `@tour-kit/core/engine` with `EngineLike` and `Handle`.
- `createEngineHandle` is now `{ ...createHandle(factory, INITIAL_SNAPSHOT), <17 verbs> }`. **Its signature and `EngineHandle`'s shape are byte-identical in the diff** — only the body moved — so the React, Vue and Svelte bindings are untouched.
- `EngineLike`'s `flush` is **optional**: an engine whose writes are synchronous has nothing pending. That is what lets `@tour-kit/hints` compose the same handle in PR B.

Rejected alternative: a `Proxy` forwarding any key. More bytes, loses verb identity unless memoised, and needs a cast on every binding.

## Verification

| Check | Result |
|---|---|
| `engine-handle.test.ts` | **20 passed** — the 14 existing `createEngineHandle` cases untouched (they are the proof the composition is equivalent) + 6 new over a fake `EngineLike` with no `flush` |
| `@tour-kit/core` whole suite | 1648 passed, 3 skipped |
| `typecheck` + `typecheck:types` | clean |
| `@tour-kit/vue` / `@tour-kit/svelte` | typecheck clean; **41** and **40** green against the rebuilt core dist |
| `git ls-files \| xargs biome check` | clean |

Bytes (`node tooling/bundle-check/check-dist-gzip.mjs`):

| Row | Before | After | Ceiling |
|---|---:|---:|---:|
| `core` | 22 857 | **22 878** | 23 000 |
| `core:engine` | 18 098 | **18 123** | 18 500 |
| `core:engine:iife` | 17 492 | **17 501** | 18 500 |

No ceiling moved. History lines added to `budgets.mjs` and the root `CLAUDE.md`.

## Finding for the recipe (gap 15 material)

`pnpm --filter @tour-kit/core typecheck:types` is the **only** runner for `src/__tests__/types/engine-handle.test-d.ts` — that script appears in no turbo pipeline and no CI workflow — and it was the only gate that caught a literal-type slip in the new test cases (`Object.freeze({ n: -1 })` widening to `Readonly<{ n: -1 }>`). `tsc --noEmit`, the vitest run and the `safe-ship-gate` hook all stayed green on it. That file is also the automated form of "the signature did not drift", since spreading `...h` onto the verbs makes `ensure`/`subscribe`/`release` structurally present and only its `Omit<TourEngine,'destroy'>` assignment plus a consumed `@ts-expect-error` pin what must not be.

## Next

PR B (`@tour-kit/hints/engine`) branches from `main` once this merges — hints' `dts` build needs core's rebuilt `.d.ts`.

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt