### PR TITLE
fix(core,hints): share the fault-isolated listener set (Phase 1 review, findings 1+2)

### DIFF
--- a/.changeset/core-create-listeners.md
+++ b/.changeset/core-create-listeners.md
@@ -1,0 +1,9 @@
+---
+"@tour-kit/core": minor
+---
+
+`createListeners`, the fault-isolated subscriber fan-out every engine keeps, exported from `@tour-kit/core/engine`.
+
+A throwing subscriber no longer aborts the notify loop. `createTourEngine` already isolated listener faults; `createHintsEngine` re-derived the same loop in the v3 Phase 1 extraction and dropped the try/catch, so one broken subscriber stopped every listener registered after it from firing — after the state change and its storage write had already landed, leaving state, storage and subscribers out of step with nothing to surface the cause. Both engines now route through one implementation, and it has direct test coverage that core's inline version never had.
+
+Exported from `/engine` because a package engine needs the same guarantee — `@tour-kit/hints/engine` uses it today, and `checklists`, `announcements` and `surveys` follow.

--- a/.changeset/hints-listener-fault-isolation.md
+++ b/.changeset/hints-listener-fault-isolation.md
@@ -1,0 +1,9 @@
+---
+"@tour-kit/hints": patch
+---
+
+Fix: a throwing subscriber no longer aborts `createHintsEngine`'s notify loop.
+
+`@tour-kit/hints/engine` re-derived core's fan-out without its per-listener `try`/`catch`, so one broken subscriber stopped every listener registered after it from firing — while the frequency-state write to storage inside the same dispatch had already landed. Surviving subscribers were left reading state that storage no longer agreed with, and nothing reported the cause. The engine now uses core's shared `createListeners`, which logs the faulting subscriber and keeps going.
+
+This is reachable by design rather than in theory: the `/engine` subpath exists so non-React consumers can subscribe directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,10 @@ Both `react` and `hints` packages depend on `core`. Turbo handles build order au
     v2 §1.5 took it to 22 621 (+47 B) — the six binding-contract re-exports
     on `/engine` plus `attachAdvanceOn`'s deferred bind. v3 Phase 1 took it to
     22 879 (+20 B over the 22 857 the gate actually printed before it) for
-    `createHandle`, the engine-agnostic half of `createEngineHandle`)
+    `createHandle`, the engine-agnostic half of `createEngineHandle`. The
+    Phase 1 review took it to 22 924 for `createListeners`, the fault-isolated
+    subscriber fan-out both engines share — leaving only **76 B of headroom**,
+    so Phase 2 must re-baseline this row deliberately rather than discover it)
   - core/engine subpath <18.5 KB (the non-React consumer's worst case: the
     engine — reducer, boot resolver, actions, transition effects, four
     storage adapters — plus the v2 §1.3b DOM behaviours (focus trap,

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -266,6 +266,13 @@ export type { EngineHandle } from '../lib/tour-engine/engine-handle'
 // checklists…) composes `createHandle` with its own instead of writing a
 // second lifecycle.
 export { createHandle } from '../lib/tour-engine/engine-handle'
+// The subscriber set every engine keeps. Exported because a package engine
+// (`@tour-kit/hints/engine`, and `checklists`/`announcements`/`surveys` next)
+// needs the same fault-isolated fan-out — a throwing subscriber must not abort
+// the notify loop and leave later subscribers reading state that storage no
+// longer agrees with.
+export { createListeners } from '../lib/tour-engine/listeners'
+export type { ListenerSet } from '../lib/tour-engine/listeners'
 export type { EngineLike, Handle } from '../lib/tour-engine/engine-handle'
 export type { TourEngineLiveOptions } from '../lib/tour-engine/create-tour-engine'
 export type { TourEngineAnalytics } from '../lib/tour-engine/context'

--- a/packages/core/src/lib/tour-engine/__tests__/listeners.test.ts
+++ b/packages/core/src/lib/tour-engine/__tests__/listeners.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `createListeners` — the subscriber set every engine keeps.
+ *
+ * The rule under test is the one that was silently lost when a second engine
+ * was written: **a broken subscriber must not take the engine down with it.**
+ * `createTourEngine` had the try/catch and no test for it; `createHintsEngine`
+ * re-derived the loop in v3 Phase 1 and dropped the try/catch entirely. This
+ * file is that rule's only direct coverage, and both engines now route through
+ * the implementation it exercises.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { logger } from '../../../utils/logger'
+import { createListeners } from '../listeners'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createListeners', () => {
+  it('fans out synchronously, in subscription order', () => {
+    const set = createListeners('test')
+    const seen: number[] = []
+    set.add(() => seen.push(1))
+    set.add(() => seen.push(2))
+
+    set.notify()
+
+    expect(seen).toEqual([1, 2])
+  })
+
+  it('a throwing listener does not stop the ones after it', () => {
+    // The whole point. Before this existed, `createHintsEngine` aborted the
+    // loop here — and its storage write had already landed, so every listener
+    // after the thrower was reading state that storage no longer agreed with.
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const set = createListeners('createHintsEngine')
+    const seen: string[] = []
+
+    set.add(() => seen.push('before'))
+    set.add(() => {
+      throw new Error('subscriber is broken')
+    })
+    set.add(() => seen.push('after'))
+
+    expect(() => set.notify()).not.toThrow()
+    expect(seen, 'the fan-out aborted at the throwing listener').toEqual(['before', 'after'])
+    expect(warn).toHaveBeenCalledWith('createHintsEngine: listener threw', expect.any(Error))
+  })
+
+  it('a throwing listener still throws on the NEXT notify — it is not evicted', () => {
+    // Deliberate: silently dropping a subscriber would be a second, quieter
+    // desync. The contract is "keep going", not "self-heal".
+    vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const set = createListeners('test')
+    let calls = 0
+    set.add(() => {
+      calls++
+      throw new Error('still broken')
+    })
+
+    set.notify()
+    set.notify()
+
+    expect(calls, 'the throwing listener was silently evicted').toBe(2)
+  })
+
+  it('the label names the engine, so the warning says which one threw', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    createListeners('createTourEngine').add(() => {
+      throw new Error('x')
+    })
+    const set = createListeners('createTourEngine')
+    set.add(() => {
+      throw new Error('x')
+    })
+    set.notify()
+
+    expect(warn).toHaveBeenCalledWith('createTourEngine: listener threw', expect.any(Error))
+  })
+
+  it('unsubscribe removes exactly one listener and is idempotent', () => {
+    const set = createListeners('test')
+    let a = 0
+    let b = 0
+    const off = set.add(() => a++)
+    set.add(() => b++)
+
+    off()
+    off() // twice — must not throw or drop the other
+    set.notify()
+
+    expect([a, b]).toEqual([0, 1])
+  })
+
+  it('clear() drops every listener', () => {
+    const set = createListeners('test')
+    let calls = 0
+    set.add(() => calls++)
+    set.add(() => calls++)
+
+    set.clear()
+    set.notify()
+
+    expect(calls).toBe(0)
+  })
+})

--- a/packages/core/src/lib/tour-engine/create-tour-engine.ts
+++ b/packages/core/src/lib/tour-engine/create-tour-engine.ts
@@ -32,7 +32,6 @@ import type { MultiPagePersistenceConfig, RouterAdapter } from '../../types/rout
 import type { TourCallbackContext } from '../../types/state'
 import type { Tour } from '../../types/tour'
 import type { TourAction, TourReducerState } from '../../types/tour-reducer'
-import { logger } from '../../utils/logger'
 import { validateTour } from '../validate-tour'
 import type { TourRouteError } from '../wait-for-step-target'
 import {
@@ -56,6 +55,7 @@ import { createTerminalStore } from './adapters/terminal-store'
 import { resolveBootStart, runBootStart } from './boot'
 import type { CrossTabActiveMessage, TourEngineAnalytics, TourEngineContext } from './context'
 import { buildCallbackContext } from './helpers'
+import { createListeners } from './listeners'
 import { navigateToStepImpl } from './navigate-to-step'
 import { MAX_HIDDEN_CHAIN, tourReducer } from './reducer'
 import { applyTransitionEffects, subscribeCrossTabPause } from './transition-effects'
@@ -250,7 +250,7 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
   /** The cross-tab route listener is installed on the first real boot, once. */
   let storageSubscribed = false
 
-  const listeners = new Set<() => void>()
+  const listeners = createListeners('createTourEngine')
   const abortControllerRef: { current: AbortController | null } = { current: null }
   const bootAbortRef: { current: AbortController | null } = { current: null }
   const completedTourIdRef: { current: string | null } = { current: null }
@@ -272,20 +272,12 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
     snapshot = buildCallbackContext(state, currentTour(), data)
   }
 
-  function notify(): void {
-    // Synchronous, and deliberately: §1.4's useSyncExternalStore collapses the
-    // renders, and a microtask-coalesced notify would make getState() stale
-    // immediately after a synchronous dispatch — which is exactly what the
-    // direct-drive tests rely on.
-    for (const listener of listeners) {
-      try {
-        listener()
-      } catch (err) {
-        // A broken subscriber must not take the tour down with it.
-        logger.warn('createTourEngine: listener threw', err)
-      }
-    }
-  }
+  // Synchronous, and deliberately: §1.4's useSyncExternalStore collapses the
+  // renders, and a microtask-coalesced notify would make getState() stale
+  // immediately after a synchronous dispatch — which is exactly what the
+  // direct-drive tests rely on. The per-listener try/catch that keeps a broken
+  // subscriber from taking the tour down lives in `createListeners`.
+  const notify = listeners.notify
 
   function dispatch(action: TourAction): void {
     if (destroyed) return
@@ -575,10 +567,7 @@ export function createTourEngine(options: CreateTourEngineOptions): TourEngine {
 
     subscribe: (listener: () => void) => {
       if (destroyed) return () => {}
-      listeners.add(listener)
-      return () => {
-        listeners.delete(listener)
-      }
+      return listeners.add(listener)
     },
 
     // Terminal, idempotent, and NOT a pause. React 18 StrictMode runs

--- a/packages/core/src/lib/tour-engine/listeners.ts
+++ b/packages/core/src/lib/tour-engine/listeners.ts
@@ -1,0 +1,67 @@
+/**
+ * The subscriber set every engine keeps, with the one rule that is easy to
+ * lose when a second engine is written: **a broken subscriber must not take
+ * the engine down with it.**
+ *
+ * `createTourEngine` had this from the start. `createHintsEngine` (v3 Phase 1)
+ * re-derived the same three lines and dropped the try/catch, which is a real
+ * fault: a throwing listener aborts the fan-out mid-loop, so listeners
+ * registered after it never fire — while the state change and any storage
+ * write that preceded the notify have already landed. State, storage and
+ * subscribers desync, and nothing surfaces the cause.
+ *
+ * That is not hypothetical for an `/engine` subpath, whose entire purpose is
+ * third-party non-React subscribers. Three more package engines land in v3
+ * Phases 2-3 (`checklists`, `announcements`, `surveys`), so this is the shared
+ * home rather than a fourth and fifth copy.
+ *
+ * Deliberately NOT a reducer store. Core's public `getState()` returns a
+ * snapshot derived from reducer state via `buildCallbackContext`, hints'
+ * returns the reducer state itself, and core notifies outside `dispatch` for
+ * `setData`. A shared store would fit one engine and contort the other; the
+ * listener set is the part that is genuinely identical in both.
+ */
+import { logger } from '../../utils/logger'
+
+export interface ListenerSet {
+  /** Subscribe. The returned unsubscribe is idempotent. */
+  add: (listener: () => void) => () => void
+  /**
+   * Fan out synchronously — a microtask-coalesced notify would make
+   * `getState()` stale immediately after a synchronous dispatch, which is what
+   * direct-drive tests depend on. A throwing listener is logged and skipped;
+   * every other listener still runs.
+   */
+  notify: () => void
+  /** Drop every listener. Called from `destroy()`. */
+  clear: () => void
+}
+
+/**
+ * @param label - prefix for the warning a throwing listener produces, so the
+ *   log names the engine rather than this module.
+ */
+export function createListeners(label: string): ListenerSet {
+  const listeners = new Set<() => void>()
+
+  return {
+    add: (listener: () => void) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    notify: () => {
+      for (const listener of listeners) {
+        try {
+          listener()
+        } catch (err) {
+          logger.warn(`${label}: listener threw`, err)
+        }
+      }
+    },
+    clear: () => {
+      listeners.clear()
+    },
+  }
+}

--- a/packages/hints/src/lib/hints-engine/__tests__/create-hints-engine.test.ts
+++ b/packages/hints/src/lib/hints-engine/__tests__/create-hints-engine.test.ts
@@ -97,6 +97,32 @@ describe('createHintsEngine — the contract', () => {
     expect(spy.mock.calls.length, 'the second boot() re-read storage').toBe(reads)
   })
 
+  it('a throwing subscriber does not abort the fan-out, and storage stays in step', () => {
+    // Regression, v3 Phase 1 review. This engine re-derived core's notify loop
+    // and dropped its per-listener try/catch, so one broken subscriber aborted
+    // the fan-out — while the storage write inside `dispatch` had ALREADY
+    // landed. Every listener after the thrower then read state that storage no
+    // longer agreed with. `/engine` exists for third-party subscribers, so this
+    // is reachable by design, not hypothetically.
+    const e = createHintsEngine({ storage })
+    e.setHints([{ id: ID, frequency: { type: 'times', count: 3 } }])
+    e.boot()
+
+    const seen: string[] = []
+    e.subscribe(() => seen.push('before'))
+    e.subscribe(() => {
+      throw new Error('subscriber is broken')
+    })
+    e.subscribe(() => seen.push('after'))
+
+    expect(() => e.showHint(ID)).not.toThrow()
+    expect(seen, 'the fan-out aborted at the throwing listener').toContain('after')
+    // The write landed and the surviving subscribers can see the state it
+    // describes — that is the desync the try/catch prevents.
+    expect(storage.getItem(KEY)).toContain('"viewCount":1')
+    expect(e.getState().activeHint).toBe(ID)
+  })
+
   it('a verb before setHints is UNGATED and a verb before boot() is UNPERSISTED', () => {
     // Engine semantics, pinned deliberately: one writer for configs, storage at
     // boot. It is the BINDING that closes this window by seeding its factory

--- a/packages/hints/src/lib/hints-engine/create-hints-engine.ts
+++ b/packages/hints/src/lib/hints-engine/create-hints-engine.ts
@@ -20,7 +20,12 @@
  * whole reducer state including `frequencyState`; and a dispatch notifies
  * per action rather than per React commit. Observable state is identical.
  */
-import { canShowAfterDismissal, canShowByFrequency, logger } from '@tour-kit/core/engine'
+import {
+  canShowAfterDismissal,
+  canShowByFrequency,
+  createListeners,
+  logger,
+} from '@tour-kit/core/engine'
 import type { FrequencyRule, HintsActions } from '@tour-kit/core/engine'
 import { readPersistedEntries, resolveStorage, syncStorage } from './persistence'
 import { emptyFrequencyState, hintsReducer } from './reducer'
@@ -58,7 +63,7 @@ export function createHintsEngine(options: CreateHintsEngineOptions = {}): Hints
   let configs: ReadonlyMap<string, HintEngineConfig> = new Map()
   const registered = new Set<string>()
   const hydrated = new Set<string>()
-  const listeners = new Set<() => void>()
+  const listeners = createListeners('createHintsEngine')
 
   function dispatch(action: HintsAction): void {
     if (destroyed) return
@@ -71,7 +76,11 @@ export function createHintsEngine(options: CreateHintsEngineOptions = {}): Hints
     if (storage && prev.frequencyState !== next.frequencyState) {
       syncStorage(storage, prev.frequencyState, next.frequencyState, hydrated)
     }
-    for (const listener of listeners) listener()
+    // Fault-isolated: a throwing subscriber must not abort the fan-out. The
+    // storage write above has already landed, so a listener that took the loop
+    // down would leave later subscribers reading state that storage no longer
+    // agrees with.
+    listeners.notify()
   }
 
   function hydrate(): void {
@@ -126,10 +135,7 @@ export function createHintsEngine(options: CreateHintsEngineOptions = {}): Hints
     getState: () => state,
     subscribe: (listener) => {
       if (destroyed) return () => {}
-      listeners.add(listener)
-      return () => {
-        listeners.delete(listener)
-      }
+      return listeners.add(listener)
     },
     boot,
     setHints,

--- a/tooling/bundle-check/budgets.mjs
+++ b/tooling/bundle-check/budgets.mjs
@@ -95,6 +95,18 @@
  *     engine composes it rather than writing a second lifecycle —
  *     `@tour-kit/hints/engine` is the first.
  *
+ *     The v3 Phase 1 REVIEW added 55 B more (18 123 -> 18 178) for
+ *     `createListeners`: the fault-isolated subscriber fan-out both engines
+ *     now share. `createHintsEngine` had re-derived core's notify loop and
+ *     dropped its per-listener try/catch, so a throwing subscriber aborted the
+ *     fan-out after the storage write had landed. Three more package engines
+ *     land in Phases 2-3; this is the shared home rather than five copies.
+ *
+ *     NOTE for Phase 2: `core` is now at 22 924 against 23 000 — **76 B of
+ *     headroom**. Do not assume room on that row. A slice that needs more must
+ *     re-baseline it deliberately, with the measured number, not discover it
+ *     as a CI failure.
+ *
  *     Do NOT split a `/engine/dom` entry to keep this number flat: the row
  *     measures the import-everything worst case, a bundler tree-shakes the
  *     rest (`sideEffects: false`), and the only consumer who pays all of it is


### PR DESCRIPTION
Review fix 1 of 3 for the v3 Phase 1 PRs (#134/#135/#136). **This one is the blocker.**

## The bug

`createHintsEngine` re-derived `createTourEngine`'s notify loop and dropped its per-listener `try`/`catch`.

```js
// core, create-tour-engine.ts:275 — had this from the start
for (const listener of listeners) {
  try { listener() } catch (err) { logger.warn('createTourEngine: listener threw', err) }
}

// hints, create-hints-engine.ts:75 — the extraction lost it
for (const listener of listeners) listener()
```

A throwing subscriber aborted the fan-out mid-loop, so every listener registered after it never fired — **while the state change and the frequency-state write to storage inside the same `dispatch` had already landed.** Surviving subscribers were left reading state that storage no longer agreed with, and nothing surfaced the cause. That's the announcements queue-desync class.

It is reachable by design, not in theory: the `/engine` subpath exists so non-React consumers can subscribe directly, and the Vue example added in #136 is one such subscriber.

## The fix

`createListeners(label)` in `lib/tour-engine/listeners.ts`, exported from `@tour-kit/core/engine` so package engines can use it. Both engines route through it. Six direct cases — coverage core's inline version never had — including that a throwing listener is logged and skipped rather than silently **evicted**, since self-healing would be a second, quieter desync.

Seen red before the fix landed, with the bare loop restored:

```
× a throwing subscriber does not abort the fan-out, and storage stays in step
  Tests  1 failed | 20 passed (21)
```

## Why this is smaller than the review asked for

The review's first finding called for a shared `createReducerStore`, on the grounds that both engines hand-roll state + listeners + guarded dispatch + destroy. **Reading core properly kills that idea**, and I'd rather say so than build it:

- core's public `getState()` returns a snapshot **derived** from reducer state via `buildCallbackContext`; hints' returns the reducer state itself
- core notifies **outside** `dispatch` (`setData`)
- core's `destroy()` does six things beyond clearing listeners — abort controllers, flow-session flush, broadcast close, teardown stack

A shared store would need a derive seam and a notify-without-dispatch seam and would still leave most of core's destroy outside it: an abstraction that fits one engine and contorts the other, which is the thing this repo's review bar exists to prevent. The listener set is the part that is genuinely identical — and it is where the bug was.

Three more package engines land in Phases 2–3 (`checklists`, `announcements`, `surveys`), so this is the shared home rather than a fourth and fifth copy of the same loop.

## Bytes

| Row | Before | After | Ceiling |
|---|---:|---:|---:|
| `core` | 22 878 | **22 924** | 23 000 |
| `core:engine` | 18 123 | **18 178** | 18 500 |
| `core:engine:iife` | 17 501 | **17 550** | 18 500 |
| `hints` | 6 231 | **6 240** | 6 500 |
| `hints:engine` | 2 195 | **2 203** | 2 500 |

No ceiling moved. Putting `createListeners` inside `engine-handle.ts` to dodge a module boundary measured at **zero** byte difference, so it stays a focused module.

⚠️ **Flagged for Phase 2, in both `budgets.mjs` and `CLAUDE.md`: `core` is now at 22 924 against 23 000 — 76 B of headroom.** A slice needing more must re-baseline that row deliberately with a measured number, not discover it as a CI failure.

## Gates

| Check | Result |
|---|---|
| `@tour-kit/core` | 1 656 passed, 3 skipped |
| `@tour-kit/hints` | 370 passed |
| `@tour-kit/vue` / `@tour-kit/svelte` | 41 / 40 |
| `pnpm typecheck` | 0 errors |
| `git ls-files \| xargs biome check` | clean |
| `pnpm dist:size` | all rows ✓ |

Next: findings 3, 5, 6, 7 (duplicate `HintState`, the `as` cast, null-storage branches, the pass-through module), then finding 4 (the guard-test factory).

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt