### PR TITLE
test(tooling): share the engine-guard plumbing, and propagate the closure rule (Phase 1 review, finding 4)

### DIFF
--- a/packages/analytics/src/__tests__/no-react-in-engine-dist.test.ts
+++ b/packages/analytics/src/__tests__/no-react-in-engine-dist.test.ts
@@ -13,35 +13,37 @@
  *     either the matcher broke or the package changed shape — both deserve a
  *     red, and without it a broken regex is green forever.
  *
- * `splitting: false` in this package, so the built entry IS its own closure —
- * no walk needed for the JS. The declarations are different: rollup-plugin-dts
- * chunks shared types regardless, under a content-hashed name that changes on
- * every rebuild, so the d.ts scan walks with `closureOf` and never spells the
- * hash.
+ * Every scan reads the import CLOSURE, never the entry, through the shared
+ * helpers in `tooling/bundle-check/engine-guard.mjs`. This package builds with
+ * `splitting: false`, so for the JS the two are the same file today — but that
+ * is a tsup setting asserted nowhere, and the v3 Phase 1 review MEASURED what an
+ * entry-only scan costs when it flips: with the guard reading the entry, a React
+ * provider exported from the engine barrel left the specifier scan green. The
+ * declarations were never equivalent anyway — rollup-plugin-dts chunks shared
+ * types regardless, under a content-hashed name that changes on every rebuild,
+ * so the d.ts scan has always had to walk. Never spell the hash.
  */
-import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { SPECIFIER_PREFIX, specifierPattern } from '../../../../tooling/bundle-check/closure.mjs'
 import {
-  RELATIVE_SPECIFIER,
-  SPECIFIER_PREFIX,
-  closureOf,
-  specifierPattern,
-} from '../../../../tooling/bundle-check/closure.mjs'
+  assertClosureIsNotTheShell,
+  assertEngineExportsResolve,
+  assertEngineFilesExist,
+  closureSrc,
+  enginePaths,
+  distExists as pkgDistExists,
+  reachableFrom,
+  read,
+  startsWithClientDirective,
+} from '../../../../tooling/bundle-check/engine-guard.mjs'
 
 const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
-const DIST = join(PKG_ROOT, 'dist')
+const P = enginePaths(PKG_ROOT)
 // The DIRECTORY, not the files: gating on a filename turns a typo into a
 // silent skip (measured in v2 §1.5 — "3 skipped", green, proving nothing).
-const distExists = () => existsSync(DIST)
-
-const ENGINE_JS = join(DIST, 'engine', 'index.js')
-const ENGINE_CJS = join(DIST, 'engine', 'index.cjs')
-const ENGINE_DTS = join(DIST, 'engine', 'index.d.ts')
-const ENGINE_DCTS = join(DIST, 'engine', 'index.d.cts')
-const MAIN_JS = join(DIST, 'index.js')
-const MAIN_DTS = join(DIST, 'index.d.ts')
+const distExists = () => pkgDistExists(PKG_ROOT)
 
 const FORBIDDEN = ['react', 'react-dom', '@tour-kit/license'] as const
 
@@ -63,39 +65,36 @@ const FORBIDDEN = ['react', 'react-dom', '@tour-kit/license'] as const
  */
 const BARE_CORE = new RegExp(`${SPECIFIER_PREFIX}["']@tour-kit/core["']`)
 
-const read = (p: string) => readFileSync(p, 'utf8')
-// rollup-plugin-dts chunks shared declarations even with `splitting: false`
-// (a content-hashed `dist/plugin-*.d.ts` exists today); `closureOf` follows
-// them because `resolveEmitted` maps `.js → .d.ts` and `.cjs → .d.cts`. It
-// tries the literal path first, so a `'../plugins/posthog.js'` re-export also
-// pulls the real plugin JS in — a superset scan, deliberately kept.
-const readDts = (entry: string) => closureOf(entry).map(read).join('\n')
-
 describe('@tour-kit/analytics/engine ships no React', () => {
+  it.skipIf(!distExists())('ANTI-VACUITY — the engine closure is more than a shell', () => {
+    // This package builds with `splitting: false`, so the entry IS the closure
+    // today — but that is a tsup setting asserted nowhere else, and the v3
+    // Phase 1 review measured what an entry-only scan costs when it flips.
+    for (const entry of [P.engineJs, P.engineCjs]) assertClosureIsNotTheShell(expect, entry)
+  })
+
   it.skipIf(!distExists())('names the four built engine files', () => {
-    for (const f of [ENGINE_JS, ENGINE_CJS, ENGINE_DTS, ENGINE_DCTS]) {
-      expect(existsSync(f), `${f} missing — every scan below would be vacuous`).toBe(true)
-    }
+    assertEngineFilesExist(expect, P)
   })
 
   it.skipIf(!distExists())('CONTROL — the main entry trips the same matcher', () => {
     // If this stops tripping, the matcher broke or the package changed shape.
-    expect(specifierPattern('react').test(read(MAIN_JS))).toBe(true)
-    expect(specifierPattern('@tour-kit/license').test(read(MAIN_JS))).toBe(true)
-    expect(specifierPattern('react').test(read(MAIN_DTS))).toBe(true)
+    expect(specifierPattern('react').test(closureSrc(P.mainJs))).toBe(true)
+    expect(specifierPattern('@tour-kit/license').test(closureSrc(P.mainJs))).toBe(true)
+    expect(specifierPattern('react').test(closureSrc(P.mainDts))).toBe(true)
   })
 
   it.skipIf(!distExists())('the engine JS names none of the React-side specifiers', () => {
-    for (const f of [ENGINE_JS, ENGINE_CJS]) {
+    for (const f of [P.engineJs, P.engineCjs]) {
       for (const pkg of FORBIDDEN) {
-        expect(specifierPattern(pkg).test(read(f)), `${f} must not import ${pkg}`).toBe(false)
+        expect(specifierPattern(pkg).test(closureSrc(f)), `${f} closure imports ${pkg}`).toBe(false)
       }
     }
   })
 
   it.skipIf(!distExists())('the engine .d.ts closure names none of them either', () => {
-    for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
-      const source = readDts(entry)
+    for (const entry of [P.engineDts, P.engineDcts]) {
+      const source = closureSrc(entry)
       for (const pkg of FORBIDDEN) {
         expect(specifierPattern(pkg).test(source), `${entry} closure names ${pkg}`).toBe(false)
       }
@@ -105,16 +104,16 @@ describe('@tour-kit/analytics/engine ships no React', () => {
   it.skipIf(!distExists())('imports @tour-kit/core/engine, never the bare main entry', () => {
     // `specifierPattern('@tour-kit/core')` matches the `/engine` form too, so it
     // can only prove PRESENCE. Absence of the bare form needs `BARE_CORE`.
-    for (const f of [ENGINE_JS, ENGINE_CJS]) {
-      const source = read(f)
+    for (const f of [P.engineJs, P.engineCjs]) {
+      const source = closureSrc(f)
       expect(BARE_CORE.test(source), `${f} imports bare core`).toBe(false)
       expect(
         specifierPattern('@tour-kit/core').test(source),
         `${f} should import core/engine`
       ).toBe(true)
     }
-    for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
-      expect(BARE_CORE.test(readDts(entry)), `${entry} names bare core`).toBe(false)
+    for (const entry of [P.engineDts, P.engineDcts]) {
+      expect(BARE_CORE.test(closureSrc(entry)), `${entry} names bare core`).toBe(false)
     }
   })
 
@@ -123,64 +122,25 @@ describe('@tour-kit/analytics/engine ships no React', () => {
     // external and inlines core. The budget row would only catch it after the
     // ~50 B threshold, and `analytics:main` would jump by kilobytes. Naming a
     // symbol that exists ONLY inside core is the cheap direct test.
-    expect(read(MAIN_JS)).not.toMatch(/createTourEngine/)
-    expect(read(ENGINE_JS)).not.toMatch(/createTourEngine/)
+    expect(closureSrc(P.mainJs)).not.toMatch(/createTourEngine/)
+    expect(closureSrc(P.engineJs)).not.toMatch(/createTourEngine/)
   })
 
   it.skipIf(!distExists())("'use client' lands on the React entry only", () => {
-    const startsWithDirective = (p: string) => /^['"]use client['"];?/.test(read(p))
-    expect(startsWithDirective(ENGINE_JS)).toBe(false)
-    expect(startsWithDirective(ENGINE_CJS)).toBe(false)
+    expect(startsWithClientDirective(P.engineJs)).toBe(false)
+    expect(startsWithClientDirective(P.engineCjs)).toBe(false)
     // Both halves: losing the directive on the main entry is equally a break —
     // it is what lets <AnalyticsProvider> work inside an RSC tree.
-    expect(startsWithDirective(MAIN_JS)).toBe(true)
-    expect(startsWithDirective(join(DIST, 'index.cjs'))).toBe(true)
+    expect(startsWithClientDirective(P.mainJs)).toBe(true)
+    expect(startsWithClientDirective(P.mainCjs)).toBe(true)
   })
 
   it.skipIf(!distExists())('every path the ./engine exports block names resolves', () => {
-    // The `types` condition of an `exports` block is never exercised by an
-    // `import()` — core solves this with a separate portability test, which
-    // neither new package gets. This is the cheap closure: a `.d.mts` typo, a
-    // dropped `./`, or a `.d.ts`/`.d.cts` swap is invisible to every other case
-    // here and breaks a consumer's typecheck rather than their build.
-    const pkg = JSON.parse(read(join(PKG_ROOT, 'package.json'))) as {
-      exports: Record<string, { import: Record<string, string>; require: Record<string, string> }>
-    }
-    const block = pkg.exports['./engine']
-    expect(block, 'package.json has no "./engine" exports key').toBeDefined()
-
-    const paths = [
-      block.import.types,
-      block.import.default,
-      block.require.types,
-      block.require.default,
-    ]
-    expect(paths.filter(Boolean)).toHaveLength(4)
-    for (const rel of paths) {
-      expect(rel.startsWith('./'), `${rel} is not a relative exports target`).toBe(true)
-      expect(existsSync(join(PKG_ROOT, rel)), `${rel} does not exist on disk`).toBe(true)
-    }
+    assertEngineExportsResolve(expect, PKG_ROOT)
   })
 
   it('no source file the engine barrel reaches imports react, license or bare core', () => {
-    // Walk the barrel's relative imports to fixpoint. `.ts` first, then
-    // `/index.ts`, so `../utils`-style directory imports resolve too.
-    // RELATIVE_SPECIFIER is a module-level /g regex: matchAll only, never .test.
-    const seen = new Set<string>()
-    const queue = [join(PKG_ROOT, 'src', 'engine', 'index.ts')]
-    while (queue.length > 0) {
-      const file = queue.shift() as string
-      if (seen.has(file)) continue
-      seen.add(file)
-      const source = read(file)
-      for (const [, spec] of source.matchAll(RELATIVE_SPECIFIER)) {
-        const base = resolve(dirname(file), spec)
-        const next = [`${base}.ts`, join(base, 'index.ts'), `${base}.tsx`].find(existsSync)
-        if (!next) throw new Error(`${file}: cannot resolve ${spec}`)
-        queue.push(next)
-      }
-    }
-    const files = [...seen]
+    const files = reachableFrom(join(PKG_ROOT, 'src', 'engine', 'index.ts'))
     // The walker can fail silently; say out loud what it must have found.
     // The floor is pinned at today's exact count (barrel + tracker + queue +
     // 5 plugins + 2 type files = 10) — an anti-vacuity floor, not a target.
@@ -191,11 +151,11 @@ describe('@tour-kit/analytics/engine ships no React', () => {
     for (const file of files) {
       const source = read(file)
       expect(file.endsWith('.tsx'), `${file} is a React file`).toBe(false)
-      expect(/from\s*["']react(\/[^"']*)?["']/.test(source), `${file} imports react`).toBe(false)
-      expect(/from\s*["']@tour-kit\/license["']/.test(source), `${file} imports license`).toBe(
+      expect(specifierPattern('react').test(source), `${file} imports react`).toBe(false)
+      expect(specifierPattern('@tour-kit/license').test(source), `${file} imports license`).toBe(
         false
       )
-      expect(/from\s*["']@tour-kit\/core["']/.test(source), `${file} imports bare core`).toBe(false)
+      expect(BARE_CORE.test(source), `${file} imports bare core`).toBe(false)
     }
   })
 })

--- a/packages/hints/src/__tests__/no-react-in-engine-dist.test.ts
+++ b/packages/hints/src/__tests__/no-react-in-engine-dist.test.ts
@@ -20,30 +20,29 @@
  * and one `import type … from '../../types'` in a lib file would put both in the
  * declaration closure.
  */
-import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { SPECIFIER_PREFIX, specifierPattern } from '../../../../tooling/bundle-check/closure.mjs'
 import {
-  RELATIVE_SPECIFIER,
-  SPECIFIER_PREFIX,
-  closureOf,
-  specifierPattern,
-} from '../../../../tooling/bundle-check/closure.mjs'
+  assertClosureIsNotTheShell,
+  assertEngineExportsResolve,
+  assertEngineFilesExist,
+  assertEngineNotInInjectUseClient,
+  closureSrc,
+  enginePaths,
+  distExists as pkgDistExists,
+  reachableFrom,
+  read,
+  startsWithClientDirective,
+} from '../../../../tooling/bundle-check/engine-guard.mjs'
 
 const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
-const DIST = join(PKG_ROOT, 'dist')
+const P = enginePaths(PKG_ROOT)
 // The DIRECTORY, not the files: gating on a filename turns a typo into a
 // silent skip (measured in v2 §1.5 — "3 skipped", green, proving nothing).
-const distExists = () => existsSync(DIST)
-
-const ENGINE_JS = join(DIST, 'engine', 'index.js')
-const ENGINE_CJS = join(DIST, 'engine', 'index.cjs')
-const ENGINE_DTS = join(DIST, 'engine', 'index.d.ts')
-const ENGINE_DCTS = join(DIST, 'engine', 'index.d.cts')
-const MAIN_JS = join(DIST, 'index.js')
-const MAIN_CJS = join(DIST, 'index.cjs')
-const MAIN_DTS = join(DIST, 'index.d.ts')
+const distExists = () => pkgDistExists(PKG_ROOT)
+const BARREL = join(PKG_ROOT, 'src', 'engine', 'index.ts')
 
 /**
  * Everything that must never follow the state machine through the engine door.
@@ -95,60 +94,16 @@ const CONTROL_DTS = [
  */
 const BARE_CORE = new RegExp(`${SPECIFIER_PREFIX}["']@tour-kit/core["']`)
 
-const read = (p: string) => readFileSync(p, 'utf8')
-/**
- * The closure, never the entry. Under `splitting: true` the engine entry is a
- * re-export shell; reading it makes every scan below vacuous. `closureOf` maps
- * `.js → .d.ts` / `.cjs → .d.cts` and tries the literal path first, so this
- * over-includes for declarations. That is a superset scan and it is stronger.
- */
-const closureSrc = (entry: string) => closureOf(entry).map(read).join('\n')
-
-/**
- * Every source file reachable from `entry` through relative imports, to
- * fixpoint. `.ts` first, then `/index.ts`, then `.tsx` — a `.tsx` leaking in is
- * caught by the assertions rather than by failing to resolve.
- *
- * `RELATIVE_SPECIFIER` is a module-level /g regex: `matchAll` only, never
- * `.test`, which would carry `lastIndex` between calls.
- */
-function reachableFrom(entry: string): string[] {
-  const seen = new Set<string>()
-  const queue = [entry]
-  while (queue.length > 0) {
-    const file = queue.shift() as string
-    if (seen.has(file)) continue
-    seen.add(file)
-    for (const [, spec] of read(file).matchAll(RELATIVE_SPECIFIER)) {
-      const base = resolve(dirname(file), spec)
-      const next = [`${base}.ts`, join(base, 'index.ts'), `${base}.tsx`].find(existsSync)
-      if (!next) throw new Error(`${file}: cannot resolve ${spec}`)
-      queue.push(next)
-    }
-  }
-  return [...seen]
-}
-
 describe('@tour-kit/hints/engine ships no React', () => {
   it.skipIf(!distExists())('names the four built engine files', () => {
-    for (const f of [ENGINE_JS, ENGINE_CJS, ENGINE_DTS, ENGINE_DCTS]) {
-      expect(existsSync(f), `${f} missing — every scan below would be vacuous`).toBe(true)
-    }
+    assertEngineFilesExist(expect, P)
   })
 
   it.skipIf(!distExists())('ANTI-VACUITY — the engine closure is more than the shell', () => {
     // Two files is the NORMAL shape for a split package (the main closure is
-    // four), so the file count discriminates almost nothing. The byte count is
-    // the load-bearing half: the shell alone is ~200 B, a real closure is ~6 KB.
-    for (const entry of [ENGINE_JS, ENGINE_CJS]) {
-      const files = closureOf(entry)
-      expect(files.length, `${entry}: closureOf followed nothing`).toBeGreaterThanOrEqual(2)
-      const bytes = files.reduce((n, f) => n + readFileSync(f).length, 0)
-      expect(
-        bytes,
-        `expected the engine closure to exceed 2 000 raw bytes — got ${bytes}; closureOf followed nothing and is reading the re-export shell`
-      ).toBeGreaterThan(2000)
-    }
+    // four), so the file count discriminates almost nothing. The BYTE count is
+    // the load-bearing half: the shell alone is ~200 B, a real closure ~6 KB.
+    for (const entry of [P.engineJs, P.engineCjs]) assertClosureIsNotTheShell(expect, entry)
   })
 
   it.skipIf(!distExists())('CONTROL — the main closure trips the same matchers', () => {
@@ -157,12 +112,12 @@ describe('@tour-kit/hints/engine ships no React', () => {
     // tripping, the matcher broke or the package changed shape — both deserve
     // a red, because a broken matcher turns every assertion below into a
     // vacuous pass.
-    for (const src of [closureSrc(MAIN_JS), closureSrc(MAIN_CJS)]) {
+    for (const src of [closureSrc(P.mainJs), closureSrc(P.mainCjs)]) {
       for (const pkg of CONTROL_JS) {
         expect(specifierPattern(pkg).test(src), `main should name ${pkg}`).toBe(true)
       }
     }
-    const dts = closureSrc(MAIN_DTS)
+    const dts = closureSrc(P.mainDts)
     for (const pkg of CONTROL_DTS) {
       expect(specifierPattern(pkg).test(dts), `main .d.ts should name ${pkg}`).toBe(true)
     }
@@ -170,11 +125,11 @@ describe('@tour-kit/hints/engine ships no React', () => {
     // imports bare `@tour-kit/core` (twenty source files do). Without this, a
     // BARE_CORE that silently stopped matching would turn the engine's
     // "never bare core" case into a vacuous pass.
-    expect(BARE_CORE.test(closureSrc(MAIN_JS)), 'BARE_CORE stopped matching').toBe(true)
+    expect(BARE_CORE.test(closureSrc(P.mainJs)), 'BARE_CORE stopped matching').toBe(true)
   })
 
   it.skipIf(!distExists())('the engine JS closure names none of the React-side specifiers', () => {
-    for (const entry of [ENGINE_JS, ENGINE_CJS]) {
+    for (const entry of [P.engineJs, P.engineCjs]) {
       const src = closureSrc(entry)
       for (const pkg of FORBIDDEN) {
         expect(specifierPattern(pkg).test(src), `${entry} closure imports ${pkg}`).toBe(false)
@@ -183,7 +138,7 @@ describe('@tour-kit/hints/engine ships no React', () => {
   })
 
   it.skipIf(!distExists())('the engine .d.ts closure names none of them either', () => {
-    for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
+    for (const entry of [P.engineDts, P.engineDcts]) {
       const src = closureSrc(entry)
       for (const pkg of FORBIDDEN) {
         expect(specifierPattern(pkg).test(src), `${entry} closure names ${pkg}`).toBe(false)
@@ -197,7 +152,7 @@ describe('@tour-kit/hints/engine ships no React', () => {
     // names one — so this is the narrower claim: it reaches core through the
     // React-free door only. Bare `@tour-kit/core` would pull the main barrel's
     // providers, fourteen hooks and `UnifiedSlot` into a Vue consumer's graph.
-    for (const entry of [ENGINE_JS, ENGINE_CJS, ENGINE_DTS, ENGINE_DCTS]) {
+    for (const entry of [P.engineJs, P.engineCjs, P.engineDts, P.engineDcts]) {
       const src = closureSrc(entry)
       expect(BARE_CORE.test(src), `${entry} closure imports bare @tour-kit/core`).toBe(false)
       expect(
@@ -213,50 +168,29 @@ describe('@tour-kit/hints/engine ships no React', () => {
     // entry is a shell and the case would be vacuous forever.
     // `createTourEngine` is a core symbol hints imports nowhere, so its
     // appearance means core's source was inlined rather than externalised.
-    for (const entry of [ENGINE_JS, ENGINE_CJS]) {
+    for (const entry of [P.engineJs, P.engineCjs]) {
       expect(closureSrc(entry), `${entry} inlined core`).not.toMatch(/createTourEngine/)
     }
-    expect(closureSrc(MAIN_JS), 'main inlined core').not.toMatch(/createTourEngine/)
+    expect(closureSrc(P.mainJs), 'main inlined core').not.toMatch(/createTourEngine/)
   })
 
   it.skipIf(!distExists())("'use client' lands on the React entries only", () => {
-    const startsWithDirective = (p: string) => /^['"]use client['"];?/.test(read(p))
-    expect(startsWithDirective(ENGINE_JS)).toBe(false)
-    expect(startsWithDirective(ENGINE_CJS)).toBe(false)
+    expect(startsWithClientDirective(P.engineJs)).toBe(false)
+    expect(startsWithClientDirective(P.engineCjs)).toBe(false)
     // Both halves, and `headless` too: losing the directive on either React
     // entry is equally a break.
-    expect(startsWithDirective(MAIN_JS)).toBe(true)
-    expect(startsWithDirective(MAIN_CJS)).toBe(true)
-    expect(startsWithDirective(join(DIST, 'headless.js'))).toBe(true)
-    expect(startsWithDirective(join(DIST, 'headless.cjs'))).toBe(true)
+    expect(startsWithClientDirective(P.mainJs)).toBe(true)
+    expect(startsWithClientDirective(P.mainCjs)).toBe(true)
+    expect(startsWithClientDirective(join(P.dist, 'headless.js'))).toBe(true)
+    expect(startsWithClientDirective(join(P.dist, 'headless.cjs'))).toBe(true)
   })
 
   it.skipIf(!distExists())('every path the ./engine exports block names resolves', () => {
-    // The `types` condition of an `exports` block is never exercised by an
-    // `import()`. A `.d.mts` typo, a dropped `./`, or a `.d.ts`/`.d.cts` swap is
-    // invisible to every other case here and breaks a consumer's typecheck
-    // rather than their build.
-    const pkg = JSON.parse(read(join(PKG_ROOT, 'package.json'))) as {
-      exports: Record<string, { import: Record<string, string>; require: Record<string, string> }>
-    }
-    const block = pkg.exports['./engine']
-    expect(block, 'package.json has no "./engine" exports key').toBeDefined()
-
-    const paths = [
-      block.import.types,
-      block.import.default,
-      block.require.types,
-      block.require.default,
-    ]
-    expect(paths.filter(Boolean)).toHaveLength(4)
-    for (const rel of paths) {
-      expect(rel.startsWith('./'), `${rel} is not a relative exports target`).toBe(true)
-      expect(existsSync(join(PKG_ROOT, rel)), `${rel} does not exist on disk`).toBe(true)
-    }
+    assertEngineExportsResolve(expect, PKG_ROOT)
   })
 
   it('every source file the engine barrel reaches lives under lib/hints-engine/', () => {
-    const files = reachableFrom(join(PKG_ROOT, 'src', 'engine', 'index.ts'))
+    const files = reachableFrom(BARREL)
     // A silently-empty walk passes every assertion below it forever. Say out
     // loud what it must have found: the barrel plus six lib modules is today's
     // exact count — a floor, not a target.
@@ -264,7 +198,6 @@ describe('@tour-kit/hints/engine ships no React', () => {
     expect(files.some((f) => f.endsWith('lib/hints-engine/create-hints-engine.ts'))).toBe(true)
     expect(files.length).toBeGreaterThanOrEqual(7)
 
-    const barrel = join(PKG_ROOT, 'src', 'engine', 'index.ts')
     for (const file of files) {
       const source = read(file)
       expect(file.endsWith('.tsx'), `${file} is a React file`).toBe(false)
@@ -272,7 +205,7 @@ describe('@tour-kit/hints/engine ships no React', () => {
       // @tour-kit/media, so one `import type … from '../../types'` in a lib
       // file would put both in the declaration closure — and a TYPE import
       // leaves no trace in the JS, so only this case would catch it.
-      if (file !== barrel) {
+      if (file !== BARREL) {
         expect(
           file.includes(`${join('lib', 'hints-engine')}`),
           `${file} is reachable from the engine barrel but is not under lib/hints-engine/`
@@ -288,13 +221,9 @@ describe('@tour-kit/hints/engine ships no React', () => {
   })
 
   it('the engine entry is never stamped with a client directive', () => {
-    // The source half of the `'use client'` case above: `injectUseClient` is
-    // called in tsup's `onSuccess`, and adding `'engine/index'` to its list is
-    // a one-word change that only the built-bytes case would otherwise catch —
-    // and only after a rebuild.
-    const config = read(join(PKG_ROOT, 'tsup.config.ts'))
-    const call = config.match(/injectUseClient\(\[([^\]]*)\]\)/)
-    expect(call, 'injectUseClient call not found in tsup.config.ts').not.toBeNull()
-    expect(call?.[1]).not.toMatch(/engine/)
+    // The source half of the `'use client'` byte case above: adding the engine
+    // entry to `injectUseClient` is a one-word change that the built-bytes case
+    // only catches after a rebuild.
+    assertEngineNotInInjectUseClient(expect, PKG_ROOT)
   })
 })

--- a/packages/scheduling/src/__tests__/no-react-in-engine-dist.test.ts
+++ b/packages/scheduling/src/__tests__/no-react-in-engine-dist.test.ts
@@ -5,105 +5,95 @@
  * installed. That is a property of the BYTES tsup emitted, so every case here
  * reads a real built file — nothing is faked, stubbed or mocked.
  *
- * This package is the harder of the two to guard, because its engine names
- * *nothing* — so "does the file mention X" cannot be its own control. The
- * sibling main entry is the control instead: it legitimately names three of the
- * four forbidden specifiers (see CONTROL_SPECIFIERS for why not the fourth),
- * and if it ever stops, either the matcher broke or the package changed shape.
- * Both deserve a red.
+ * This package is the harder one to guard, because its engine names *nothing* —
+ * so "does the file mention X" cannot be its own control. The sibling main
+ * closure is the control instead: it legitimately names three of the four
+ * forbidden specifiers (see CONTROL_SPECIFIERS for why not the fourth), and if
+ * it ever stops, either the matcher broke or the package changed shape.
  *
- * `splitting: false`, so the built entry IS its own closure for the JS. The
- * declarations are not: rollup-plugin-dts chunks shared types regardless, under
- * a content-hashed name that changes every rebuild, so the d.ts scan walks with
- * `closureOf` and never spells the hash.
+ * Every scan reads the import CLOSURE, never the entry. This package builds
+ * with `splitting: false` today, so the two happen to be the same file for the
+ * JS — but that is a property of the tsup config, asserted nowhere, and the v3
+ * Phase 1 review demonstrated what an entry-only scan costs: with the guard
+ * reading the entry, a React provider exported from the engine barrel left the
+ * specifier scan GREEN. The anti-vacuity case makes the difference visible if
+ * `splitting` is ever flipped.
  */
-import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { SPECIFIER_PREFIX, specifierPattern } from '../../../../tooling/bundle-check/closure.mjs'
 import {
-  RELATIVE_SPECIFIER,
-  SPECIFIER_PREFIX,
-  closureOf,
-  specifierPattern,
-} from '../../../../tooling/bundle-check/closure.mjs'
+  assertClosureIsNotTheShell,
+  assertEngineExportsResolve,
+  assertEngineFilesExist,
+  closureSrc,
+  enginePaths,
+  distExists as pkgDistExists,
+  reachableFrom,
+  read,
+  startsWithClientDirective,
+} from '../../../../tooling/bundle-check/engine-guard.mjs'
 
 const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
-const DIST = join(PKG_ROOT, 'dist')
+const P = enginePaths(PKG_ROOT)
 // The DIRECTORY, not the files: gating on a filename turns a typo into a
 // silent skip (measured in v2 §1.5 — "3 skipped", green, proving nothing).
-const distExists = () => existsSync(DIST)
-
-const ENGINE_JS = join(DIST, 'engine', 'index.js')
-const ENGINE_CJS = join(DIST, 'engine', 'index.cjs')
-const ENGINE_DTS = join(DIST, 'engine', 'index.d.ts')
-const ENGINE_DCTS = join(DIST, 'engine', 'index.d.cts')
-const MAIN_JS = join(DIST, 'index.js')
-const MAIN_DTS = join(DIST, 'index.d.ts')
+const distExists = () => pkgDistExists(PKG_ROOT)
 
 // `@tour-kit/analytics` is the hooks' optional peer. It must not follow the
 // twenty-four pure functions through the engine door.
 const FORBIDDEN = ['react', 'react-dom', '@tour-kit/license', '@tour-kit/analytics'] as const
 
 /**
- * What the CONTROL asserts the main entry still names — deliberately NOT the
+ * What the CONTROL asserts the main closure still names — deliberately NOT the
  * same list as FORBIDDEN, and the difference is measured rather than assumed.
  *
  * `react-dom` is in this package's tsup `external` list, but nothing in the
  * package actually imports it, so it appears in neither built entry. A control
- * that loops over FORBIDDEN therefore fails against a perfectly correct build
- * ("main should name react-dom: expected false to be true"). Forbidding it on
- * the engine side is still right — it is a React-side specifier that must never
- * appear — but a guard may only use as its control what the sibling entry
- * demonstrably contains.
+ * that loops over FORBIDDEN therefore fails against a perfectly correct build.
+ * Forbidding it on the engine side is still right; a guard may only use as its
+ * control what the sibling demonstrably contains.
  */
 const CONTROL_SPECIFIERS = ['react', '@tour-kit/license', '@tour-kit/analytics'] as const
 
 /**
  * Any BARE specifier, in every call shape a bundler emits — `from`, `import(`
- * and `require(`. The leading `[^"'.]` excludes relative paths, which all start
- * with `.`; everything else is a package.
+ * and `require(`. The leading `[^"\'.]` excludes relative paths, which all
+ * start with `.`; everything else is a package.
  */
-const BARE_SPECIFIER = new RegExp(`${SPECIFIER_PREFIX}["'][^"'.]`)
-
-const read = (p: string) => readFileSync(p, 'utf8')
-// rollup-plugin-dts chunks shared declarations even with `splitting: false`,
-// under a content-hashed name that changes on every rebuild — so never spell
-// it, walk it. `closureOf` maps `.js → .d.ts` / `.cjs → .d.cts` and tries the
-// literal path first, so this over-includes real JS. That is a superset scan,
-// and it is stronger than the declaration chain alone.
-const readDts = (entry: string) => closureOf(entry).map(read).join('\n')
+const BARE_SPECIFIER = new RegExp(`${SPECIFIER_PREFIX}["\'][^"\'.]`)
 
 describe('@tour-kit/scheduling/engine ships no React', () => {
   it.skipIf(!distExists())('names the four built engine files', () => {
-    for (const f of [ENGINE_JS, ENGINE_CJS, ENGINE_DTS, ENGINE_DCTS]) {
-      expect(existsSync(f), `${f} missing — every scan below would be vacuous`).toBe(true)
-    }
+    assertEngineFilesExist(expect, P)
   })
 
-  it.skipIf(!distExists())('CONTROL — the main entry trips the same matcher', () => {
-    // The engine names nothing external, so "the file mentions X" cannot be its
-    // own control. The sibling entry is. If any of these stops tripping, the
-    // matcher broke or the package changed shape.
+  it.skipIf(!distExists())('ANTI-VACUITY — the engine closure is more than a shell', () => {
+    for (const entry of [P.engineJs, P.engineCjs]) assertClosureIsNotTheShell(expect, entry)
+  })
+
+  it.skipIf(!distExists())('CONTROL — the main closure trips the same matcher', () => {
     for (const pkg of CONTROL_SPECIFIERS) {
-      expect(specifierPattern(pkg).test(read(MAIN_JS)), `main should name ${pkg}`).toBe(true)
+      expect(specifierPattern(pkg).test(closureSrc(P.mainJs)), `main should name ${pkg}`).toBe(true)
     }
-    expect(specifierPattern('react').test(read(MAIN_DTS))).toBe(true)
+    expect(specifierPattern('react').test(closureSrc(P.mainDts))).toBe(true)
   })
 
-  it.skipIf(!distExists())('the engine JS names none of the React-side specifiers', () => {
-    for (const f of [ENGINE_JS, ENGINE_CJS]) {
+  it.skipIf(!distExists())('the engine JS closure names none of the React-side specifiers', () => {
+    for (const entry of [P.engineJs, P.engineCjs]) {
+      const src = closureSrc(entry)
       for (const pkg of FORBIDDEN) {
-        expect(specifierPattern(pkg).test(read(f)), `${f} must not import ${pkg}`).toBe(false)
+        expect(specifierPattern(pkg).test(src), `${entry} closure imports ${pkg}`).toBe(false)
       }
     }
   })
 
   it.skipIf(!distExists())('the engine .d.ts closure names none of them either', () => {
-    for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
-      const source = readDts(entry)
+    for (const entry of [P.engineDts, P.engineDcts]) {
+      const src = closureSrc(entry)
       for (const pkg of FORBIDDEN) {
-        expect(specifierPattern(pkg).test(source), `${entry} closure names ${pkg}`).toBe(false)
+        expect(specifierPattern(pkg).test(src), `${entry} closure names ${pkg}`).toBe(false)
       }
     }
   })
@@ -111,81 +101,33 @@ describe('@tour-kit/scheduling/engine ships no React', () => {
   it.skipIf(!distExists())('the engine names NO bare specifier at all', () => {
     // Scheduling's engine depends on nothing. Rather than enumerate what it
     // must not import, pin the stronger property: every specifier it emits is
-    // relative. A new dependency of any kind — not just a React-side one —
-    // fails here, which is the case analytics spends on `@tour-kit/core/engine`.
-    //
-    // Built from `SPECIFIER_PREFIX`, not hand-rolled. The hand-rolled version
-    // was two regexes covering `from` and `require(`, which left `import(`
-    // unguarded — and a lazy `import('some-package')` is precisely how a bare
-    // specifier enters a bundle in this repo (analytics' four vendor plugins
-    // load their SDKs that way). A case that claims NO bare specifier AT ALL
-    // has to mean all three call shapes, or the title is a lie.
-    for (const f of [ENGINE_JS, ENGINE_CJS]) {
-      expect(BARE_SPECIFIER.test(read(f)), `${f} names a bare specifier`).toBe(false)
-    }
-    for (const entry of [ENGINE_DTS, ENGINE_DCTS]) {
-      expect(BARE_SPECIFIER.test(readDts(entry)), `${entry} closure names a bare specifier`).toBe(
-        false
-      )
+    // relative. Built from `SPECIFIER_PREFIX`, so it covers `from`, `import(`
+    // AND `require(` — a hand-rolled pair covering only two would miss a lazy
+    // `import('some-package')`, which is exactly how a bare specifier enters a
+    // bundle in this repo.
+    for (const entry of [P.engineJs, P.engineCjs, P.engineDts, P.engineDcts]) {
+      expect(BARE_SPECIFIER.test(closureSrc(entry)), `${entry} names a bare specifier`).toBe(false)
     }
   })
 
   it.skipIf(!distExists())("'use client' lands on the React entry only", () => {
-    const startsWithDirective = (p: string) => /^['"]use client['"];?/.test(read(p))
-    expect(startsWithDirective(ENGINE_JS)).toBe(false)
-    expect(startsWithDirective(ENGINE_CJS)).toBe(false)
+    expect(startsWithClientDirective(P.engineJs)).toBe(false)
+    expect(startsWithClientDirective(P.engineCjs)).toBe(false)
     // Both halves: losing the directive on the main entry is equally a break —
     // it is what lets <ScheduleGate> work inside an RSC tree.
-    expect(startsWithDirective(MAIN_JS)).toBe(true)
-    expect(startsWithDirective(join(DIST, 'index.cjs'))).toBe(true)
+    expect(startsWithClientDirective(P.mainJs)).toBe(true)
+    expect(startsWithClientDirective(P.mainCjs)).toBe(true)
   })
 
   it.skipIf(!distExists())('every path the ./engine exports block names resolves', () => {
-    // The `types` condition of an `exports` block is never exercised by an
-    // `import()` — core solves this with a separate portability test, which
-    // neither new package gets. This is the cheap closure: a `.d.mts` typo, a
-    // dropped `./`, or a `.d.ts`/`.d.cts` swap is invisible to every other case
-    // here and breaks a consumer's typecheck rather than their build.
-    const pkg = JSON.parse(read(join(PKG_ROOT, 'package.json'))) as {
-      exports: Record<string, { import: Record<string, string>; require: Record<string, string> }>
-    }
-    const block = pkg.exports['./engine']
-    expect(block, 'package.json has no "./engine" exports key').toBeDefined()
-
-    const paths = [
-      block.import.types,
-      block.import.default,
-      block.require.types,
-      block.require.default,
-    ]
-    expect(paths.filter(Boolean)).toHaveLength(4)
-    for (const rel of paths) {
-      expect(rel.startsWith('./'), `${rel} is not a relative exports target`).toBe(true)
-      expect(existsSync(join(PKG_ROOT, rel)), `${rel} does not exist on disk`).toBe(true)
-    }
+    assertEngineExportsResolve(expect, PKG_ROOT)
   })
 
   it('no source file the engine barrel reaches imports react, license or analytics', () => {
-    // Walk the barrel's relative imports to fixpoint. `.ts` first, then
-    // `/index.ts`, so `../utils`-style directory imports resolve.
-    // RELATIVE_SPECIFIER is a module-level /g regex: matchAll only, never .test.
-    const seen = new Set<string>()
-    const queue = [join(PKG_ROOT, 'src', 'engine', 'index.ts')]
-    while (queue.length > 0) {
-      const file = queue.shift() as string
-      if (seen.has(file)) continue
-      seen.add(file)
-      for (const [, spec] of read(file).matchAll(RELATIVE_SPECIFIER)) {
-        const base = resolve(dirname(file), spec)
-        const next = [`${base}.ts`, join(base, 'index.ts'), `${base}.tsx`].find(existsSync)
-        if (!next) throw new Error(`${file}: cannot resolve ${spec}`)
-        queue.push(next)
-      }
-    }
-    const files = [...seen]
+    const files = reachableFrom(join(PKG_ROOT, 'src', 'engine', 'index.ts'))
     // A silently-empty walk passes every assertion below it forever. Say out
-    // loud what it must have found. 15 = barrel + utils/index + 9 util leaves
-    // + types/index + 3 type files, today's exact count — a floor, not a target.
+    // loud what it must have found. 15 = barrel + utils/index + 9 util leaves +
+    // types/index + 3 type files — today's exact count, a floor not a target.
     expect(files.some((f) => f.endsWith('utils/is-schedule-active.ts'))).toBe(true)
     expect(files.some((f) => f.endsWith('types/schedule.ts'))).toBe(true)
     expect(files.length).toBeGreaterThanOrEqual(15)
@@ -193,13 +135,9 @@ describe('@tour-kit/scheduling/engine ships no React', () => {
     for (const file of files) {
       const source = read(file)
       expect(file.endsWith('.tsx'), `${file} is a React file`).toBe(false)
-      expect(/from\s*["']react(\/[^"']*)?["']/.test(source), `${file} imports react`).toBe(false)
-      expect(/from\s*["']@tour-kit\/license["']/.test(source), `${file} imports license`).toBe(
-        false
-      )
-      expect(/from\s*["']@tour-kit\/analytics["']/.test(source), `${file} imports analytics`).toBe(
-        false
-      )
+      for (const pkg of ['react', '@tour-kit/license', '@tour-kit/analytics'] as const) {
+        expect(specifierPattern(pkg).test(source), `${file} imports ${pkg}`).toBe(false)
+      }
     }
   })
 })

--- a/tooling/bundle-check/engine-guard.d.mts
+++ b/tooling/bundle-check/engine-guard.d.mts
@@ -1,0 +1,63 @@
+/**
+ * Types for `engine-guard.mjs`, hand-written for the same reason
+ * `closure.d.mts` is: the module stays plain ESM and has no build of its own.
+ *
+ * `expect` is typed loosely on purpose — these helpers are called from Vitest
+ * test files and taking the assertion function as a parameter keeps this file
+ * free of a Vitest import, so nothing here is pulled into a non-test context.
+ */
+type ExpectLike = (
+  actual: unknown,
+  message?: string
+) => {
+  toBe(expected: unknown): void
+  toBeDefined(): void
+  toBeGreaterThan(expected: number): void
+  toHaveLength(expected: number): void
+  not: { toBeNull(): void; toMatch(expected: RegExp): void }
+}
+
+export interface EnginePaths {
+  dist: string
+  engineJs: string
+  engineCjs: string
+  engineDts: string
+  engineDcts: string
+  mainJs: string
+  mainCjs: string
+  mainDts: string
+}
+
+/** Read a built file as UTF-8. */
+export declare function read(path: string): string
+
+/** The four built engine files plus the sibling main entry used as control. */
+export declare function enginePaths(pkgRoot: string): EnginePaths
+
+/** Gate on the `dist` DIRECTORY — a filename gate turns a typo into a skip. */
+export declare function distExists(pkgRoot: string): boolean
+
+/** The four built engine files exist — run first, or later scans are vacuous. */
+export declare function assertEngineFilesExist(expect: ExpectLike, paths: EnginePaths): void
+
+/** The entry plus every chunk it imports, concatenated. Never the entry alone. */
+export declare function closureSrc(entry: string): string
+
+/** Assert the closure exceeds `minBytes` raw — catches a walker that followed nothing. */
+export declare function assertClosureIsNotTheShell(
+  expect: ExpectLike,
+  entry: string,
+  minBytes?: number
+): void
+
+/** Every source file reachable from `entry` by relative imports, to fixpoint. */
+export declare function reachableFrom(entry: string): string[]
+
+/** Every path the `./engine` exports block names exists on disk. */
+export declare function assertEngineExportsResolve(expect: ExpectLike, pkgRoot: string): void
+
+/** Does the file begin with a `'use client'` directive? */
+export declare function startsWithClientDirective(path: string): boolean
+
+/** The engine entry is not listed in tsup's `injectUseClient(...)` call. */
+export declare function assertEngineNotInInjectUseClient(expect: ExpectLike, pkgRoot: string): void

--- a/tooling/bundle-check/engine-guard.mjs
+++ b/tooling/bundle-check/engine-guard.mjs
@@ -1,0 +1,165 @@
+/**
+ * The scaffolding every `no-react-in-engine-dist.test.ts` repeats.
+ *
+ * Three packages ship an `/engine` subpath today (`analytics`, `scheduling`,
+ * `hints`) and three more land in v3 Phases 2–3. Their guards were
+ * copy-and-edit descendants of one another, ~700 lines of shared boilerplate
+ * with the real per-package content — the forbidden list, the control list, the
+ * source-walk rule — buried inside it.
+ *
+ * This file holds only what is genuinely identical, and deliberately NOT a
+ * `describeEngineGuard(config)` case factory: the cases differ per package in
+ * ways that are the point (scheduling's engine may name NO bare specifier;
+ * hints' names exactly one), and a factory with eight config flags would hide
+ * that behind a mechanism. Each package keeps its own readable `describe`; the
+ * plumbing lives here.
+ *
+ * The one discipline this exists to propagate:
+ *
+ *   **Scan the import CLOSURE, never the entry.**
+ *
+ * Under `splitting: true` a built entry is a re-export shell of a couple of
+ * hundred bytes and the code sits in `chunk-*.js` beside it, so a scan of the
+ * entry passes forever no matter what the package imports. Demonstrated in v3
+ * Phase 1: with a guard reading the entry, exporting the React provider from
+ * the engine barrel left "the engine names no React-side specifier" GREEN.
+ *
+ * `analytics` and `scheduling` build with `splitting: false` today, so reading
+ * their entry happens to be equivalent — but that is a property of their tsup
+ * config, which is asserted nowhere. `assertClosureIsNotTheShell` closes that:
+ * it is cheap for an unsplit package and it is the only thing standing between
+ * a future `splitting: true` and a silently vacuous guard.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { RELATIVE_SPECIFIER, closureOf } from './closure.mjs'
+
+/** Read a built file as UTF-8. */
+export const read = (p) => readFileSync(p, 'utf8')
+
+/**
+ * The four built files an `/engine` subpath must emit, plus the sibling main
+ * entry every guard uses as its positive control.
+ */
+export function enginePaths(pkgRoot) {
+  const dist = join(pkgRoot, 'dist')
+  return {
+    dist,
+    engineJs: join(dist, 'engine', 'index.js'),
+    engineCjs: join(dist, 'engine', 'index.cjs'),
+    engineDts: join(dist, 'engine', 'index.d.ts'),
+    engineDcts: join(dist, 'engine', 'index.d.cts'),
+    mainJs: join(dist, 'index.js'),
+    mainCjs: join(dist, 'index.cjs'),
+    mainDts: join(dist, 'index.d.ts'),
+  }
+}
+
+/**
+ * Gate on the `dist` DIRECTORY, never a filename: gating on a file turns a typo
+ * into a silent skip (measured in v2 §1.5 — "3 skipped", green, proving
+ * nothing).
+ */
+export const distExists = (pkgRoot) => existsSync(join(pkgRoot, 'dist'))
+
+/**
+ * The four built engine files exist. Every scan below a missing file would be
+ * vacuous, so this runs first in each guard.
+ */
+export function assertEngineFilesExist(expect, paths) {
+  for (const f of [paths.engineJs, paths.engineCjs, paths.engineDts, paths.engineDcts]) {
+    expect(existsSync(f), `${f} missing — every scan below would be vacuous`).toBe(true)
+  }
+}
+
+/**
+ * The source of every specifier scan: the entry PLUS every chunk it imports,
+ * concatenated. `closureOf` maps `.js -> .d.ts` / `.cjs -> .d.cts` and tries
+ * the literal path first, so for declarations this over-includes — a superset
+ * scan, stronger than the declaration chain alone.
+ */
+export const closureSrc = (entry) => closureOf(entry).map(read).join('\n')
+
+/**
+ * Assert a closure is bigger than a re-export shell could be.
+ *
+ * The BYTE floor is the load-bearing half. File count discriminates almost
+ * nothing: shell-plus-one-chunk is exactly what a correct split build looks
+ * like, and an unsplit entry is legitimately one file. What this catches is a
+ * walker that followed nothing and is reading ~200 bytes of re-export.
+ */
+export function assertClosureIsNotTheShell(expect, entry, minBytes = 2000) {
+  const files = closureOf(entry)
+  const bytes = files.reduce((n, f) => n + readFileSync(f).length, 0)
+  expect(
+    bytes,
+    `expected the closure of ${entry} to exceed ${minBytes} raw bytes — got ${bytes}; closureOf followed nothing and is reading the re-export shell`
+  ).toBeGreaterThan(minBytes)
+}
+
+/**
+ * Every source file reachable from `entry` through relative imports, to
+ * fixpoint. `.ts` first, then `/index.ts`, then `.tsx` — a `.tsx` leaking in is
+ * caught by the caller's assertions rather than by failing to resolve.
+ *
+ * `RELATIVE_SPECIFIER` is a module-level /g regex: `matchAll` only, never
+ * `.test`, which would carry `lastIndex` between calls.
+ */
+export function reachableFrom(entry) {
+  const seen = new Set()
+  const queue = [entry]
+  while (queue.length > 0) {
+    const file = queue.shift()
+    if (seen.has(file)) continue
+    seen.add(file)
+    for (const [, spec] of read(file).matchAll(RELATIVE_SPECIFIER)) {
+      const base = resolve(dirname(file), spec)
+      const next = [`${base}.ts`, join(base, 'index.ts'), `${base}.tsx`].find(existsSync)
+      if (!next) throw new Error(`${file}: cannot resolve ${spec}`)
+      queue.push(next)
+    }
+  }
+  return [...seen]
+}
+
+/**
+ * Every path the `./engine` exports block names exists on disk.
+ *
+ * The `types` condition is never exercised by an `import()`, so a `.d.mts`
+ * typo, a dropped `./`, or a `.d.ts`/`.d.cts` swap is invisible to every other
+ * case and breaks a consumer's typecheck rather than their build.
+ */
+export function assertEngineExportsResolve(expect, pkgRoot) {
+  const pkg = JSON.parse(read(join(pkgRoot, 'package.json')))
+  const block = pkg.exports?.['./engine']
+  expect(block, 'package.json has no "./engine" exports key').toBeDefined()
+
+  const paths = [
+    block.import?.types,
+    block.import?.default,
+    block.require?.types,
+    block.require?.default,
+  ]
+  expect(paths.filter(Boolean)).toHaveLength(4)
+  for (const rel of paths) {
+    expect(rel.startsWith('./'), `${rel} is not a relative exports target`).toBe(true)
+    expect(existsSync(join(pkgRoot, rel)), `${rel} does not exist on disk`).toBe(true)
+  }
+}
+
+/** Does the file begin with a `'use client'` directive? */
+export const startsWithClientDirective = (p) => /^['"]use client['"];?/.test(read(p))
+
+/**
+ * The engine entry is never listed in tsup's `injectUseClient(...)` call.
+ *
+ * The source half of the `'use client'` byte assertion: adding the engine entry
+ * to that list is a one-word change, and the built-bytes case only catches it
+ * after a rebuild.
+ */
+export function assertEngineNotInInjectUseClient(expect, pkgRoot) {
+  const config = read(join(pkgRoot, 'tsup.config.ts'))
+  const call = config.match(/injectUseClient\(\[([^\]]*)\]\)/)
+  expect(call, 'injectUseClient call not found in tsup.config.ts').not.toBeNull()
+  expect(call?.[1]).not.toMatch(/engine/)
+}


### PR DESCRIPTION
Review fix 3 of 3 for the v3 Phase 1 PRs. Follows #137 and #138, both merged.

## The real problem wasn't duplication

v3 Phase 1 found that scanning the built **entry** instead of its **import closure** makes an engine guard vacuous under `splitting: true` — and I fixed it in `hints` only. `analytics` and `scheduling` kept reading their entries. Their correctness rested entirely on `splitting: false`, a tsup setting that appears **only in comments** (`analytics/tsup.config.ts:30`, `scheduling/tsup.config.ts:18`) and is asserted nowhere.

**Demonstrated, not argued.** Flipping `scheduling` to `splitting: true` and exporting `ScheduleGate` from its engine barrel — a genuine React leak:

```
engine entry under splitting:true:  710 bytes  (a re-export shell)

entry-only scan sees react:  false   <- the OLD guard would have PASSED
closure scan sees react:     true    <- the new one catches it

→ 4 cases red: JS closure, d.ts closure, bare-specifier, source walk
```

Reverted after measuring; scheduling is back to 9 green.

## What's shared

`tooling/bundle-check/engine-guard.mjs` with a hand-written `.d.mts` — the convention `closure.mjs` already set, so tooling stays plain ESM runnable under bare `node`. It holds `enginePaths`, `distExists`, `closureSrc`, `reachableFrom`, `assertEngineFilesExist`, `assertClosureIsNotTheShell`, `assertEngineExportsResolve`, `startsWithClientDirective`, `assertEngineNotInInjectUseClient`.

**Deliberately not a `describeEngineGuard(config)` case factory.** The cases differ per package in ways that are the point — scheduling's engine may name *no* bare specifier, hints' names exactly one — and a factory with eight config flags would hide that behind a mechanism, which is the failure mode this repo's review bar exists to catch. Each package keeps its own readable `describe`; only the plumbing moves.

Every guard also gains the anti-vacuity case, whose load-bearing half is **bytes** rather than file count. Margins are comfortable: analytics 11 952, scheduling 9 034, hints 6 189 raw against a 2 000 floor.

## Correcting my own review

I claimed in the review that this would "collapse ~700 lines". **It doesn't, and line count was the wrong thing to promise.**

| | Before | After |
|---|---:|---:|
| the three guards | 706 | **533** |
| shared module + types | 0 | **228** |
| raw total | 706 | **761** |

The real wins: each of the next three packages costs ~150 lines instead of ~250, a guard fix lands once instead of three-to-six times, and the closure discipline is uniform and provably load-bearing rather than accidental.

## Verification

| Check | Result |
|---|---|
| `@tour-kit/analytics` | 263 passed (guard 10) |
| `@tour-kit/scheduling` | 135 passed (guard 9) |
| `@tour-kit/hints` | 370 passed (guard 11) |
| `@tour-kit/core` | 1 656 passed |
| `pnpm typecheck` | 0 errors |
| `git ls-files \| xargs biome check` | clean |

No changeset: nothing shipped changes. Test and tooling code only.

This closes all seven review findings.

https://claude.ai/code/session_01T8dE19jkw4BnXhAeuFSPjt