### PR TITLE
feat(examples): a hint rendered from the engine alone in vue-app (v3 Phase 1, PR C)

### DIFF
--- a/e2e/vue/hints.localhost.spec.ts
+++ b/e2e/vue/hints.localhost.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * v3 Phase 1 — a hint rendered from `@tour-kit/hints/engine` alone.
+ *
+ * The Vue app imports no `@tour-kit/hints` component and no React. The dot, the
+ * tooltip and the Dismiss button are hand-written Vue over the engine's state,
+ * positioned by the engine's own `getHotspotPosition`. If any of these three
+ * pass, a non-React consumer can genuinely run hints.
+ */
+test.describe('Vue — a hint from @tour-kit/hints/engine', () => {
+  test('the dot renders at the target', async ({ page }) => {
+    await page.goto('/')
+    const dot = page.getByTestId('hint-dot-export')
+    await expect(dot).toBeVisible()
+
+    const t = await page.locator('#hint-target').boundingBox()
+    const d = await dot.boundingBox()
+    // getHotspotPosition('top-right') = { top: rect.top - 4, left: rect.right - 4 }
+    expect(Math.abs((d?.y ?? 0) - ((t?.y ?? 0) - 4))).toBeLessThan(2)
+    expect(Math.abs((d?.x ?? 0) - ((t?.x ?? 0) + (t?.width ?? 0) - 4))).toBeLessThan(2)
+  })
+
+  test('click opens, Dismiss closes', async ({ page }) => {
+    await page.goto('/')
+    await page.getByTestId('hint-dot-export').click()
+    await expect(page.getByTestId('hint-tooltip-export')).toBeVisible()
+
+    await page.getByTestId('hint-dismiss-export').click()
+    await expect(page.getByTestId('hint-tooltip-export')).toHaveCount(0)
+    await expect(page.getByTestId('hint-dot-export')).toHaveCount(0)
+  })
+
+  test("a 'once' dismissal survives a reload", async ({ page }) => {
+    await page.goto('/')
+    await page.getByTestId('hint-dot-export').click()
+    await page.getByTestId('hint-dismiss-export').click()
+
+    // Read the blob BEFORE reloading: a reload assertion alone would also pass
+    // if the dot had never rendered at all.
+    const blob = await page.evaluate(() => localStorage.getItem('tourkit:hint:freq:export'))
+    expect(blob).toContain('"isDismissed":true')
+
+    await page.reload()
+    await page.waitForSelector('#hint-target')
+    await expect(page.getByTestId('hint-dot-export')).toHaveCount(0)
+  })
+})

--- a/examples/vue-app/README.md
+++ b/examples/vue-app/README.md
@@ -21,3 +21,38 @@ pnpm --filter vue-tour-kit-demo dev   # http://localhost:5175
 | `tour-card` | the card itself |
 | `tour-card-title` / `tour-card-content` | step text |
 | `tour-back` / `tour-next` / `tour-skip` | the card's button row |
+
+## The hint (v3 Phase 1)
+
+The dot beside **Export** on the Home route is a hint driven by
+`@tour-kit/hints/engine` — the state machine, its frequency persistence and
+`getHotspotPosition`, with no React. `src/composables/useHintsEngine.ts` wraps
+`createHintsHandle` and bridges it to a `shallowRef`;
+`src/components/HintDot.vue` renders the dot and the tooltip itself. No
+`@tour-kit/hints` component is imported anywhere, and this app installs no
+React.
+
+Two things this example exists to pin, both of which cost a debugging session:
+
+- **The factory seeds the engine.** `provideHintsEngine` calls `setHints` and
+  `boot()` *inside* the factory handed to `createHintsHandle`, because a child's
+  `onMounted` runs before the parent's — the same rule React's binding follows.
+  Without the seed the first verb runs against an engine with no configs and no
+  storage, and a persisted dismissal does not suppress the dot.
+- **`HintDot` starts tracking from `onMounted` AND a watch.** `<App>` mounts and
+  boots before vue-router resolves the initial route, so by the time `HintDot`
+  sets up the hint is usually already registered. An `{ immediate: true }` watch
+  therefore fires once, during setup, when `#hint-target` is not in the document
+  yet — and never again, because its source never changes. Silent no-dot.
+
+`react` and `react-dom` are optional peers of `@tour-kit/hints`, so no package
+manager auto-installs them here. React *does* appear in `node_modules`, because
+`@tour-kit/hints` hard-depends on `@tour-kit/media` which requires it — but not
+in this app's bundle, and `vue-tsc` typechecks against a React-free `.d.ts`.
+
+| testid | what |
+|---|---|
+| `hint-target` | the hint's anchor (`#hint-target`, the Export button) |
+| `hint-dot-export` | the dot, positioned by `getHotspotPosition('top-right', rect)` |
+| `hint-tooltip-export` | the popup, open only while `state.hints.get('export').isOpen` |
+| `hint-dismiss-export` | dismisses; `frequency: 'once'` makes it stick across reloads |

--- a/examples/vue-app/package.json
+++ b/examples/vue-app/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
+    "@tour-kit/hints": "workspace:*",
     "@tour-kit/vue": "workspace:*",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"

--- a/examples/vue-app/src/App.vue
+++ b/examples/vue-app/src/App.vue
@@ -2,6 +2,7 @@
 import { createVueRouterAdapter, provideTourKit } from '@tour-kit/vue'
 import { useRouter } from 'vue-router'
 import TourCard from './components/TourCard.vue'
+import { provideHintsEngine } from './composables/useHintsEngine'
 import { tours } from './tours'
 
 const router = useRouter()
@@ -17,6 +18,10 @@ const kit = provideTourKit({
   routePersistence: { enabled: true, flowSession: { storage: 'sessionStorage' } },
   enableTestBridge: true,
 })
+
+// The hints engine, provided the same way the tour kit is. `'once'` makes the
+// dismissal sticky and persisted, which is what the reload e2e case proves.
+provideHintsEngine([{ id: 'export', frequency: 'once' }])
 
 const start = () => {
   void kit.start('proof')

--- a/examples/vue-app/src/components/HintDot.vue
+++ b/examples/vue-app/src/components/HintDot.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { getHotspotPosition, type HotspotPosition } from '@tour-kit/hints/engine'
+import { type RectTracker, trackRect } from '@tour-kit/vue'
+import { computed, onMounted, onScopeDispose, shallowRef, watch } from 'vue'
+import { useHintsKit } from '../composables/useHintsEngine'
+
+const props = withDefaults(
+  defineProps<{ id: string; target: string; position?: HotspotPosition }>(),
+  { position: 'top-right' }
+)
+
+const { handle, state } = useHintsKit()
+
+const hint = computed(() => state.value.hints.get(props.id))
+const isOpen = computed(() => hint.value?.isOpen ?? false)
+const isDismissed = computed(() => hint.value?.isDismissed ?? false)
+
+const rect = shallowRef<DOMRect | null>(null)
+let tracker: RectTracker | null = null
+
+/**
+ * Start tracking only once the ENGINE knows the hint, and only once this
+ * component's DOM neighbours exist. The first state the dot sees is then the
+ * hydrated one, so a persisted dismissal never flashes a dot before
+ * suppressing it.
+ *
+ * Both triggers below are needed, and neither alone is enough:
+ *
+ * - `onMounted`, because the engine is usually ALREADY registered by the time
+ *   this component sets up. `<App>` mounts and boots before vue-router
+ *   resolves the initial route, so `<HintDot>`'s setup runs after the seed. An
+ *   `{ immediate: true }` watch therefore fires exactly once, during setup,
+ *   when `#hint-target` is not in the document yet — and never again, because
+ *   its source never changes. That is a silent no-dot.
+ * - the watch, because on a route where the config arrives later (or a hint
+ *   added to `setHints` after mount) registration is the later of the two.
+ *
+ * `startTracking` is idempotent, so whichever fires second is a no-op.
+ */
+function startTracking(): void {
+  if (tracker || hint.value === undefined) return
+  const el = document.querySelector<HTMLElement>(props.target)
+  if (!el) return
+  tracker = trackRect(
+    el,
+    (r) => {
+      rect.value = r
+    },
+    { observeResize: true }
+  )
+  tracker.update()
+}
+
+onMounted(startTracking)
+watch(() => hint.value !== undefined, startTracking)
+
+onScopeDispose(() => tracker?.stop())
+
+const pos = computed(() => (rect.value ? getHotspotPosition(props.position, rect.value) : null))
+</script>
+
+<template>
+  <button
+    v-if="!isDismissed && pos"
+    :data-testid="`hint-dot-${id}`"
+    type="button"
+    class="hint-dot"
+    :style="{ top: `${pos.top}px`, left: `${pos.left}px` }"
+    :aria-label="isOpen ? 'Hide hint' : 'Show hint'"
+    :aria-expanded="isOpen"
+    @click="isOpen ? handle.hideHint(id) : handle.showHint(id)"
+  />
+  <div
+    v-if="!isDismissed && pos && isOpen"
+    role="tooltip"
+    :data-testid="`hint-tooltip-${id}`"
+    class="hint-tooltip"
+    :style="{ top: `${pos.top + 16}px`, left: `${pos.left}px` }"
+  >
+    <slot>Export your data from here.</slot>
+    <button :data-testid="`hint-dismiss-${id}`" type="button" @click="handle.dismissHint(id)">
+      Dismiss
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.hint-dot {
+  position: fixed;
+  width: 12px;
+  height: 12px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: #2563eb;
+  cursor: pointer;
+  z-index: 40;
+}
+.hint-tooltip {
+  position: fixed;
+  z-index: 41;
+  max-width: 220px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: #111827;
+  color: #f9fafb;
+  font-size: 13px;
+}
+.hint-tooltip button {
+  display: block;
+  margin-top: 6px;
+}
+</style>

--- a/examples/vue-app/src/composables/useHintsEngine.ts
+++ b/examples/vue-app/src/composables/useHintsEngine.ts
@@ -1,0 +1,66 @@
+import {
+  type HintEngineConfig,
+  type HintsEngineState,
+  type HintsHandle,
+  createHintsEngine,
+  createHintsHandle,
+} from '@tour-kit/hints/engine'
+import {
+  type InjectionKey,
+  type ShallowRef,
+  inject,
+  onMounted,
+  onScopeDispose,
+  provide,
+  shallowRef,
+} from 'vue'
+
+export interface HintsKit {
+  handle: HintsHandle
+  state: ShallowRef<HintsEngineState>
+}
+
+export const HINTS_KEY: InjectionKey<HintsKit> = Symbol('hints')
+
+/**
+ * The React binding's shape in Vue's lifecycle vocabulary.
+ *
+ * The factory SEEDS the engine — `setHints` and `boot()` — because a child's
+ * `onMounted` runs before the parent's, exactly as a child effect does in
+ * React. A dot that showed itself on mount would otherwise find no configs and
+ * no storage, and a persisted dismissal would not suppress it.
+ *
+ * Nothing constructs in `setup()`: `handle.getState()` returns the frozen
+ * `INITIAL_HINTS_STATE` until the first verb, and `handle.boot()` is `ensure()`
+ * in disguise, so it waits for the client's `onMounted`. That is what makes
+ * this SSR-safe without a `typeof window` check anywhere in the file.
+ */
+export function provideHintsEngine(hints: HintEngineConfig[]): HintsKit {
+  const handle = createHintsHandle(() => {
+    const engine = createHintsEngine()
+    engine.setHints(hints)
+    engine.boot()
+    return engine
+  })
+
+  const state = shallowRef<HintsEngineState>(handle.getState())
+  const off = handle.subscribe(() => {
+    state.value = handle.getState()
+  })
+
+  onMounted(() => handle.boot())
+  onScopeDispose(() => {
+    off()
+    handle.release()
+  })
+
+  const kit: HintsKit = { handle, state }
+  provide(HINTS_KEY, kit)
+  return kit
+}
+
+export function useHintsKit(): HintsKit {
+  const kit = inject(HINTS_KEY)
+  if (!kit) throw new Error('useHintsKit must be used under provideHintsEngine()')
+  return kit
+}

--- a/examples/vue-app/src/pages/Home.vue
+++ b/examples/vue-app/src/pages/Home.vue
@@ -1,7 +1,21 @@
+<script setup lang="ts">
+import HintDot from '../components/HintDot.vue'
+</script>
+
 <template>
   <section>
     <h2>Home</h2>
     <p>Step one of the tour points at the button below.</p>
     <button id="start-here" data-testid="start-here" type="button">Start here</button>
+
+    <p>
+      The dot beside <em>Export</em> is a hint, rendered from
+      <code>@tour-kit/hints/engine</code> alone — no React, no
+      <code>@tour-kit/hints</code> components. Dismissing it is sticky: the
+      hint's frequency rule is <code>once</code>, so it stays gone after a
+      reload.
+    </p>
+    <button id="hint-target" data-testid="hint-target" type="button">Export</button>
+    <HintDot id="export" target="#hint-target" position="top-right" />
   </section>
 </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,6 +645,9 @@ importers:
       '@floating-ui/dom':
         specifier: ^1.7.6
         version: 1.7.6
+      '@tour-kit/hints':
+        specifier: workspace:*
+        version: link:../../packages/hints
       '@tour-kit/vue':
         specifier: workspace:*
         version: link:../../packages/vue


### PR DESCRIPTION
**v3 Phase 1, PR C of three — the last one.** Plan: `plan/v3/1-hints-honest-pilot.md`, Tasks 1.6–1.7. Follows #134 and #135, both merged.

## What

A Vue app renders a working hint — dot, tooltip, sticky dismissal across a reload — importing `@tour-kit/hints/engine` and nothing else. No `@tour-kit/hints` component, no React in the bundle. That is the claim PR B's byte guards make; this is the claim run in a real browser.

- `src/composables/useHintsEngine.ts` — `createHintsHandle` with a `shallowRef` bridge, `boot()` on the parent's `onMounted`, `release()` on scope dispose. Nothing constructs in `setup()`, so it is SSR-safe with no `typeof window` check anywhere in the file.
- `src/components/HintDot.vue` — `trackRect` + `getHotspotPosition`, with the dot, tooltip and Dismiss markup written by hand. That is what a non-React consumer actually has to do, which is what makes it an honest test rather than a demo.
- `e2e/vue/hints.localhost.spec.ts` — three cases. `pnpm e2e:vue` is **12 passed** (9 existing + 3 new).

## Two ordering findings, both of which cost a debugging session

Both are now in `examples/vue-app/README.md`, where the next binding author will hit them.

**1. The factory seeds the engine.** `provideHintsEngine` calls `setHints` and `boot()` *inside* the factory handed to `createHintsHandle`, because a child's `onMounted` runs before the parent's — exactly as a child effect does in React. This is PR B's Decision 12 confirmed in a second framework, which upgrades it from "a React rule" to "a binding-pattern rule". Recipe gap 20 says so.

**2. `HintDot` tracks from `onMounted` AND a non-immediate watch, and neither alone is enough.** The plan's design used `{ immediate: true }` with the note *"safe: reads a shallowRef, constructs nothing"* — safe from a **construction** standpoint, but not from a **DOM** one.

`<App>` mounts and boots before vue-router resolves the initial route, so by the time `<HintDot>` sets up the hint is already registered. The immediate watch therefore fires exactly once, during setup, when `#hint-target` is not in the document yet — and never again, because its source never changes.

The failure mode is a **silent no-dot on a fully-rendered page with no error**, which is why the first e2e run was 3 failed against a page snapshot showing everything else present. Found by instrumenting rather than guessing. `startTracking()` is idempotent, so whichever trigger fires second is a no-op.

## Task 1.7 — the outcome (on disk; `plan/` and `wiki-tech/` are gitignored)

`plan/v3/handoff.md` has a Phase 1 Outcome block in Phase 0's shape, and two of its sentences are corrected against the evidence:

- *"19 React hooks in the provider"* was the **hook count**. There were 21 hook calls of which **four** were effects, and one of those existed only to feed a stable callback and disappeared outright. The estimate it implied was ~3× the real one. **Count effects.**
- Step 6's *"a binding over `createEngineHandle`"* is **"over `createHandle`"** (recipe gap 15).

The recipe page gains gaps 15–21 and checklist row 14.

## Verdict: GO for Phase 2

| | |
|---|---:|
| A-open → C-merge | one afternoon, against a 4-week stop-line |
| planned / actual | 29 h planned · ~3 h 25 min wall-clock |
| findings beyond the plan | **4**, none over ~20 min |
| existing tests moved | **zero** — 24 files / 295 passed, `git diff` empty |
| `hints` / `hints:engine` | 6 231 / 6 500 · 2 195 / 2 500 |
| `pnpm e2e:vue` | **12 passed** |

The ratio is agent wall-clock against human-hour estimates and is not a claim the estimate was 9× wrong — Phase 0 carries the same caveat. What it settles is the gate's real question: **no unpriced work appeared.**

**The number Phase 2 should carry is the shape, not the scalar.** Phase 0 found the packaging half does not amortise; Phase 1 found the opposite about the extraction half, for a reason worth stating — the binding rewrite, the part that looked riskiest, was the cheap half (485 lines → 82, all 295 green on the first run), and the hours went where the plan predicted: the engine's own test suite and the guards. `checklists` gets that shape plus two things `hints` never had to pay: it is Pro, so the `LicenseGate` question is live, and its task dependency graph has no equivalent here.

## Verification

| Check | Result |
|---|---|
| `pnpm e2e:vue` | **12 passed** (9 existing + 3 new) |
| `pnpm --filter vue-tour-kit-demo typecheck` | clean — `vue-tsc` resolving one React-free `.d.ts` |
| `pnpm install --frozen-lockfile` | clean after the workspace dependency |
| `git ls-files \| xargs biome check` | clean |

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt