### PR TITLE
refactor(core,hints): one HintState, one sync storage type, no cast (Phase 1 review, findings 3+5+6+7)

### DIFF
--- a/.changeset/core-sync-storage.md
+++ b/.changeset/core-sync-storage.md
@@ -1,0 +1,9 @@
+---
+"@tour-kit/core": minor
+---
+
+`SyncStorage`, the synchronous storage-adapter shape, and `createPrefixedStorage` now preserves it.
+
+Core's `Storage` permits `Promise`-returning methods so async adapters are possible, but several code paths read `getItem` inline and cannot use those. Each had re-declared the synchronous three-method shape locally. `SyncStorage` is now the one declaration, exported from the root, `/engine` and `utils`.
+
+`createPrefixedStorage` is overloaded: hand it a synchronous adapter and you get a synchronous adapter back. It is a pure pass-through, so the wide return type was never accurate — it just forced every synchronous consumer to re-narrow with an `as` cast. `createNoopStorage()` is likewise typed `SyncStorage`, since every method on it is synchronous; narrowing a return type is safe for existing callers.

--- a/.changeset/hints-one-hint-state.md
+++ b/.changeset/hints-one-hint-state.md
@@ -1,0 +1,9 @@
+---
+"@tour-kit/hints": patch
+---
+
+Fix: `@tour-kit/hints` and `@tour-kit/hints/engine` exported two different `HintState` types.
+
+The package declared its own `HintState` while the engine subpath published core's. The two were byte-identical, so it compiled — but a consumer importing the type from both entry points held two unrelated declarations, and the day either grew a field that would have surfaced as an inscrutable `Map` variance error. `@tour-kit/hints` now re-exports core's, as it already did for `HotspotPosition`. No shape change.
+
+`HintsStorage` is now an alias of core's new `SyncStorage` rather than a third local copy of the same three methods, and `resolveStorage()` returns core's no-op adapter instead of `null` when there is no `window` — the engine's storage field is non-nullable as a result. Neither is visible to a React consumer.

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -188,6 +188,7 @@ export {
   throttleTime,
   throttleLeading,
 } from '../utils'
+export type { SyncStorage } from '../utils'
 export type {
   LogLevel,
   LoggerConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -174,6 +174,7 @@ export {
   throttleTime,
   throttleLeading,
 } from './utils'
+export type { SyncStorage } from './utils'
 export type {
   LogLevel,
   LoggerConfig,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -33,6 +33,7 @@ export {
   safeJSONParse,
   createPrefixedStorage,
 } from './storage'
+export type { SyncStorage } from './storage'
 
 export {
   announce,

--- a/packages/core/src/utils/storage.ts
+++ b/packages/core/src/utils/storage.ts
@@ -3,6 +3,25 @@
 import type { PersistenceConfig, Storage as StorageAdapter } from '../types'
 
 /**
+ * The SYNCHRONOUS three-method subset of the storage adapter.
+ *
+ * Core's `Storage` permits `Promise`-returning methods for async adapters;
+ * several code paths cannot use those because they read `getItem` inline. Those
+ * paths had each re-declared this shape locally — `@tour-kit/hints`'
+ * persistence layer, and the option types in `@tour-kit/announcements` and
+ * `@tour-kit/surveys`. One declaration, here, so `createPrefixedStorage` can
+ * promise to hand a synchronous adapter back.
+ *
+ * `window.localStorage`, `createMemoryStorage()` and the in-memory test shims
+ * all satisfy it structurally.
+ */
+export interface SyncStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+/**
  * Create storage adapter from config
  */
 export function createStorageAdapter(storageType: PersistenceConfig['storage']): StorageAdapter {
@@ -25,9 +44,14 @@ export function createStorageAdapter(storageType: PersistenceConfig['storage']):
 }
 
 /**
- * No-op storage for SSR
+ * No-op storage for SSR.
+ *
+ * Typed `SyncStorage` rather than the wide `Storage`: every method here is
+ * synchronous, and declaring it wide made it unusable as the stand-in for a
+ * synchronous adapter — which is its whole purpose. Narrowing a return type is
+ * safe for existing callers.
  */
-export function createNoopStorage(): StorageAdapter {
+export function createNoopStorage(): SyncStorage {
   return {
     getItem: () => null,
     setItem: () => {},
@@ -86,8 +110,23 @@ export function safeJSONParse<T>(value: string | null, fallback: T): T {
 }
 
 /**
- * Create storage with key prefix
+ * Create storage with key prefix.
+ *
+ * Overloaded rather than generic, because this is a pure pass-through:
+ * `getItem` returns exactly what the inner `getItem` returned, so a caller
+ * holding a SYNCHRONOUS adapter must get a synchronous one back. Returning the
+ * wide `Storage` — which permits `Promise`-returning methods — forced every
+ * synchronous consumer to re-narrow with an `as` cast; `@tour-kit/hints`'
+ * persistence layer had one until the v3 Phase 1 review.
+ *
+ * NOT `<S extends Storage>(storage: S) => S`: that promises to return the
+ * caller's exact type, which would oblige the wrapper to carry a DOM
+ * `Storage`'s `length`, `key()` and `clear()` too — and spreading them copies
+ * `length` as a number frozen at wrap time rather than a live getter. The
+ * wrapper deliberately returns the three-method adapter and nothing else.
  */
+export function createPrefixedStorage(storage: SyncStorage, prefix: string): SyncStorage
+export function createPrefixedStorage(storage: StorageAdapter, prefix: string): StorageAdapter
 export function createPrefixedStorage(storage: StorageAdapter, prefix: string): StorageAdapter {
   const prefixKey = (key: string) => `${prefix}:${key}`
 

--- a/packages/hints/src/components/headless/hint-hotspot.tsx
+++ b/packages/hints/src/components/headless/hint-hotspot.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import * as React from 'react'
+import { getHotspotPosition } from '../../lib/hints-engine/hotspot-position'
 import type { HotspotPosition } from '../../types'
-import { getHotspotPosition } from '../hotspot-position'
 
 export interface HintHotspotHeadlessProps extends React.ComponentPropsWithoutRef<'button'> {
   /** Target element's bounding rect */

--- a/packages/hints/src/components/hint-hotspot.tsx
+++ b/packages/hints/src/components/hint-hotspot.tsx
@@ -2,12 +2,12 @@
 
 import { cn, useReducedMotion, useUILibrary } from '@tour-kit/core'
 import * as React from 'react'
+import { getHotspotPosition } from '../lib/hints-engine/hotspot-position'
 import { Slot, UnifiedSlot } from '../lib/slot'
 import type { HotspotPosition } from '../types'
 import { HintBadge } from '../variants/badge'
 import { HintBeaconWithLabel } from '../variants/beacon-with-label'
 import { HintWhatsNewPill } from '../variants/whats-new-pill'
-import { getHotspotPosition } from './hotspot-position'
 import {
   type HintHotspotVariantName,
   type HintHotspotVariants,

--- a/packages/hints/src/components/hotspot-position.ts
+++ b/packages/hints/src/components/hotspot-position.ts
@@ -1,4 +1,0 @@
-// v3 Phase 1 — the implementation moved to `lib/hints-engine/hotspot-position.ts`
-// so `@tour-kit/hints/engine` can publish it. This re-export keeps
-// `hint-hotspot.tsx` and the three variants importing from where they always did.
-export { getHotspotPosition } from '../lib/hints-engine/hotspot-position'

--- a/packages/hints/src/lib/hints-engine/__tests__/handle.test.ts
+++ b/packages/hints/src/lib/hints-engine/__tests__/handle.test.ts
@@ -9,23 +9,8 @@
  */
 import { describe, expect, it } from 'vitest'
 import { createMockStorage } from '../../../__tests__/mock-storage'
-import type { HintsContextValue } from '../../../types'
 import { createHintsEngine } from '../create-hints-engine'
 import { INITIAL_HINTS_STATE, createHintsHandle } from '../handle'
-import type { HintsEngineState } from '../types'
-
-/**
- * The engine's snapshot must stay assignable to the React context value.
- * Core's `HintState` and hints' own are two independent declarations of the
- * same shape (`packages/core/src/types/hints.ts` and
- * `packages/hints/src/types/index.ts`); the binding assigns the first into the
- * second, and it compiles only while they agree. This line is the compile-time
- * pin — `packages/hints/tsconfig.json` includes `src/**\/*`, so `pnpm typecheck`
- * and the safe-ship-gate hook are its runners.
- */
-const _snapshotFitsContext: HintsContextValue['hints'] =
-  null as unknown as HintsEngineState['hints']
-void _snapshotFitsContext
 
 function counting(storage?: Storage) {
   let constructed = 0

--- a/packages/hints/src/lib/hints-engine/__tests__/persistence.ssr.test.ts
+++ b/packages/hints/src/lib/hints-engine/__tests__/persistence.ssr.test.ts
@@ -6,13 +6,28 @@
  * `typeof window === 'undefined'` guard fires, and a stub with `window` present
  * makes that a lie that passes. The docblock is FILE-scoped — one further down
  * does nothing and the file silently runs in jsdom.
+ *
+ * The contract changed in the Phase 1 review: this used to return `null`, and
+ * the engine carried `storage: HintsStorage | null` plus two null-checks. It
+ * now returns core's no-op adapter, so the engine's field is non-nullable and
+ * those branches are gone. What must still not happen before `boot()` is
+ * HYDRATION — a lifecycle rule, guarded by `booted`, not by a null.
  */
 import { describe, expect, it } from 'vitest'
 import { resolveStorage } from '../persistence'
 
 describe('resolveStorage under SSR', () => {
-  it('returns null without throwing when there is no window', () => {
+  it('returns a usable no-op adapter instead of null, and never throws', () => {
     expect(typeof globalThis.window, 'this file is not running in node').toBe('undefined')
-    expect(resolveStorage(undefined)).toBeNull()
+
+    const storage = resolveStorage(undefined)
+
+    expect(storage).not.toBeNull()
+    expect(() => storage.setItem('hint:freq:a', '{"viewCount":1}')).not.toThrow()
+    expect(() => storage.removeItem('hint:freq:a')).not.toThrow()
+    // A no-op swallows the write, so the read comes back empty — which is what
+    // makes the engine's post-boot hydrate a no-op on the server rather than a
+    // special case at every call site.
+    expect(storage.getItem('hint:freq:a')).toBeNull()
   })
 })

--- a/packages/hints/src/lib/hints-engine/create-hints-engine.ts
+++ b/packages/hints/src/lib/hints-engine/create-hints-engine.ts
@@ -24,6 +24,7 @@ import {
   canShowAfterDismissal,
   canShowByFrequency,
   createListeners,
+  createNoopStorage,
   logger,
 } from '@tour-kit/core/engine'
 import type { FrequencyRule, HintsActions } from '@tour-kit/core/engine'
@@ -59,7 +60,11 @@ export function createHintsEngine(options: CreateHintsEngineOptions = {}): Hints
   let state: HintsEngineState = { hints: new Map(), activeHint: null, frequencyState: new Map() }
   let destroyed = false
   let booted = false
-  let storage: HintsStorage | null = null
+  // Never null: `resolveStorage` hands back a no-op when there is no window,
+  // and a no-op stands in until `boot()` resolves the real one. What must not
+  // happen before boot is HYDRATION, and that is guarded by `booted` below —
+  // the invariant is a lifecycle one, not a nullability one.
+  let storage: HintsStorage = createNoopStorage()
   let configs: ReadonlyMap<string, HintEngineConfig> = new Map()
   const registered = new Set<string>()
   const hydrated = new Set<string>()
@@ -73,7 +78,7 @@ export function createHintsEngine(options: CreateHintsEngineOptions = {}): Hints
     state = next
     // The provider's persist effect, minus React's post-commit delay: same
     // condition, same diff, same swallowed failures.
-    if (storage && prev.frequencyState !== next.frequencyState) {
+    if (prev.frequencyState !== next.frequencyState) {
       syncStorage(storage, prev.frequencyState, next.frequencyState, hydrated)
     }
     // Fault-isolated: a throwing subscriber must not abort the fan-out. The
@@ -84,7 +89,11 @@ export function createHintsEngine(options: CreateHintsEngineOptions = {}): Hints
   }
 
   function hydrate(): void {
-    if (!storage) return
+    // Before `boot()` there is no real storage yet, and `readPersistedEntries`
+    // MARKS every id it looks at as hydrated. Running it early would therefore
+    // burn the ids and make the real hydrate at boot skip them all — which is
+    // why this guard is `booted` and not a null-check on `storage`.
+    if (!booted) return
     const entries = readPersistedEntries(storage, [...configs.keys()], hydrated)
     if (entries.length > 0) dispatch({ type: 'HYDRATE_FREQUENCY', entries })
   }
@@ -150,7 +159,7 @@ export function createHintsEngine(options: CreateHintsEngineOptions = {}): Hints
       if (destroyed) return
       destroyed = true
       listeners.clear()
-      storage = null
+      storage = createNoopStorage()
     },
   }
 }

--- a/packages/hints/src/lib/hints-engine/persistence.ts
+++ b/packages/hints/src/lib/hints-engine/persistence.ts
@@ -10,7 +10,7 @@
  * The `'tourkit'` prefix and the `hint:freq:<id>` key shape do NOT move, so
  * blobs written by 2.1.0 read back unchanged.
  */
-import { createPrefixedStorage, safeJSONParse } from '@tour-kit/core/engine'
+import { createNoopStorage, createPrefixedStorage, safeJSONParse } from '@tour-kit/core/engine'
 import type { FrequencyState } from '@tour-kit/core/engine'
 import type { HintsStorage } from './types'
 
@@ -96,25 +96,29 @@ export function syncStorage(
   }
 }
 
-function defaultStorage(): HintsStorage | null {
-  if (typeof window === 'undefined') return null
+function defaultStorage(): HintsStorage {
+  if (typeof window === 'undefined') return createNoopStorage()
   try {
     return window.localStorage
   } catch {
-    return null
+    // Private browsing throws on access, not on use.
+    return createNoopStorage()
   }
 }
 
 /**
- * `undefined` selects `window.localStorage`; no window (SSR) selects nothing.
+ * `undefined` selects `window.localStorage`; no window (SSR) selects a no-op.
  *
- * The cast narrows core's `Storage` — which permits Promise-returning adapters
- * — down to the synchronous three-method shape this path reads. Both
- * `localStorage` and the in-memory test mock are synchronous; an async adapter
- * would silently break hydration.
+ * No cast: `createPrefixedStorage` is overloaded to hand a synchronous adapter
+ * back when given one, so the sync shape survives the wrap. It used to return
+ * core's wide `Storage` and every synchronous consumer re-narrowed with `as`.
+ *
+ * Never null. `createNoopStorage()` is core's answer to "there is no storage
+ * here" and it keeps the engine's `storage` field non-nullable, which deletes
+ * two branches at its call sites. The engine still must not HYDRATE before
+ * `boot()` — but that is a lifecycle rule, guarded by `booted`, not something
+ * to encode as a null.
  */
-export function resolveStorage(storage: HintsStorage | undefined): HintsStorage | null {
-  const raw = storage ?? defaultStorage()
-  if (!raw) return null
-  return createPrefixedStorage(raw, 'tourkit') as HintsStorage
+export function resolveStorage(storage: HintsStorage | undefined): HintsStorage {
+  return createPrefixedStorage(storage ?? defaultStorage(), 'tourkit')
 }

--- a/packages/hints/src/lib/hints-engine/types.ts
+++ b/packages/hints/src/lib/hints-engine/types.ts
@@ -7,7 +7,7 @@
  * thing the subpath exists to avoid. Every type the engine needs is either
  * declared here or imported from `@tour-kit/core/engine`.
  */
-import type { FrequencyRule, FrequencyState, HintState } from '@tour-kit/core/engine'
+import type { FrequencyRule, FrequencyState, HintState, SyncStorage } from '@tour-kit/core/engine'
 
 /** The slice of a hint config the engine reads. `HintConfig` is assignable to it. */
 export interface HintEngineConfig {
@@ -34,12 +34,11 @@ export type HintsAction =
   | { type: 'HYDRATE_FREQUENCY'; entries: ReadonlyArray<readonly [string, FrequencyState]> }
 
 /**
- * The SYNCHRONOUS 3-method subset of DOM `Storage` the persistence path reads.
- * `window.localStorage` and the in-memory test mock both satisfy it. Core's
- * `Storage` type permits Promise-returning adapters; those do not work here.
+ * The SYNCHRONOUS 3-method subset of the storage adapter this engine reads.
+ *
+ * An alias, not a declaration: core owns the shape as `SyncStorage`. The name
+ * stays because `@tour-kit/hints/engine` publishes it. Core's wide `Storage`
+ * permits Promise-returning adapters; those do not work here, because the
+ * hydration path reads `getItem` inline.
  */
-export interface HintsStorage {
-  getItem(key: string): string | null
-  setItem(key: string, value: string): void
-  removeItem(key: string): void
-}
+export type HintsStorage = SyncStorage

--- a/packages/hints/src/types/index.ts
+++ b/packages/hints/src/types/index.ts
@@ -1,6 +1,7 @@
 import type {
   AudienceProp,
   FrequencyRule,
+  HintState,
   HotspotPosition,
   LocalizedText,
   Placement,
@@ -12,6 +13,13 @@ import type * as React from 'react'
 // Re-export Placement from core for convenience
 export type { Placement }
 export type { HotspotPosition }
+// Core owns `HintState`, as it owns `HotspotPosition` above. This package
+// declared its own byte-identical copy until the v3 Phase 1 review: with the
+// engine subpath publishing core's, `@tour-kit/hints` and
+// `@tour-kit/hints/engine` were exporting two different declarations under one
+// name. Identical today, so it compiled — and the day either grew a field, a
+// consumer mixing the two entry points got an inscrutable `Map` variance error.
+export type { HintState }
 
 export interface HintConfig {
   id: string
@@ -53,12 +61,6 @@ export interface HintConfig {
   onClick?: () => void
   onShow?: () => void
   onDismiss?: () => void
-}
-
-export interface HintState {
-  id: string
-  isOpen: boolean
-  isDismissed: boolean
 }
 
 export interface HintsContextValue {

--- a/packages/hints/src/variants/badge.tsx
+++ b/packages/hints/src/variants/badge.tsx
@@ -3,8 +3,8 @@
 import { cn, useUILibrary } from '@tour-kit/core'
 import * as React from 'react'
 
-import { getHotspotPosition } from '../components/hotspot-position'
 import { hintHotspotVariants } from '../components/ui/hint-variants'
+import { getHotspotPosition } from '../lib/hints-engine/hotspot-position'
 import { Slot, UnifiedSlot } from '../lib/slot'
 import type { HotspotPosition } from '../types'
 

--- a/packages/hints/src/variants/beacon-with-label.tsx
+++ b/packages/hints/src/variants/beacon-with-label.tsx
@@ -3,8 +3,8 @@
 import { cn, useReducedMotion, useUILibrary } from '@tour-kit/core'
 import * as React from 'react'
 
-import { getHotspotPosition } from '../components/hotspot-position'
 import { hintHotspotVariants } from '../components/ui/hint-variants'
+import { getHotspotPosition } from '../lib/hints-engine/hotspot-position'
 import { Slot, UnifiedSlot } from '../lib/slot'
 import type { HotspotPosition } from '../types'
 

--- a/packages/hints/src/variants/whats-new-pill.tsx
+++ b/packages/hints/src/variants/whats-new-pill.tsx
@@ -3,8 +3,8 @@
 import { cn, useReducedMotion, useUILibrary } from '@tour-kit/core'
 import * as React from 'react'
 
-import { getHotspotPosition } from '../components/hotspot-position'
 import { hintHotspotVariants } from '../components/ui/hint-variants'
+import { getHotspotPosition } from '../lib/hints-engine/hotspot-position'
 import { Slot, UnifiedSlot } from '../lib/slot'
 import type { HotspotPosition } from '../types'
 


### PR DESCRIPTION
Review fix 2 of 3 for the v3 Phase 1 PRs (#134/#135/#136). Stacked on #137 (merged). **Every finding here deletes code.**

## 3 — `@tour-kit/hints` was publishing two different `HintState` types

`src/index.ts` exported the package's own declaration; `src/engine/index.ts` exported core's. Byte-identical, so it compiled — and a consumer importing the type from both entry points held two unrelated declarations. The day either grew a field, that surfaces as a `Map` variance error inside `hints-provider.tsx` with no obvious cause.

The package now re-exports core's, exactly as it already did for `HotspotPosition` two lines above in the same file. The compile-time pin I added in Phase 1's `handle.test.ts` is deleted along with the duplicate it was pinning — asserting that two declarations stay identical was never the right fix when one of them shouldn't exist.

## 5 — the `as HintsStorage` cast is gone, by fixing core

`createPrefixedStorage` is a pure pass-through whose `getItem` returns exactly what the inner one returned, yet it took and returned core's wide `Storage` (which permits `Promise`-returning methods). Every synchronous consumer had to re-narrow with a cast. It's now overloaded — synchronous adapter in, synchronous adapter out.

Core also gains `SyncStorage` as the single declaration of that shape. It was written three times in this repo: `hints`' persistence layer, `announcements/src/types/announcement.ts:234`, `surveys/src/types/survey.ts:181`. The latter two can drop theirs in a follow-up.

**One dead end worth recording, because it nearly shipped.** My first attempt was `<S extends Storage>(storage: S, prefix: string): S`. That promises to return the caller's *exact* type, which obliges the wrapper to carry a DOM `Storage`'s `length`, `key()` and `clear()` — and `{ ...storage }` copies `length` as a number **frozen at wrap time** rather than a live getter. Caught before commit; the reasoning is now in the code so it isn't re-attempted.

## 6 — `resolveStorage` returns a no-op instead of `null`

Core already owns `createNoopStorage()` for exactly this. The engine's `storage` field is non-nullable now and two branches are gone.

The subtlety that made this worth care: `if (!storage) return` in `hydrate()` was **not** a null check. `readPersistedEntries` *marks* every id it looks at as hydrated, so running it before real storage exists would burn the ids and make the real hydrate at `boot()` skip them all. The guard is now `if (!booted) return`, which states the actual lifecycle invariant instead of encoding it as a nullability one.

`createNoopStorage()` is typed `SyncStorage` too — every method on it is synchronous, and declaring it wide made it unusable as the stand-in for a synchronous adapter, which is its whole purpose. Narrowing a return type is safe for existing callers.

## 7 — `components/hotspot-position.ts` deleted

A one-line pass-through kept alive so five import sites stayed untouched. Five sites is a trivial rename; a permanent identity module is not. All five now import `lib/hints-engine/hotspot-position` directly.

## Verification

One test changed, and it is **not** one of the 295: `persistence.ssr.test.ts` was written in this phase and asserted the old `null` contract. It now pins the new one — a usable no-op that swallows writes and reads back empty, under a real `node` environment.

| Check | Result |
|---|---|
| the 295 oracle (vs `e1725c6f`) | **24 files / 295 passed**, diff empty |
| `@tour-kit/core` | 1 656 passed |
| `@tour-kit/hints` | 370 passed |
| `pnpm typecheck` | 0 errors |
| `git ls-files \| xargs biome check` | clean |
| `pnpm dist:size` | core 22 923 · hints 6 243 · hints:engine 2 212 — all ✓ |

Proof the dedup actually landed in the published types:

```
main declares its own HintState: false
main re-exports core HintState:  true
casts remaining in hints/persistence.ts: 0
```

Next: finding 4 — the guard-test factory in `tooling/bundle-check/`, which also closes the latent hole where `analytics` and `scheduling` still scan their entry rather than their closure.

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt